### PR TITLE
feature: add coroutine-based protocol functions (Phase 5)

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -117,6 +117,7 @@ set(kth_headers
   include/kth/network/protocols/protocol.hpp
   include/kth/network/protocols/protocol_ping_60001.hpp
   include/kth/network/protocols/protocol_reject_70002.hpp
+  include/kth/network/protocols_coro.hpp
   include/kth/network/settings.hpp
   include/kth/network/version.hpp
   include/kth/network.hpp
@@ -147,6 +148,7 @@ set(kth_sources
   src/p2p.cpp
   src/peer_session.cpp
   src/peer_manager.cpp
+  src/protocols_coro.cpp
   src/proxy.cpp
   src/settings.cpp
   src/version.cpp
@@ -188,6 +190,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     test/p2p.cpp
     test/peer_manager.cpp
     test/peer_session.cpp
+    test/protocols_coro.cpp
   )
 
   target_include_directories(kth_network_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)

--- a/src/network/include/kth/network.hpp
+++ b/src/network/include/kth/network.hpp
@@ -35,6 +35,7 @@
 #include <kth/network/protocols/protocol_timer.hpp>
 #include <kth/network/protocols/protocol_version_31402.hpp>
 #include <kth/network/protocols/protocol_version_70002.hpp>
+#include <kth/network/protocols_coro.hpp>
 #include <kth/network/sessions/session.hpp>
 #include <kth/network/sessions/session_batch.hpp>
 #include <kth/network/sessions/session_inbound.hpp>

--- a/src/network/include/kth/network/protocols_coro.hpp
+++ b/src/network/include/kth/network/protocols_coro.hpp
@@ -1,0 +1,163 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NETWORK_PROTOCOLS_CORO_HPP
+#define KTH_NETWORK_PROTOCOLS_CORO_HPP
+
+#include <chrono>
+#include <expected>
+#include <string>
+
+#include <kth/domain.hpp>
+#include <kth/infrastructure.hpp>
+#include <kth/network/define.hpp>
+#include <kth/network/peer_session.hpp>
+#include <kth/network/settings.hpp>
+
+#include <asio/awaitable.hpp>
+#include <asio/steady_timer.hpp>
+#include <asio/use_awaitable.hpp>
+#include <asio/experimental/awaitable_operators.hpp>
+
+namespace kth::network {
+
+// =============================================================================
+// Message Helpers
+// =============================================================================
+
+/// Wait for a specific message type from the peer
+/// Returns the deserialized message or an error code
+/// @param peer The peer session to receive from
+/// @param timeout Maximum time to wait for the message
+template <typename Message>
+::asio::awaitable<std::expected<Message, code>> wait_for_message(
+    peer_session& peer,
+    std::chrono::seconds timeout)
+{
+    using namespace ::asio::experimental::awaitable_operators;
+
+    auto executor = co_await ::asio::this_coro::executor;
+    ::asio::steady_timer timer(executor, timeout);
+
+    // Race between message receive and timeout
+    auto result = co_await (
+        peer.messages().async_receive(::asio::as_tuple(::asio::use_awaitable)) ||
+        timer.async_wait(::asio::as_tuple(::asio::use_awaitable))
+    );
+
+    // Check which completed first
+    if (result.index() == 1) {
+        // Timeout won
+        co_return std::unexpected(error::channel_timeout);
+    }
+
+    // Message received
+    auto& [ec, raw] = std::get<0>(result);
+    if (ec) {
+        co_return std::unexpected(error::channel_stopped);
+    }
+
+    // Check command matches expected type
+    if (raw.heading.command() != Message::command) {
+        // Wrong message type - could handle differently
+        co_return std::unexpected(error::bad_stream);
+    }
+
+    // Deserialize the message
+    byte_reader reader(raw.payload);
+    auto msg = Message::from_data(reader, peer.negotiated_version());
+    if (!msg) {
+        co_return std::unexpected(error::bad_stream);
+    }
+
+    co_return std::move(*msg);
+}
+
+/// Wait for any message from the peer (returns raw_message)
+/// @param peer The peer session to receive from
+/// @param timeout Maximum time to wait
+::asio::awaitable<std::expected<raw_message, code>> wait_for_any_message(
+    peer_session& peer,
+    std::chrono::seconds timeout);
+
+// =============================================================================
+// Version Handshake Protocol
+// =============================================================================
+
+/// Configuration for version handshake
+struct handshake_config {
+    uint32_t protocol_version;      // Our protocol version
+    uint64_t services;              // Our services
+    uint64_t invalid_services;      // Services we reject
+    uint32_t minimum_version;       // Minimum peer version we accept
+    uint64_t minimum_services;      // Minimum peer services we accept
+    std::string user_agent;         // Our user agent string
+    uint32_t start_height;          // Our current block height
+    uint64_t nonce;                 // Connection nonce
+    std::chrono::seconds timeout;   // Handshake timeout
+    std::vector<std::string> user_agent_blacklist;  // Blacklisted user agents
+};
+
+/// Result of a successful handshake
+struct handshake_result {
+    domain::message::version::const_ptr peer_version;
+    uint32_t negotiated_version;
+};
+
+/// Perform version handshake with a peer
+/// Exchanges version messages and negotiates protocol version
+/// @param peer The peer session
+/// @param config Handshake configuration
+/// @return handshake_result on success, error code on failure
+[[nodiscard]]
+KN_API ::asio::awaitable<std::expected<handshake_result, code>> perform_handshake(
+    peer_session& peer,
+    handshake_config const& config);
+
+/// Create handshake config from network settings
+[[nodiscard]]
+KN_API handshake_config make_handshake_config(
+    settings const& network_settings,
+    uint32_t current_height,
+    uint64_t nonce);
+
+// =============================================================================
+// Ping/Pong Protocol
+// =============================================================================
+
+/// Run ping/pong loop with a peer
+/// Sends periodic pings and responds to incoming pings
+/// Runs until the peer is stopped or an error occurs
+/// @param peer The peer session
+/// @param ping_interval Time between pings
+/// @return Error code when loop terminates
+[[nodiscard]]
+KN_API ::asio::awaitable<code> run_ping_pong(
+    peer_session& peer,
+    std::chrono::seconds ping_interval);
+
+// =============================================================================
+// Address Protocol
+// =============================================================================
+
+/// Request addresses from a peer
+/// @param peer The peer session
+/// @param timeout Maximum time to wait for response
+/// @return Vector of addresses or error
+[[nodiscard]]
+KN_API ::asio::awaitable<std::expected<domain::message::address, code>> request_addresses(
+    peer_session& peer,
+    std::chrono::seconds timeout);
+
+/// Send our addresses to a peer
+/// @param peer The peer session
+/// @param addresses Addresses to send
+[[nodiscard]]
+KN_API ::asio::awaitable<code> send_addresses(
+    peer_session& peer,
+    domain::message::address const& addresses);
+
+} // namespace kth::network
+
+#endif // KTH_NETWORK_PROTOCOLS_CORO_HPP

--- a/src/network/src/protocols_coro.cpp
+++ b/src/network/src/protocols_coro.cpp
@@ -1,0 +1,371 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/network/protocols_coro.hpp>
+
+#include <algorithm>
+
+#include <asio/co_spawn.hpp>
+#include <asio/experimental/awaitable_operators.hpp>
+
+namespace kth::network {
+
+using namespace ::asio::experimental::awaitable_operators;
+using namespace std::chrono_literals;
+
+// =============================================================================
+// Message Helpers
+// =============================================================================
+
+::asio::awaitable<std::expected<raw_message, code>> wait_for_any_message(
+    peer_session& peer,
+    std::chrono::seconds timeout)
+{
+    auto executor = co_await ::asio::this_coro::executor;
+    ::asio::steady_timer timer(executor, timeout);
+
+    auto result = co_await (
+        peer.messages().async_receive(::asio::as_tuple(::asio::use_awaitable)) ||
+        timer.async_wait(::asio::as_tuple(::asio::use_awaitable))
+    );
+
+    if (result.index() == 1) {
+        co_return std::unexpected(error::channel_timeout);
+    }
+
+    auto& [ec, raw] = std::get<0>(result);
+    if (ec) {
+        co_return std::unexpected(error::channel_stopped);
+    }
+
+    co_return raw;
+}
+
+// =============================================================================
+// Version Handshake Protocol
+// =============================================================================
+
+namespace {
+
+domain::message::version make_version_message(
+    handshake_config const& config,
+    infrastructure::config::authority const& peer_authority)
+{
+    domain::message::version version;
+    version.set_value(config.protocol_version);
+    version.set_services(config.services);
+    version.set_timestamp(static_cast<uint64_t>(zulu_time()));
+    version.set_address_receiver(peer_authority.to_network_address());
+    version.set_nonce(config.nonce);
+    version.set_user_agent(config.user_agent);
+    version.set_start_height(config.start_height);
+
+    // The peer's services cannot be reflected, so zero it
+    version.address_receiver().set_services(domain::message::version::service::none);
+
+    // We match our declared services
+    version.address_sender().set_services(config.services);
+
+    return version;
+}
+
+bool is_user_agent_blacklisted(
+    std::string const& user_agent,
+    std::vector<std::string> const& blacklist)
+{
+    return std::any_of(blacklist.begin(), blacklist.end(),
+        [&user_agent](std::string const& blacklisted) {
+            if (blacklisted.size() <= user_agent.size()) {
+                return std::equal(blacklisted.begin(), blacklisted.end(), user_agent.begin());
+            }
+            return std::equal(user_agent.begin(), user_agent.end(), blacklisted.begin());
+        });
+}
+
+bool validate_peer_version(
+    domain::message::version const& peer_version,
+    handshake_config const& config,
+    infrastructure::config::authority const& authority)
+{
+    // Check blacklist
+    if (is_user_agent_blacklisted(peer_version.user_agent(), config.user_agent_blacklist)) {
+        spdlog::debug("[protocol] Invalid user agent (blacklisted) for peer [{}] user agent: {}",
+            authority, peer_version.user_agent());
+        return false;
+    }
+
+    // Check invalid services
+    if ((peer_version.services() & config.invalid_services) != 0) {
+        spdlog::debug("[protocol] Invalid peer services ({}) for [{}]",
+            peer_version.services(), authority);
+        return false;
+    }
+
+    // Check minimum services
+    if ((peer_version.services() & config.minimum_services) != config.minimum_services) {
+        spdlog::debug("[protocol] Insufficient peer services ({}) for [{}]",
+            peer_version.services(), authority);
+        return false;
+    }
+
+    // Check minimum version
+    if (peer_version.value() < config.minimum_version) {
+        spdlog::debug("[protocol] Insufficient peer protocol version ({}) for [{}]",
+            peer_version.value(), authority);
+        return false;
+    }
+
+    return true;
+}
+
+} // anonymous namespace
+
+::asio::awaitable<std::expected<handshake_result, code>> perform_handshake(
+    peer_session& peer,
+    handshake_config const& config)
+{
+    auto const& authority = peer.authority();
+
+    spdlog::debug("[protocol] Starting handshake with [{}]", authority);
+
+    // Send our version message
+    auto version_msg = make_version_message(config, authority);
+    auto send_ec = co_await peer.send(version_msg);
+    if (send_ec != error::success) {
+        spdlog::debug("[protocol] Failed to send version to [{}]", authority);
+        co_return std::unexpected(send_ec);
+    }
+
+    // We need to receive both version and verack from the peer
+    // The order may vary, so we track what we've received
+    bool got_version = false;
+    bool got_verack = false;
+    domain::message::version::const_ptr peer_version;
+
+    auto deadline = std::chrono::steady_clock::now() + config.timeout;
+
+    while (!got_version || !got_verack) {
+        auto remaining = std::chrono::duration_cast<std::chrono::seconds>(
+            deadline - std::chrono::steady_clock::now());
+
+        if (remaining <= 0s) {
+            spdlog::debug("[protocol] Handshake timeout with [{}]", authority);
+            co_return std::unexpected(error::channel_timeout);
+        }
+
+        // Wait for next message
+        auto msg_result = co_await wait_for_any_message(peer, remaining);
+        if (!msg_result) {
+            spdlog::debug("[protocol] Failed to receive message from [{}]: {}",
+                authority, msg_result.error().message());
+            co_return std::unexpected(msg_result.error());
+        }
+
+        auto const& raw = *msg_result;
+        auto const& command = raw.heading.command();
+
+        if (command == domain::message::version::command && !got_version) {
+            // Parse version message
+            byte_reader reader(raw.payload);
+            auto version_result = domain::message::version::from_data(reader, peer.negotiated_version());
+            if (!version_result) {
+                spdlog::debug("[protocol] Failed to parse version from [{}]", authority);
+                co_return std::unexpected(error::bad_stream);
+            }
+            auto version = std::make_shared<domain::message::version>(std::move(*version_result));
+
+            spdlog::debug("[protocol] Received version from [{}] protocol ({}) user agent: {}",
+                authority, version->value(), version->user_agent());
+
+            // Validate
+            if (!validate_peer_version(*version, config, authority)) {
+                co_return std::unexpected(error::channel_stopped);
+            }
+
+            peer_version = version;
+            got_version = true;
+
+            // Send verack in response
+            auto verack_ec = co_await peer.send(domain::message::verack{});
+            if (verack_ec != error::success) {
+                spdlog::debug("[protocol] Failed to send verack to [{}]", authority);
+                co_return std::unexpected(verack_ec);
+            }
+        }
+        else if (command == domain::message::verack::command && !got_verack) {
+            spdlog::debug("[protocol] Received verack from [{}]", authority);
+            got_verack = true;
+        }
+        else {
+            // Unexpected message during handshake - log but continue
+            spdlog::debug("[protocol] Unexpected message '{}' during handshake with [{}]",
+                command, authority);
+        }
+    }
+
+    // Calculate negotiated version
+    auto negotiated = std::min(peer_version->value(), config.protocol_version);
+
+    // Update peer session
+    peer.set_peer_version(peer_version);
+    peer.set_negotiated_version(negotiated);
+
+    spdlog::debug("[protocol] Handshake complete with [{}], negotiated version {}",
+        authority, negotiated);
+
+    co_return handshake_result{peer_version, negotiated};
+}
+
+handshake_config make_handshake_config(
+    settings const& network_settings,
+    uint32_t current_height,
+    uint64_t nonce)
+{
+    return handshake_config{
+        .protocol_version = network_settings.protocol_maximum,
+        .services = network_settings.services,
+        .invalid_services = network_settings.invalid_services,
+        .minimum_version = network_settings.protocol_minimum,
+        .minimum_services = domain::message::version::service::none,
+        .user_agent = network_settings.user_agent,
+        .start_height = current_height,
+        .nonce = nonce,
+        .timeout = std::chrono::seconds(network_settings.channel_handshake_seconds),
+        .user_agent_blacklist = network_settings.user_agent_blacklist
+    };
+}
+
+// =============================================================================
+// Ping/Pong Protocol
+// =============================================================================
+
+::asio::awaitable<code> run_ping_pong(
+    peer_session& peer,
+    std::chrono::seconds ping_interval)
+{
+    auto executor = co_await ::asio::this_coro::executor;
+    ::asio::steady_timer ping_timer(executor);
+
+    uint64_t last_ping_nonce = 0;
+
+    while (!peer.stopped()) {
+        // Wait for either:
+        // 1. Ping interval expires -> send ping
+        // 2. Message received -> check if it's ping/pong
+        ping_timer.expires_after(ping_interval);
+
+        auto result = co_await (
+            peer.messages().async_receive(::asio::as_tuple(::asio::use_awaitable)) ||
+            ping_timer.async_wait(::asio::as_tuple(::asio::use_awaitable))
+        );
+
+        if (peer.stopped()) {
+            break;
+        }
+
+        if (result.index() == 1) {
+            // Timer expired - send ping
+            auto [timer_ec] = std::get<1>(result);
+            if (!timer_ec) {
+                pseudo_random::fill(reinterpret_cast<uint8_t*>(&last_ping_nonce), sizeof(last_ping_nonce));
+                domain::message::ping ping_msg(last_ping_nonce);
+
+                auto ec = co_await peer.send(ping_msg);
+                if (ec != error::success) {
+                    spdlog::debug("[protocol] Failed to send ping to [{}]", peer.authority());
+                    co_return ec;
+                }
+
+                spdlog::trace("[protocol] Sent ping to [{}] nonce={}", peer.authority(), last_ping_nonce);
+            }
+        }
+        else {
+            // Message received
+            auto& [ec, raw] = std::get<0>(result);
+            if (ec) {
+                co_return error::channel_stopped;
+            }
+
+            auto const& command = raw.heading.command();
+
+            if (command == domain::message::ping::command) {
+                // Received ping - respond with pong
+                byte_reader reader(raw.payload);
+                auto ping_result = domain::message::ping::from_data(reader, peer.negotiated_version());
+                if (ping_result) {
+                    domain::message::pong pong_msg(ping_result->nonce());
+                    auto pong_ec = co_await peer.send(pong_msg);
+                    if (pong_ec != error::success) {
+                        spdlog::debug("[protocol] Failed to send pong to [{}]", peer.authority());
+                    }
+                    spdlog::trace("[protocol] Responded pong to [{}]", peer.authority());
+                }
+            }
+            else if (command == domain::message::pong::command) {
+                // Received pong - could verify nonce matches our last ping
+                byte_reader pong_reader(raw.payload);
+                auto pong_result = domain::message::pong::from_data(pong_reader, peer.negotiated_version());
+                if (pong_result) {
+                    spdlog::trace("[protocol] Received pong from [{}] nonce={}",
+                        peer.authority(), pong_result->nonce());
+                }
+            }
+            // Other messages are ignored by this protocol
+        }
+    }
+
+    co_return error::channel_stopped;
+}
+
+// =============================================================================
+// Address Protocol
+// =============================================================================
+
+::asio::awaitable<std::expected<domain::message::address, code>> request_addresses(
+    peer_session& peer,
+    std::chrono::seconds timeout)
+{
+    // Send getaddr
+    auto ec = co_await peer.send(domain::message::get_address{});
+    if (ec != error::success) {
+        co_return std::unexpected(ec);
+    }
+
+    // Wait for addr response
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+
+    while (true) {
+        auto remaining = std::chrono::duration_cast<std::chrono::seconds>(
+            deadline - std::chrono::steady_clock::now());
+
+        if (remaining <= 0s) {
+            co_return std::unexpected(error::channel_timeout);
+        }
+
+        auto msg_result = co_await wait_for_any_message(peer, remaining);
+        if (!msg_result) {
+            co_return std::unexpected(msg_result.error());
+        }
+
+        auto const& raw = *msg_result;
+        if (raw.heading.command() == domain::message::address::command) {
+            byte_reader reader(raw.payload);
+            auto addr_result = domain::message::address::from_data(reader, peer.negotiated_version());
+            if (!addr_result) {
+                co_return std::unexpected(error::bad_stream);
+            }
+            co_return std::move(*addr_result);
+        }
+        // Continue waiting for addr message
+    }
+}
+
+::asio::awaitable<code> send_addresses(
+    peer_session& peer,
+    domain::message::address const& addresses)
+{
+    co_return co_await peer.send(addresses);
+}
+
+} // namespace kth::network

--- a/src/network/test/protocols_coro.cpp
+++ b/src/network/test/protocols_coro.cpp
@@ -1,0 +1,407 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include <test_helpers.hpp>
+
+#include <kth/network.hpp>
+
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+
+using namespace kth;
+using namespace kth::network;
+using namespace std::chrono_literals;
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+std::pair<::asio::ip::tcp::socket, ::asio::ip::tcp::socket>
+make_connected_sockets_proto(::asio::io_context& ctx) {
+    ::asio::ip::tcp::acceptor acceptor(ctx, {::asio::ip::tcp::v4(), 0});
+    auto port = acceptor.local_endpoint().port();
+
+    ::asio::ip::tcp::socket client(ctx);
+    ::asio::ip::tcp::socket server(ctx);
+
+    std::thread accept_thread([&]() {
+        server = acceptor.accept();
+    });
+
+    client.connect({::asio::ip::address_v4::loopback(), port});
+
+    accept_thread.join();
+
+    return {std::move(client), std::move(server)};
+}
+
+template<typename Predicate>
+void run_until_proto(::asio::io_context& ctx, Predicate pred, std::chrono::milliseconds timeout = 1000ms) {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!pred() && std::chrono::steady_clock::now() < deadline) {
+        ctx.run_for(10ms);
+    }
+}
+
+network::settings make_test_settings_proto() {
+    network::settings settings;
+    settings.identifier = 0xe8f3e1e3;  // BCH testnet magic
+    settings.protocol_maximum = 70015;
+    settings.protocol_minimum = 31402;
+    settings.services = 0;
+    settings.invalid_services = 0;
+    settings.validate_checksum = true;
+    settings.channel_inactivity_minutes = 1;
+    settings.channel_expiration_minutes = 5;
+    settings.channel_handshake_seconds = 30;
+    settings.inbound_port = 18333;
+    settings.user_agent = "/KnuthTest:0.1.0/";
+    return settings;
+}
+
+// Build a valid Bitcoin protocol message
+data_chunk build_message_proto(std::string const& command, data_chunk const& payload, uint32_t magic) {
+    data_chunk message;
+    message.reserve(24 + payload.size());
+
+    auto const magic_le = to_little_endian(magic);
+    message.insert(message.end(), magic_le.begin(), magic_le.end());
+
+    std::array<uint8_t, 12> cmd{};
+    std::copy_n(command.begin(), std::min(command.size(), size_t{12}), cmd.begin());
+    message.insert(message.end(), cmd.begin(), cmd.end());
+
+    auto const size_le = to_little_endian(static_cast<uint32_t>(payload.size()));
+    message.insert(message.end(), size_le.begin(), size_le.end());
+
+    auto const hash = bitcoin_hash(payload);
+    message.insert(message.end(), hash.begin(), hash.begin() + 4);
+
+    message.insert(message.end(), payload.begin(), payload.end());
+
+    return message;
+}
+
+// =============================================================================
+// handshake_config Tests
+// =============================================================================
+
+TEST_CASE("make_handshake_config from settings", "[protocols_coro]") {
+    auto settings = make_test_settings_proto();
+
+    auto config = make_handshake_config(settings, 100000, 12345);
+
+    REQUIRE(config.protocol_version == 70015);
+    REQUIRE(config.minimum_version == 31402);
+    REQUIRE(config.user_agent == "/KnuthTest:0.1.0/");
+    REQUIRE(config.start_height == 100000);
+    REQUIRE(config.nonce == 12345);
+    REQUIRE(config.timeout == 30s);
+}
+
+// =============================================================================
+// wait_for_any_message Tests
+// =============================================================================
+
+TEST_CASE("wait_for_any_message receives message", "[protocols_coro]") {
+    ::asio::io_context ctx;
+    auto settings = make_test_settings_proto();
+    auto [client, server] = make_connected_sockets_proto(ctx);
+
+    auto peer = std::make_shared<peer_session>(std::move(server), settings);
+
+    std::atomic<bool> done{false};
+    std::expected<raw_message, code> result = std::unexpected(error::unknown);
+
+    // Start session
+    ::asio::co_spawn(ctx, peer->run(), ::asio::detached);
+
+    // Wait for message
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        result = co_await wait_for_any_message(*peer, 5s);
+        done = true;
+    }, ::asio::detached);
+
+    ctx.run_for(50ms);
+
+    // Send a ping message from client
+    auto ping_msg = build_message_proto("ping", {}, settings.identifier);
+    std::error_code write_ec;
+    ::asio::write(client, ::asio::buffer(ping_msg), write_ec);
+    REQUIRE(!write_ec);
+
+    run_until_proto(ctx, [&]{ return done.load(); });
+
+    peer->stop();
+    ctx.run_for(10ms);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->heading.command() == "ping");
+}
+
+TEST_CASE("wait_for_any_message timeout", "[protocols_coro]") {
+    ::asio::io_context ctx;
+    auto settings = make_test_settings_proto();
+    auto [client, server] = make_connected_sockets_proto(ctx);
+
+    auto peer = std::make_shared<peer_session>(std::move(server), settings);
+
+    std::atomic<bool> done{false};
+    std::expected<raw_message, code> result = std::unexpected(error::unknown);
+
+    ::asio::co_spawn(ctx, peer->run(), ::asio::detached);
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        result = co_await wait_for_any_message(*peer, 1s);  // Short timeout
+        done = true;
+    }, ::asio::detached);
+
+    // Don't send anything - should timeout
+    run_until_proto(ctx, [&]{ return done.load(); }, 2000ms);
+
+    peer->stop();
+    ctx.run_for(10ms);
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == error::channel_timeout);
+}
+
+// =============================================================================
+// Handshake Tests (simulated peer)
+// =============================================================================
+
+TEST_CASE("perform_handshake success", "[protocols_coro]") {
+    ::asio::io_context ctx;
+    auto settings = make_test_settings_proto();
+    auto [client, server] = make_connected_sockets_proto(ctx);
+
+    auto peer = std::make_shared<peer_session>(std::move(server), settings);
+    auto config = make_handshake_config(settings, 100000, 12345);
+
+    std::atomic<bool> done{false};
+    std::expected<handshake_result, code> result = std::unexpected(error::unknown);
+
+    // Start peer session
+    ::asio::co_spawn(ctx, peer->run(), ::asio::detached);
+
+    // Run handshake
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        result = co_await perform_handshake(*peer, config);
+        done = true;
+    }, ::asio::detached);
+
+    ctx.run_for(50ms);
+
+    // Simulate remote peer: receive version, send version + verack
+
+    // Read the version message our peer sent
+    std::array<uint8_t, 1024> recv_buf;
+    std::error_code read_ec;
+    auto n = client.read_some(::asio::buffer(recv_buf), read_ec);
+    REQUIRE(!read_ec);
+    REQUIRE(n > 24);  // At least header size
+
+    // Create and send remote version
+    domain::message::version remote_version;
+    remote_version.set_value(70015);
+    remote_version.set_services(0);
+    remote_version.set_timestamp(static_cast<uint64_t>(zulu_time()));
+    remote_version.set_nonce(99999);
+    remote_version.set_user_agent("/RemotePeer:1.0/");
+    remote_version.set_start_height(50000);
+
+    auto version_payload = remote_version.to_data(70015);
+    auto version_msg = build_message_proto("version", version_payload, settings.identifier);
+    ::asio::write(client, ::asio::buffer(version_msg), read_ec);
+    REQUIRE(!read_ec);
+
+    ctx.run_for(50ms);
+
+    // Send verack
+    auto verack_msg = build_message_proto("verack", {}, settings.identifier);
+    ::asio::write(client, ::asio::buffer(verack_msg), read_ec);
+    REQUIRE(!read_ec);
+
+    run_until_proto(ctx, [&]{ return done.load(); }, 2000ms);
+
+    peer->stop();
+    ctx.run_for(10ms);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->peer_version != nullptr);
+    REQUIRE(result->peer_version->user_agent() == "/RemotePeer:1.0/");
+    REQUIRE(result->negotiated_version == 70015);
+}
+
+TEST_CASE("perform_handshake timeout", "[protocols_coro]") {
+    ::asio::io_context ctx;
+    auto settings = make_test_settings_proto();
+    auto [client, server] = make_connected_sockets_proto(ctx);
+
+    auto peer = std::make_shared<peer_session>(std::move(server), settings);
+    auto config = make_handshake_config(settings, 100000, 12345);
+    config.timeout = 1s;  // Short timeout for test
+
+    std::atomic<bool> done{false};
+    std::expected<handshake_result, code> result = std::unexpected(error::unknown);
+
+    ::asio::co_spawn(ctx, peer->run(), ::asio::detached);
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        result = co_await perform_handshake(*peer, config);
+        done = true;
+    }, ::asio::detached);
+
+    // Don't respond - should timeout
+    run_until_proto(ctx, [&]{ return done.load(); }, 3000ms);
+
+    peer->stop();
+    ctx.run_for(10ms);
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == error::channel_timeout);
+}
+
+TEST_CASE("perform_handshake rejects low version peer", "[protocols_coro]") {
+    ::asio::io_context ctx;
+    auto settings = make_test_settings_proto();
+    auto [client, server] = make_connected_sockets_proto(ctx);
+
+    auto peer = std::make_shared<peer_session>(std::move(server), settings);
+    auto config = make_handshake_config(settings, 100000, 12345);
+    config.minimum_version = 70000;  // Require higher version
+
+    std::atomic<bool> done{false};
+    std::expected<handshake_result, code> result = std::unexpected(error::unknown);
+
+    ::asio::co_spawn(ctx, peer->run(), ::asio::detached);
+
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        result = co_await perform_handshake(*peer, config);
+        done = true;
+    }, ::asio::detached);
+
+    ctx.run_for(50ms);
+
+    // Read version from our peer
+    std::array<uint8_t, 1024> recv_buf;
+    std::error_code read_ec;
+    client.read_some(::asio::buffer(recv_buf), read_ec);
+
+    // Send version with low protocol version
+    domain::message::version remote_version;
+    remote_version.set_value(31402);  // Too low
+    remote_version.set_services(0);
+    remote_version.set_timestamp(static_cast<uint64_t>(zulu_time()));
+    remote_version.set_nonce(99999);
+    remote_version.set_user_agent("/OldPeer:0.1/");
+    remote_version.set_start_height(50000);
+
+    auto version_payload = remote_version.to_data(31402);
+    auto version_msg = build_message_proto("version", version_payload, settings.identifier);
+    ::asio::write(client, ::asio::buffer(version_msg), read_ec);
+
+    run_until_proto(ctx, [&]{ return done.load(); }, 2000ms);
+
+    peer->stop();
+    ctx.run_for(10ms);
+
+    REQUIRE(!result.has_value());
+    REQUIRE(result.error() == error::channel_stopped);
+}
+
+// =============================================================================
+// Ping/Pong Tests
+// =============================================================================
+
+TEST_CASE("run_ping_pong responds to ping", "[protocols_coro]") {
+    ::asio::io_context ctx;
+    auto settings = make_test_settings_proto();
+    auto [client, server] = make_connected_sockets_proto(ctx);
+
+    auto peer = std::make_shared<peer_session>(std::move(server), settings);
+
+    // Start peer session and ping/pong loop
+    ::asio::co_spawn(ctx, peer->run(), ::asio::detached);
+    ::asio::co_spawn(ctx, run_ping_pong(*peer, 60s), ::asio::detached);  // Long interval so we don't auto-ping
+
+    ctx.run_for(50ms);
+
+    // Send a ping from client
+    domain::message::ping ping{123456789};
+    auto ping_payload = ping.to_data(70015);
+    auto ping_msg = build_message_proto("ping", ping_payload, settings.identifier);
+
+    std::error_code write_ec;
+    ::asio::write(client, ::asio::buffer(ping_msg), write_ec);
+    REQUIRE(!write_ec);
+
+    // Should receive pong in response
+    std::array<uint8_t, 1024> recv_buf;
+    std::atomic<size_t> bytes_received{0};
+    std::string received_command;
+
+    client.async_read_some(::asio::buffer(recv_buf), [&](auto ec, size_t n) {
+        if (!ec && n >= 24) {
+            bytes_received = n;
+            // Extract command from header (bytes 4-16)
+            std::string cmd(reinterpret_cast<char*>(recv_buf.data() + 4), 12);
+            cmd = cmd.c_str();  // Trim nulls
+            received_command = cmd;
+        }
+    });
+
+    run_until_proto(ctx, [&]{ return bytes_received.load() > 0; });
+
+    peer->stop();
+    ctx.run_for(10ms);
+
+    REQUIRE(bytes_received > 0);
+    REQUIRE(received_command == "pong");
+}
+
+TEST_CASE("run_ping_pong sends periodic pings", "[protocols_coro]") {
+    ::asio::io_context ctx;
+    auto settings = make_test_settings_proto();
+    auto [client, server] = make_connected_sockets_proto(ctx);
+
+    auto peer = std::make_shared<peer_session>(std::move(server), settings);
+
+    // Short ping interval for testing
+    ::asio::co_spawn(ctx, peer->run(), ::asio::detached);
+    ::asio::co_spawn(ctx, run_ping_pong(*peer, 1s), ::asio::detached);
+
+    // Wait for a ping to be sent
+    std::array<uint8_t, 1024> recv_buf;
+    std::atomic<bool> received_ping{false};
+
+    std::function<void(std::error_code, size_t)> read_handler;
+    read_handler = [&](std::error_code ec, size_t n) {
+        if (!ec && n >= 24) {
+            std::string cmd(reinterpret_cast<char*>(recv_buf.data() + 4), 12);
+            cmd = cmd.c_str();
+            if (cmd == "ping") {
+                received_ping = true;
+                return;
+            }
+        }
+        if (!peer->stopped()) {
+            client.async_read_some(::asio::buffer(recv_buf), read_handler);
+        }
+    };
+    client.async_read_some(::asio::buffer(recv_buf), read_handler);
+
+    run_until_proto(ctx, [&]{ return received_ping.load(); }, 3000ms);
+
+    peer->stop();
+    ctx.run_for(10ms);
+
+    REQUIRE(received_ping);
+}


### PR DESCRIPTION
## Summary
- Implement protocol logic as free functions using C++20 coroutines
- Add `wait_for_message<T>()` and `wait_for_any_message()` helpers for message reception with timeout
- Add `perform_handshake()` for version/verack exchange
- Add `run_ping_pong()` for keepalive loop
- Add `request_addresses()` and `send_addresses()` for addr protocol

These replace the complex protocol class hierarchy with simple, composable coroutine functions that operate on `peer_session`.

## Test plan
- [x] Unit tests for handshake (success, timeout, version rejection)
- [x] Unit tests for ping/pong (responds to ping, sends periodic pings)
- [x] Unit tests for message waiting (receives message, timeout)
- [x] Builds successfully

## Dependencies
- Depends on PR #144 (Phase 4: peer_manager)