### PR TITLE
feat: add banlist, peer deduplication, and sync improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,13 @@ if (KTH_WITH_JEMALLOC)
     message(STATUS "Knuth: jemalloc enabled")
 endif()
 
+# Stats/profiling support
+option(KTH_WITH_STATS "Enable performance statistics collection" OFF)
+if (KTH_WITH_STATS)
+    add_definitions(-DKTH_WITH_STATS)
+    message(STATUS "Knuth: stats/profiling enabled")
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/ci_utils/cmake)
 include(KnuthTools)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,8 +32,8 @@ def _get_target_year(compile_year: int) -> int:
     return _BASE_PERIOD_YEAR + (periods_since_base + 1) * _PERIOD_LENGTH_YEARS
 
 
-def _calculate_block_capacity(compile_year: int) -> int:
-    """Calculate block capacity aligned to 2^16 for a given compilation year."""
+def _calculate_header_capacity(compile_year: int) -> int:
+    """Calculate header index capacity aligned to 2^16 for a given compilation year."""
     target_year = _get_target_year(compile_year)
     target_date = datetime(target_year, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
     seconds_since_genesis = (target_date - _GENESIS_TIMESTAMP).total_seconds()
@@ -72,6 +72,7 @@ class KthRecipe(KnuthConanFileV2):
         "with_png": [True, False],
         "with_qrencode": [True, False],
         "with_jemalloc": [True, False],
+        "with_stats": [True, False],
         "asio_standalone": [True, False],
 
         # secp256k1 options
@@ -120,6 +121,7 @@ class KthRecipe(KnuthConanFileV2):
         #   3. Compile LMDB separately without jemalloc linkage
         # For now, keep disabled until a proper solution is implemented.
         "with_jemalloc": False,
+        "with_stats": True,
         "asio_standalone": True,
 
         # secp256k1 options
@@ -266,6 +268,7 @@ class KthRecipe(KnuthConanFileV2):
         tc.variables["KTH_WITH_PNG"] = option_on_off(self.options.with_png)
         tc.variables["KTH_WITH_QRENCODE"] = option_on_off(self.options.with_qrencode)
         tc.variables["KTH_WITH_JEMALLOC"] = option_on_off(self.options.with_jemalloc)
+        tc.variables["KTH_WITH_STATS"] = option_on_off(self.options.with_stats)
         tc.variables["KTH_ASIO_STANDALONE"] = option_on_off(self.options.asio_standalone)
 
         # Secp256k1 --------------------------------------------
@@ -297,10 +300,10 @@ class KthRecipe(KnuthConanFileV2):
 
         tc.variables["CURRENCY"] = self.options.currency
 
-        # Block index capacity based on compilation year
-        block_capacity = _calculate_block_capacity(datetime.now().year)
-        tc.variables["KTH_BLOCK_INDEX_CAPACITY"] = block_capacity
-        self.output.info(f"Block index capacity: {block_capacity:,} blocks")
+        # Header index capacity based on compilation year
+        header_capacity = _calculate_header_capacity(datetime.now().year)
+        tc.variables["KTH_HEADER_INDEX_CAPACITY"] = header_capacity
+        self.output.info(f"Header index capacity: {header_capacity:,} headers")
 
         # Generate secp256k1 precomputed tables before CMake generation
         self._generate_secp256k1_tables()

--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -55,13 +55,13 @@ endif()
 
 message(STATUS "Knuth: Cryptocurrency: ${CURRENCY}")
 
-# Block index capacity (number of blocks for static array allocation)
-# Default: 1,179,648 blocks (~2030, aligned to 2^16)
-if(NOT DEFINED KTH_BLOCK_INDEX_CAPACITY)
-  set(KTH_BLOCK_INDEX_CAPACITY 1179648)
+# Header index capacity (number of headers for static array allocation)
+# Default: 1,179,648 headers (~2030, aligned to 2^16)
+if(NOT DEFINED KTH_HEADER_INDEX_CAPACITY)
+  set(KTH_HEADER_INDEX_CAPACITY 1179648)
 endif()
-message(STATUS "Knuth: Block index capacity: ${KTH_BLOCK_INDEX_CAPACITY}")
-add_definitions(-DKTH_BLOCK_INDEX_CAPACITY=${KTH_BLOCK_INDEX_CAPACITY})
+message(STATUS "Knuth: Header index capacity: ${KTH_HEADER_INDEX_CAPACITY}")
+add_definitions(-DKTH_HEADER_INDEX_CAPACITY=${KTH_HEADER_INDEX_CAPACITY})
 
 
 if (NOT GLOBAL_BUILD)
@@ -129,6 +129,7 @@ endif()
 set(kth_sources_just_legacy
   src/interface/block_chain.cpp
   # src/interface/block_chain_old_db.cpp
+  src/header_index.cpp
   src/pools/block_entry.cpp
   src/pools/block_organizer.cpp
   src/pools/block_pool.cpp
@@ -166,6 +167,7 @@ set(kth_headers
   include/kth/blockchain/interface
   include/kth/blockchain/interface/block_chain.hpp
   include/kth/blockchain/define.hpp
+  include/kth/blockchain/header_index.hpp
   include/kth/blockchain/populate/populate_transaction.hpp
   include/kth/blockchain/populate/populate_chain_state.hpp
   include/kth/blockchain/populate/populate_block.hpp
@@ -236,51 +238,53 @@ _group_sources(${PROJECT_NAME} "${CMAKE_CURRENT_LIST_DIR}")
 
 # Tests
 # ------------------------------------------------------------------------------
-# if (ENABLE_TEST)
-#     enable_testing()
-#     find_package(Catch2 3 REQUIRED)
+if (ENABLE_TEST)
+    enable_testing()
+    find_package(Catch2 3 REQUIRED)
 
-#     set(kth_blockchain_test_sources
-#         test/block_chain.cpp
-#         test/block_entry.cpp
-#         test/block_pool.cpp
-#         test/branch.cpp
-#         test/transaction_entry.cpp
-#         test/transaction_pool.cpp
-#         test/validate_block.cpp
-#         test/validate_transaction.cpp
-#         test/utxo.cpp
-#         test/main.cpp
-#     )
+    set(kth_blockchain_test_sources
+        test/header_index.cpp
+    )
 
-#     if (WITH_MEMPOOL)
-#         set(kth_blockchain_test_sources
-#             ${kth_blockchain_test_sources}
-#             test/mempool_tests.cpp
-#         )
-#     endif()
+    # TODO(fernando): re-enable these tests when fixed
+    # test/block_chain.cpp
+    # test/block_entry.cpp
+    # test/block_pool.cpp
+    # test/branch.cpp
+    # test/transaction_entry.cpp
+    # test/transaction_pool.cpp
+    # test/validate_block.cpp
+    # test/validate_transaction.cpp
+    # test/utxo.cpp
 
-#     add_executable(kth_blockchain_test
-#         ${kth_blockchain_test_sources}
-#     )
+    if (WITH_MEMPOOL)
+        set(kth_blockchain_test_sources
+            ${kth_blockchain_test_sources}
+            test/mempool_tests.cpp
+        )
+    endif()
 
-#     target_include_directories(kth_blockchain_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)
-#     target_link_libraries(kth_blockchain_test PUBLIC ${PROJECT_NAME})
-#     target_link_libraries(kth_blockchain_test PRIVATE Catch2::Catch2WithMain)
+    add_executable(kth_blockchain_test
+        ${kth_blockchain_test_sources}
+    )
 
-#     _group_sources(kth_blockchain_test "${CMAKE_CURRENT_LIST_DIR}/test")
+    target_include_directories(kth_blockchain_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)
+    target_link_libraries(kth_blockchain_test PUBLIC ${PROJECT_NAME})
+    target_link_libraries(kth_blockchain_test PRIVATE Catch2::Catch2WithMain)
 
-#     include(CTest)
-#     # Try to use Catch2 automatic test discovery
-#     find_package(Catch2 QUIET)
-#     if(Catch2_FOUND)
-#       include(Catch)
-#       catch_discover_tests(kth_blockchain_test)
-#     else()
-#       # Fallback to manual test registration
-#       add_test(NAME kth_blockchain_test COMMAND kth_blockchain_test)
-#     endif()
-# endif()
+    _group_sources(kth_blockchain_test "${CMAKE_CURRENT_LIST_DIR}/test")
+
+    include(CTest)
+    # Try to use Catch2 automatic test discovery
+    find_package(Catch2 QUIET)
+    if(Catch2_FOUND)
+      include(Catch)
+      catch_discover_tests(kth_blockchain_test)
+    else()
+      # Fallback to manual test registration
+      add_test(NAME kth_blockchain_test COMMAND kth_blockchain_test)
+    endif()
+endif()
 
 # Tools
 # ------------------------------------------------------------------------------

--- a/src/blockchain/include/kth/blockchain.hpp
+++ b/src/blockchain/include/kth/blockchain.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <kth/blockchain/define.hpp>
+#include <kth/blockchain/header_index.hpp>
 #include <kth/blockchain/settings.hpp>
 #include <kth/blockchain/version.hpp>
 #include <kth/blockchain/interface/block_chain.hpp>

--- a/src/blockchain/include/kth/blockchain/header_index.hpp
+++ b/src/blockchain/include/kth/blockchain/header_index.hpp
@@ -1,0 +1,332 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_HEADER_INDEX_HPP
+#define KTH_BLOCKCHAIN_HEADER_INDEX_HPP
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include <boost/unordered/concurrent_flat_map.hpp>
+
+#include <kth/blockchain/define.hpp>
+#include <kth/domain.hpp>
+
+namespace kth::blockchain {
+
+// =============================================================================
+// Header Index - Global index of all known block headers
+//
+// Equivalent to BCHN's mapBlockIndex - stores metadata for ALL known headers,
+// not just the active chain. This enables:
+//   - O(1) lookup by hash
+//   - O(log n) ancestor lookup via skip pointers
+//   - Fork tracking and reorganization
+//   - Headers-first sync
+//
+// Memory layout (SoA - Structure of Arrays):
+// For ~1.18M blocks (default capacity):
+//   prev_block_hashes: 37.7 MB (1,179,648 × 32 bytes)
+//   parent_indices:     4.7 MB (1,179,648 × 4 bytes)
+//   skip_indices:       4.7 MB
+//   heights:            4.7 MB
+//   chain_works:        9.4 MB (1,179,648 × 8 bytes)
+//   statuses:           4.7 MB
+//   versions:           4.7 MB
+//   merkle_roots:      37.7 MB (1,179,648 × 32 bytes)
+//   timestamps:         4.7 MB
+//   bits:               4.7 MB
+//   nonces:             4.7 MB
+//   ─────────────────────────────
+//   Total:            ~125 MB
+//
+// Thread safety:
+//   - Writers: CFM's bucket lock during insert_and_visit
+//   - Readers: CFM's bucket lock during visit/cvisit provides acquire semantics
+//   - Traversal: safe via happens-before transitivity through ancestor chain
+// =============================================================================
+
+// Default capacity - enough for ~2030 (aligned to 2^20 + buffer)
+// Defined via CMake/Conan as KTH_HEADER_INDEX_CAPACITY
+#ifndef KTH_HEADER_INDEX_CAPACITY
+#define KTH_HEADER_INDEX_CAPACITY 1179648
+#endif
+
+/// Status flags for indexed headers (similar to BCHN's BlockStatus)
+enum class header_status : uint32_t {
+    none                    = 0,
+
+    // Validation state
+    valid_header            = 1 << 0,   // Header syntax valid
+    valid_tree              = 1 << 1,   // Transactions merkle root valid
+    valid_chain             = 1 << 2,   // Connects to valid chain
+    valid_scripts           = 1 << 3,   // Scripts & signatures valid
+
+    // Data availability
+    have_data               = 1 << 4,   // Full block data available
+    have_undo               = 1 << 5,   // Undo data available
+
+    // Chain state
+    failed_valid            = 1 << 6,   // Descends from failed block
+    failed_child            = 1 << 7,   // Parent failed validation
+
+    // Derived flags
+    valid_mask              = valid_header | valid_tree | valid_chain | valid_scripts,
+};
+
+constexpr header_status operator|(header_status a, header_status b) noexcept {
+    return header_status(uint32_t(a) | uint32_t(b));
+}
+
+constexpr header_status operator&(header_status a, header_status b) noexcept {
+    return header_status(uint32_t(a) & uint32_t(b));
+}
+
+constexpr bool has_flag(header_status status, header_status flag) noexcept {
+    return (uint32_t(status) & uint32_t(flag)) != 0;
+}
+
+/// All data for a single header entry
+struct header_entry {
+    domain::chain::header header;
+    hash_digest hash{};
+    uint32_t parent_index{};
+    uint32_t skip_index{};
+    int32_t height{};
+    uint64_t chain_work{};
+    header_status status{};
+};
+
+/// Result of adding a header to the index
+struct header_index_result {
+    bool inserted{false};       // true if new header was added
+    uint32_t index{0};          // index of the header (new or existing)
+    bool capacity_warning{false}; // true if at 95% capacity
+};
+
+/// Hash function for hash_digest.
+/// This used to call `GetCheapHash()` in uint256, which was later moved; the
+/// cheap hash function simply calls ReadLE64() however, so the end result is
+/// identical. (Comment from BCHN's BlockHasher in chain.h)
+struct hash_digest_hasher {
+    constexpr size_t operator()(hash_digest const& hash) const noexcept {
+        return from_little_endian_unsafe<size_t>(hash);
+    }
+};
+
+/// Global index of all known block headers.
+/// Thread-safe, lock-free reads, bucket-locked writes.
+struct KB_API header_index {
+    using index_t = uint32_t;
+    static constexpr index_t null_index = std::numeric_limits<index_t>::max();
+    static constexpr size_t default_capacity = KTH_HEADER_INDEX_CAPACITY;
+
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /// Construct with specified capacity.
+    /// @param capacity Maximum number of headers to store.
+    explicit header_index(size_t capacity = default_capacity);
+
+    ~header_index() = default;
+
+    // Non-copyable, non-movable (contains atomics and concurrent map)
+    header_index(header_index const&) = delete;
+    header_index& operator=(header_index const&) = delete;
+    header_index(header_index&&) = delete;
+    header_index& operator=(header_index&&) = delete;
+
+    // =========================================================================
+    // Core Operations
+    // =========================================================================
+
+    /// Add a header to the index.
+    /// Thread-safe. If header already exists, returns existing index.
+    /// @param hash The header's hash.
+    /// @param header The header data.
+    /// @return Result with insertion status and index.
+    [[nodiscard]]
+    header_index_result add(hash_digest const& hash, domain::chain::header const& header);
+
+    /// Find a header by hash.
+    /// Thread-safe, lock-free.
+    /// @param hash The header's hash.
+    /// @return Index if found, null_index otherwise.
+    [[nodiscard]]
+    index_t find(hash_digest const& hash) const;
+
+    /// Check if a header exists.
+    /// @param hash The header's hash.
+    [[nodiscard]]
+    bool contains(hash_digest const& hash) const;
+
+    // =========================================================================
+    // Field Accessors
+    // =========================================================================
+
+    [[nodiscard]] hash_digest get_prev_block_hash(index_t idx) const;
+    [[nodiscard]] index_t get_parent_index(index_t idx) const;
+    [[nodiscard]] index_t get_skip_index(index_t idx) const;
+    [[nodiscard]] int32_t get_height(index_t idx) const;
+    [[nodiscard]] uint64_t get_chain_work(index_t idx) const;
+    [[nodiscard]] header_status get_status(index_t idx) const;
+    [[nodiscard]] uint32_t get_version(index_t idx) const;
+    [[nodiscard]] hash_digest get_merkle(index_t idx) const;
+    [[nodiscard]] uint32_t get_timestamp(index_t idx) const;
+    [[nodiscard]] uint32_t get_bits(index_t idx) const;
+    [[nodiscard]] uint32_t get_nonce(index_t idx) const;
+
+    /// Get all fields for a header at once.
+    [[nodiscard]] header_entry get_entry(index_t idx) const;
+
+    /// Get the stored hash of a header.
+    [[nodiscard]] hash_digest get_hash(index_t idx) const;
+
+    /// Reconstruct the full header from stored fields.
+    [[nodiscard]] domain::chain::header get_header(index_t idx) const;
+
+    // =========================================================================
+    // Status Management
+    // =========================================================================
+
+    /// Set status flags for a header.
+    void set_status(index_t idx, header_status status);
+
+    /// Add status flags to a header (OR with existing).
+    void add_status(index_t idx, header_status flags);
+
+    /// Check if header has specific status flags.
+    [[nodiscard]]
+    bool has_status(index_t idx, header_status flags) const;
+
+    // =========================================================================
+    // Chain Work Management
+    // =========================================================================
+
+    /// Update chain work for a header.
+    void set_chain_work(index_t idx, uint64_t work);
+
+    // =========================================================================
+    // Traversal Primitives
+    // =========================================================================
+
+    /// Traverse backwards from start_idx, calling visitor for each entry.
+    /// @param start_idx Starting index.
+    /// @param max_steps Maximum steps to traverse (0 = unlimited).
+    /// @param visitor Callable with signature void(index_t idx).
+    template <typename Visitor>
+    void traverse_back(index_t start_idx, size_t max_steps, Visitor&& visitor) const;
+
+    /// Get ancestor at specific height using linear traversal.
+    /// O(n) where n = height difference.
+    /// @param start_idx Starting index.
+    /// @param target_height Target height.
+    /// @return Ancestor index or null_index if not found.
+    [[nodiscard]]
+    index_t get_ancestor_linear(index_t start_idx, int32_t target_height) const;
+
+    /// Get ancestor at specific height using skip pointers.
+    /// O(log n) where n = height difference.
+    /// @param start_idx Starting index.
+    /// @param target_height Target height.
+    /// @return Ancestor index or null_index if not found.
+    [[nodiscard]]
+    index_t get_ancestor(index_t start_idx, int32_t target_height) const;
+
+    /// Find the common ancestor of two headers.
+    /// @param idx_a First header index.
+    /// @param idx_b Second header index.
+    /// @return Common ancestor index or null_index if none.
+    [[nodiscard]]
+    index_t find_fork(index_t idx_a, index_t idx_b) const;
+
+    // =========================================================================
+    // State Queries
+    // =========================================================================
+
+    /// Get the number of headers in the index.
+    [[nodiscard]]
+    size_t size() const;
+
+    /// Get the capacity of the index.
+    [[nodiscard]]
+    size_t capacity() const;
+
+    /// Check if index is at warning threshold (95% full).
+    [[nodiscard]]
+    bool at_capacity_warning() const;
+
+    /// Get estimated memory usage in bytes.
+    [[nodiscard]]
+    size_t memory_usage() const;
+
+private:
+    // Skip list helpers (from BCHN)
+    [[nodiscard]]
+    static int32_t invert_lowest_one(int32_t n);
+
+    [[nodiscard]]
+    static int32_t get_skip_height(int32_t height);
+
+    [[nodiscard]]
+    index_t build_skip(index_t parent_idx, int32_t height) const;
+
+    [[nodiscard]]
+    index_t get_ancestor_internal(index_t start_idx, int32_t target_height) const;
+
+    // SoA storage - one vector per field
+    std::vector<hash_digest> hashes_;  // Block hash (stored, not recomputed)
+    std::vector<hash_digest> prev_block_hashes_;
+    std::vector<index_t> parent_indices_;
+    std::vector<index_t> skip_indices_;
+    std::vector<int32_t> heights_;
+    std::vector<uint64_t> chain_works_;
+    // TODO(fernando): if we find data races causing issues, consider using atomics again
+    // std::unique_ptr<std::atomic<uint32_t>[]> statuses_;  // atomic array for lock-free status updates
+    std::vector<uint32_t> statuses_;
+    std::vector<uint32_t> versions_;
+    std::vector<hash_digest> merkle_roots_;
+    std::vector<uint32_t> timestamps_;
+    std::vector<uint32_t> bits_;
+    std::vector<uint32_t> nonces_;
+
+    // Index counter
+    std::atomic<index_t> next_idx_{0};
+
+    // Concurrent hash map - provides synchronization
+    boost::concurrent_flat_map<hash_digest, index_t, hash_digest_hasher> hash_to_idx_;
+
+    // Configuration
+    size_t const capacity_;
+    size_t const warn_threshold_;
+};
+
+// =============================================================================
+// Template Implementation
+// =============================================================================
+
+template <typename Visitor>
+void header_index::traverse_back(index_t start_idx, size_t max_steps, Visitor&& visitor) const {
+    if (start_idx == null_index) {
+        return;
+    }
+
+    index_t idx = start_idx;
+    size_t steps = 0;
+
+    while (idx != null_index && (max_steps == 0 || steps < max_steps)) {
+        visitor(idx);
+        idx = parent_indices_[idx];
+        ++steps;
+    }
+}
+
+} // namespace kth::blockchain
+
+#endif // KTH_BLOCKCHAIN_HEADER_INDEX_HPP

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -19,6 +19,7 @@
 #include <kth/domain.hpp>
 
 #include <kth/blockchain/define.hpp>
+#include <kth/blockchain/header_index.hpp>
 #include <kth/blockchain/pools/block_organizer.hpp>
 #include <kth/blockchain/pools/branch.hpp>
 #include <kth/blockchain/pools/mempool_transaction_summary.hpp>
@@ -147,6 +148,10 @@ struct KB_API block_chain {
     bool is_stale() const;
     settings const& chain_settings() const;
     executor_type executor() const;
+
+    /// Access the header index (for headers-first sync).
+    [[nodiscard]] header_index& headers() { return header_index_; }
+    [[nodiscard]] header_index const& headers() const { return header_index_; }
 
 #if defined(KTH_WITH_MEMPOOL)
     std::pair<std::vector<kth::mining::transaction_element>, uint64_t> get_block_template() const;
@@ -357,6 +362,7 @@ private:
 
     transaction_organizer transaction_organizer_;
     block_organizer block_organizer_;
+    header_index header_index_;
 };
 
 } // namespace kth::blockchain

--- a/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
@@ -8,10 +8,9 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
-#include <mutex>
-#include <vector>
 
 #include <kth/blockchain/define.hpp>
+#include <kth/blockchain/header_index.hpp>
 #include <kth/blockchain/settings.hpp>
 #include <kth/blockchain/validate/validate_header.hpp>
 #include <kth/domain.hpp>
@@ -19,62 +18,40 @@
 
 namespace kth::blockchain {
 
-// Forward declaration
-struct block_chain;
-
 /// Result of adding headers to the organizer
 struct header_organize_result {
     code error;
     size_t headers_added{0};
-    size_t cache_size{0};
-    size_t cache_memory_bytes{0};
-};
-
-/// Configuration for the header cache
-struct header_cache_config {
-    /// Maximum memory to use for header cache (bytes)
-    /// Default: 256 MB
-    size_t max_cache_memory = 256 * 1024 * 1024;
-
-    /// Memory overhead factor (for allocator overhead)
-    /// Default: 1.12 (~12% overhead for jemalloc)
-    double memory_overhead = 1.12;
-
-    /// Auto-flush when cache reaches this percentage of max
-    /// Default: 0.9 (90%)
-    double auto_flush_threshold = 0.9;
+    size_t index_size{0};
+    size_t index_memory_bytes{0};
 };
 
 /// Header organizer for headers-first sync.
-/// Validates and caches headers during initial block download (IBD).
+/// Validates headers and stores them in the header_index.
 ///
 /// ARCHITECTURE:
 /// -------------
-/// The organizer maintains an in-memory cache of validated headers.
-/// Headers are validated as they arrive and stored in the cache.
-/// When flush() is called (or cache is full), headers are persisted to DB.
+/// The organizer validates headers as they arrive and stores them
+/// in the header_index (SoA structure with O(1) hash lookup and
+/// O(log n) ancestor lookup via skip pointers).
 ///
-/// This design allows:
-/// 1. Fast header validation without DB round-trips
-/// 2. Batch DB writes for efficiency
-/// 3. Memory-aware caching with configurable limits
+/// The header_index is owned by block_chain and passed by reference.
 ///
 /// THREAD SAFETY:
 /// --------------
-/// All public methods are thread-safe (protected by mutex).
+/// Thread-safe through header_index's concurrent_flat_map.
 struct KB_API header_organizer {
     using ptr = std::shared_ptr<header_organizer>;
+    using index_t = header_index::index_t;
 
     /// Construct a header organizer.
-    /// @param[in] chain     Reference to the blockchain.
+    /// @param[in] index     Reference to the header index (owned by block_chain).
     /// @param[in] settings  Blockchain settings.
     /// @param[in] network   The network type.
-    /// @param[in] config    Cache configuration.
-    header_organizer(block_chain& chain, settings const& settings,
-                     domain::config::network network,
-                     header_cache_config config = {});
+    header_organizer(header_index& index, settings const& settings,
+                     domain::config::network network);
 
-    ~header_organizer();
+    ~header_organizer() = default;
 
     // Non-copyable
     header_organizer(header_organizer const&) = delete;
@@ -83,109 +60,78 @@ struct KB_API header_organizer {
     bool start();
     bool stop();
 
-    /// Initialize the organizer with current chain state.
-    /// Must be called before adding headers.
-    /// @param[in] current_height     Current header height in DB.
-    /// @param[in] current_tip_hash   Hash of current header tip.
-    /// @param[in] expected_headers   Estimated number of headers to sync (for pre-allocation).
-    void initialize(size_t current_height, hash_digest const& current_tip_hash,
-                    size_t expected_headers = 0);
+    /// Sync tip state from the header index.
+    /// Call after header_index has been initialized (e.g., with genesis).
+    void sync_tip();
 
     /// Add a batch of headers to the organizer.
-    /// Validates all headers and adds valid ones to the cache.
-    /// May auto-flush to DB if cache is getting full.
+    /// Validates all headers and adds valid ones to the index.
     /// @param[in] headers  The headers to add.
     /// @return Result with error code and statistics.
     [[nodiscard]]
     header_organize_result add_headers(domain::message::header::list const& headers);
 
-    /// Flush all cached headers to the database.
-    /// @return error::success or the storage error.
-    [[nodiscard]]
-    code flush();
+    // =========================================================================
+    // Index Access
+    // =========================================================================
 
-    /// Get the block hashes of all cached headers.
-    /// Useful for requesting blocks after headers are synced.
+    /// Get the header index.
     [[nodiscard]]
-    std::vector<hash_digest> get_cached_hashes() const;
+    header_index& index() { return index_; }
 
-    /// Clear the cache without flushing to DB.
-    /// Use with caution - discards unwritten headers.
-    void clear_cache();
+    [[nodiscard]]
+    header_index const& index() const { return index_; }
+
+    /// Find a header by hash.
+    [[nodiscard]]
+    index_t find(hash_digest const& hash) const { return index_.find(hash); }
+
+    /// Check if a header exists.
+    [[nodiscard]]
+    bool contains(hash_digest const& hash) const { return index_.contains(hash); }
 
     // =========================================================================
     // State queries
     // =========================================================================
 
-    /// Get the current header tip height (DB + cache).
+    /// Get the current tip index.
     [[nodiscard]]
-    size_t header_height() const;
+    index_t tip_index() const { return tip_index_; }
+
+    /// Get the current header tip height.
+    [[nodiscard]]
+    int32_t header_height() const;
 
     /// Get the hash of the header tip.
     [[nodiscard]]
-    hash_digest header_tip_hash() const;
+    hash_digest const& header_tip_hash() const { return tip_hash_; }
 
-    /// Get the number of headers in cache.
+    /// Get the number of headers in the index.
     [[nodiscard]]
-    size_t cache_size() const;
+    size_t size() const { return index_.size(); }
 
-    /// Get estimated memory usage of the cache.
+    /// Get estimated memory usage.
     [[nodiscard]]
-    size_t cache_memory() const;
-
-    /// Check if cache has pending headers.
-    [[nodiscard]]
-    bool has_pending() const;
-
-    /// Calculate optimal batch size based on available memory.
-    /// @param[in] items_needed  Total headers we want to sync.
-    /// @return Optimal number of headers to cache.
-    [[nodiscard]]
-    size_t calculate_optimal_cache_size(size_t items_needed) const;
+    size_t memory_usage() const { return index_.memory_usage(); }
 
 protected:
     [[nodiscard]]
-    bool stopped() const {
-        return stopped_;
-    }
+    bool stopped() const { return stopped_; }
 
 private:
     // Validate a single header against expected previous
     [[nodiscard]]
-    code validate(domain::chain::header const& header, size_t height,
+    code validate(domain::chain::header const& header, int32_t height,
                   hash_digest const& previous) const;
 
-    // Estimate memory for a single header
-    [[nodiscard]]
-    static size_t estimated_header_size();
-
-    // Internal cache_memory without lock (caller must hold mutex_)
-    [[nodiscard]]
-    size_t cache_memory_impl() const;
-
-    // Internal flush without lock (caller must hold mutex_)
-    [[nodiscard]]
-    code flush_impl();
-
-    // Check if we should auto-flush
-    [[nodiscard]]
-    bool should_auto_flush() const;
-
     // Members
-    block_chain& chain_;
+    header_index& index_;
     std::atomic<bool> stopped_{false};
     validate_header validator_;
-    header_cache_config config_;
-    mutable std::mutex mutex_;
 
-    // Chain state (protected by mutex_)
-    size_t db_header_height_{0};       // Height of headers in DB
-    hash_digest db_tip_hash_{null_hash};  // Hash of DB header tip
-
-    // Cache state (protected by mutex_)
-    domain::chain::header::list header_cache_;
-    std::vector<hash_digest> hash_cache_;  // Parallel cache of hashes
-    hash_digest cache_tip_hash_{null_hash};
+    // Current tip state
+    index_t tip_index_{header_index::null_index};
+    hash_digest tip_hash_{null_hash};
 };
 
 } // namespace kth::blockchain

--- a/src/blockchain/src/header_index.cpp
+++ b/src/blockchain/src/header_index.cpp
@@ -1,0 +1,409 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/blockchain/header_index.hpp>
+
+#include <cstring>
+
+#include <kth/infrastructure/utility/stats.hpp>
+
+namespace kth::blockchain {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+header_index::header_index(size_t capacity)
+    : capacity_(capacity)
+    , warn_threshold_((capacity * 95) / 100)
+{
+    // Pre-allocate all vectors to capacity
+    hashes_.resize(capacity_);
+    prev_block_hashes_.resize(capacity_);
+    parent_indices_.resize(capacity_);
+    skip_indices_.resize(capacity_);
+    heights_.resize(capacity_);
+    chain_works_.resize(capacity_);
+    statuses_.resize(capacity_);
+    versions_.resize(capacity_);
+    merkle_roots_.resize(capacity_);
+    timestamps_.resize(capacity_);
+    bits_.resize(capacity_);
+    nonces_.resize(capacity_);
+
+    // Reserve hash map capacity
+    hash_to_idx_.reserve(capacity_);
+}
+
+// =============================================================================
+// Core Operations
+// =============================================================================
+
+header_index_result header_index::add(hash_digest const& hash, domain::chain::header const& header) {
+    header_index_result result;
+
+    // IMPORTANT: Find parent BEFORE insert_and_visit to avoid nested visits
+    // (nested visits on same bucket = deadlock!)
+    index_t parent_idx = null_index;
+    int32_t height = 0;
+    uint64_t chain_work = 0;
+
+    KTH_STATS_TIME_START(find_parent);
+    hash_to_idx_.visit(header.previous_block_hash(), [&](auto const& parent_pair) {
+        parent_idx = parent_pair.second;
+    });
+    KTH_STATS_TIME_END(global_sync_stats(), find_parent, find_parent_time_ns, find_parent_calls);
+
+    if (parent_idx != null_index) {
+        height = heights_[parent_idx] + 1;
+        chain_work = chain_works_[parent_idx] + 1;  // TODO: Calculate actual work from bits
+    }
+
+    // Build skip pointer BEFORE acquiring insert lock (O(log n) operation)
+    KTH_STATS_TIME_START(build_skip);
+    index_t const skip_idx = build_skip(parent_idx, height);
+    KTH_STATS_TIME_END(global_sync_stats(), build_skip, build_skip_time_ns, build_skip_calls);
+
+    // Now do the insert with all info already computed
+    KTH_STATS_TIME_START(insert);
+    hash_to_idx_.insert_and_visit(
+        {hash, null_index},
+        [&](auto& pair) {
+            // Newly inserted - initialize everything
+            index_t const idx = next_idx_.fetch_add(1, std::memory_order_relaxed);
+
+            // Bounds check
+            if (idx >= capacity_) {
+                result.index = null_index;
+                return;
+            }
+
+            // Store in vectors (all writes happen under bucket lock)
+            hashes_[idx] = hash;
+            prev_block_hashes_[idx] = header.previous_block_hash();
+            parent_indices_[idx] = parent_idx;
+            skip_indices_[idx] = skip_idx;
+            heights_[idx] = height;
+            chain_works_[idx] = chain_work;
+            statuses_[idx] = 0;
+            versions_[idx] = header.version();
+            merkle_roots_[idx] = header.merkle();
+            timestamps_[idx] = header.timestamp();
+            bits_[idx] = header.bits();
+            nonces_[idx] = header.nonce();
+
+            // Update the map value with actual index
+            pair.second = idx;
+            result.index = idx;
+            result.inserted = true;
+        },
+        [&](auto const& pair) {
+            // Already existed - just get the index
+            result.index = pair.second;
+        }
+    );
+    KTH_STATS_TIME_END(global_sync_stats(), insert, insert_time_ns, insert_calls);
+
+    result.capacity_warning = (result.index != null_index && result.index >= warn_threshold_);
+
+    return result;
+}
+
+header_index::index_t header_index::find(hash_digest const& hash) const {
+    index_t result = null_index;
+    hash_to_idx_.visit(hash, [&](auto const& pair) {
+        result = pair.second;
+    });
+    return result;
+}
+
+bool header_index::contains(hash_digest const& hash) const {
+    return find(hash) != null_index;
+}
+
+// =============================================================================
+// Field Accessors
+// =============================================================================
+
+hash_digest header_index::get_prev_block_hash(index_t idx) const {
+    return prev_block_hashes_[idx];
+}
+
+header_index::index_t header_index::get_parent_index(index_t idx) const {
+    return parent_indices_[idx];
+}
+
+header_index::index_t header_index::get_skip_index(index_t idx) const {
+    return skip_indices_[idx];
+}
+
+int32_t header_index::get_height(index_t idx) const {
+    return heights_[idx];
+}
+
+uint64_t header_index::get_chain_work(index_t idx) const {
+    return chain_works_[idx];
+}
+
+header_status header_index::get_status(index_t idx) const {
+    return header_status(statuses_[idx]);
+}
+
+uint32_t header_index::get_version(index_t idx) const {
+    return versions_[idx];
+}
+
+hash_digest header_index::get_merkle(index_t idx) const {
+    return merkle_roots_[idx];
+}
+
+uint32_t header_index::get_timestamp(index_t idx) const {
+    return timestamps_[idx];
+}
+
+uint32_t header_index::get_bits(index_t idx) const {
+    return bits_[idx];
+}
+
+uint32_t header_index::get_nonce(index_t idx) const {
+    return nonces_[idx];
+}
+
+header_entry header_index::get_entry(index_t idx) const {
+    return {
+        get_header(idx),
+        hashes_[idx],
+        parent_indices_[idx],
+        skip_indices_[idx],
+        heights_[idx],
+        chain_works_[idx],
+        header_status(statuses_[idx])
+    };
+}
+
+hash_digest header_index::get_hash(index_t idx) const {
+    return hashes_[idx];
+}
+
+domain::chain::header header_index::get_header(index_t idx) const {
+    return {
+        versions_[idx],
+        prev_block_hashes_[idx],
+        merkle_roots_[idx],
+        timestamps_[idx],
+        bits_[idx],
+        nonces_[idx]
+    };
+}
+
+// =============================================================================
+// Status Management
+// =============================================================================
+
+void header_index::set_status(index_t idx, header_status status) {
+    statuses_[idx] = uint32_t(status);
+}
+
+void header_index::add_status(index_t idx, header_status flags) {
+    statuses_[idx] |= uint32_t(flags);
+}
+
+bool header_index::has_status(index_t idx, header_status flags) const {
+    return (statuses_[idx] & uint32_t(flags)) == uint32_t(flags);
+}
+
+// =============================================================================
+// Chain Work Management
+// =============================================================================
+
+void header_index::set_chain_work(index_t idx, uint64_t work) {
+    chain_works_[idx] = work;
+}
+
+// =============================================================================
+// Traversal Primitives
+// =============================================================================
+
+header_index::index_t header_index::get_ancestor_linear(index_t start_idx, int32_t target_height) const {
+    if (start_idx == null_index || target_height < 0) {
+        return null_index;
+    }
+
+    int32_t current_height = heights_[start_idx];
+    if (target_height > current_height) {
+        return null_index;
+    }
+
+    int32_t remaining = current_height - target_height;
+    index_t idx = start_idx;
+
+    while (remaining > 0 && idx != null_index) {
+        idx = parent_indices_[idx];
+        --remaining;
+    }
+    return idx;
+}
+
+header_index::index_t header_index::get_ancestor(index_t start_idx, int32_t target_height) const {
+    if (start_idx == null_index || target_height < 0) {
+        return null_index;
+    }
+
+    if (target_height > heights_[start_idx]) {
+        return null_index;
+    }
+
+    index_t idx = start_idx;
+    int32_t height_walk = heights_[start_idx];
+
+    while (height_walk > target_height) {
+        int32_t height_skip = get_skip_height(height_walk);
+        int32_t height_skip_prev = get_skip_height(height_walk - 1);
+
+        if (skip_indices_[idx] != null_index &&
+            (height_skip == target_height ||
+             (height_skip > target_height &&
+              !(height_skip_prev < height_skip - 2 && height_skip_prev >= target_height)))) {
+            idx = skip_indices_[idx];
+            height_walk = height_skip;
+        } else {
+            idx = parent_indices_[idx];
+            --height_walk;
+        }
+
+        if (height_walk <= target_height) {
+            break;
+        }
+    }
+    return idx;
+}
+
+header_index::index_t header_index::find_fork(index_t idx_a, index_t idx_b) const {
+    if (idx_a == null_index || idx_b == null_index) {
+        return null_index;
+    }
+
+    int32_t height_a = heights_[idx_a];
+    int32_t height_b = heights_[idx_b];
+
+    // Equalize heights using skip pointers for efficiency
+    if (height_a > height_b) {
+        idx_a = get_ancestor(idx_a, height_b);
+        height_a = height_b;
+    } else if (height_b > height_a) {
+        idx_b = get_ancestor(idx_b, height_a);
+        height_b = height_a;
+    }
+
+    // Walk back in parallel until they meet
+    while (idx_a != idx_b && idx_a != null_index && idx_b != null_index) {
+        idx_a = parent_indices_[idx_a];
+        idx_b = parent_indices_[idx_b];
+    }
+
+    return (idx_a == idx_b) ? idx_a : null_index;
+}
+
+// =============================================================================
+// State Queries
+// =============================================================================
+
+size_t header_index::size() const {
+    return hash_to_idx_.size();
+}
+
+size_t header_index::capacity() const {
+    return capacity_;
+}
+
+bool header_index::at_capacity_warning() const {
+    return next_idx_.load(std::memory_order_relaxed) > warn_threshold_;
+}
+
+size_t header_index::memory_usage() const {
+    // Calculate approximate memory usage
+    size_t const count = size();
+
+    size_t total = 0;
+    total += capacity_ * sizeof(hash_digest);    // hashes_
+    total += capacity_ * sizeof(hash_digest);    // prev_block_hashes_
+    total += capacity_ * sizeof(index_t);        // parent_indices_
+    total += capacity_ * sizeof(index_t);        // skip_indices_
+    total += capacity_ * sizeof(int32_t);        // heights_
+    total += capacity_ * sizeof(uint64_t);       // chain_works_
+    total += capacity_ * sizeof(uint32_t);       // statuses_
+    total += capacity_ * sizeof(uint32_t);       // versions_
+    total += capacity_ * sizeof(hash_digest);    // merkle_roots_
+    total += capacity_ * sizeof(uint32_t);       // timestamps_
+    total += capacity_ * sizeof(uint32_t);       // bits_
+    total += capacity_ * sizeof(uint32_t);       // nonces_
+
+    // Estimate hash map overhead (~1.5x for load factor + bucket overhead)
+    total += count * (sizeof(hash_digest) + sizeof(index_t)) * 3 / 2;
+
+    return total;
+}
+
+// =============================================================================
+// Skip List Helpers
+// =============================================================================
+
+int32_t header_index::invert_lowest_one(int32_t n) {
+    return n & (n - 1);
+}
+
+int32_t header_index::get_skip_height(int32_t height) {
+    if (height < 2) {
+        return 0;
+    }
+    // For odd heights: more aggressive skip
+    // For even heights: just invert lowest bit
+    return (height & 1)
+        ? invert_lowest_one(invert_lowest_one(height - 1)) + 1
+        : invert_lowest_one(height);
+}
+
+header_index::index_t header_index::build_skip(index_t parent_idx, int32_t height) const {
+    if (parent_idx == null_index) {
+        return null_index;
+    }
+    return get_ancestor_internal(parent_idx, get_skip_height(height));
+}
+
+header_index::index_t header_index::get_ancestor_internal(index_t start_idx, int32_t target_height) const {
+    // Same as get_ancestor but can be called during add() under bucket lock
+    if (start_idx == null_index || target_height < 0) {
+        return null_index;
+    }
+
+    if (target_height > heights_[start_idx]) {
+        return null_index;
+    }
+
+    index_t idx = start_idx;
+    int32_t height_walk = heights_[start_idx];
+
+    while (height_walk > target_height) {
+        int32_t height_skip = get_skip_height(height_walk);
+        int32_t height_skip_prev = get_skip_height(height_walk - 1);
+
+        if (skip_indices_[idx] != null_index &&
+            (height_skip == target_height ||
+             (height_skip > target_height &&
+              !(height_skip_prev < height_skip - 2 && height_skip_prev >= target_height)))) {
+            idx = skip_indices_[idx];
+            height_walk = height_skip;
+        } else {
+            idx = parent_indices_[idx];
+            --height_walk;
+        }
+
+        if (height_walk <= target_height) {
+            break;
+        }
+    }
+    return idx;
+}
+
+} // namespace kth::blockchain

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -111,7 +111,7 @@ block_chain::block_chain(threadpool& pool,
 }
 
 block_chain::~block_chain() {
-    close();
+    (void)close();
 }
 
 // =============================================================================
@@ -140,6 +140,18 @@ bool block_chain::start() {
     if ( ! block_organizer_.start()) {
         spdlog::error("[blockchain] Failed to start block organizer.");
         return false;
+    }
+
+    // Initialize header_index with genesis block
+    auto const genesis = get_header(0);
+    if (genesis) {
+        auto const hash = genesis->hash();
+        auto const [inserted, index, capacity_warning] = header_index_.add(hash, *genesis);
+        if ( ! inserted) {
+            spdlog::error("[blockchain] Failed to initialize header index with genesis block.");
+            return false;
+        }
+        spdlog::info("[blockchain] Header index initialized with genesis: {}", encode_hash(hash));
     }
 
     return true;
@@ -871,7 +883,7 @@ block_chain::fetch_locator_block_headers(get_headers_const_ptr locator,
         }
     }
 
-    auto message = std::make_shared<headers>();
+    auto message = std::make_shared<domain::message::headers>();
     message->elements().reserve(floor_subtract(end, begin));
 
     for (auto height = begin; height < end; ++height) {

--- a/src/blockchain/src/pools/header_organizer.cpp
+++ b/src/blockchain/src/pools/header_organizer.cpp
@@ -4,37 +4,25 @@
 
 #include <kth/blockchain/pools/header_organizer.hpp>
 
-#include <algorithm>
+#include <spdlog/spdlog.h>
 
-#include <kth/blockchain/interface/block_chain.hpp>
+#include <kth/infrastructure/utility/stats.hpp>
+
 #include <kth/blockchain/settings.hpp>
 #include <kth/blockchain/validate/validate_header.hpp>
 #include <kth/domain.hpp>
-#include <kth/infrastructure/utility/system_memory.hpp>
 
 namespace kth::blockchain {
 
-using namespace kth::domain::chain;
-
 // =============================================================================
-// Construction / Destruction
+// Construction
 // =============================================================================
 
-header_organizer::header_organizer(block_chain& chain, settings const& settings,
-                                   domain::config::network network,
-                                   header_cache_config config)
-    : chain_(chain)
+header_organizer::header_organizer(header_index& index, settings const& settings,
+                                   domain::config::network network)
+    : index_(index)
     , validator_(settings, network)
-    , config_(config)
 {}
-
-header_organizer::~header_organizer() {
-    // Attempt to flush any pending headers on destruction
-    if (has_pending()) {
-        spdlog::warn("[header_organizer] Destroying with {} unflushed headers",
-            header_cache_.size());
-    }
-}
 
 // =============================================================================
 // Lifecycle
@@ -54,24 +42,16 @@ bool header_organizer::stop() {
 // Initialization
 // =============================================================================
 
-void header_organizer::initialize(size_t current_height, hash_digest const& current_tip_hash,
-                                  size_t expected_headers) {
-    std::lock_guard lock(mutex_);
-
-    db_header_height_ = current_height;
-    db_tip_hash_ = current_tip_hash;
-    cache_tip_hash_ = current_tip_hash;
-
-    // Pre-allocate cache if we know how many headers to expect
-    if (expected_headers > 0) {
-        auto const optimal_size = calculate_optimal_cache_size(expected_headers);
-        header_cache_.reserve(optimal_size);
-        hash_cache_.reserve(optimal_size);
-
-        spdlog::info("[header_organizer] Initialized: DB height {}, cache pre-allocated for {} headers",
-            current_height, optimal_size);
-    } else {
-        spdlog::info("[header_organizer] Initialized: DB height {}", current_height);
+void header_organizer::sync_tip() {
+    // Sync tip from the header index (assumes index is already initialized)
+    auto const size = index_.size();
+    if (size > 0) {
+        // For now, assume tip is the last added entry (index size - 1)
+        // TODO(fernando): properly track the actual chain tip when we support forks
+        tip_index_ = index_t(size - 1);
+        tip_hash_ = index_.get_hash(tip_index_);
+        spdlog::info("[header_organizer] Synced tip: index {}, hash {}",
+            tip_index_, encode_hash(tip_hash_));
     }
 }
 
@@ -92,25 +72,21 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
         return result;
     }
 
-    std::lock_guard lock(mutex_);
-
     spdlog::debug("[header_organizer] add_headers() called with {} headers", headers.size());
 
-    // Current tip is either from cache or from DB
-    hash_digest prev_hash = cache_tip_hash_;
-    size_t height = db_header_height_ + header_cache_.size() + 1;
+    // Current tip for validation
+    hash_digest prev_hash = tip_hash_;
+    int32_t height = index_.get_height(tip_index_) + 1;
 
-    spdlog::debug("[header_organizer] Starting validation loop at height {}, cache_tip_hash: {}",
-        height, encode_hash(cache_tip_hash_));
-
-    if (!headers.empty()) {
-        spdlog::debug("[header_organizer] First header previous_block_hash: {}",
-            encode_hash(headers.front().previous_block_hash()));
-    }
+    spdlog::debug("[header_organizer] Starting validation at height {}, tip_hash: {}",
+        height, encode_hash(tip_hash_));
 
     for (auto const& header : headers) {
         // Validate header
+        KTH_STATS_TIME_START(validate);
         auto const ec = validate(header, height, prev_hash);
+        KTH_STATS_TIME_END(global_sync_stats(), validate, validate_time_ns, validate_calls);
+
         if (ec) {
             spdlog::debug("[header_organizer] Header validation failed at height {}: {}",
                 height, ec.message());
@@ -118,195 +94,68 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
             break;
         }
 
-        // Compute hash and add to caches
+        // Compute hash and add to index
+        KTH_STATS_TIME_START(hash);
         auto const hash = header.hash();
-        header_cache_.push_back(header);
-        hash_cache_.push_back(hash);
+        KTH_STATS_TIME_END(global_sync_stats(), hash, hash_time_ns, hash_calls);
 
-        prev_hash = hash;
-        cache_tip_hash_ = hash;
-        ++height;
-        ++result.headers_added;
+        KTH_STATS_TIME_START(index_add);
+        auto const add_result = index_.add(hash, header);
+        KTH_STATS_TIME_END(global_sync_stats(), index_add, index_add_time_ns, index_add_calls);
 
-        // Log progress every 500 headers
-        if (result.headers_added % 500 == 0) {
-            spdlog::debug("[header_organizer] Validated {} headers...", result.headers_added);
+        if (add_result.inserted) {
+            tip_index_ = add_result.index;
+            tip_hash_ = hash;
+            prev_hash = hash;
+            ++height;
+            ++result.headers_added;
+
+            // Mark as valid header
+            index_.add_status(add_result.index, header_status::valid_header);
+
+            if (add_result.capacity_warning) {
+                spdlog::warn("[header_organizer] Header index at 95% capacity!");
+            }
+        } else {
+            // Header already existed - this shouldn't happen in normal sync
+            spdlog::debug("[header_organizer] Header already exists at index {}",
+                add_result.index);
+        }
+
+        // Log progress every 1000 headers
+        if (result.headers_added > 0 && result.headers_added % 1000 == 0) {
+            spdlog::debug("[header_organizer] Validated {} headers, height {}...",
+                result.headers_added, height - 1);
         }
     }
 
-    spdlog::debug("[header_organizer] Validation complete: {} headers added", result.headers_added);
+    spdlog::debug("[header_organizer] Validation complete: {} headers added, total size {}",
+        result.headers_added, index_.size());
 
-    result.cache_size = header_cache_.size();
-    result.cache_memory_bytes = cache_memory_impl();
-
-    // Check if we should auto-flush
-    if (should_auto_flush()) {
-        spdlog::info("[header_organizer] Cache threshold reached ({} headers, {} MB), auto-flushing",
-            header_cache_.size(),
-            result.cache_memory_bytes / (1024 * 1024));
-
-        auto const flush_ec = flush_impl();  // Use _impl to avoid deadlock (we already hold mutex_)
-        if (flush_ec && result.error == error::success) {
-            result.error = flush_ec;
-        }
-    }
+    result.index_size = index_.size();
+    result.index_memory_bytes = index_.memory_usage();
 
     return result;
-}
-
-// =============================================================================
-// Flush to Database
-// =============================================================================
-
-code header_organizer::flush() {
-    std::lock_guard lock(mutex_);
-    return flush_impl();
-}
-
-// Internal version without lock (caller must hold mutex_)
-code header_organizer::flush_impl() {
-    if (header_cache_.empty()) {
-        return error::success;
-    }
-
-    auto const start_height = db_header_height_ + 1;
-    auto const count = header_cache_.size();
-
-    spdlog::debug("[header_organizer] Flushing {} headers to DB starting at height {}",
-        count, start_height);
-
-    // Store all headers in batch
-    auto const ec = chain_.organize_headers_batch(header_cache_, start_height);
-    if (ec && ec != error::duplicate_block) {
-        spdlog::warn("[header_organizer] Failed to flush headers batch: {}", ec.message());
-        return ec;
-    }
-
-    // Update DB state
-    db_header_height_ = start_height + count - 1;
-    db_tip_hash_ = cache_tip_hash_;
-
-    // Clear cache
-    header_cache_.clear();
-    hash_cache_.clear();
-
-    spdlog::debug("[header_organizer] Flush complete, DB height now {}", db_header_height_);
-
-    return error::success;
-}
-
-// =============================================================================
-// Cache Access
-// =============================================================================
-
-std::vector<hash_digest> header_organizer::get_cached_hashes() const {
-    std::lock_guard lock(mutex_);
-    return hash_cache_;
-}
-
-void header_organizer::clear_cache() {
-    std::lock_guard lock(mutex_);
-
-    header_cache_.clear();
-    header_cache_.shrink_to_fit();
-    hash_cache_.clear();
-    hash_cache_.shrink_to_fit();
-
-    // Reset cache tip to DB tip
-    cache_tip_hash_ = db_tip_hash_;
 }
 
 // =============================================================================
 // State Queries
 // =============================================================================
 
-size_t header_organizer::header_height() const {
-    std::lock_guard lock(mutex_);
-    return db_header_height_ + header_cache_.size();
-}
-
-hash_digest header_organizer::header_tip_hash() const {
-    std::lock_guard lock(mutex_);
-    return cache_tip_hash_;
-}
-
-size_t header_organizer::cache_size() const {
-    std::lock_guard lock(mutex_);
-    return header_cache_.size();
-}
-
-size_t header_organizer::cache_memory() const {
-    std::lock_guard lock(mutex_);
-    return cache_memory_impl();
-}
-
-// Internal version without lock (caller must hold mutex_)
-size_t header_organizer::cache_memory_impl() const {
-    auto const header_size = estimated_header_size();
-    auto const hash_size = sizeof(hash_digest);
-    return static_cast<size_t>(
-        (header_cache_.size() * header_size + hash_cache_.size() * hash_size)
-        * config_.memory_overhead
-    );
-}
-
-bool header_organizer::has_pending() const {
-    std::lock_guard lock(mutex_);
-    return !header_cache_.empty();
-}
-
-// =============================================================================
-// Memory Estimation
-// =============================================================================
-
-size_t header_organizer::calculate_optimal_cache_size(size_t items_needed) const {
-    // Header size + hash size per item
-    auto const item_size = estimated_header_size() + sizeof(hash_digest);
-
-    auto const available = kth::get_available_system_memory();
-    if (available == 0) {
-        // Fallback: use config max or reasonable default
-        auto const max_items = config_.max_cache_memory / item_size;
-        return std::min(items_needed, max_items);
+int32_t header_organizer::header_height() const {
+    if (tip_index_ == header_index::null_index) {
+        return -1;  // No headers yet (only genesis)
     }
-
-    // Memory per item including overhead
-    auto const bytes_per_item = static_cast<size_t>(item_size * config_.memory_overhead);
-
-    // Use configured max or fraction of available memory (whichever is smaller)
-    auto const memory_fraction = available / 2;  // Use at most 50% of available
-    auto const usable_memory = std::min(config_.max_cache_memory, memory_fraction);
-
-    // Calculate how many items we can fit
-    auto const max_items = bytes_per_item > 0 ? usable_memory / bytes_per_item : 0;
-
-    return std::min(items_needed, max_items);
-}
-
-size_t header_organizer::estimated_header_size() {
-    // Header base size: version(4) + prev_hash(32) + merkle(32) + time(4) + bits(4) + nonce(4) = 80 bytes
-    // Plus std::vector overhead and alignment
-    return 80 + 48;  // ~128 bytes estimated with overhead
+    return index_.get_height(tip_index_);
 }
 
 // =============================================================================
-// Internal Helpers
+// Validation
 // =============================================================================
 
-code header_organizer::validate(domain::chain::header const& header, size_t height,
+code header_organizer::validate(domain::chain::header const& header, int32_t height,
                                 hash_digest const& previous) const {
-    return validator_.validate(header, height, previous);
-}
-
-bool header_organizer::should_auto_flush() const {
-    // Note: caller must hold mutex_
-    auto const current_memory = static_cast<size_t>(
-        (header_cache_.size() * estimated_header_size() + hash_cache_.size() * sizeof(hash_digest))
-        * config_.memory_overhead
-    );
-
-    auto const threshold = static_cast<size_t>(config_.max_cache_memory * config_.auto_flush_threshold);
-    return current_memory >= threshold;
+    return validator_.validate(header, static_cast<size_t>(height), previous);
 }
 
 } // namespace kth::blockchain

--- a/src/blockchain/test/header_index.cpp
+++ b/src/blockchain/test/header_index.cpp
@@ -1,0 +1,533 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <kth/blockchain.hpp>
+
+using namespace kth;
+using namespace kth::blockchain;
+using namespace kth::domain::chain;
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+namespace {
+
+// Create a deterministic hash from an integer
+hash_digest make_hash(uint32_t id) {
+    hash_digest hash{};
+    // Fill with the id value for easy identification
+    hash[0] = uint8_t(id & 0xFF);
+    hash[1] = uint8_t((id >> 8) & 0xFF);
+    hash[2] = uint8_t((id >> 16) & 0xFF);
+    hash[3] = uint8_t((id >> 24) & 0xFF);
+    return hash;
+}
+
+// Create a test header with specific values
+header make_header(uint32_t version, hash_digest const& prev_hash,
+                   hash_digest const& merkle, uint32_t timestamp,
+                   uint32_t bits, uint32_t nonce) {
+    return header{version, prev_hash, merkle, timestamp, bits, nonce};
+}
+
+// Create a simple header chain
+header make_header_at(uint32_t height, hash_digest const& prev_hash) {
+    return make_header(1, prev_hash, make_hash(height + 1000), height * 600, 0x1d00ffff, height);
+}
+
+} // namespace
+
+// =============================================================================
+// Construction tests
+// =============================================================================
+
+TEST_CASE("header_index default construction", "[header_index]") {
+    header_index index;
+    REQUIRE(index.size() == 0);
+    REQUIRE(index.capacity() == header_index::default_capacity);
+    REQUIRE_FALSE(index.at_capacity_warning());
+}
+
+TEST_CASE("header_index custom capacity", "[header_index]") {
+    header_index index(1000);
+    REQUIRE(index.size() == 0);
+    REQUIRE(index.capacity() == 1000);
+}
+
+// =============================================================================
+// Add/Find/Contains tests
+// =============================================================================
+
+TEST_CASE("header_index add single header", "[header_index]") {
+    header_index index(100);
+
+    auto const prev_hash = null_hash;
+    auto const hdr = make_header_at(0, prev_hash);
+    auto const hash = hdr.hash();
+
+    auto const result = index.add(hash, hdr);
+
+    REQUIRE(result.inserted == true);
+    REQUIRE(result.index == 0);
+    REQUIRE(result.capacity_warning == false);
+    REQUIRE(index.size() == 1);
+}
+
+TEST_CASE("header_index add duplicate returns existing index", "[header_index]") {
+    header_index index(100);
+
+    auto const hdr = make_header_at(0, null_hash);
+    auto const hash = hdr.hash();
+
+    auto const result1 = index.add(hash, hdr);
+    auto const result2 = index.add(hash, hdr);
+
+    REQUIRE(result1.inserted == true);
+    REQUIRE(result2.inserted == false);
+    REQUIRE(result1.index == result2.index);
+    REQUIRE(index.size() == 1);
+}
+
+TEST_CASE("header_index find existing header", "[header_index]") {
+    header_index index(100);
+
+    auto const hdr = make_header_at(0, null_hash);
+    auto const hash = hdr.hash();
+
+    (void)index.add(hash, hdr);
+    auto const found_idx = index.find(hash);
+
+    REQUIRE(found_idx != header_index::null_index);
+    REQUIRE(found_idx == 0);
+}
+
+TEST_CASE("header_index find non-existing header returns null_index", "[header_index]") {
+    header_index index(100);
+
+    auto const found_idx = index.find(make_hash(999));
+    REQUIRE(found_idx == header_index::null_index);
+}
+
+TEST_CASE("header_index contains", "[header_index]") {
+    header_index index(100);
+
+    auto const hdr = make_header_at(0, null_hash);
+    auto const hash = hdr.hash();
+
+    REQUIRE_FALSE(index.contains(hash));
+    (void)index.add(hash, hdr);
+    REQUIRE(index.contains(hash));
+}
+
+// =============================================================================
+// Field accessor tests
+// =============================================================================
+
+TEST_CASE("header_index field accessors", "[header_index]") {
+    header_index index(100);
+
+    auto const prev_hash = make_hash(42);
+    auto const merkle = make_hash(100);
+    uint32_t const version = 2;
+    uint32_t const timestamp = 1234567890;
+    uint32_t const bits = 0x1d00ffff;
+    uint32_t const nonce = 12345;
+
+    auto const hdr = make_header(version, prev_hash, merkle, timestamp, bits, nonce);
+    auto const hash = hdr.hash();
+
+    auto const result = index.add(hash, hdr);
+    auto const idx = result.index;
+
+    REQUIRE(index.get_prev_block_hash(idx) == prev_hash);
+    REQUIRE(index.get_version(idx) == version);
+    REQUIRE(index.get_merkle(idx) == merkle);
+    REQUIRE(index.get_timestamp(idx) == timestamp);
+    REQUIRE(index.get_bits(idx) == bits);
+    REQUIRE(index.get_nonce(idx) == nonce);
+}
+
+TEST_CASE("header_index get_entry returns all fields", "[header_index]") {
+    header_index index(100);
+
+    auto const prev_hash = make_hash(42);
+    auto const merkle = make_hash(100);
+    uint32_t const version = 2;
+    uint32_t const timestamp = 1234567890;
+    uint32_t const bits = 0x1d00ffff;
+    uint32_t const nonce = 12345;
+
+    auto const hdr = make_header(version, prev_hash, merkle, timestamp, bits, nonce);
+    auto const hash = hdr.hash();
+
+    auto const result = index.add(hash, hdr);
+    auto const entry = index.get_entry(result.index);
+
+    REQUIRE(entry.header.previous_block_hash() == prev_hash);
+    REQUIRE(entry.header.version() == version);
+    REQUIRE(entry.header.merkle() == merkle);
+    REQUIRE(entry.header.timestamp() == timestamp);
+    REQUIRE(entry.header.bits() == bits);
+    REQUIRE(entry.header.nonce() == nonce);
+    REQUIRE(entry.height == 0);  // Genesis has no parent
+    REQUIRE(entry.status == header_status::none);
+}
+
+// =============================================================================
+// Parent/height tracking tests
+// =============================================================================
+
+TEST_CASE("header_index parent linkage", "[header_index]") {
+    header_index index(100);
+
+    // Add genesis (no parent)
+    auto const genesis = make_header_at(0, null_hash);
+    auto const genesis_hash = genesis.hash();
+    auto const genesis_result = index.add(genesis_hash, genesis);
+
+    REQUIRE(index.get_parent_index(genesis_result.index) == header_index::null_index);
+    REQUIRE(index.get_height(genesis_result.index) == 0);
+
+    // Add block 1 (parent = genesis)
+    auto const block1 = make_header_at(1, genesis_hash);
+    auto const block1_hash = block1.hash();
+    auto const block1_result = index.add(block1_hash, block1);
+
+    REQUIRE(index.get_parent_index(block1_result.index) == genesis_result.index);
+    REQUIRE(index.get_height(block1_result.index) == 1);
+
+    // Add block 2 (parent = block1)
+    auto const block2 = make_header_at(2, block1_hash);
+    auto const block2_hash = block2.hash();
+    auto const block2_result = index.add(block2_hash, block2);
+
+    REQUIRE(index.get_parent_index(block2_result.index) == block1_result.index);
+    REQUIRE(index.get_height(block2_result.index) == 2);
+}
+
+// =============================================================================
+// Status management tests
+// =============================================================================
+
+TEST_CASE("header_index status management", "[header_index]") {
+    header_index index(100);
+
+    auto const hdr = make_header_at(0, null_hash);
+    auto const hash = hdr.hash();
+    auto const result = index.add(hash, hdr);
+    auto const idx = result.index;
+
+    // Initial status is none
+    REQUIRE(index.get_status(idx) == header_status::none);
+    REQUIRE_FALSE(index.has_status(idx, header_status::valid_header));
+
+    // Set status
+    index.set_status(idx, header_status::valid_header);
+    REQUIRE(index.has_status(idx, header_status::valid_header));
+    REQUIRE_FALSE(index.has_status(idx, header_status::have_data));
+
+    // Add status (OR)
+    index.add_status(idx, header_status::have_data);
+    REQUIRE(index.has_status(idx, header_status::valid_header));
+    REQUIRE(index.has_status(idx, header_status::have_data));
+
+    // Check combined flags
+    auto const expected = header_status::valid_header | header_status::have_data;
+    REQUIRE(index.get_status(idx) == expected);
+}
+
+TEST_CASE("header_index status has_flag helper", "[header_index]") {
+    auto const status = header_status::valid_header | header_status::have_data;
+
+    REQUIRE(has_flag(status, header_status::valid_header));
+    REQUIRE(has_flag(status, header_status::have_data));
+    REQUIRE_FALSE(has_flag(status, header_status::have_undo));
+    REQUIRE_FALSE(has_flag(status, header_status::failed_valid));
+}
+
+// =============================================================================
+// Chain work tests
+// =============================================================================
+
+TEST_CASE("header_index chain work", "[header_index]") {
+    header_index index(100);
+
+    auto const hdr = make_header_at(0, null_hash);
+    auto const hash = hdr.hash();
+    auto const result = index.add(hash, hdr);
+    auto const idx = result.index;
+
+    // Initial chain work (set by add based on parent)
+    auto const initial_work = index.get_chain_work(idx);
+
+    // Update chain work
+    index.set_chain_work(idx, 12345678);
+    REQUIRE(index.get_chain_work(idx) == 12345678);
+}
+
+// =============================================================================
+// Traversal tests
+// =============================================================================
+
+TEST_CASE("header_index traverse_back", "[header_index]") {
+    header_index index(100);
+
+    // Build a chain of 5 blocks
+    hash_digest prev_hash = null_hash;
+    std::vector<header_index::index_t> indices;
+
+    for (uint32_t i = 0; i < 5; ++i) {
+        auto const hdr = make_header_at(i, prev_hash);
+        auto const hash = hdr.hash();
+        auto const result = index.add(hash, hdr);
+        indices.push_back(result.index);
+        prev_hash = hash;
+    }
+
+    // Traverse from tip
+    std::vector<header_index::index_t> visited;
+    index.traverse_back(indices.back(), 0, [&](header_index::index_t idx) {
+        visited.push_back(idx);
+    });
+
+    REQUIRE(visited.size() == 5);
+    REQUIRE(visited[0] == indices[4]);
+    REQUIRE(visited[1] == indices[3]);
+    REQUIRE(visited[2] == indices[2]);
+    REQUIRE(visited[3] == indices[1]);
+    REQUIRE(visited[4] == indices[0]);
+}
+
+TEST_CASE("header_index traverse_back with max_steps", "[header_index]") {
+    header_index index(100);
+
+    // Build a chain of 5 blocks
+    hash_digest prev_hash = null_hash;
+    std::vector<header_index::index_t> indices;
+
+    for (uint32_t i = 0; i < 5; ++i) {
+        auto const hdr = make_header_at(i, prev_hash);
+        auto const hash = hdr.hash();
+        auto const result = index.add(hash, hdr);
+        indices.push_back(result.index);
+        prev_hash = hash;
+    }
+
+    // Traverse only 2 steps
+    std::vector<header_index::index_t> visited;
+    index.traverse_back(indices.back(), 2, [&](header_index::index_t idx) {
+        visited.push_back(idx);
+    });
+
+    REQUIRE(visited.size() == 2);
+    REQUIRE(visited[0] == indices[4]);
+    REQUIRE(visited[1] == indices[3]);
+}
+
+TEST_CASE("header_index get_ancestor_linear", "[header_index]") {
+    header_index index(100);
+
+    // Build a chain of 10 blocks
+    hash_digest prev_hash = null_hash;
+    std::vector<header_index::index_t> indices;
+
+    for (uint32_t i = 0; i < 10; ++i) {
+        auto const hdr = make_header_at(i, prev_hash);
+        auto const hash = hdr.hash();
+        auto const result = index.add(hash, hdr);
+        indices.push_back(result.index);
+        prev_hash = hash;
+    }
+
+    // Get ancestor at height 5 from tip (height 9)
+    auto const ancestor = index.get_ancestor_linear(indices.back(), 5);
+    REQUIRE(ancestor == indices[5]);
+
+    // Get ancestor at height 0 (genesis)
+    auto const genesis = index.get_ancestor_linear(indices.back(), 0);
+    REQUIRE(genesis == indices[0]);
+
+    // Get ancestor at same height
+    auto const same = index.get_ancestor_linear(indices[5], 5);
+    REQUIRE(same == indices[5]);
+
+    // Get ancestor at higher height (invalid)
+    auto const invalid = index.get_ancestor_linear(indices[5], 7);
+    REQUIRE(invalid == header_index::null_index);
+}
+
+TEST_CASE("header_index get_ancestor with skip pointers", "[header_index]") {
+    header_index index(100);
+
+    // Build a longer chain to test skip pointers
+    hash_digest prev_hash = null_hash;
+    std::vector<header_index::index_t> indices;
+
+    for (uint32_t i = 0; i < 100; ++i) {
+        auto const hdr = make_header_at(i, prev_hash);
+        auto const hash = hdr.hash();
+        auto const result = index.add(hash, hdr);
+        indices.push_back(result.index);
+        prev_hash = hash;
+    }
+
+    // Test various ancestor lookups
+    REQUIRE(index.get_ancestor(indices[99], 50) == indices[50]);
+    REQUIRE(index.get_ancestor(indices[99], 0) == indices[0]);
+    REQUIRE(index.get_ancestor(indices[50], 25) == indices[25]);
+    REQUIRE(index.get_ancestor(indices[99], 99) == indices[99]);
+}
+
+// =============================================================================
+// Fork finding tests
+// =============================================================================
+
+TEST_CASE("header_index find_fork same chain", "[header_index]") {
+    header_index index(100);
+
+    // Build a chain of 10 blocks
+    hash_digest prev_hash = null_hash;
+    std::vector<header_index::index_t> indices;
+
+    for (uint32_t i = 0; i < 10; ++i) {
+        auto const hdr = make_header_at(i, prev_hash);
+        auto const hash = hdr.hash();
+        auto const result = index.add(hash, hdr);
+        indices.push_back(result.index);
+        prev_hash = hash;
+    }
+
+    // Fork of block 5 and block 9 should be block 5
+    auto const fork = index.find_fork(indices[5], indices[9]);
+    REQUIRE(fork == indices[5]);
+
+    // Fork of same block is itself
+    auto const same = index.find_fork(indices[5], indices[5]);
+    REQUIRE(same == indices[5]);
+}
+
+TEST_CASE("header_index find_fork different branches", "[header_index]") {
+    header_index index(100);
+
+    // Build main chain: 0 -> 1 -> 2 -> 3 -> 4
+    hash_digest prev_hash = null_hash;
+    std::vector<header_index::index_t> main_chain;
+
+    for (uint32_t i = 0; i < 5; ++i) {
+        auto const hdr = make_header_at(i, prev_hash);
+        auto const hash = hdr.hash();
+        auto const result = index.add(hash, hdr);
+        main_chain.push_back(result.index);
+        prev_hash = hash;
+    }
+
+    // Build fork from block 2: 2 -> 3' -> 4'
+    prev_hash = index.get_prev_block_hash(main_chain[3]);  // Get hash of block 2
+    // Actually we need the hash of block 2, not prev_block_hash of block 3
+    // Let me fix this - we need to compute the hash
+
+    // For simplicity, let's create a fork by using a different merkle root
+    auto const fork_base_hash = make_header_at(2, index.get_prev_block_hash(main_chain[2])).hash();
+
+    // Build fork: use block 2's hash as parent for fork
+    // We need to get hash of block 2 from the main chain
+    // Since we don't store the hash, let's rebuild it
+    auto hdr2 = make_header_at(2, index.get_prev_block_hash(main_chain[2]));
+    auto hash2 = hdr2.hash();
+
+    // Create fork block 3' with different merkle
+    auto fork3 = make_header(1, hash2, make_hash(9999), 3 * 600, 0x1d00ffff, 999);
+    auto fork3_hash = fork3.hash();
+    auto fork3_result = index.add(fork3_hash, fork3);
+
+    // Create fork block 4'
+    auto fork4 = make_header(1, fork3_hash, make_hash(9998), 4 * 600, 0x1d00ffff, 998);
+    auto fork4_hash = fork4.hash();
+    auto fork4_result = index.add(fork4_hash, fork4);
+
+    // Find fork point between main_chain[4] and fork4
+    auto const fork_point = index.find_fork(main_chain[4], fork4_result.index);
+    REQUIRE(fork_point == main_chain[2]);
+}
+
+// =============================================================================
+// Capacity tests
+// =============================================================================
+
+TEST_CASE("header_index capacity warning", "[header_index]") {
+    header_index index(100);  // 95% threshold = 95
+
+    // Add 95 headers (indices 0-94), just below threshold
+    hash_digest prev_hash = null_hash;
+    for (uint32_t i = 0; i < 95; ++i) {
+        auto const hdr = make_header_at(i, prev_hash);
+        auto const hash = hdr.hash();
+        auto const result = index.add(hash, hdr);
+        prev_hash = hash;
+        REQUIRE_FALSE(result.capacity_warning);
+        REQUIRE_FALSE(index.at_capacity_warning());
+    }
+
+    // Add 96th header (index 95) - triggers warning
+    auto const hdr = make_header_at(95, prev_hash);
+    auto const result = index.add(hdr.hash(), hdr);
+    REQUIRE(result.capacity_warning);
+    REQUIRE(index.at_capacity_warning());
+}
+
+TEST_CASE("header_index memory_usage", "[header_index]") {
+    header_index index(1000);
+
+    REQUIRE(index.memory_usage() > 0);
+
+    // Add some headers
+    hash_digest prev_hash = null_hash;
+    for (uint32_t i = 0; i < 10; ++i) {
+        auto const hdr = make_header_at(i, prev_hash);
+        auto const hash = hdr.hash();
+        (void)index.add(hash, hdr);
+        prev_hash = hash;
+    }
+
+    // Memory usage should still be based on capacity, not size
+    REQUIRE(index.memory_usage() > 0);
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+TEST_CASE("header_index null_index traversal", "[header_index]") {
+    header_index index(100);
+
+    std::vector<header_index::index_t> visited;
+    index.traverse_back(header_index::null_index, 0, [&](header_index::index_t idx) {
+        visited.push_back(idx);
+    });
+
+    REQUIRE(visited.empty());
+}
+
+TEST_CASE("header_index get_ancestor from null_index", "[header_index]") {
+    header_index index(100);
+
+    auto const result = index.get_ancestor(header_index::null_index, 0);
+    REQUIRE(result == header_index::null_index);
+}
+
+TEST_CASE("header_index orphan header (parent not found)", "[header_index]") {
+    header_index index(100);
+
+    // Add a header whose parent doesn't exist
+    auto const orphan = make_header_at(5, make_hash(999));
+    auto const orphan_hash = orphan.hash();
+    auto const result = index.add(orphan_hash, orphan);
+
+    REQUIRE(result.inserted == true);
+    REQUIRE(index.get_parent_index(result.index) == header_index::null_index);
+    REQUIRE(index.get_height(result.index) == 0);  // Height is 0 because no parent found
+}

--- a/src/domain/include/kth/domain/message/version.hpp
+++ b/src/domain/include/kth/domain/message/version.hpp
@@ -31,34 +31,45 @@ struct KD_API version {
     using const_ptr = std::shared_ptr<const version>;
 
     enum level : uint32_t {
-        // compact blocks protocol FIX
-        bip152_fix = 70015,  //TODO(fernando): See how to name this, because there is no BIP for that...
+        // Feature negotiation before verack (BIP155 sendaddrv2 support)
+        // BCHN: FEATURE_NEGOTIATION_BEFORE_VERACK_VERSION
+        feature_negotiation = 70016,
 
-        // compact blocks protocol
+        // Not banning for invalid compact blocks
+        // BCHN: INVALID_CB_NO_BAN_VERSION
+        invalid_cb_no_ban = 70015,
+
+        // Short-id-based block download (compact blocks, BIP152)
+        // BCHN: SHORT_IDS_BLOCKS_VERSION
         bip152 = 70014,
 
-        // fee_filter
+        // Fee filter (BIP133)
+        // BCHN: FEEFILTER_VERSION
         bip133 = 70013,
 
-        // send_headers
+        // Send headers (BIP130)
+        // BCHN: SENDHEADERS_VERSION
         bip130 = 70012,
 
-        // node_bloom service bit
+        // Node bloom service bit (BIP111)
+        // BCHN: NO_BLOOM_VERSION
         bip111 = 70011,
 
-        // node_utxo service bit (draft)
+        // Node UTXO service bit (BIP64, draft only)
         bip64 = 70004,
 
-        // reject (satoshi node writes version.relay starting here)
+        // Reject message (BIP61, deprecated)
         bip61 = 70002,
 
-        // filters, merkle_block, not_found, version.relay
+        // Bloom filters, merkle_block, not_found, version.relay (BIP37)
         bip37 = 70001,
 
-        // memory_pool
+        // Memory pool (BIP35)
         bip35 = 60002,
 
-        // ping.nonce, pong
+        // Ping nonce, pong (BIP31) - first version with BIP31 support
+        // Note: BCHN defines BIP0031_VERSION = 60000 and uses `> 60000`
+        // We define bip31 = 60001 and use `>= bip31` (equivalent logic)
         bip31 = 60001,
 
         // Don't request blocks from nodes of versions 32000-32400.
@@ -67,7 +78,8 @@ struct KD_API version {
         // Don't request blocks from nodes of versions 32000-32400.
         no_blocks_start = 32000,
 
-    // This preceded the BIP system.
+        // Minimum version for headers-first sync
+        // BCHN: MIN_PEER_PROTO_VERSION
 #if defined(KTH_CURRENCY_LTC)
         headers = 70002,
 #else
@@ -77,36 +89,73 @@ struct KD_API version {
         // We require at least this of peers, address.time fields.
         minimum = 31402,
 
+        // Initial protocol version before negotiation
+        // BCHN: INIT_PROTO_VERSION
+        initial = 209,
+
         // We support at most this internally (bound to settings default).
-        maximum = bip152_fix,
+        // BCHN: PROTOCOL_VERSION
+        maximum = feature_negotiation,
 
         // Used to generate canonical size required by consensus checks.
         canonical = 0
     };
 
     enum service : uint64_t {
-        // The node exposes no services.
+        // Nothing
         none = 0,
 
-        // The node is capable of serving the block chain (full node).
+        // NODE_NETWORK means that the node is capable of serving the complete block
+        // chain. It is currently set by all non-pruned nodes, and is unset by SPV
+        // clients or other light clients.
         node_network = (1U << 0),
 
-        // Requires version.value >= level::bip64 (BIP64 is draft only).
-        // The node is capable of responding to the getutxo protocol request.
-        node_utxo = (1U << 1),
+        // NODE_GETUTXO means the node is capable of responding to the getutxo
+        // protocol request. See BIP64 for details on how this is implemented.
+        node_getutxo = (1U << 1),
 
-        // Requires version.value >= level::bip111
-
-        // The node is capable and willing to handle bloom-filtered connections.
+        // NODE_BLOOM means the node is capable and willing to handle bloom-filtered
+        // connections. Nodes used to support this by default, without advertising
+        // this bit, but no longer do as of protocol version 70011 (= NO_BLOOM_VERSION)
         node_bloom = (1U << 2),
 
-        // // Independent of network protocol level.
-        // // The node is capable of responding to witness inventory requests.
-        // node_witness = (1U << 3),
+        // Bit 3 is reserved (was NODE_WITNESS in BTC)
 
 #if defined(KTH_CURRENCY_BCH)
-        node_network_cash = (1U << 5)  //TODO(kth): check what happens with node_network (or node_network_cash)
-#endif                                //KTH_CURRENCY_BCH
+        // NODE_XTHIN means the node supports Xtreme Thinblocks. If this is turned
+        // off then the node will not service nor make xthin requests.
+        node_xthin = (1U << 4),
+
+        // NODE_BITCOIN_CASH means the node supports Bitcoin Cash and the
+        // associated consensus rule changes.
+        // This service bit is intended to be used prior until some time after the
+        // UAHF activation when the Bitcoin Cash network has adequately separated.
+        // TODO: remove (free up) the NODE_BITCOIN_CASH service bit once no longer needed.
+        node_bitcoin_cash = (1U << 5),
+
+        // NODE_GRAPHENE means the node supports Graphene blocks.
+        // If this is turned off then the node will not service graphene requests
+        // nor make graphene requests.
+        node_graphene = (1U << 6),
+
+        // NODE_CF means that the node supports BIP 157/158 style
+        // compact filters on block data.
+        node_compact_filters = (1U << 8),
+#endif  // KTH_CURRENCY_BCH
+
+        // NODE_NETWORK_LIMITED means the same as NODE_NETWORK with the limitation
+        // of only serving the last 288 (2 day) blocks.
+        // See BIP159 for details on how this is implemented.
+        node_network_limited = (1U << 10),
+
+#if defined(KTH_CURRENCY_BCH)
+        // NODE_EXTVERSION indicates if node is using extversion.
+        node_extversion = (1U << 11),
+#endif  // KTH_CURRENCY_BCH
+
+        // The last non-experimental service bit, helper for looping over the flags.
+        // Bits 24-31 are reserved for temporary experiments.
+        node_last_non_experimental = (1U << 23)
     };
 
     version() = default;

--- a/src/infrastructure/CMakeLists.txt
+++ b/src/infrastructure/CMakeLists.txt
@@ -228,6 +228,7 @@ set(kth_sources_just_legacy
         src/utility/scope_lock.cpp
 
         src/utility/sequential_lock.cpp
+        src/utility/stats.cpp
         src/utility/string.cpp
         src/utility/system_memory.cpp
         src/utility/thread.cpp
@@ -396,6 +397,7 @@ set(kth_headers
     include/kth/infrastructure/utility/pseudo_random_broken_do_not_use.hpp
 
     include/kth/infrastructure/utility/reader.hpp
+    include/kth/infrastructure/utility/salted_hashers.hpp
     include/kth/infrastructure/utility/scope_lock.hpp
     include/kth/infrastructure/utility/sequential_lock.hpp
     include/kth/infrastructure/utility/serializer.hpp

--- a/src/infrastructure/include/kth/infrastructure.hpp
+++ b/src/infrastructure/include/kth/infrastructure.hpp
@@ -101,6 +101,7 @@
 #include <kth/infrastructure/utility/pseudo_random.hpp>
 #include <kth/infrastructure/utility/pseudo_random_broken_do_not_use.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
+#include <kth/infrastructure/utility/salted_hashers.hpp>
 #include <kth/infrastructure/utility/scope_lock.hpp>
 #include <kth/infrastructure/utility/sequential_lock.hpp>
 #include <kth/infrastructure/utility/serializer.hpp>

--- a/src/infrastructure/include/kth/infrastructure/config/authority.hpp
+++ b/src/infrastructure/include/kth/infrastructure/config/authority.hpp
@@ -5,6 +5,8 @@
 #ifndef KTH_INFRASTUCTURE_CONFIG_AUTHORITY_HPP
 #define KTH_INFRASTUCTURE_CONFIG_AUTHORITY_HPP
 
+//TODO: Refactor
+
 #include <cstdint>
 #include <iostream>
 #include <string>

--- a/src/infrastructure/include/kth/infrastructure/utility/salted_hashers.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/salted_hashers.hpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_INFRASTRUCTURE_SALTED_HASHERS_HPP
+#define KTH_INFRASTRUCTURE_SALTED_HASHERS_HPP
+
+#include <array>
+#include <cstdint>
+
+#include <kth/infrastructure/define.hpp>
+#include <kth/infrastructure/math/sip_hash.hpp>
+#include <kth/infrastructure/utility/asio.hpp>
+#include <kth/infrastructure/utility/pseudo_random.hpp>
+
+namespace kth {
+
+// =============================================================================
+// Salted IP Address Hasher (BCHN-style)
+// =============================================================================
+// Uses SipHash-2-4 with random salt for hash table resistance against
+// collision attacks. Salt is generated once per hasher instance.
+
+struct KI_API salted_ip_hasher {
+    salted_ip_hasher() noexcept {
+        std::array<uint64_t, 2> salt{};
+        pseudo_random::fill(salt);
+        k0_ = salt[0];
+        k1_ = salt[1];
+    }
+
+    size_t operator()(::asio::ip::address const& addr) const noexcept {
+        sip_hasher hasher(k0_, k1_);
+        if (addr.is_v4()) {
+            auto const bytes = addr.to_v4().to_bytes();
+            hasher.write(bytes.data(), bytes.size());
+        } else {
+            auto const bytes = addr.to_v6().to_bytes();
+            hasher.write(bytes.data(), bytes.size());
+        }
+        return size_t(hasher.finalize());
+    }
+
+private:
+    uint64_t k0_;
+    uint64_t k1_;
+};
+
+} // namespace kth
+
+#endif // KTH_INFRASTRUCTURE_SALTED_HASHERS_HPP

--- a/src/infrastructure/include/kth/infrastructure/utility/stats.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/stats.hpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_INFRASTRUCTURE_STATS_HPP
+#define KTH_INFRASTRUCTURE_STATS_HPP
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+
+#include <kth/infrastructure/define.hpp>
+
+namespace kth {
+
+// =============================================================================
+// Compile-time stats toggle
+// =============================================================================
+//
+// When KTH_WITH_STATS is defined, statistics collection is enabled.
+// When disabled, all stats macros compile to no-ops with zero overhead.
+//
+// Usage:
+//   KTH_STATS_DECLARE(my_component)           // In header, declares stats struct
+//   KTH_STATS_TIME_START(my_op)               // Start timing
+//   KTH_STATS_TIME_END(stats, my_op)          // End timing and record
+//   KTH_STATS_INCREMENT(stats, my_counter)    // Increment counter
+//
+// =============================================================================
+
+#ifdef KTH_WITH_STATS
+
+// =============================================================================
+// Stats enabled - full implementation
+// =============================================================================
+
+/// Timing scope helper - RAII-based timing
+struct stats_timer {
+    using clock = std::chrono::steady_clock;
+    clock::time_point start{clock::now()};
+
+    [[nodiscard]]
+    uint64_t elapsed_ns() const {
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(
+            clock::now() - start).count();
+    }
+};
+
+/// Base stats structure with common operations
+struct stats_base {
+    void reset_all() {}  // Override in derived
+};
+
+// Macro to start timing
+#define KTH_STATS_TIME_START(name) \
+    auto const _kth_stats_timer_##name = kth::stats_timer{}
+
+// Macro to end timing and accumulate (also increments count)
+#define KTH_STATS_TIME_END(stats_obj, name, time_field, count_field) \
+    do { \
+        (stats_obj).time_field.fetch_add( \
+            _kth_stats_timer_##name.elapsed_ns(), \
+            std::memory_order_relaxed); \
+        (stats_obj).count_field.fetch_add(1, std::memory_order_relaxed); \
+    } while(0)
+
+// Macro to end timing WITHOUT incrementing count (for batch timing)
+#define KTH_STATS_TIME_ADD(stats_obj, name, time_field) \
+    (stats_obj).time_field.fetch_add( \
+        _kth_stats_timer_##name.elapsed_ns(), \
+        std::memory_order_relaxed)
+
+// Macro to increment a counter
+#define KTH_STATS_INCREMENT(stats_obj, field) \
+    (stats_obj).field.fetch_add(1, std::memory_order_relaxed)
+
+// Macro to add to a counter
+#define KTH_STATS_ADD(stats_obj, field, value) \
+    (stats_obj).field.fetch_add(value, std::memory_order_relaxed)
+
+// Macro to get average time in microseconds
+#define KTH_STATS_AVG_US(stats_obj, time_field, count_field) \
+    ((stats_obj).count_field.load(std::memory_order_relaxed) > 0 \
+        ? (stats_obj).time_field.load(std::memory_order_relaxed) / 1000 / \
+          (stats_obj).count_field.load(std::memory_order_relaxed) \
+        : 0)
+
+// Macro to get average time in milliseconds
+#define KTH_STATS_AVG_MS(stats_obj, time_field, count_field) \
+    ((stats_obj).count_field.load(std::memory_order_relaxed) > 0 \
+        ? (stats_obj).time_field.load(std::memory_order_relaxed) / 1000000 / \
+          (stats_obj).count_field.load(std::memory_order_relaxed) \
+        : 0)
+
+// Conditional code block
+#define KTH_STATS_ENABLED 1
+#define KTH_IF_STATS(code) code
+
+#else // !KTH_WITH_STATS
+
+// =============================================================================
+// Stats disabled - zero overhead no-ops
+// =============================================================================
+
+#define KTH_STATS_TIME_START(name) ((void)0)
+#define KTH_STATS_TIME_END(stats_obj, name, time_field, count_field) ((void)0)
+#define KTH_STATS_TIME_ADD(stats_obj, name, time_field) ((void)0)
+#define KTH_STATS_INCREMENT(stats_obj, field) ((void)0)
+#define KTH_STATS_ADD(stats_obj, field, value) ((void)0)
+#define KTH_STATS_AVG_US(stats_obj, time_field, count_field) (0)
+#define KTH_STATS_AVG_MS(stats_obj, time_field, count_field) (0)
+
+#define KTH_STATS_ENABLED 0
+#define KTH_IF_STATS(code) ((void)0)
+
+#endif // KTH_WITH_STATS
+
+// =============================================================================
+// Sync stats structure - used by header sync and block sync
+// =============================================================================
+
+struct sync_stats {
+    // Header organizer stats
+    std::atomic<uint64_t> validate_calls{0};
+    std::atomic<uint64_t> validate_time_ns{0};
+    std::atomic<uint64_t> hash_calls{0};
+    std::atomic<uint64_t> hash_time_ns{0};
+    std::atomic<uint64_t> index_add_calls{0};
+    std::atomic<uint64_t> index_add_time_ns{0};
+
+    // Header index internal stats
+    std::atomic<uint64_t> find_parent_calls{0};
+    std::atomic<uint64_t> find_parent_time_ns{0};
+    std::atomic<uint64_t> build_skip_calls{0};
+    std::atomic<uint64_t> build_skip_time_ns{0};
+    std::atomic<uint64_t> insert_calls{0};
+    std::atomic<uint64_t> insert_time_ns{0};
+
+    // Batch-level stats (sync_session)
+    std::atomic<uint64_t> batch_count{0};
+    std::atomic<uint64_t> batch_locator_ns{0};
+    std::atomic<uint64_t> batch_network_ns{0};
+    std::atomic<uint64_t> batch_process_ns{0};
+
+    void reset() {
+        validate_calls = 0;
+        validate_time_ns = 0;
+        hash_calls = 0;
+        hash_time_ns = 0;
+        index_add_calls = 0;
+        index_add_time_ns = 0;
+        find_parent_calls = 0;
+        find_parent_time_ns = 0;
+        build_skip_calls = 0;
+        build_skip_time_ns = 0;
+        insert_calls = 0;
+        insert_time_ns = 0;
+        batch_count = 0;
+        batch_locator_ns = 0;
+        batch_network_ns = 0;
+        batch_process_ns = 0;
+    }
+};
+
+// =============================================================================
+// Global stats instance (when enabled)
+// =============================================================================
+
+#ifdef KTH_WITH_STATS
+KI_API sync_stats& global_sync_stats();
+#else
+// When disabled, provide inline stub that does nothing
+inline sync_stats& global_sync_stats() {
+    static sync_stats dummy;
+    return dummy;
+}
+#endif
+
+} // namespace kth
+
+#endif // KTH_INFRASTRUCTURE_STATS_HPP

--- a/src/infrastructure/src/utility/stats.cpp
+++ b/src/infrastructure/src/utility/stats.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/infrastructure/utility/stats.hpp>
+
+#ifdef KTH_WITH_STATS
+
+namespace kth {
+
+sync_stats& global_sync_stats() {
+    static sync_stats instance;
+    return instance;
+}
+
+} // namespace kth
+
+#endif // KTH_WITH_STATS

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -92,7 +92,9 @@ endif()
 
 # Modern coroutine-based headers (KEEP)
 set(kth_headers
+  include/kth/network/banlist.hpp
   include/kth/network/define.hpp
+  include/kth/network/net_permissions.hpp
   include/kth/network/peer_session.hpp
   include/kth/network/peer_manager.hpp
   include/kth/network/p2p_node.hpp
@@ -141,6 +143,8 @@ set(kth_headers
 
 # Modern coroutine-based sources (KEEP)
 set(kth_sources
+  src/banlist.cpp
+  src/net_permissions.cpp
   src/p2p_node.cpp
   src/peer_session.cpp
   src/peer_manager.cpp

--- a/src/network/include/kth/network/banlist.hpp
+++ b/src/network/include/kth/network/banlist.hpp
@@ -1,0 +1,157 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NETWORK_BANLIST_HPP
+#define KTH_NETWORK_BANLIST_HPP
+
+#include <chrono>
+#include <expected>
+#include <string>
+
+#include <boost/unordered/concurrent_flat_map.hpp>
+
+#include <kth/infrastructure.hpp>
+#include <kth/network/define.hpp>
+
+namespace kth::network {
+
+// =============================================================================
+// Ban Reason (BCHN-style)
+// =============================================================================
+
+enum class ban_reason : uint8_t {
+    unknown = 0,
+    node_misbehaving = 1,      // Misbehavior (invalid messages, etc.)
+    manually_added = 2,        // Manually banned by user
+    checkpoint_failed = 3,     // Sent headers failing checkpoint (wrong chain)
+};
+
+// =============================================================================
+// Ban Entry
+// =============================================================================
+// Represents a single ban entry with creation time, expiration, and reason.
+// Based on BCHN's CBanEntry.
+
+struct KN_API ban_entry {
+    using clock = std::chrono::system_clock;
+    using time_point = clock::time_point;
+
+    time_point create_time{clock::now()};
+    time_point ban_until{};
+    ban_reason reason{ban_reason::unknown};
+
+    /// Check if the ban has expired
+    [[nodiscard]]
+    constexpr bool is_expired() const {
+        return clock::now() >= ban_until;
+    }
+
+    /// Get remaining ban duration
+    [[nodiscard]]
+    std::chrono::seconds remaining() const {
+        auto const now = clock::now();
+        if (now >= ban_until) {
+            return std::chrono::seconds{0};
+        }
+        return std::chrono::duration_cast<std::chrono::seconds>(ban_until - now);
+    }
+};
+
+// =============================================================================
+// Banlist
+// =============================================================================
+// Thread-safe banlist using boost::concurrent_flat_map.
+// Based on BCHN's CBanDB.
+// Bans by IP address only (port is ignored).
+
+class KN_API banlist {
+public:
+    using clock = std::chrono::system_clock;
+    static constexpr auto default_ban_duration = std::chrono::hours{24};
+
+    /// Construct banlist with optional persistence file
+    explicit banlist(kth::path file_path = {});
+
+    /// Ban an IP address
+    /// @param ip The IP address to ban
+    /// @param duration How long to ban (default 24 hours)
+    /// @param reason Why the peer is being banned
+    void ban(
+        ::asio::ip::address const& ip,
+        std::chrono::seconds duration = default_ban_duration,
+        ban_reason reason = ban_reason::node_misbehaving);
+
+    /// Ban an authority (IP:port, port is ignored)
+    void ban(
+        infrastructure::config::authority const& authority,
+        std::chrono::seconds duration = default_ban_duration,
+        ban_reason reason = ban_reason::node_misbehaving);
+
+    /// Unban an IP address
+    /// @return true if the IP was banned and is now unbanned
+    bool unban(::asio::ip::address const& ip);
+
+    /// Unban an authority
+    bool unban(infrastructure::config::authority const& authority);
+
+    /// Check if an IP address is banned
+    [[nodiscard]]
+    bool is_banned(::asio::ip::address const& ip) const;
+
+    /// Check if an authority is banned
+    [[nodiscard]]
+    bool is_banned(infrastructure::config::authority const& authority) const;
+
+    /// Get ban entry for an IP (if banned)
+    [[nodiscard]]
+    std::optional<ban_entry> get_ban(::asio::ip::address const& ip) const;
+
+    /// Get number of bans (includes expired, use sweep_expired() to clean)
+    [[nodiscard]]
+    size_t size() const;
+
+    /// Clear all bans
+    void clear();
+
+    /// Remove expired bans
+    void sweep_expired();
+
+    /// Load banlist from file
+    /// @return true on success, false on failure
+    bool load();
+
+    /// Save banlist to file
+    /// @return true on success, false on failure
+    bool save() const;
+
+    /// Get all current bans (for debugging/display)
+    [[nodiscard]]
+    std::vector<std::pair<std::string, ban_entry>> get_all_bans() const;
+
+private:
+    // boost::concurrent_flat_map provides thread-safe operations without mutex
+    // Uses salted_ip_hasher for hash table collision resistance (BCHN-style)
+    boost::concurrent_flat_map<::asio::ip::address, ban_entry, ::kth::salted_ip_hasher> bans_;
+    kth::path file_path_;
+};
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/// Convert ban_reason to string
+[[nodiscard]]
+constexpr std::string_view to_string(ban_reason reason) {
+    switch (reason) {
+        case ban_reason::unknown: return "unknown";
+        case ban_reason::node_misbehaving: return "misbehaving";
+        case ban_reason::manually_added: return "manually added";
+        case ban_reason::checkpoint_failed: return "checkpoint failed (wrong chain)";
+    }
+    return "unknown";
+}
+
+} // namespace kth::network
+
+#endif // KTH_NETWORK_BANLIST_HPP

--- a/src/network/include/kth/network/net_permissions.hpp
+++ b/src/network/include/kth/network/net_permissions.hpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NETWORK_NET_PERMISSIONS_HPP
+#define KTH_NETWORK_NET_PERMISSIONS_HPP
+
+#include <cstdint>
+#include <expected>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <kth/infrastructure/config/authority.hpp>
+#include <kth/network/define.hpp>
+
+namespace kth::network {
+
+// =============================================================================
+// Permission Flags
+// =============================================================================
+// Based on BCHN's NetPermissionFlags (net_permissions.h)
+//
+// These flags control what a peer is allowed to do and whether they can be
+// banned/disconnected for misbehavior.
+
+enum class permission_flags : uint32_t {
+    none = 0,
+
+    // Can query bloomfilter even if bloom filters are disabled
+    bloomfilter = 1U << 1,
+
+    // Always relay transactions from this peer, even if already in mempool
+    // or rejected from policy. Implies relay.
+    forcerelay = 1U << 2,
+
+    // Relay and accept transactions from this peer, even if -blocksonly is true.
+    // This peer is also not subject to limits on how many transaction INVs are tracked.
+    relay = 1U << 3,
+
+    // Can't be banned/disconnected/discouraged for misbehavior.
+    // Used for trusted peers (whitelisted IPs, manual connections).
+    noban = 1U << 4,
+
+    // Can query the mempool
+    mempool = 1U << 5,
+
+    // Can request addrs without hitting a privacy-preserving cache,
+    // and send us unlimited amounts of addrs.
+    addr = 1U << 7,
+
+    // True if the user did not specifically set fine-grained permissions.
+    // When set, default permissions are applied based on legacy whitelist behavior.
+    is_implicit = 1U << 31,
+
+    // All permissions combined
+    all = bloomfilter | forcerelay | relay | noban | mempool | addr
+};
+
+// Bitwise operators for permission_flags
+constexpr permission_flags operator|(permission_flags a, permission_flags b) {
+    return permission_flags(uint32_t(a) | uint32_t(b));
+}
+
+constexpr permission_flags operator&(permission_flags a, permission_flags b) {
+    return permission_flags(uint32_t(a) & uint32_t(b));
+}
+
+constexpr permission_flags operator~(permission_flags a) {
+    return permission_flags(~uint32_t(a));
+}
+
+constexpr permission_flags& operator|=(permission_flags& a, permission_flags b) {
+    return a = a | b;
+}
+
+constexpr permission_flags& operator&=(permission_flags& a, permission_flags b) {
+    return a = a & b;
+}
+
+// =============================================================================
+// Permission Utilities (free functions)
+// =============================================================================
+
+/// Check if a specific permission flag is set
+[[nodiscard]]
+constexpr bool has_permission(permission_flags flags, permission_flags flag) {
+    return (flags & flag) == flag;
+}
+
+/// Add a permission flag
+constexpr void add_permission(permission_flags& flags, permission_flags flag) {
+    flags |= flag;
+}
+
+/// Remove a permission flag
+constexpr void clear_permission(permission_flags& flags, permission_flags flag) {
+    flags &= ~flag;
+}
+
+/// Convert permission flags to human-readable strings
+[[nodiscard]]
+KN_API std::vector<std::string> to_strings(permission_flags flags);
+
+/// Parse permission string (e.g., "noban,relay,mempool")
+/// Returns permission_flags on success, error message on failure
+[[nodiscard]]
+KN_API std::expected<permission_flags, std::string> parse_permissions(std::string_view str);
+
+// =============================================================================
+// Whitelist Permission Entry
+// =============================================================================
+// Represents a whitelisted subnet with associated permissions.
+// Parsed from config like: -whitelist=noban,relay@192.168.1.0/24
+
+struct KN_API whitelist_permissions {
+    permission_flags flags{permission_flags::none};
+    infrastructure::config::authority subnet;  // IP or subnet to match
+};
+
+/// Parse whitelist entry string
+/// Format: [permissions@]<IP|subnet>
+/// Examples:
+///   "192.168.1.0/24"           -> implicit permissions
+///   "noban@192.168.1.0/24"     -> noban permission
+///   "noban,relay@10.0.0.1"     -> noban + relay permissions
+[[nodiscard]]
+KN_API std::expected<whitelist_permissions, std::string> parse_whitelist(std::string_view str);
+
+// =============================================================================
+// Whitebind Permission Entry
+// =============================================================================
+// Represents a bind address with associated permissions for incoming connections.
+// Parsed from config like: -whitebind=noban@0.0.0.0:8333
+
+struct KN_API whitebind_permissions {
+    permission_flags flags{permission_flags::none};
+    infrastructure::config::authority bind_address;
+};
+
+/// Parse whitebind entry string
+/// Format: [permissions@]<bind_address>
+[[nodiscard]]
+KN_API std::expected<whitebind_permissions, std::string> parse_whitebind(std::string_view str);
+
+} // namespace kth::network
+
+#endif // KTH_NETWORK_NET_PERMISSIONS_HPP

--- a/src/network/include/kth/network/p2p_node.hpp
+++ b/src/network/include/kth/network/p2p_node.hpp
@@ -12,11 +12,13 @@
 #include <string>
 #include <vector>
 
+#include <boost/unordered/concurrent_flat_set.hpp>
 #include <boost/unordered/unordered_flat_map.hpp>
 
 #include <kth/domain.hpp>
 #include <kth/infrastructure.hpp>
 
+#include <kth/network/banlist.hpp>
 #include <kth/network/define.hpp>
 #include <kth/network/hosts.hpp>
 #include <kth/network/peer_manager.hpp>
@@ -227,6 +229,26 @@ public:
     [[nodiscard]]
     message_dispatcher& dispatcher();
 
+    // Banlist management
+    // -------------------------------------------------------------------------
+
+    /// Get the banlist
+    [[nodiscard]]
+    banlist& bans();
+
+    [[nodiscard]]
+    banlist const& bans() const;
+
+    /// Ban a peer (convenience method)
+    void ban_peer(
+        peer_session::ptr const& peer,
+        std::chrono::seconds duration = banlist::default_ban_duration,
+        ban_reason reason = ban_reason::node_misbehaving);
+
+    /// Check if an address is banned
+    [[nodiscard]]
+    bool is_banned(infrastructure::config::authority const& authority) const;
+
 private:
     // Internal coroutines
     ::asio::awaitable<void> run_seeding();
@@ -247,6 +269,11 @@ private:
     threadpool pool_;
     peer_manager manager_;
     hosts hosts_;
+    banlist banlist_;
+
+    // Track IPs currently being connected to (for deduplication)
+    // Prevents multiple simultaneous connection attempts to the same IP
+    boost::concurrent_flat_set<::asio::ip::address, salted_ip_hasher> pending_connections_;
 
     // Acceptor for inbound connections
     std::unique_ptr<::asio::ip::tcp::acceptor> acceptor_;

--- a/src/network/include/kth/network/peer_manager.hpp
+++ b/src/network/include/kth/network/peer_manager.hpp
@@ -83,6 +83,11 @@ public:
     /// @return true if exists
     ::asio::awaitable<bool> exists_by_authority(infrastructure::config::authority const& authority) const;
 
+    /// Check if a peer with the given IP exists (ignores port)
+    /// @param ip The IP address to check
+    /// @return true if exists
+    ::asio::awaitable<bool> exists_by_ip(::asio::ip::address const& ip) const;
+
     /// Find a peer by nonce
     /// @param nonce The nonce to find
     /// @return The peer session or nullptr if not found

--- a/src/network/include/kth/network/peer_session.hpp
+++ b/src/network/include/kth/network/peer_session.hpp
@@ -16,6 +16,7 @@
 #include <kth/domain.hpp>
 #include <kth/infrastructure.hpp>
 #include <kth/network/define.hpp>
+#include <kth/network/net_permissions.hpp>
 #include <kth/network/settings.hpp>
 
 // Asio includes for coroutines
@@ -71,7 +72,10 @@ public:
     using inbound_channel = concurrent_channel<raw_message>;
 
     /// Construct a peer session from an established socket
-    peer_session(socket_type socket, settings const& settings);
+    /// @param socket The connected socket
+    /// @param settings Network settings
+    /// @param inbound True if this is an inbound connection (we accepted it)
+    peer_session(socket_type socket, settings const& settings, bool inbound = false);
 
     /// Destructor - ensures clean shutdown
     ~peer_session();
@@ -172,6 +176,53 @@ public:
     bool notify() const;
     void set_notify(bool value);
 
+    /// Check if this is an inbound connection (peer connected to us)
+    [[nodiscard]]
+    bool is_inbound() const;
+
+    /// Check if this is an outbound connection (we connected to peer)
+    /// BCHN prefers outbound peers for sync (fPreferredDownload)
+    [[nodiscard]]
+    bool is_outbound() const;
+
+    /// Check if peer is a full node (has NODE_NETWORK or NODE_NETWORK_LIMITED service)
+    /// BCHN: fClient = !(services & NODE_NETWORK) && !(services & NODE_NETWORK_LIMITED)
+    [[nodiscard]]
+    bool is_full_node() const;
+
+    /// Check if peer is a light client (no NODE_NETWORK service)
+    [[nodiscard]]
+    bool is_client() const;
+
+    /// Check if this is a one-shot connection (connect, get addrs, disconnect)
+    [[nodiscard]]
+    bool is_one_shot() const;
+
+    /// Mark this as a one-shot connection
+    void set_one_shot(bool value);
+
+    /// Check if peer has a specific permission
+    [[nodiscard]]
+    bool has_permission(permission_flags flag) const;
+
+    /// Get all permission flags for this peer
+    [[nodiscard]]
+    permission_flags permissions() const;
+
+    /// Set permission flags for this peer
+    void set_permissions(permission_flags flags);
+
+    /// Add a permission flag
+    void add_permission(permission_flags flag);
+
+    /// Remove a permission flag
+    void clear_permission(permission_flags flag);
+
+    /// Check if this peer is preferred for download (BCHN fPreferredDownload)
+    /// fPreferredDownload = (!fInbound || HasPermission(PF_NOBAN)) && !fOneShot && !fClient
+    [[nodiscard]]
+    bool is_preferred_download() const;
+
 private:
     // -------------------------------------------------------------------------
     // Internal coroutines
@@ -234,6 +285,13 @@ private:
     std::atomic<uint64_t> nonce_{0};
     std::atomic<bool> notify_{true};
     kth::atomic<domain::message::version::const_ptr> peer_version_;
+
+    // Connection direction (set at construction, never changes)
+    bool const inbound_connection_;
+
+    // Connection flags (can be set after construction)
+    std::atomic<bool> one_shot_{false};
+    std::atomic<uint32_t> permission_flags_{uint32_t(permission_flags::none)};
 
     // Buffers (only accessed from read_loop, no synchronization needed)
     data_chunk heading_buffer_;

--- a/src/network/include/kth/network/settings.hpp
+++ b/src/network/include/kth/network/settings.hpp
@@ -12,6 +12,7 @@
 #include <kth/infrastructure.hpp>
 
 #include <kth/network/define.hpp>
+#include <kth/network/net_permissions.hpp>
 
 namespace kth::network {
 
@@ -66,6 +67,18 @@ struct KN_API settings {
 #endif
     ;
 
+    // Whitelist configuration (BCHN-style permissions)
+    // Peers matching these subnets get special permissions
+    std::vector<whitelist_permissions> whitelist;
+
+    // Whitebind configuration
+    // Bind addresses with permissions for incoming connections
+    std::vector<whitebind_permissions> whitebind;
+
+    // Legacy whitelist behavior flags (BCHN compatibility)
+    bool whitelist_force_relay{false};  // -whitelistforcerelay
+    bool whitelist_relay{true};         // -whitelistrelay
+
     /// Helpers.
     asio::duration connect_timeout() const;
     asio::duration channel_handshake() const;
@@ -73,6 +86,17 @@ struct KN_API settings {
     asio::duration channel_inactivity() const;
     asio::duration channel_expiration() const;
     asio::duration channel_germination() const;
+
+    /// Get permissions for an address based on whitelist configuration
+    /// Returns permission_flags::none if address is not whitelisted
+    [[nodiscard]]
+    permission_flags get_whitelist_permissions(
+        infrastructure::config::authority const& addr) const;
+
+    /// Apply legacy whitelist behavior to implicit permissions
+    /// (BCHN: -whitelistforcerelay, -whitelistrelay)
+    [[nodiscard]]
+    permission_flags apply_legacy_whitelist_permissions(permission_flags flags) const;
 };
 
 } // namespace kth::network

--- a/src/network/src/banlist.cpp
+++ b/src/network/src/banlist.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/network/banlist.hpp>
+
+#include <fstream>
+#include <sstream>
+#include <system_error>
+
+#include <spdlog/spdlog.h>
+
+namespace kth::network {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+banlist::banlist(kth::path file_path)
+    : file_path_(std::move(file_path))
+{}
+
+// =============================================================================
+// Ban/Unban operations
+// =============================================================================
+
+void banlist::ban(
+    ::asio::ip::address const& ip,
+    std::chrono::seconds duration,
+    ban_reason reason)
+{
+    ban_entry entry;
+    entry.create_time = clock::now();
+    entry.ban_until = entry.create_time + duration;
+    entry.reason = reason;
+
+    bans_.insert_or_assign(ip, entry);
+
+    spdlog::info("[banlist] Banned {} for {}s, reason: {}",
+        ip.to_string(), duration.count(), to_string(reason));
+}
+
+void banlist::ban(
+    infrastructure::config::authority const& authority,
+    std::chrono::seconds duration,
+    ban_reason reason)
+{
+    ban(authority.asio_ip(), duration, reason);
+}
+
+bool banlist::unban(::asio::ip::address const& ip) {
+    auto const erased = bans_.erase(ip);
+    if (erased > 0) {
+        spdlog::info("[banlist] Unbanned {}", ip.to_string());
+        return true;
+    }
+    return false;
+}
+
+bool banlist::unban(infrastructure::config::authority const& authority) {
+    return unban(authority.asio_ip());
+}
+
+// =============================================================================
+// Query operations
+// =============================================================================
+
+bool banlist::is_banned(::asio::ip::address const& ip) const {
+    bool banned = false;
+    bans_.cvisit(ip, [&banned](auto const& entry) {
+        banned = ! entry.second.is_expired();
+    });
+    return banned;
+}
+
+bool banlist::is_banned(infrastructure::config::authority const& authority) const {
+    return is_banned(authority.asio_ip());
+}
+
+std::optional<ban_entry> banlist::get_ban(::asio::ip::address const& ip) const {
+    std::optional<ban_entry> result;
+    bans_.cvisit(ip, [&result](auto const& entry) {
+        if ( ! entry.second.is_expired()) {
+            result = entry.second;
+        }
+    });
+    return result;
+}
+
+size_t banlist::size() const {
+    return bans_.size();
+}
+
+void banlist::clear() {
+    bans_.clear();
+    spdlog::info("[banlist] Cleared all bans");
+}
+
+void banlist::sweep_expired() {
+    size_t removed = 0;
+
+    bans_.erase_if([&removed](auto const& entry) {
+        if (entry.second.is_expired()) {
+            spdlog::debug("[banlist] Expired ban removed for {}", entry.first.to_string());
+            ++removed;
+            return true;
+        }
+        return false;
+    });
+
+    if (removed > 0) {
+        spdlog::debug("[banlist] Swept {} expired bans", removed);
+    }
+}
+
+std::vector<std::pair<std::string, ban_entry>> banlist::get_all_bans() const {
+    std::vector<std::pair<std::string, ban_entry>> result;
+
+    bans_.cvisit_all([&result](auto const& entry) {
+        if ( ! entry.second.is_expired()) {
+            result.emplace_back(entry.first.to_string(), entry.second);
+        }
+    });
+
+    return result;
+}
+
+// =============================================================================
+// Persistence
+// =============================================================================
+
+bool banlist::load() {
+    if (file_path_.empty()) {
+        return true;  // No persistence configured
+    }
+
+    std::ifstream file(file_path_);
+    if ( ! file.is_open()) {
+        // File doesn't exist yet - that's OK
+        return true;
+    }
+
+    bans_.clear();
+
+    std::string line;
+    size_t loaded = 0;
+
+    while (std::getline(file, line)) {
+        if (line.empty() || line[0] == '#') {
+            continue;  // Skip empty lines and comments
+        }
+
+        std::istringstream iss(line);
+        std::string ip_str;
+        int64_t create_time_epoch;
+        int64_t ban_until_epoch;
+        int reason_int;
+
+        if (iss >> ip_str >> create_time_epoch >> ban_until_epoch >> reason_int) {
+            std::error_code ec;
+            auto const ip = ::asio::ip::make_address(ip_str, ec);
+            if (ec) {
+                spdlog::warn("[banlist] Invalid IP address in banlist file: {}", ip_str);
+                continue;
+            }
+
+            ban_entry entry;
+            entry.create_time = clock::time_point(std::chrono::seconds(create_time_epoch));
+            entry.ban_until = clock::time_point(std::chrono::seconds(ban_until_epoch));
+            entry.reason = ban_reason(reason_int);
+
+            // Only load non-expired bans
+            if ( ! entry.is_expired()) {
+                bans_.insert_or_assign(ip, entry);
+                ++loaded;
+            }
+        }
+    }
+
+    spdlog::info("[banlist] Loaded {} bans from {}", loaded, file_path_.string());
+    return true;
+}
+
+bool banlist::save() const {
+    if (file_path_.empty()) {
+        return true;  // No persistence configured
+    }
+
+    std::ofstream file(file_path_);
+    if ( ! file.is_open()) {
+        spdlog::error("[banlist] Failed to open {} for writing", file_path_.string());
+        return false;
+    }
+
+    file << "# Knuth banlist - format: IP create_time ban_until reason\n";
+
+    size_t saved = 0;
+    bans_.cvisit_all([&file, &saved](auto const& entry) {
+        if ( ! entry.second.is_expired()) {
+            auto const create_epoch = std::chrono::duration_cast<std::chrono::seconds>(
+                entry.second.create_time.time_since_epoch()).count();
+            auto const until_epoch = std::chrono::duration_cast<std::chrono::seconds>(
+                entry.second.ban_until.time_since_epoch()).count();
+
+            file << entry.first.to_string() << ' '
+                 << create_epoch << ' '
+                 << until_epoch << ' '
+                 << int(entry.second.reason) << '\n';
+            ++saved;
+        }
+    });
+
+    spdlog::debug("[banlist] Saved {} bans to {}", saved, file_path_.string());
+    return true;
+}
+
+} // namespace kth::network

--- a/src/network/src/net_permissions.cpp
+++ b/src/network/src/net_permissions.cpp
@@ -1,0 +1,191 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/network/net_permissions.hpp>
+
+#include <algorithm>
+#include <cctype>
+
+namespace kth::network {
+
+// =============================================================================
+// Permission Utilities
+// =============================================================================
+
+std::vector<std::string> to_strings(permission_flags flags) {
+    std::vector<std::string> result;
+
+    if (has_permission(flags, permission_flags::bloomfilter)) {
+        result.emplace_back("bloomfilter");
+    }
+    if (has_permission(flags, permission_flags::forcerelay)) {
+        result.emplace_back("forcerelay");
+    } else if (has_permission(flags, permission_flags::relay)) {
+        // Only add relay if forcerelay isn't set (forcerelay implies relay)
+        result.emplace_back("relay");
+    }
+    if (has_permission(flags, permission_flags::noban)) {
+        result.emplace_back("noban");
+    }
+    if (has_permission(flags, permission_flags::mempool)) {
+        result.emplace_back("mempool");
+    }
+    if (has_permission(flags, permission_flags::addr)) {
+        result.emplace_back("addr");
+    }
+
+    return result;
+}
+
+std::expected<permission_flags, std::string> parse_permissions(std::string_view str) {
+    auto output = permission_flags::none;
+
+    if (str.empty()) {
+        return output;  // Empty string = no permissions
+    }
+
+    size_t pos = 0;
+    while (pos < str.size()) {
+        // Find next comma or end
+        auto const comma = str.find(',', pos);
+        auto token = str.substr(pos, comma == std::string_view::npos ? std::string_view::npos : comma - pos);
+        pos = comma == std::string_view::npos ? str.size() : comma + 1;
+
+        // Trim whitespace
+        while ( ! token.empty() && std::isspace(int(uint8_t(token.front())))) {
+            token.remove_prefix(1);
+        }
+        while ( ! token.empty() && std::isspace(int(uint8_t(token.back())))) {
+            token.remove_suffix(1);
+        }
+
+        if (token.empty()) {
+            continue;
+        }
+
+        // Convert to lowercase for comparison
+        std::string lower(token);
+        std::ranges::transform(lower, lower.begin(),
+            [](unsigned char c) { return std::tolower(c); });
+
+        if (lower == "bloomfilter" || lower == "bloom") {
+            add_permission(output, permission_flags::bloomfilter);
+        } else if (lower == "forcerelay") {
+            add_permission(output, permission_flags::forcerelay);
+        } else if (lower == "relay") {
+            add_permission(output, permission_flags::relay);
+        } else if (lower == "noban") {
+            add_permission(output, permission_flags::noban);
+        } else if (lower == "mempool") {
+            add_permission(output, permission_flags::mempool);
+        } else if (lower == "addr") {
+            add_permission(output, permission_flags::addr);
+        } else if (lower == "all") {
+            add_permission(output, permission_flags::all);
+        } else {
+            return std::unexpected("Unknown permission: " + lower);
+        }
+    }
+
+    return output;
+}
+
+// =============================================================================
+// Whitelist Permission Entry
+// =============================================================================
+
+std::expected<whitelist_permissions, std::string> parse_whitelist(std::string_view str) {
+    if (str.empty()) {
+        return std::unexpected("Empty whitelist entry");
+    }
+
+    whitelist_permissions output;
+
+    // Check for permissions@address format
+    auto const at_pos = str.find('@');
+    std::string_view address_str;
+    std::string_view permissions_str;
+
+    if (at_pos != std::string_view::npos) {
+        permissions_str = str.substr(0, at_pos);
+        address_str = str.substr(at_pos + 1);
+    } else {
+        // No @ sign - entire string is the address, use implicit permissions
+        address_str = str;
+        output.flags = permission_flags::is_implicit;
+    }
+
+    // Parse permissions if present
+    if ( ! permissions_str.empty()) {
+        auto result = parse_permissions(permissions_str);
+        if ( ! result) {
+            return std::unexpected(result.error());
+        }
+        output.flags = *result;
+    }
+
+    // Parse address/subnet
+    if (address_str.empty()) {
+        return std::unexpected("Missing address in whitelist entry");
+    }
+
+    // Try to parse as authority (IP:port or just IP)
+    try {
+        output.subnet = infrastructure::config::authority(std::string(address_str));
+    } catch (std::exception const& e) {
+        return std::unexpected("Invalid address: " + std::string(e.what()));
+    }
+
+    return output;
+}
+
+// =============================================================================
+// Whitebind Permission Entry
+// =============================================================================
+
+std::expected<whitebind_permissions, std::string> parse_whitebind(std::string_view str) {
+    if (str.empty()) {
+        return std::unexpected("Empty whitebind entry");
+    }
+
+    whitebind_permissions output;
+
+    // Check for permissions@address format
+    auto const at_pos = str.find('@');
+    std::string_view address_str;
+    std::string_view permissions_str;
+
+    if (at_pos != std::string_view::npos) {
+        permissions_str = str.substr(0, at_pos);
+        address_str = str.substr(at_pos + 1);
+    } else {
+        // No @ sign - entire string is the bind address, use implicit permissions
+        address_str = str;
+        output.flags = permission_flags::is_implicit;
+    }
+
+    // Parse permissions if present
+    if ( ! permissions_str.empty()) {
+        auto result = parse_permissions(permissions_str);
+        if ( ! result) {
+            return std::unexpected(result.error());
+        }
+        output.flags = *result;
+    }
+
+    // Parse bind address
+    if (address_str.empty()) {
+        return std::unexpected("Missing bind address in whitebind entry");
+    }
+
+    try {
+        output.bind_address = infrastructure::config::authority(std::string(address_str));
+    } catch (std::exception const& e) {
+        return std::unexpected("Invalid bind address: " + std::string(e.what()));
+    }
+
+    return output;
+}
+
+} // namespace kth::network

--- a/src/network/src/p2p_node.cpp
+++ b/src/network/src/p2p_node.cpp
@@ -130,6 +130,29 @@ message_dispatcher& p2p_node::dispatcher() {
     return dispatcher_;
 }
 
+banlist& p2p_node::bans() {
+    return banlist_;
+}
+
+banlist const& p2p_node::bans() const {
+    return banlist_;
+}
+
+void p2p_node::ban_peer(
+    peer_session::ptr const& peer,
+    std::chrono::seconds duration,
+    ban_reason reason)
+{
+    if (peer) {
+        banlist_.ban(peer->authority(), duration, reason);
+        peer->stop(error::channel_stopped);
+    }
+}
+
+bool p2p_node::is_banned(infrastructure::config::authority const& authority) const {
+    return banlist_.is_banned(authority);
+}
+
 // =============================================================================
 // Message Dispatcher implementation
 // =============================================================================
@@ -212,6 +235,21 @@ awaitable_expected<peer_session::ptr> p2p_node::connect(
     }
 
     auto peer = *result;
+    auto const ip = peer->authority().asio_ip();
+
+    // Check if already connected to this IP
+    if (co_await manager_.exists_by_ip(ip)) {
+        spdlog::debug("[p2p_node] Already connected to IP {}, skipping", ip.to_string());
+        peer->stop();
+        co_return std::unexpected(error::address_in_use);
+    }
+
+    // Check banlist before proceeding
+    if (banlist_.is_banned(peer->authority())) {
+        spdlog::debug("[p2p_node] Rejecting connection to banned peer {}:{}", host, port);
+        peer->stop();
+        co_return std::unexpected(error::address_blocked);
+    }
 
     // Start the session's message pump
     ::asio::co_spawn(executor, peer->run(), ::asio::detached);
@@ -230,8 +268,9 @@ awaitable_expected<peer_session::ptr> p2p_node::connect(
         co_return std::unexpected(handshake_result.error());
     }
 
-    spdlog::info("[p2p_node] Handshake complete with {}:{}, version {}",
-        host, port, handshake_result->negotiated_version);
+    spdlog::info("[p2p_node] Handshake complete with {}:{}, version {}, {}",
+        host, port, handshake_result->negotiated_version,
+        handshake_result->peer_version->user_agent());
 
     // Add to peer manager
     auto ec = co_await manager_.add(peer);
@@ -499,6 +538,14 @@ std::vector<peer_session::ptr> p2p_node::get_peers() const {
 
         // Handle the new connection in a separate coroutine
         ::asio::co_spawn(executor, [this, peer, executor]() -> ::asio::awaitable<void> {
+            // Check banlist before proceeding
+            if (banlist_.is_banned(peer->authority())) {
+                spdlog::debug("[p2p_node] Rejecting inbound connection from banned peer {}",
+                    peer->authority());
+                peer->stop();
+                co_return;
+            }
+
             // Start the session's message pump
             ::asio::co_spawn(executor, peer->run(), ::asio::detached);
 
@@ -516,8 +563,9 @@ std::vector<peer_session::ptr> p2p_node::get_peers() const {
                 co_return;
             }
 
-            spdlog::info("[p2p_node] Inbound handshake complete from {}, version {}",
-                peer->authority(), handshake_result->negotiated_version);
+            spdlog::info("[p2p_node] Inbound handshake complete from {}, version {}, {}",
+                peer->authority(), handshake_result->negotiated_version,
+                handshake_result->peer_version->user_agent());
 
             // Add to peer manager
             auto ec = co_await manager_.add(peer);
@@ -640,12 +688,44 @@ std::vector<peer_session::ptr> p2p_node::get_peers() const {
             std::vector<domain::message::network_address> addresses;
             addresses.reserve(batch_size);
 
-            for (size_t i = 0; i < batch_size && !stopped_; ++i) {
+            // Fetch addresses, filtering out duplicates and already-connected IPs
+            for (size_t attempts = 0; attempts < batch_size * 3 && addresses.size() < batch_size && !stopped_; ++attempts) {
                 domain::message::network_address addr;
                 auto ec = hosts_.fetch(addr);
                 if (ec) {
                     break;
                 }
+
+                auto const authority = infrastructure::config::authority(addr);
+                auto const ip = authority.asio_ip();
+
+                // Skip if already pending connection to this IP
+                if (pending_connections_.contains(ip)) {
+                    continue;
+                }
+
+                // Skip if already connected to this IP
+                if (co_await manager_.exists_by_ip(ip)) {
+                    continue;
+                }
+
+                // Skip if banned
+                if (banlist_.is_banned(ip)) {
+                    continue;
+                }
+
+                // Check for duplicate IP in current batch
+                bool duplicate = false;
+                for (auto const& existing : addresses) {
+                    if (infrastructure::config::authority(existing).asio_ip() == ip) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if (duplicate) {
+                    continue;
+                }
+
                 addresses.push_back(addr);
             }
 
@@ -655,19 +735,24 @@ std::vector<peer_session::ptr> p2p_node::get_peers() const {
                 spdlog::debug("[p2p_node] Attempting {} parallel connections (need {}, have {})",
                     addresses.size(), needed, current_count);
 
-                // Launch connection attempts in parallel
-                std::vector<::asio::awaitable<void>> tasks;
-                tasks.reserve(addresses.size());
-
                 // Track successful connections with a shared atomic counter
                 auto success_count = std::make_shared<std::atomic<size_t>>(0);
 
                 for (auto const& addr : addresses) {
-                    auto task = [this, addr, success_count]() -> ::asio::awaitable<void> {
+                    auto const authority = infrastructure::config::authority(addr);
+                    auto const ip = authority.asio_ip();
+
+                    // Add to pending connections before spawning
+                    pending_connections_.insert(ip);
+
+                    auto task = [this, addr, ip, success_count]() -> ::asio::awaitable<void> {
                         auto const authority = infrastructure::config::authority(addr);
                         spdlog::trace("[p2p_node] Attempting connection to {}", authority);
 
                         auto result = co_await connect(authority.to_hostname(), authority.port());
+
+                        // Remove from pending connections when done
+                        pending_connections_.erase(ip);
 
                         if (!result) {
                             spdlog::trace("[p2p_node] Connection failed to {}: {}",

--- a/src/network/src/peer_manager.cpp
+++ b/src/network/src/peer_manager.cpp
@@ -133,6 +133,17 @@ peer_manager::~peer_manager() {
     }, ::asio::use_awaitable);
 }
 
+::asio::awaitable<bool> peer_manager::exists_by_ip(::asio::ip::address const& ip) const {
+    co_return co_await ::asio::co_spawn(strand_, [this, &ip]() -> ::asio::awaitable<bool> {
+        for (auto const& [nonce, peer] : peers_) {
+            if (peer->authority().asio_ip() == ip) {
+                co_return true;
+            }
+        }
+        co_return false;
+    }, ::asio::use_awaitable);
+}
+
 ::asio::awaitable<peer_session::ptr> peer_manager::find_by_nonce(uint64_t nonce) const {
     co_return co_await ::asio::co_spawn(strand_, [this, nonce]() -> ::asio::awaitable<peer_session::ptr> {
         auto it = peers_.find(nonce);

--- a/src/network/src/peer_session.cpp
+++ b/src/network/src/peer_session.cpp
@@ -36,7 +36,7 @@ infrastructure::config::authority extract_authority(::asio::ip::tcp::socket cons
 // Construction / Destruction
 // =============================================================================
 
-peer_session::peer_session(socket_type socket, settings const& settings)
+peer_session::peer_session(socket_type socket, settings const& settings, bool inbound)
     : socket_(std::move(socket))
     , strand_(socket_.get_executor())
     , outbound_(strand_, 100)  // Buffer up to 100 outbound messages
@@ -56,9 +56,11 @@ peer_session::peer_session(socket_type socket, settings const& settings)
     , inactivity_timeout_(std::chrono::minutes(settings.channel_inactivity_minutes))
     , expiration_timeout_(std::chrono::minutes(settings.channel_expiration_minutes))
     , version_(settings.protocol_maximum)
+    , inbound_connection_(inbound)
     , heading_buffer_(heading::maximum_size())
 {
-    spdlog::debug("[peer_session] Constructor completed, authority: {}", authority());
+    spdlog::debug("[peer_session] Constructor completed, authority: {}, inbound: {}",
+        authority(), inbound_connection_);
 }
 
 peer_session::~peer_session() {
@@ -196,6 +198,73 @@ bool peer_session::notify() const {
 
 void peer_session::set_notify(bool value) {
     notify_.store(value);
+}
+
+bool peer_session::is_inbound() const {
+    return inbound_connection_;
+}
+
+bool peer_session::is_outbound() const {
+    return !inbound_connection_;
+}
+
+bool peer_session::is_full_node() const {
+    auto version = peer_version();
+    if (!version) {
+        return false;  // Unknown, assume not full node
+    }
+
+    // BCHN: fClient = !(services & NODE_NETWORK) && !(services & NODE_NETWORK_LIMITED)
+    // A full node has NODE_NETWORK or NODE_NETWORK_LIMITED
+    auto const services = version->services();
+    using svc = domain::message::version::service;
+    return (services & svc::node_network) != 0
+        || (services & svc::node_network_limited) != 0;
+}
+
+bool peer_session::is_client() const {
+    return !is_full_node();
+}
+
+bool peer_session::is_one_shot() const {
+    return one_shot_.load(std::memory_order_relaxed);
+}
+
+void peer_session::set_one_shot(bool value) {
+    one_shot_.store(value, std::memory_order_relaxed);
+}
+
+bool peer_session::has_permission(permission_flags flag) const {
+    auto const flags = permission_flags(permission_flags_.load(std::memory_order_relaxed));
+    return ::kth::network::has_permission(flags, flag);
+}
+
+permission_flags peer_session::permissions() const {
+    return permission_flags(permission_flags_.load(std::memory_order_relaxed));
+}
+
+void peer_session::set_permissions(permission_flags flags) {
+    permission_flags_.store(uint32_t(flags), std::memory_order_relaxed);
+}
+
+void peer_session::add_permission(permission_flags flag) {
+    auto current = permission_flags_.load(std::memory_order_relaxed);
+    auto const new_flags = current | uint32_t(flag);
+    permission_flags_.store(new_flags, std::memory_order_relaxed);
+}
+
+void peer_session::clear_permission(permission_flags flag) {
+    auto current = permission_flags_.load(std::memory_order_relaxed);
+    auto const new_flags = current & ~uint32_t(flag);
+    permission_flags_.store(new_flags, std::memory_order_relaxed);
+}
+
+bool peer_session::is_preferred_download() const {
+    // BCHN: fPreferredDownload = (!fInbound || HasPermission(PF_NOBAN))
+    //                            && !fOneShot && !fClient
+    return (is_outbound() || has_permission(permission_flags::noban))
+        && !is_one_shot()
+        && !is_client();
 }
 
 // =============================================================================
@@ -424,8 +493,19 @@ awaitable_expected<peer_session::ptr> async_connect(
 
     spdlog::debug("[async_connect] Connected to {}:{}", hostname, port);
     spdlog::debug("[async_connect] Creating peer_session...");
-    auto session = std::make_shared<peer_session>(std::move(socket), settings);
+    // Outbound connection (we connected to them)
+    auto session = std::make_shared<peer_session>(std::move(socket), settings, /*inbound=*/false);
     spdlog::debug("[async_connect] peer_session created, authority: {}", session->authority());
+
+    // Apply whitelist permissions (BCHN-style)
+    auto flags = settings.get_whitelist_permissions(session->authority());
+    if (flags != permission_flags::none) {
+        flags = settings.apply_legacy_whitelist_permissions(flags);
+        session->set_permissions(flags);
+        spdlog::debug("[async_connect] Applied whitelist permissions to [{}]: {}",
+            session->authority(), uint32_t(flags));
+    }
+
     co_return session;
 }
 
@@ -465,7 +545,19 @@ awaitable_expected<peer_session::ptr> async_accept(
             endpoint.address().to_string(), endpoint.port());
     }
 
-    co_return std::make_shared<peer_session>(std::move(socket), settings);
+    // Inbound connection (they connected to us)
+    auto session = std::make_shared<peer_session>(std::move(socket), settings, /*inbound=*/true);
+
+    // Apply whitelist permissions (BCHN-style)
+    auto flags = settings.get_whitelist_permissions(session->authority());
+    if (flags != permission_flags::none) {
+        flags = settings.apply_legacy_whitelist_permissions(flags);
+        session->set_permissions(flags);
+        spdlog::debug("[async_accept] Applied whitelist permissions to [{}]: {}",
+            session->authority(), uint32_t(flags));
+    }
+
+    co_return session;
 }
 
 awaitable_expected<::asio::ip::tcp::acceptor> async_listen(

--- a/src/network/src/settings.cpp
+++ b/src/network/src/settings.cpp
@@ -5,6 +5,7 @@
 #include <kth/network/settings.hpp>
 
 #include <kth/domain.hpp>
+#include <kth/network/net_permissions.hpp>
 #include <kth/domain/multi_crypto_support.hpp>
 
 namespace kth::network {
@@ -194,6 +195,51 @@ duration settings::channel_expiration() const {
 
 duration settings::channel_germination() const {
     return seconds(channel_germination_seconds);
+}
+
+permission_flags settings::get_whitelist_permissions(
+    infrastructure::config::authority const& addr) const {
+
+    // Check whitelist entries for matching address
+    for (auto const& entry : whitelist) {
+        // TODO(kth): implement proper subnet matching
+        // For now, simple IP comparison
+        if (entry.subnet.ip() == addr.ip()) {
+            return entry.flags;
+        }
+    }
+
+    return permission_flags::none;
+}
+
+permission_flags settings::apply_legacy_whitelist_permissions(permission_flags flags) const {
+    // BCHN: NetPermissions::AddFlag in net_permissions.cpp
+    // This applies -whitelistforcerelay and -whitelistrelay legacy options
+    // to implicit permissions (permissions without explicit @permissions prefix)
+
+    if ( ! has_permission(flags, permission_flags::is_implicit)) {
+        // Explicit permissions - don't modify
+        return flags;
+    }
+
+    // Remove the implicit flag marker
+    clear_permission(flags, permission_flags::is_implicit);
+
+    // Apply legacy whitelist behavior
+    // BCHN: if (gArgs.GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY))
+    if (whitelist_force_relay) {
+        add_permission(flags, permission_flags::forcerelay);
+    }
+
+    // BCHN: if (gArgs.GetBoolArg("-whitelistrelay", DEFAULT_WHITELISTRELAY))
+    if (whitelist_relay) {
+        add_permission(flags, permission_flags::relay);
+    }
+
+    // BCHN also adds noban by default for implicit whitelist
+    add_permission(flags, permission_flags::noban);
+
+    return flags;
 }
 
 } // namespace kth::network

--- a/src/node/include/kth/node/sync_session.hpp
+++ b/src/node/include/kth/node/sync_session.hpp
@@ -57,7 +57,7 @@ struct sync_config {
     /// Maximum blocks to request per getdata
     size_t max_blocks_per_request{16};
 
-    /// Timeout for header requests
+    /// Timeout for individual header request (waiting for response)
     std::chrono::seconds headers_timeout{30};
 
     /// Timeout for block requests
@@ -65,6 +65,37 @@ struct sync_config {
 
     /// Minimum peer protocol version for headers-first sync
     uint32_t minimum_version{70012};
+
+    // -------------------------------------------------------------------------
+    // BCHN-style timeout parameters
+    // -------------------------------------------------------------------------
+
+    /// Headers download timeout base (BCHN: 15 minutes)
+    /// Used to calculate total allowed time for headers sync
+    std::chrono::seconds headers_download_timeout_base{15 * 60};
+
+    /// Headers download timeout per expected header (BCHN: 1ms/header)
+    /// Total timeout = base + per_header * expected_headers
+    std::chrono::microseconds headers_download_timeout_per_header{1000};
+
+    /// Chain sync timeout for outbound peers (BCHN: 20 minutes)
+    /// If peer's chain has less work than ours after this time, send getheaders
+    std::chrono::seconds chain_sync_timeout{20 * 60};
+
+    /// Headers response time after getheaders sent (BCHN: 2 minutes)
+    /// If peer doesn't respond with better chain after this, disconnect
+    std::chrono::seconds headers_response_timeout{2 * 60};
+
+    /// Block stalling timeout (BCHN: 2 seconds)
+    /// If block download window can't move for this long, disconnect
+    std::chrono::seconds block_stalling_timeout{2};
+
+    /// Block download timeout base, in units of block interval (BCHN: 10 min equivalent)
+    /// Actual timeout = block_interval * (base + per_peer * num_other_peers)
+    double block_download_timeout_base{1.0};
+
+    /// Block download timeout per additional peer (BCHN: 5 min equivalent)
+    double block_download_timeout_per_peer{0.5};
 };
 
 /// Result of a sync operation
@@ -73,6 +104,7 @@ struct sync_result {
     size_t headers_received{0};
     size_t blocks_received{0};
     size_t final_height{0};
+    bool timed_out{false};  // True if sync failed due to timeout (peer too slow)
 };
 
 /// Sync session - coordinates headers-first sync with a single peer
@@ -123,6 +155,12 @@ private:
     // Statistics
     size_t total_headers_{0};
     size_t total_blocks_{0};
+
+    // BCHN-style timeout tracking
+    using clock = std::chrono::steady_clock;
+    clock::time_point headers_sync_start_;      // When headers sync started
+    clock::time_point headers_sync_deadline_;   // Deadline for headers sync completion
+    bool headers_sync_timed_out_{false};
 };
 
 /// Create a sync session for a peer

--- a/src/node/src/executor/executor.cpp
+++ b/src/node/src/executor/executor.cpp
@@ -83,6 +83,10 @@ void executor::print_version(std::string_view extra) {
 }
 
 #if ! defined(KTH_DB_READONLY)
+// TODO(fernando): This function inserts the genesis block directly into the DB,
+// bypassing the blockchain layer (header_organizer/block_chain). When we implement
+// persistence for header_index, we should reconsider this design - ideally genesis
+// should be added through the same path as other headers for consistency.
 bool executor::init_directory(error_code& ec) {
     auto const& directory = config_.database.directory;
 

--- a/src/node/src/full_node.cpp
+++ b/src/node/src/full_node.cpp
@@ -90,7 +90,7 @@ full_node::~full_node() {
     auto ec = co_await network_.start();
     if (ec != error::success) {
         spdlog::error("[node] Failure starting network: {}", ec.message());
-        chain_.stop();
+        (void)chain_.stop();
         co_return ec;
     }
 #endif

--- a/src/node/src/sync_session.cpp
+++ b/src/node/src/sync_session.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <latch>
 
+#include <kth/infrastructure/utility/stats.hpp>
 #include <kth/infrastructure/utility/system_memory.hpp>
 #include <kth/network/protocols_coro.hpp>
 
@@ -28,7 +29,7 @@ sync_session::sync_session(
     domain::config::network network,
     sync_config const& config)
     : chain_(chain)
-    , organizer_(chain, chain.chain_settings(), network)
+    , organizer_(chain.headers(), chain.chain_settings(), network)
     , peer_(std::move(peer))
     , config_(config)
 {
@@ -47,15 +48,16 @@ sync_session::sync_session(
 
     // Get hash of current header tip (for getheaders locator)
     if (header_height_ > 0) {
+        // TODO(fernando): resuming sync - headers in DB need to be loaded into header_index
         auto const hash = chain_.get_block_hash(header_height_);
         if (hash) {
             last_header_hash_ = *hash;
         }
     } else {
-        // Genesis block hash
-        auto const genesis_header = chain_.get_header(0);
-        if (genesis_header) {
-            last_header_hash_ = genesis_header->hash();
+        // Fresh start - get genesis hash
+        auto const genesis = chain_.get_header(0);
+        if (genesis) {
+            last_header_hash_ = genesis->hash();
         }
     }
 }
@@ -111,12 +113,28 @@ sync_session::ptr make_sync_session(
         spdlog::info("[sync] System memory: total {} MB, available {} MB",
             total_mem / (1024 * 1024), available_mem / (1024 * 1024));
 
-        // Initialize organizer with current state and expected headers
-        organizer_.start();
-        organizer_.initialize(header_height_, last_header_hash_, headers_to_sync);
+        // BCHN-style: Calculate headers sync deadline
+        // Timeout = base + per_header * expected_headers
+        headers_sync_start_ = clock::now();
+        auto const timeout_duration = config_.headers_download_timeout_base +
+            std::chrono::duration_cast<std::chrono::seconds>(
+                config_.headers_download_timeout_per_header * headers_to_sync);
+        headers_sync_deadline_ = headers_sync_start_ + timeout_duration;
 
-        auto const optimal_cache = organizer_.calculate_optimal_cache_size(headers_to_sync);
-        spdlog::info("[sync] Header cache: optimal size {} headers", optimal_cache);
+        auto const timeout_secs = std::chrono::duration_cast<std::chrono::seconds>(timeout_duration).count();
+        spdlog::info("[sync] Headers sync timeout: {}s (base: {}s + {}us/header * {} headers)",
+            timeout_secs,
+            config_.headers_download_timeout_base.count(),
+            config_.headers_download_timeout_per_header.count(),
+            headers_to_sync);
+
+        // Sync organizer tip from header_index (already initialized with genesis)
+        organizer_.start();
+        organizer_.sync_tip();
+
+        // TODO(fernando): calculate optimal cache size based on available memory
+        // auto const optimal_cache = organizer_.calculate_optimal_cache_size(headers_to_sync);
+        // spdlog::info("[sync] Header cache: optimal size {} headers", optimal_cache);
 
         // Measure memory before sync
         auto const mem_before = kth::get_resident_memory();
@@ -126,10 +144,23 @@ sync_session::ptr make_sync_session(
 
         // Sync headers until complete
         while (!peer_->stopped() && !synced_) {
+            // BCHN-style: Check if we've exceeded the headers sync deadline
+            if (clock::now() > headers_sync_deadline_) {
+                auto const elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                    clock::now() - headers_sync_start_).count();
+                spdlog::warn("[sync] Headers sync timeout after {}s from [{}], "
+                    "received {} headers (peer too slow)",
+                    elapsed, peer_->authority(), total_headers_);
+                headers_sync_timed_out_ = true;
+                result.error = error::channel_timeout;
+                result.timed_out = true;
+                co_return result;
+            }
+
             auto ec = co_await sync_headers_batch();
             if (ec) {
                 if (ec == error::channel_timeout) {
-                    spdlog::debug("[sync] Headers timeout from [{}], retrying...",
+                    spdlog::debug("[sync] Headers batch timeout from [{}], retrying...",
                         peer_->authority());
                     continue;
                 }
@@ -144,21 +175,31 @@ sync_session::ptr make_sync_session(
                 auto const headers_per_sec = elapsed_secs > 0 ? total_headers_ / elapsed_secs : 0;
 
                 auto const current_synced_height = header_height_ + total_headers_;
-                auto const hash_str = encode_hash(last_header_hash_);
 
                 if (target_height_ > 0) {
                     auto const percent = (current_synced_height * 100) / target_height_;
                     auto const remaining = headers_to_sync > total_headers_ ? headers_to_sync - total_headers_ : 0;
                     auto const eta_secs = headers_per_sec > 0 ? remaining / headers_per_sec : 0;
 
-                    spdlog::info("[sync] Headers: {:>7}/{} ({:>2}%), {:>6}/s, ETA {:>3}s, cache: {} headers",
+                    spdlog::info("[sync] {:>7}/{} ({:>2}%), {:>6}/s, ETA {:>3}s",
                         current_synced_height, target_height_, percent,
-                        headers_per_sec, eta_secs,
-                        organizer_.cache_size());
+                        headers_per_sec, eta_secs);
+
+#ifdef KTH_WITH_STATS
+                    // Print detailed stats when enabled
+                    auto const& stats = global_sync_stats();
+                    auto const batch_cnt = stats.batch_count.load(std::memory_order_relaxed);
+                    if (batch_cnt > 0) {
+                        auto const loc_ms = stats.batch_locator_ns.load() / 1000000 / batch_cnt;
+                        auto const net_ms = stats.batch_network_ns.load() / 1000000 / batch_cnt;
+                        auto const proc_ms = stats.batch_process_ns.load() / 1000000 / batch_cnt;
+                        spdlog::info("[stats] loc:{}ms net:{}ms proc:{}ms/batch", loc_ms, net_ms, proc_ms);
+                    }
+#endif
                 } else {
-                    spdlog::info("[sync] Headers: {:>7}, {:>6}/s, cache: {} headers",
+                    spdlog::info("[sync] {:>7}, {:>6}/s, index: {} headers",
                         current_synced_height, headers_per_sec,
-                        organizer_.cache_size());
+                        organizer_.size());
                 }
             }
         }
@@ -171,30 +212,29 @@ sync_session::ptr make_sync_session(
             total_headers_, mem_after_headers / (1024 * 1024),
             (mem_after_headers - mem_before) / (1024 * 1024), bytes_per_header);
 
-        // Flush remaining headers to database
-        if (organizer_.has_pending()) {
-            spdlog::info("[sync] Flushing {} cached headers to database...",
-                organizer_.cache_size());
-            auto const db_start = std::chrono::steady_clock::now();
-
-            auto const flush_ec = organizer_.flush();
-            if (flush_ec && flush_ec != error::duplicate_block) {
-                spdlog::warn("[sync] Failed to flush headers: {}", flush_ec.message());
-                result.error = flush_ec;
-                co_return result;
-            }
-
-            auto const db_elapsed = std::chrono::steady_clock::now() - db_start;
-            auto const db_ms = std::chrono::duration_cast<std::chrono::milliseconds>(db_elapsed).count();
-            spdlog::info("[sync] Headers flush completed in {}ms", db_ms);
-        }
+        // TODO(fernando): implement DB persistence for headers
+        // For now headers are kept in memory only (header_index)
+        // if (organizer_.has_pending()) {
+        //     spdlog::info("[sync] Flushing {} cached headers to database...",
+        //         organizer_.cache_size());
+        //     auto const db_start = std::chrono::steady_clock::now();
+        //
+        //     auto const flush_ec = organizer_.flush();
+        //     if (flush_ec && flush_ec != error::duplicate_block) {
+        //         spdlog::warn("[sync] Failed to flush headers: {}", flush_ec.message());
+        //         result.error = flush_ec;
+        //         co_return result;
+        //     }
+        //
+        //     auto const db_elapsed = std::chrono::steady_clock::now() - db_start;
+        //     auto const db_ms = std::chrono::duration_cast<std::chrono::milliseconds>(db_elapsed).count();
+        //     spdlog::info("[sync] Headers flush completed in {}ms", db_ms);
+        // }
 
         auto const final_header_height = organizer_.header_height();
         spdlog::info("[sync] Phase 1 complete: synced to height {} ({} new headers) from [{}]",
             final_header_height, total_headers_, peer_->authority());
 
-        // Clean up organizer
-        organizer_.clear_cache();
         organizer_.stop();
 
     } else {
@@ -252,14 +292,18 @@ sync_session::ptr make_sync_session(
 
 ::asio::awaitable<code> sync_session::sync_headers_batch() {
     // Build locator from current chain state
+    KTH_STATS_TIME_START(locator);
     auto locator = build_locator();
+    KTH_STATS_TIME_ADD(global_sync_stats(), locator, batch_locator_ns);
 
     spdlog::debug("[sync] Requesting headers from [{}] with {} locator hashes",
         peer_->authority(), locator.size());
 
     // Request headers
+    KTH_STATS_TIME_START(network);
     auto headers_result = co_await request_headers(
         *peer_, locator, null_hash, config_.headers_timeout);
+    KTH_STATS_TIME_ADD(global_sync_stats(), network, batch_network_ns);
 
     if (!headers_result) {
         spdlog::debug("[sync] Failed to get headers from [{}]: {}",
@@ -281,7 +325,13 @@ sync_session::ptr make_sync_session(
     }
 
     // Add headers to organizer (validates and caches)
+    KTH_STATS_TIME_START(process);
     auto const add_result = organizer_.add_headers(headers.elements());
+    KTH_STATS_TIME_ADD(global_sync_stats(), process, batch_process_ns);
+
+    // Increment batch count once per successful batch
+    KTH_STATS_INCREMENT(global_sync_stats(), batch_count);
+
     if (add_result.error) {
         spdlog::warn("[sync] Invalid headers from [{}]: {}",
             peer_->authority(), add_result.error.message());
@@ -292,9 +342,9 @@ sync_session::ptr make_sync_session(
     total_headers_ += add_result.headers_added;
     last_header_hash_ = organizer_.header_tip_hash();
 
-    spdlog::debug("[sync] Added {} headers, cache now {} headers ({} MB)",
-        add_result.headers_added, add_result.cache_size,
-        add_result.cache_memory_bytes / (1024 * 1024));
+    spdlog::debug("[sync] Added {} headers, index now {} headers ({} MB)",
+        add_result.headers_added, add_result.index_size,
+        add_result.index_memory_bytes / (1024 * 1024));
 
     // If we got fewer than max headers (2000), peer has no more
     if (count < config_.max_headers_per_request) {
@@ -387,44 +437,52 @@ sync_session::ptr make_sync_session(
 hash_list sync_session::build_locator() const {
     hash_list locator;
 
-    // Start with the tip (from organizer if we have cached headers)
-    auto const tip_hash = organizer_.header_tip_hash();
-    if (tip_hash != null_hash) {
-        locator.push_back(tip_hash);
-    } else if (last_header_hash_ != null_hash) {
-        locator.push_back(last_header_hash_);
+    // Use header_index for headers we've synced (much faster than DB)
+    auto const& index = organizer_.index();
+    auto const tip_idx = organizer_.tip_index();
+
+    if (tip_idx == blockchain::header_index::null_index) {
+        // No headers synced yet, just use genesis from DB
+        auto const genesis_hash = chain_.get_block_hash(0);
+        if (genesis_hash) {
+            locator.push_back(*genesis_hash);
+        }
+        return locator;
     }
 
-    // Add exponentially spaced hashes going back
+    // Start with tip
+    locator.push_back(index.get_hash(tip_idx));
+
+    // Use skip pointers for O(log n) traversal to build exponentially-spaced locator
     size_t step = 1;
-    size_t height = header_height_ + total_headers_;
+    auto current_idx = tip_idx;
+    int32_t current_height = index.get_height(tip_idx);
 
-    while (height > 0) {
-        if (height <= step) {
-            height = 0;
-        } else {
-            height -= step;
+    while (current_height > 0 && locator.size() < 64) {
+        int32_t target_height = current_height > static_cast<int32_t>(step)
+            ? current_height - static_cast<int32_t>(step)
+            : 0;
+
+        // Use O(log n) ancestor lookup via skip pointers
+        auto ancestor_idx = index.get_ancestor(current_idx, target_height);
+        if (ancestor_idx == blockchain::header_index::null_index) {
+            break;
         }
 
-        auto const hash = chain_.get_block_hash(height);
-        if (hash) {
-            locator.push_back(*hash);
-        }
+        locator.push_back(index.get_hash(ancestor_idx));
+        current_idx = ancestor_idx;
+        current_height = target_height;
 
         if (locator.size() >= 10) {
             step *= 2;
         }
-
-        if (locator.size() >= 64) {
-            break;
-        }
     }
 
-    // Always include genesis
-    if (height > 0) {
-        auto const genesis_hash = chain_.get_block_hash(0);
-        if (genesis_hash) {
-            locator.push_back(*genesis_hash);
+    // Always include genesis if not already included
+    if (current_height > 0) {
+        auto genesis_idx = index.get_ancestor(current_idx, 0);
+        if (genesis_idx != blockchain::header_index::null_index) {
+            locator.push_back(index.get_hash(genesis_idx));
         }
     }
 
@@ -440,12 +498,81 @@ bool sync_session::is_synced() const {
 }
 
 std::pair<size_t, size_t> sync_session::current_heights() const {
-    return {organizer_.header_height(), block_height_};
+    auto const h = organizer_.header_height();
+    return {h >= 0 ? size_t(h) : 0, block_height_};
 }
 
 // =============================================================================
 // Utility Functions
 // =============================================================================
+
+/// Select the best peer for sync using BCHN logic:
+/// 1. Prefer "preferred download" peers (fPreferredDownload in BCHN)
+/// 2. If no preferred peers available, use any full node that's ahead of us
+/// 3. Among candidates, prefer the one with highest reported height
+///
+/// BCHN's logic (net_processing.cpp):
+///   fPreferredDownload = (!fInbound || HasPermission(PF_NOBAN))
+///                        && !fOneShot && !fClient;
+///   fFetch = fPreferredDownload || (nPreferredDownload == 0 && !fClient && !fOneShot);
+static peer_session::ptr select_sync_peer(
+    std::vector<peer_session::ptr> const& peers,
+    size_t our_height)
+{
+    peer_session::ptr best_preferred = nullptr;
+    peer_session::ptr best_fallback = nullptr;
+    uint32_t best_preferred_height = 0;
+    uint32_t best_fallback_height = 0;
+
+    for (auto const& peer : peers) {
+        if (peer->stopped()) {
+            continue;
+        }
+
+        auto version = peer->peer_version();
+        if (!version) {
+            continue;
+        }
+
+        auto const height = version->start_height();
+
+        // Only consider peers ahead of us
+        if (height <= our_height) {
+            continue;
+        }
+
+        // BCHN: fPreferredDownload = (!fInbound || PF_NOBAN) && !fOneShot && !fClient
+        if (peer->is_preferred_download()) {
+            if (height > best_preferred_height) {
+                best_preferred = peer;
+                best_preferred_height = height;
+            }
+        } else if (!peer->is_one_shot() && !peer->is_client()) {
+            // BCHN fallback: nPreferredDownload == 0 && !fClient && !fOneShot
+            if (height > best_fallback_height) {
+                best_fallback = peer;
+                best_fallback_height = height;
+            }
+        }
+    }
+
+    // Prefer "preferred download" peer if available
+    if (best_preferred) {
+        spdlog::debug("[sync] Selected preferred peer with height {} (outbound or whitelisted full node)",
+            best_preferred_height);
+        return best_preferred;
+    }
+
+    // Fall back to any full node if no preferred peers available
+    // (BCHN: nPreferredDownload == 0 && !fClient && !fOneShot)
+    if (best_fallback) {
+        spdlog::debug("[sync] Selected fallback peer with height {} (no preferred peers available)",
+            best_fallback_height);
+        return best_fallback;
+    }
+
+    return nullptr;
+}
 
 ::asio::awaitable<sync_result> sync_from_best_peer(
     block_chain& chain,
@@ -462,6 +589,9 @@ std::pair<size_t, size_t> sync_session::current_heights() const {
         our_block_height = heights->second;
     }
 
+    // BCHN-style: don't wait for minimum peers, start sync immediately
+    // when any suitable peer is available
+
     // Get all connected peers
     auto peers = co_await p2p.peers().all();
 
@@ -471,30 +601,23 @@ std::pair<size_t, size_t> sync_session::current_heights() const {
         co_return result;
     }
 
-    spdlog::info("[sync] Selecting sync peer from {} connected peers, our height: {}",
-        peers.size(), our_block_height);
-
-    // Find peer with highest start_height that's ahead of us
-    peer_session::ptr best_peer;
-    uint32_t best_height = 0;
-
+    // Count peers by type for logging
+    size_t preferred_count = 0;
+    size_t full_node_count = 0;
     for (auto const& peer : peers) {
-        auto version = peer->peer_version();
-        if (!version) {
-            continue;
+        if (peer->is_preferred_download()) {
+            ++preferred_count;
         }
-
-        auto const peer_height = version->start_height();
-
-        if (peer_height <= our_block_height) {
-            continue;
-        }
-
-        if (peer_height > best_height) {
-            best_height = peer_height;
-            best_peer = peer;
+        if (peer->is_full_node()) {
+            ++full_node_count;
         }
     }
+
+    spdlog::info("[sync] Selecting sync peer from {} peers ({} preferred, {} full nodes), our height: {}",
+        peers.size(), preferred_count, full_node_count, our_block_height);
+
+    // Select best peer using BCHN logic
+    auto best_peer = select_sync_peer(peers, our_block_height);
 
     if (!best_peer) {
         spdlog::info("[sync] No peers ahead of us (height {}), already synced?", our_block_height);
@@ -503,11 +626,77 @@ std::pair<size_t, size_t> sync_session::current_heights() const {
         co_return result;
     }
 
-    spdlog::info("[sync] Selected peer [{}] with height {} for sync",
+    auto version = best_peer->peer_version();
+    auto const best_height = version ? version->start_height() : 0;
+
+    spdlog::info("[sync] Selected {} peer [{}] with height {} for sync",
+        best_peer->is_preferred_download() ? "preferred" : "fallback",
         best_peer->authority(), best_height);
 
+    // Run sync with selected peer
     auto session = make_sync_session(chain, best_peer, network, config);
-    co_return co_await session->run();
+    result = co_await session->run();
+
+    // BCHN-style: If sync failed (including timeout), try another peer
+    // Timeout means peer is too slow - disconnect and try another
+    if (result.error) {
+        if (result.timed_out) {
+            spdlog::warn("[sync] Peer [{}] timed out (too slow), disconnecting and trying another...",
+                best_peer->authority());
+            // BCHN disconnects slow peers
+            best_peer->stop(error::channel_timeout);
+        } else if (result.error == error::checkpoints_failed) {
+            // BCHN bans peers that send headers failing checkpoint validation
+            // This typically indicates a peer on a different chain (BSV, etc.)
+            spdlog::warn("[sync] Peer [{}] sent headers failing checkpoint (wrong chain?), banning...",
+                best_peer->authority());
+            p2p.ban_peer(best_peer, std::chrono::hours{24}, network::ban_reason::checkpoint_failed);
+        } else {
+            spdlog::warn("[sync] Sync with [{}] failed: {}, trying another peer...",
+                best_peer->authority(), result.error.message());
+        }
+
+        // Remove failed peer from consideration and try again
+        peers.erase(
+            std::remove(peers.begin(), peers.end(), best_peer),
+            peers.end());
+
+        // Retry with remaining peers (up to 2 more attempts)
+        constexpr int max_retries = 2;
+        for (int retry = 0; retry < max_retries && !peers.empty(); ++retry) {
+            auto retry_peer = select_sync_peer(peers, our_block_height);
+            if (!retry_peer) {
+                break;
+            }
+
+            version = retry_peer->peer_version();
+            auto const retry_height = version ? version->start_height() : 0;
+            spdlog::info("[sync] Retry {}/{}: {} peer [{}] height {}",
+                retry + 1, max_retries,
+                retry_peer->is_preferred_download() ? "preferred" : "fallback",
+                retry_peer->authority(), retry_height);
+
+            auto retry_session = make_sync_session(chain, retry_peer, network, config);
+            result = co_await retry_session->run();
+
+            if (!result.error) {
+                break;  // Success!
+            }
+
+            if (result.timed_out) {
+                spdlog::warn("[sync] Retry peer [{}] also timed out, disconnecting...",
+                    retry_peer->authority());
+                retry_peer->stop(error::channel_timeout);
+            }
+
+            // Remove this peer and try next
+            peers.erase(
+                std::remove(peers.begin(), peers.end(), retry_peer),
+                peers.end());
+        }
+    }
+
+    co_return result;
 }
 
 } // namespace kth::node


### PR DESCRIPTION
## Summary

- Add BCHN-style banlist with SipHash salted hasher for IP addresses
- Add net_permissions system (BCHN-style permission flags)
- Add peer connection deduplication (prevents multiple connections to same IP)
- Add salted_ip_hasher using SipHash-2-4 with random salt
- Add header_index for efficient header chain management
- Ban peers that send headers failing checkpoint (wrong chain detection)
- Improve handshake logging to show user agent

## Test plan

- [ ] Build passes
- [ ] Node connects to network without duplicate connections
- [ ] Wrong-chain peers (BSV) get banned on checkpoint failure