### PR TITLE
feat(network): add peer_manager for unified peer collection

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -94,6 +94,7 @@ set(kth_headers
   include/kth/network/acceptor.hpp
   include/kth/network/define.hpp
   include/kth/network/peer_session.hpp
+  include/kth/network/peer_manager.hpp
   include/kth/network/proxy.hpp
   include/kth/network/channel.hpp
   include/kth/network/hosts.hpp
@@ -145,6 +146,7 @@ set(kth_sources
   src/message_subscriber.cpp
   src/p2p.cpp
   src/peer_session.cpp
+  src/peer_manager.cpp
   src/proxy.cpp
   src/settings.cpp
   src/version.cpp
@@ -184,6 +186,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 
   add_executable(kth_network_test
     test/p2p.cpp
+    test/peer_manager.cpp
     test/peer_session.cpp
   )
 

--- a/src/network/include/kth/network.hpp
+++ b/src/network/include/kth/network.hpp
@@ -20,6 +20,7 @@
 #include <kth/network/hosts.hpp>
 #include <kth/network/message_subscriber.hpp>
 #include <kth/network/p2p.hpp>
+#include <kth/network/peer_manager.hpp>
 #include <kth/network/peer_session.hpp>
 #include <kth/network/proxy.hpp>
 #include <kth/network/settings.hpp>

--- a/src/network/include/kth/network/peer_manager.hpp
+++ b/src/network/include/kth/network/peer_manager.hpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NETWORK_PEER_MANAGER_HPP
+#define KTH_NETWORK_PEER_MANAGER_HPP
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <kth/domain.hpp>
+#include <kth/infrastructure.hpp>
+#include <kth/network/define.hpp>
+#include <kth/network/peer_session.hpp>
+
+#include <asio/awaitable.hpp>
+#include <asio/strand.hpp>
+
+namespace kth::network {
+
+// =============================================================================
+// peer_manager: Modern coroutine-based peer connection manager
+// =============================================================================
+//
+// Replaces the legacy pending<connector>/pending<channel> collections in p2p
+// with a single unified collection. All operations are serialized through
+// a strand, eliminating the need for explicit mutexes.
+//
+// Usage:
+//   peer_manager manager(executor, settings);
+//
+//   // Add a connected peer
+//   co_await manager.add(session);
+//
+//   // Broadcast to all peers
+//   co_await manager.broadcast(message);
+//
+//   // Remove a peer
+//   co_await manager.remove(session);
+//
+// =============================================================================
+
+class KN_API peer_manager {
+public:
+    using ptr = std::shared_ptr<peer_manager>;
+    using peer_handler = std::function<void(peer_session::ptr)>;
+
+    /// Construct a peer manager
+    /// @param executor The executor for async operations
+    /// @param max_connections Maximum number of connections (0 = unlimited)
+    explicit peer_manager(::asio::any_io_executor executor, size_t max_connections = 0);
+
+    /// Destructor - stops all peers
+    ~peer_manager();
+
+    // -------------------------------------------------------------------------
+    // Peer Management
+    // -------------------------------------------------------------------------
+
+    /// Add a peer to the manager
+    /// @param peer The peer session to add
+    /// @return success if added, error if duplicate or at capacity
+    ::asio::awaitable<code> add(peer_session::ptr peer);
+
+    /// Remove a peer from the manager
+    /// @param peer The peer session to remove
+    ::asio::awaitable<void> remove(peer_session::ptr peer);
+
+    /// Remove a peer by nonce
+    /// @param nonce The nonce of the peer to remove
+    ::asio::awaitable<void> remove_by_nonce(uint64_t nonce);
+
+    /// Check if a peer with the given nonce exists
+    /// @param nonce The nonce to check
+    /// @return true if exists
+    ::asio::awaitable<bool> exists_by_nonce(uint64_t nonce) const;
+
+    /// Check if a peer with the given authority exists
+    /// @param authority The authority (ip:port) to check
+    /// @return true if exists
+    ::asio::awaitable<bool> exists_by_authority(infrastructure::config::authority const& authority) const;
+
+    /// Find a peer by nonce
+    /// @param nonce The nonce to find
+    /// @return The peer session or nullptr if not found
+    ::asio::awaitable<peer_session::ptr> find_by_nonce(uint64_t nonce) const;
+
+    /// Get all connected peers (snapshot)
+    /// @return Vector of peer sessions
+    ::asio::awaitable<std::vector<peer_session::ptr>> all() const;
+
+    /// Get the number of connected peers
+    /// @return Count of peers
+    ::asio::awaitable<size_t> count() const;
+
+    // -------------------------------------------------------------------------
+    // Synchronous accessors (for compatibility, use with care)
+    // -------------------------------------------------------------------------
+
+    /// Get the number of connected peers (non-awaitable)
+    /// Thread-safe but may be slightly stale
+    size_t count_snapshot() const;
+
+    // -------------------------------------------------------------------------
+    // Broadcasting
+    // -------------------------------------------------------------------------
+
+    /// Broadcast a message to all connected peers
+    /// @param message The message to broadcast
+    /// @return Number of peers the message was sent to
+    template <typename Message>
+    ::asio::awaitable<size_t> broadcast(Message const& message) {
+        auto peers = co_await all();
+        size_t sent = 0;
+
+        for (auto const& peer : peers) {
+            if (!peer->stopped()) {
+                auto ec = co_await peer->send(message);
+                if (!ec) {
+                    ++sent;
+                }
+            }
+        }
+
+        co_return sent;
+    }
+
+    /// Execute a handler for each peer
+    /// @param handler The handler to execute
+    ::asio::awaitable<void> for_each(peer_handler handler);
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    /// Stop all peers and clear the collection
+    void stop_all();
+
+    /// Check if the manager is stopped
+    bool stopped() const;
+
+private:
+    // Strand for serializing access to peers_
+    ::asio::strand<::asio::any_io_executor> strand_;
+
+    // Peers indexed by nonce
+    std::unordered_map<uint64_t, peer_session::ptr> peers_;
+
+    // Configuration
+    size_t const max_connections_;
+    std::atomic<bool> stopped_{false};
+    std::atomic<size_t> count_{0};  // For snapshot access
+};
+
+} // namespace kth::network
+
+#endif // KTH_NETWORK_PEER_MANAGER_HPP

--- a/src/network/src/peer_manager.cpp
+++ b/src/network/src/peer_manager.cpp
@@ -1,0 +1,206 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/network/peer_manager.hpp>
+
+#include <algorithm>
+
+#include <asio/co_spawn.hpp>
+#include <asio/dispatch.hpp>
+#include <asio/post.hpp>
+#include <asio/use_awaitable.hpp>
+
+namespace kth::network {
+
+// =============================================================================
+// Construction / Destruction
+// =============================================================================
+
+peer_manager::peer_manager(::asio::any_io_executor executor, size_t max_connections)
+    : strand_(::asio::make_strand(executor))
+    , max_connections_(max_connections)
+{}
+
+peer_manager::~peer_manager() {
+    // Direct cleanup in destructor - no async dispatch needed
+    // since no other operations can be in flight during destruction
+    stopped_.store(true);
+    for (auto& [nonce, peer] : peers_) {
+        peer->stop();
+    }
+    peers_.clear();
+    count_.store(0);
+}
+
+// =============================================================================
+// Peer Management
+// =============================================================================
+
+::asio::awaitable<code> peer_manager::add(peer_session::ptr peer) {
+    if (stopped()) {
+        co_return error::service_stopped;
+    }
+
+    if (!peer) {
+        co_return error::operation_failed;
+    }
+
+    auto nonce = peer->nonce();
+    if (nonce == 0) {
+        // Generate a temporary nonce based on address hash if not set
+        // This allows adding peers before handshake completes
+        auto const& auth = peer->authority();
+        nonce = std::hash<std::string>{}(auth.to_string());
+    }
+
+    // Execute on strand
+    auto result = co_await ::asio::co_spawn(strand_, [this, peer, nonce]() -> ::asio::awaitable<code> {
+        // Check capacity
+        if (max_connections_ > 0 && peers_.size() >= max_connections_) {
+            co_return error::channel_stopped;  // At capacity
+        }
+
+        // Check for duplicate
+        if (peers_.find(nonce) != peers_.end()) {
+            co_return error::address_in_use;  // Duplicate nonce
+        }
+
+        // Check for duplicate authority
+        auto const& new_auth = peer->authority();
+        for (auto const& [existing_nonce, existing_peer] : peers_) {
+            if (existing_peer->authority() == new_auth) {
+                co_return error::address_in_use;  // Duplicate authority
+            }
+        }
+
+        // Add peer
+        peers_.emplace(nonce, peer);
+        count_.store(peers_.size());
+
+        spdlog::debug("[peer_manager] Added peer [{}], total: {}",
+            peer->authority(), peers_.size());
+
+        co_return error::success;
+    }, ::asio::use_awaitable);
+
+    co_return result;
+}
+
+::asio::awaitable<void> peer_manager::remove(peer_session::ptr peer) {
+    if (!peer) {
+        co_return;
+    }
+
+    auto nonce = peer->nonce();
+    if (nonce == 0) {
+        auto const& auth = peer->authority();
+        nonce = std::hash<std::string>{}(auth.to_string());
+    }
+
+    co_await remove_by_nonce(nonce);
+}
+
+::asio::awaitable<void> peer_manager::remove_by_nonce(uint64_t nonce) {
+    co_await ::asio::co_spawn(strand_, [this, nonce]() -> ::asio::awaitable<void> {
+        auto it = peers_.find(nonce);
+        if (it != peers_.end()) {
+            spdlog::debug("[peer_manager] Removed peer [{}], remaining: {}",
+                it->second->authority(), peers_.size() - 1);
+            peers_.erase(it);
+            count_.store(peers_.size());
+        }
+        co_return;
+    }, ::asio::use_awaitable);
+}
+
+::asio::awaitable<bool> peer_manager::exists_by_nonce(uint64_t nonce) const {
+    co_return co_await ::asio::co_spawn(strand_, [this, nonce]() -> ::asio::awaitable<bool> {
+        co_return peers_.find(nonce) != peers_.end();
+    }, ::asio::use_awaitable);
+}
+
+::asio::awaitable<bool> peer_manager::exists_by_authority(
+    infrastructure::config::authority const& authority) const
+{
+    co_return co_await ::asio::co_spawn(strand_, [this, &authority]() -> ::asio::awaitable<bool> {
+        for (auto const& [nonce, peer] : peers_) {
+            if (peer->authority() == authority) {
+                co_return true;
+            }
+        }
+        co_return false;
+    }, ::asio::use_awaitable);
+}
+
+::asio::awaitable<peer_session::ptr> peer_manager::find_by_nonce(uint64_t nonce) const {
+    co_return co_await ::asio::co_spawn(strand_, [this, nonce]() -> ::asio::awaitable<peer_session::ptr> {
+        auto it = peers_.find(nonce);
+        if (it != peers_.end()) {
+            co_return it->second;
+        }
+        co_return nullptr;
+    }, ::asio::use_awaitable);
+}
+
+::asio::awaitable<std::vector<peer_session::ptr>> peer_manager::all() const {
+    co_return co_await ::asio::co_spawn(strand_, [this]() -> ::asio::awaitable<std::vector<peer_session::ptr>> {
+        std::vector<peer_session::ptr> result;
+        result.reserve(peers_.size());
+        for (auto const& [nonce, peer] : peers_) {
+            result.push_back(peer);
+        }
+        co_return result;
+    }, ::asio::use_awaitable);
+}
+
+::asio::awaitable<size_t> peer_manager::count() const {
+    co_return co_await ::asio::co_spawn(strand_, [this]() -> ::asio::awaitable<size_t> {
+        co_return peers_.size();
+    }, ::asio::use_awaitable);
+}
+
+size_t peer_manager::count_snapshot() const {
+    return count_.load();
+}
+
+// =============================================================================
+// Broadcasting
+// =============================================================================
+
+::asio::awaitable<void> peer_manager::for_each(peer_handler handler) {
+    auto peers = co_await all();
+    for (auto const& peer : peers) {
+        if (!peer->stopped()) {
+            handler(peer);
+        }
+    }
+}
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+void peer_manager::stop_all() {
+    if (stopped_.exchange(true)) {
+        return;  // Already stopped
+    }
+
+    spdlog::debug("[peer_manager] Stopping all peers");
+
+    // Post to strand to safely iterate and clean up
+    // Note: Callers should run the io_context to ensure completion
+    ::asio::post(strand_, [this]() {
+        for (auto& [nonce, peer] : peers_) {
+            peer->stop();
+        }
+        peers_.clear();
+        count_.store(0);
+    });
+}
+
+bool peer_manager::stopped() const {
+    return stopped_.load();
+}
+
+} // namespace kth::network

--- a/src/network/test/peer_manager.cpp
+++ b/src/network/test/peer_manager.cpp
@@ -1,0 +1,620 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include <test_helpers.hpp>
+
+#include <kth/network.hpp>
+
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+
+using namespace kth;
+using namespace kth::network;
+using namespace std::chrono_literals;
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+// Create a connected socket pair for testing (client, server)
+std::pair<::asio::ip::tcp::socket, ::asio::ip::tcp::socket>
+make_connected_sockets_pm(::asio::io_context& ctx) {
+    ::asio::ip::tcp::acceptor acceptor(ctx, {::asio::ip::tcp::v4(), 0});
+    auto port = acceptor.local_endpoint().port();
+
+    ::asio::ip::tcp::socket client(ctx);
+    ::asio::ip::tcp::socket server(ctx);
+
+    std::thread accept_thread([&]() {
+        server = acceptor.accept();
+    });
+
+    client.connect({::asio::ip::address_v4::loopback(), port});
+
+    accept_thread.join();
+
+    return {std::move(client), std::move(server)};
+}
+
+// Helper to run context with timeout and stop condition
+template<typename Predicate>
+void run_until_pm(::asio::io_context& ctx, Predicate pred, std::chrono::milliseconds timeout = 1000ms) {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!pred() && std::chrono::steady_clock::now() < deadline) {
+        ctx.run_for(10ms);
+    }
+}
+
+// Create default settings for testing
+network::settings make_test_settings_pm() {
+    network::settings settings;
+    settings.identifier = 0xe8f3e1e3;  // BCH testnet magic
+    settings.protocol_maximum = 70015;
+    settings.validate_checksum = true;
+    settings.channel_inactivity_minutes = 1;
+    settings.channel_expiration_minutes = 5;
+    settings.inbound_port = 18333;
+    return settings;
+}
+
+// Create a peer_session for testing
+peer_session::ptr make_test_peer(::asio::io_context& ctx) {
+    auto settings = make_test_settings_pm();
+    auto [client, server] = make_connected_sockets_pm(ctx);
+    return std::make_shared<peer_session>(std::move(server), settings);
+}
+
+// =============================================================================
+// Construction Tests
+// =============================================================================
+
+TEST_CASE("peer_manager construction", "[peer_manager]") {
+    ::asio::io_context ctx;
+
+    peer_manager manager(ctx.get_executor(), 100);
+
+    REQUIRE(!manager.stopped());
+    REQUIRE(manager.count_snapshot() == 0);
+}
+
+TEST_CASE("peer_manager construction unlimited", "[peer_manager]") {
+    ::asio::io_context ctx;
+
+    peer_manager manager(ctx.get_executor(), 0);  // Unlimited
+
+    REQUIRE(!manager.stopped());
+}
+
+// =============================================================================
+// Add/Remove Tests
+// =============================================================================
+
+TEST_CASE("peer_manager add peer", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    auto peer = make_test_peer(ctx);
+    peer->set_nonce(12345);
+
+    std::atomic<bool> done{false};
+    code result = error::unknown;
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        result = co_await manager.add(peer);
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(result == error::success);
+    REQUIRE(manager.count_snapshot() == 1);
+}
+
+TEST_CASE("peer_manager add multiple peers", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    std::vector<peer_session::ptr> peers;
+    for (int i = 0; i < 5; ++i) {
+        auto peer = make_test_peer(ctx);
+        peer->set_nonce(1000 + i);
+        peers.push_back(peer);
+    }
+
+    std::atomic<int> added{0};
+
+    for (auto const& peer : peers) {
+        ::asio::co_spawn(ctx, [&, peer]() -> ::asio::awaitable<void> {
+            auto result = co_await manager.add(peer);
+            if (result == error::success) {
+                ++added;
+            }
+        }, ::asio::detached);
+    }
+
+    run_until_pm(ctx, [&]{ return added.load() >= 5; });
+
+    REQUIRE(added == 5);
+    REQUIRE(manager.count_snapshot() == 5);
+}
+
+TEST_CASE("peer_manager add duplicate nonce rejected", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    auto peer1 = make_test_peer(ctx);
+    peer1->set_nonce(12345);
+
+    auto peer2 = make_test_peer(ctx);
+    peer2->set_nonce(12345);  // Same nonce
+
+    std::atomic<bool> done{false};
+    code result1 = error::unknown;
+    code result2 = error::unknown;
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        result1 = co_await manager.add(peer1);
+        result2 = co_await manager.add(peer2);
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(result1 == error::success);
+    REQUIRE(result2 == error::address_in_use);
+    REQUIRE(manager.count_snapshot() == 1);
+}
+
+TEST_CASE("peer_manager add null peer rejected", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    std::atomic<bool> done{false};
+    code result = error::unknown;
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        result = co_await manager.add(nullptr);
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(result == error::operation_failed);
+    REQUIRE(manager.count_snapshot() == 0);
+}
+
+TEST_CASE("peer_manager remove peer", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    auto peer = make_test_peer(ctx);
+    peer->set_nonce(12345);
+
+    std::atomic<bool> done{false};
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        co_await manager.add(peer);
+        REQUIRE(manager.count_snapshot() == 1);
+
+        co_await manager.remove(peer);
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(manager.count_snapshot() == 0);
+}
+
+TEST_CASE("peer_manager remove by nonce", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    auto peer = make_test_peer(ctx);
+    peer->set_nonce(12345);
+
+    std::atomic<bool> done{false};
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        co_await manager.add(peer);
+        REQUIRE(manager.count_snapshot() == 1);
+
+        co_await manager.remove_by_nonce(12345);
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(manager.count_snapshot() == 0);
+}
+
+TEST_CASE("peer_manager remove nonexistent is safe", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    std::atomic<bool> done{false};
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        co_await manager.remove_by_nonce(99999);
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(manager.count_snapshot() == 0);
+}
+
+// =============================================================================
+// Capacity Tests
+// =============================================================================
+
+TEST_CASE("peer_manager capacity limit", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 3);  // Max 3 peers
+
+    std::vector<peer_session::ptr> peers;
+    for (int i = 0; i < 5; ++i) {
+        auto peer = make_test_peer(ctx);
+        peer->set_nonce(1000 + i);
+        peers.push_back(peer);
+    }
+
+    std::atomic<int> success_count{0};
+    std::atomic<int> rejected_count{0};
+    std::atomic<int> done_count{0};
+
+    for (auto const& peer : peers) {
+        ::asio::co_spawn(ctx, [&, peer]() -> ::asio::awaitable<void> {
+            auto result = co_await manager.add(peer);
+            if (result == error::success) {
+                ++success_count;
+            } else if (result == error::channel_stopped) {
+                ++rejected_count;
+            }
+            ++done_count;
+        }, ::asio::detached);
+    }
+
+    run_until_pm(ctx, [&]{ return done_count.load() >= 5; });
+
+    REQUIRE(success_count == 3);
+    REQUIRE(rejected_count == 2);
+    REQUIRE(manager.count_snapshot() == 3);
+}
+
+// =============================================================================
+// Lookup Tests
+// =============================================================================
+
+TEST_CASE("peer_manager exists by nonce", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    auto peer = make_test_peer(ctx);
+    peer->set_nonce(12345);
+
+    std::atomic<bool> done{false};
+    bool exists_before = true;
+    bool exists_after = false;
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        exists_before = co_await manager.exists_by_nonce(12345);
+        co_await manager.add(peer);
+        exists_after = co_await manager.exists_by_nonce(12345);
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(!exists_before);
+    REQUIRE(exists_after);
+}
+
+TEST_CASE("peer_manager find by nonce", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    auto peer = make_test_peer(ctx);
+    peer->set_nonce(12345);
+
+    std::atomic<bool> done{false};
+    peer_session::ptr found_before = nullptr;
+    peer_session::ptr found_after = nullptr;
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        found_before = co_await manager.find_by_nonce(12345);
+        co_await manager.add(peer);
+        found_after = co_await manager.find_by_nonce(12345);
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(found_before == nullptr);
+    REQUIRE(found_after != nullptr);
+    REQUIRE(found_after.get() == peer.get());
+}
+
+TEST_CASE("peer_manager count", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    std::atomic<bool> done{false};
+    size_t count1 = 999;
+    size_t count2 = 999;
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        count1 = co_await manager.count();
+
+        auto peer = make_test_peer(ctx);
+        peer->set_nonce(12345);
+        co_await manager.add(peer);
+
+        count2 = co_await manager.count();
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(count1 == 0);
+    REQUIRE(count2 == 1);
+}
+
+TEST_CASE("peer_manager all", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    std::vector<peer_session::ptr> added_peers;
+    for (int i = 0; i < 3; ++i) {
+        auto peer = make_test_peer(ctx);
+        peer->set_nonce(1000 + i);
+        added_peers.push_back(peer);
+    }
+
+    std::atomic<bool> done{false};
+    std::vector<peer_session::ptr> retrieved_peers;
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        for (auto const& peer : added_peers) {
+            co_await manager.add(peer);
+        }
+        retrieved_peers = co_await manager.all();
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(retrieved_peers.size() == 3);
+}
+
+// =============================================================================
+// for_each Tests
+// =============================================================================
+
+TEST_CASE("peer_manager for_each", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    std::vector<peer_session::ptr> peers;
+    for (int i = 0; i < 3; ++i) {
+        auto peer = make_test_peer(ctx);
+        peer->set_nonce(1000 + i);
+        peers.push_back(peer);
+    }
+
+    std::atomic<bool> done{false};
+    std::atomic<int> visited_count{0};
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        for (auto const& peer : peers) {
+            co_await manager.add(peer);
+        }
+
+        co_await manager.for_each([&](peer_session::ptr) {
+            ++visited_count;
+        });
+
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(visited_count == 3);
+}
+
+TEST_CASE("peer_manager for_each skips stopped peers", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    std::vector<peer_session::ptr> peers;
+    for (int i = 0; i < 3; ++i) {
+        auto peer = make_test_peer(ctx);
+        peer->set_nonce(1000 + i);
+        peers.push_back(peer);
+    }
+
+    // Stop one peer
+    peers[1]->stop();
+
+    std::atomic<bool> done{false};
+    std::atomic<int> visited_count{0};
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        for (auto const& peer : peers) {
+            co_await manager.add(peer);
+        }
+
+        co_await manager.for_each([&](peer_session::ptr) {
+            ++visited_count;
+        });
+
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(visited_count == 2);  // Only 2 active peers visited
+}
+
+// =============================================================================
+// Lifecycle Tests
+// =============================================================================
+
+TEST_CASE("peer_manager stop_all", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    std::vector<peer_session::ptr> peers;
+    for (int i = 0; i < 3; ++i) {
+        auto peer = make_test_peer(ctx);
+        peer->set_nonce(1000 + i);
+        peers.push_back(peer);
+    }
+
+    std::atomic<bool> done{false};
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        for (auto const& peer : peers) {
+            co_await manager.add(peer);
+        }
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(!manager.stopped());
+    REQUIRE(manager.count_snapshot() == 3);
+
+    manager.stop_all();
+    REQUIRE(manager.stopped());
+
+    // Run io_context to process the posted stop operation
+    // poll() processes all ready handlers without blocking
+    ctx.restart();
+    ctx.poll();
+
+    REQUIRE(manager.count_snapshot() == 0);
+
+    // All peers should be stopped
+    for (auto const& peer : peers) {
+        REQUIRE(peer->stopped());
+    }
+}
+
+TEST_CASE("peer_manager stop_all is idempotent", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    manager.stop_all();
+    REQUIRE(manager.stopped());
+
+    manager.stop_all();  // Second call should be safe
+    REQUIRE(manager.stopped());
+}
+
+TEST_CASE("peer_manager add after stop rejected", "[peer_manager]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    manager.stop_all();
+
+    auto peer = make_test_peer(ctx);
+    peer->set_nonce(12345);
+
+    std::atomic<bool> done{false};
+    code result = error::unknown;
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        result = co_await manager.add(peer);
+        done = true;
+    }, ::asio::detached);
+
+    run_until_pm(ctx, [&]{ return done.load(); });
+
+    REQUIRE(result == error::service_stopped);
+}
+
+// =============================================================================
+// Concurrent Access Tests
+// =============================================================================
+
+TEST_CASE("peer_manager concurrent add/remove", "[peer_manager][concurrent]") {
+    ::asio::io_context ctx;
+    peer_manager manager(ctx.get_executor(), 100);
+
+    constexpr int num_operations = 50;
+    std::atomic<int> completed{0};
+
+    // Spawn many concurrent add operations
+    for (int i = 0; i < num_operations; ++i) {
+        ::asio::co_spawn(ctx, [&, i]() -> ::asio::awaitable<void> {
+            auto peer = make_test_peer(ctx);
+            peer->set_nonce(static_cast<uint64_t>(i));
+            co_await manager.add(peer);
+
+            // Immediately remove half
+            if (i % 2 == 0) {
+                co_await manager.remove(peer);
+            }
+
+            ++completed;
+        }, ::asio::detached);
+    }
+
+    run_until_pm(ctx, [&]{ return completed.load() >= num_operations; }, 5000ms);
+
+    REQUIRE(completed == num_operations);
+    // Half should remain (odd numbered)
+    REQUIRE(manager.count_snapshot() == num_operations / 2);
+}
+
+// =============================================================================
+// Destructor Test
+// =============================================================================
+
+TEST_CASE("peer_manager destructor stops peers", "[peer_manager]") {
+    ::asio::io_context ctx;
+    std::vector<peer_session::ptr> peers;
+
+    {
+        peer_manager manager(ctx.get_executor(), 100);
+
+        for (int i = 0; i < 3; ++i) {
+            auto peer = make_test_peer(ctx);
+            peer->set_nonce(1000 + i);
+            peers.push_back(peer);
+        }
+
+        std::atomic<bool> done{false};
+
+        ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+            for (auto const& peer : peers) {
+                co_await manager.add(peer);
+            }
+            done = true;
+        }, ::asio::detached);
+
+        run_until_pm(ctx, [&]{ return done.load(); });
+
+        // manager destructor called here
+    }
+
+    // Wait for stop to propagate (async post to strand from destructor)
+    run_until_pm(ctx, [&]{
+        for (auto const& peer : peers) {
+            if (!peer->stopped()) return false;
+        }
+        return true;
+    });
+
+    // All peers should be stopped
+    for (auto const& peer : peers) {
+        REQUIRE(peer->stopped());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `peer_manager` class that replaces the legacy `pending<connector>`/`pending<channel>` collections
- Uses `asio::strand` for serialization instead of explicit mutexes
- All operations are coroutines (`asio::awaitable`)
- Includes broadcast template and for_each iteration

## Changes
- `peer_manager.hpp` - Header with class definition
- `peer_manager.cpp` - Full implementation
- `peer_manager.cpp` (test) - Comprehensive unit tests
- Updated CMakeLists.txt and network.hpp

## Test plan
- [x] Unit tests pass for all peer_manager operations
- [x] Existing network tests continue to pass