### PR TITLE
style: prefer function-style casts over static_cast for simple types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ build-asan/
 test_runner/
 doc/release-notes/*.backup
 src/domain/CMakeLists.txt
-bchn/
-/bitcoin-core/
 *.mdb
 *.log
+banlist.dat
+hosts.cache
+other-nodes/

--- a/scripts/temp/migrate_entity_from_data.py
+++ b/scripts/temp/migrate_entity_from_data.py
@@ -195,7 +195,7 @@ def migrate_entity_from_data(content, file_path):
             if type_name:
                 new_lines.append(f'{indent}byte_reader reader({data_var});')
                 new_lines.append(f'{indent}auto exp_result = {type_name}::from_data(reader, {version_var});')
-                new_lines.append(f'{indent}bool result = static_cast<bool>(exp_result);')
+                new_lines.append(f'{indent}bool result = bool(exp_result);')
                 new_lines.append(f'{indent}if (result) {instance_name} = std::move(*exp_result);')
                 modified = True
                 print(f"  Migrated bool entity_from_data in {file_path}:{i+1}")

--- a/src/blockchain/include/kth/blockchain/mining/mempool_v1.hpp
+++ b/src/blockchain/include/kth/blockchain/mining/mempool_v1.hpp
@@ -108,8 +108,8 @@ void sort_ltor(bool sorted, all_transactions_t& all, std::vector<size_t>& candid
             auto const& a = all[ia];
             auto const& b = all[ib];
             // return fee_per_size_cmp{}(a, b);
-            auto const value_a = static_cast<double>(a.children_fees()) / a.children_size();
-            auto const value_b = static_cast<double>(b.children_fees()) / b.children_size();
+            auto const value_a = double(a.children_fees()) / a.children_size();
+            auto const value_b = double(b.children_fees()) / b.children_size();
             return value_b < value_a;
         };
         // candidates.sort(cmp);
@@ -1284,8 +1284,8 @@ private:
         auto const& node_a = all_transactions_[a];
         auto const& node_b = all_transactions_[b];
 
-        auto const value_a = static_cast<double>(node_a.children_fees()) / node_a.children_size();
-        auto const value_b = static_cast<double>(node_b.children_fees()) / node_b.children_size();
+        auto const value_a = double(node_a.children_fees()) / node_a.children_size();
+        auto const value_b = double(node_b.children_fees()) / node_b.children_size();
 
         return value_b < value_a;
     }
@@ -1359,7 +1359,7 @@ private:
     removal_list_t what_to_remove(index_t to_insert_index, uint64_t fees, size_t size, size_t sigops) const {
         //precondition: candidate_transactions_.size() > 0
 
-        auto pack_benefit = static_cast<double>(fees) / size;
+        auto pack_benefit = double(fees) / size;
 
         auto it = candidate_transactions_.end() - 1;
 
@@ -1385,7 +1385,7 @@ private:
                     fee_accum += std::get<0>(res);
                     size_accum += std::get<1>(res);
 
-                    auto to_remove_benefit = static_cast<double>(fee_accum) / size_accum;
+                    auto to_remove_benefit = double(fee_accum) / size_accum;
                     if (pack_benefit <= to_remove_benefit) {
                         return {};
                     }
@@ -1738,14 +1738,14 @@ private:
 
     void reindex_parent_for_removal(mining::node const& node, mining::node& parent, index_t parent_index) {
         // cout << "reindex_parent_quitar\n";
-        auto node_benefit = static_cast<double>(node.fee()) / node.size();
-        auto accum_benefit = static_cast<double>(parent.children_fees()) / parent.children_size();
+        auto node_benefit = double(node.fee()) / node.size();
+        auto accum_benefit = double(parent.children_fees()) / parent.children_size();
 
         // reduce_values(node, parent);
         parent.decrement_values(node.fee(), node.size(), node.sigops());
 
 #ifndef NDEBUG
-        auto accum_benefit_new = static_cast<double>(parent.children_fees()) / parent.children_size();
+        auto accum_benefit_new = double(parent.children_fees()) / parent.children_size();
 #endif
 
         if (node_benefit == accum_benefit) {
@@ -1844,10 +1844,10 @@ private:
 
     //TODO(review-Dario): This method is very hard to follow
     void reindex_parent_from_insertion(mining::node const& node, mining::node& parent, index_t parent_index) {
-        auto node_benefit = static_cast<double>(node.fee()) / node.size();                          //a
-        auto accum_benefit = static_cast<double>(parent.children_fees()) / parent.children_size();  //b
-        auto node_accum_benefit = static_cast<double>(node.children_fees()) / node.children_size(); //c
-        auto old_accum_benefit = static_cast<double>(parent.children_fees() - node.fee()) / (parent.children_size() - node.size());  //d?
+        auto node_benefit = double(node.fee()) / node.size();                          //a
+        auto accum_benefit = double(parent.children_fees()) / parent.children_size();  //b
+        auto node_accum_benefit = double(node.children_fees()) / node.children_size(); //c
+        auto old_accum_benefit = double(parent.children_fees() - node.fee()) / (parent.children_size() - node.size());  //d?
 
         // std::print("{}", "node_benefit:       " << node_benefit << "\n");
         // std::print("{}", "accum_benefit:      " << accum_benefit << "\n");
@@ -2004,7 +2004,7 @@ private:
     //     std::println("");
     //     for (auto mi : candidate_transactions_) {
     //         auto& temp_node = all_transactions_[mi];
-    //         auto benefit = static_cast<double>(temp_node.children_fees()) / temp_node.children_size();
+    //         auto benefit = double(temp_node.children_fees()) / temp_node.children_size();
     //         std::print("{}, ", benefit);
     //     }
     //     std::println("");
@@ -2036,10 +2036,10 @@ private:
 
             if (parent.candidate_index() != null_index) {
 
-                // auto parent_benefit = static_cast<double>(parent.children_fees()) / parent.children_size();
+                // auto parent_benefit = double(parent.children_fees()) / parent.children_size();
                 // std::print("{}", "Parent stage0 benefit " << parent_benefit << "\n");
                 parent.increment_values(node.fee(), node.size(), node.sigops());
-                // parent_benefit = static_cast<double>(parent.children_fees()) / parent.children_size();
+                // parent_benefit = double(parent.children_fees()) / parent.children_size();
                 // std::print("{}", "Parent stage1 benefit " << parent_benefit << "\n");
 
                 reindex_parent_from_insertion(node, parent, pi);
@@ -2063,7 +2063,7 @@ private:
         auto& node = all_transactions_[node_index];
 
         // std::println("--------------------------------------------------");
-        // auto node_benefit = static_cast<double>(node.children_fees()) / node.children_size();
+        // auto node_benefit = double(node.children_fees()) / node.children_size();
         // std::print("{}", "Before insert " << node_index << "\n");
         // std::print("{}", "New node benefit " << node_benefit << "\n");
         // print_candidates();

--- a/src/blockchain/include/kth/blockchain/mining/mempool_v1_old.hpp
+++ b/src/blockchain/include/kth/blockchain/mining/mempool_v1_old.hpp
@@ -823,8 +823,8 @@ private:
         auto const& node_a = all_transactions_[a];
         auto const& node_b = all_transactions_[b];
 
-        auto const value_a = static_cast<double>(node_a.children_fees()) / node_a.children_size();
-        auto const value_b = static_cast<double>(node_b.children_fees()) / node_b.children_size();
+        auto const value_a = double(node_a.children_fees()) / node_a.children_size();
+        auto const value_b = double(node_b.children_fees()) / node_b.children_size();
 
         return value_b < value_a;
     }
@@ -914,9 +914,9 @@ private:
         //precondition: candidate_transactions_.size() > 0
 
         // auto const& node = all_transactions_[node_index];
-        // auto node_benefit = static_cast<double>(node.fee()) / node.size();
+        // auto node_benefit = double(node.fee()) / node.size();
 
-        auto pack_benefit = static_cast<double>(fees) / size;
+        auto pack_benefit = double(fees) / size;
 
         auto it = candidate_transactions_.end() - 1;
 
@@ -943,7 +943,7 @@ private:
                     fee_accum += std::get<0>(res);
                     size_accum += std::get<1>(res);
 
-                    auto to_remove_benefit = static_cast<double>(fee_accum) / size_accum;
+                    auto to_remove_benefit = double(fee_accum) / size_accum;
                     //El beneficio del elemento que voy a insertar es "peor" que el peor que el del peor elemento que tengo como candidato. Entonces, no sigo.
                     if (pack_benefit <= to_remove_benefit) {
                         //El beneficio acumulado de los elementos a remover es "mejor" que el que tengo para insertar.
@@ -1262,13 +1262,13 @@ private:
 
     void reindex_parent_for_removal(mining::node const& node, mining::node& parent, index_t parent_index) {
         // cout << "reindex_parent_quitar\n";
-        auto node_benefit = static_cast<double>(node.fee()) / node.size();
-        auto accum_benefit = static_cast<double>(parent.children_fees()) / parent.children_size();
+        auto node_benefit = double(node.fee()) / node.size();
+        auto accum_benefit = double(parent.children_fees()) / parent.children_size();
 
         // reduce_values(node, parent);
         parent.decrement_values(node.fee(), node.size(), node.sigops());
 
-        auto accum_benefit_new = static_cast<double>(parent.children_fees()) / parent.children_size();
+        auto accum_benefit_new = double(parent.children_fees()) / parent.children_size();
 
         if (node_benefit == accum_benefit) {
             return;
@@ -1331,10 +1331,10 @@ private:
 
         // std::println("hhhhh");
 
-        auto node_benefit = static_cast<double>(node.fee()) / node.size();                          //a
-        auto accum_benefit = static_cast<double>(parent.children_fees()) / parent.children_size();  //b
-        auto node_accum_benefit = static_cast<double>(node.children_fees()) / node.children_size(); //c
-        auto old_accum_benefit = static_cast<double>(parent.children_fees() - node.fee()) / (parent.children_size() - node.size());  //d?
+        auto node_benefit = double(node.fee()) / node.size();                          //a
+        auto accum_benefit = double(parent.children_fees()) / parent.children_size();  //b
+        auto node_accum_benefit = double(node.children_fees()) / node.children_size(); //c
+        auto old_accum_benefit = double(parent.children_fees() - node.fee()) / (parent.children_size() - node.size());  //d?
 
         // std::print("{}", "node_benefit:       " << node_benefit << "\n");
         // std::print("{}", "accum_benefit:      " << accum_benefit << "\n");
@@ -1672,7 +1672,7 @@ private:
     //     std::println("");
     //     for (auto mi : candidate_transactions_) {
     //         auto& temp_node = all_transactions_[mi];
-    //         auto benefit = static_cast<double>(temp_node.children_fees()) / temp_node.children_size();
+    //         auto benefit = double(temp_node.children_fees()) / temp_node.children_size();
     //         std::print("{}, ", benefit);
     //     }
     //     std::println("");
@@ -1715,10 +1715,10 @@ private:
                 // }
 
 
-                auto parent_benefit = static_cast<double>(parent.children_fees()) / parent.children_size();
+                auto parent_benefit = double(parent.children_fees()) / parent.children_size();
                 // std::print("{}", "Parent stage0 benefit " << parent_benefit << "\n");
                 parent.increment_values(node.fee(), node.size(), node.sigops());
-                parent_benefit = static_cast<double>(parent.children_fees()) / parent.children_size();
+                parent_benefit = double(parent.children_fees()) / parent.children_size();
                 // std::print("{}", "Parent stage1 benefit " << parent_benefit << "\n");
 
                 reindex_parent_from_insertion(node, parent, pi);
@@ -1742,7 +1742,7 @@ private:
         auto& node = all_transactions_[node_index];
 
         // std::println("--------------------------------------------------");
-        auto node_benefit = static_cast<double>(node.children_fees()) / node.children_size();
+        auto node_benefit = double(node.children_fees()) / node.children_size();
         // std::print("{}", "Before insert " << node_index << "\n");
         // std::print("{}", "New node benefit " << node_benefit << "\n");
         // print_candidates();

--- a/src/blockchain/include/kth/blockchain/mining/mempool_v2.hpp
+++ b/src/blockchain/include/kth/blockchain/mining/mempool_v2.hpp
@@ -72,7 +72,7 @@ std::set<typename Container::value_type, Cmp> to_ordered_set(F f, Container cons
 
 constexpr inline
 double benefit(uint64_t fee, size_t size) {
-    return static_cast<double>(fee) / size;
+    return double(fee) / size;
 }
 
 struct fee_per_size_cmp {

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -106,7 +106,7 @@ block_chain::block_chain(threadpool& pool, blockchain::settings const& chain_set
 
 uint32_t get_clock_now() {
     auto const now = std::chrono::high_resolution_clock::now();
-    return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count());
+    return uint32_t(std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count());
 }
 
 bool block_chain::get_output(domain::chain::output& out_output, size_t& out_height,

--- a/src/blockchain/src/pools/transaction_organizer.cpp
+++ b/src/blockchain/src/pools/transaction_organizer.cpp
@@ -400,7 +400,7 @@ uint64_t transaction_organizer::price(transaction_const_ptr tx) const {
     auto sigop = sigop_fee > 0 ? sigop_fee * tx->signature_operations() : 0;
 
     // Require at least one satoshi per tx if there are any fees configured.
-    return std::max(uint64_t(1), static_cast<uint64_t>(byte + sigop));
+    return std::max(uint64_t(1), uint64_t(byte + sigop));
 }
 
 } // namespace kth::blockchain

--- a/src/blockchain/src/populate/populate_chain_state.cpp
+++ b/src/blockchain/src/populate/populate_chain_state.cpp
@@ -129,7 +129,7 @@ bool populate_chain_state::populate_timestamps(chain_state::data& data, chain_st
     }
 
     if (is_transaction_pool(branch)) {
-        data.timestamp.self = static_cast<uint32_t>(zulu_time());
+        data.timestamp.self = uint32_t(zulu_time());
         return true;
     }
 

--- a/src/blockchain/test/block_index_bench/01-index_based.hpp
+++ b/src/blockchain/test/block_index_bench/01-index_based.hpp
@@ -60,7 +60,7 @@ uint32_t add(hash_digest const& hash, header_data const& hdr) {
         return it->second;
     }
 
-    uint32_t const idx = static_cast<uint32_t>(blocks_.size());
+    uint32_t const idx = uint32_t(blocks_.size());
 
     // Find parent
     uint32_t parent_idx = null_index;

--- a/src/blockchain/test/block_index_bench/02-index_based_preallocated.hpp
+++ b/src/blockchain/test/block_index_bench/02-index_based_preallocated.hpp
@@ -69,7 +69,7 @@ public:
             return it->second;
         }
 
-        uint32_t const idx = static_cast<uint32_t>(blocks_.size());
+        uint32_t const idx = uint32_t(blocks_.size());
 
         // Find parent
         uint32_t parent_idx = null_index;

--- a/src/blockchain/test/block_index_bench/03-index_based_soa.hpp
+++ b/src/blockchain/test/block_index_bench/03-index_based_soa.hpp
@@ -119,7 +119,7 @@ public:
             return it->second;
         }
 
-        uint32_t const idx = static_cast<uint32_t>(blocks_.size());
+        uint32_t const idx = uint32_t(blocks_.size());
 
         // Find parent
         uint32_t parent_idx = null_index;

--- a/src/blockchain/test/block_index_bench/04-vector_aos_ptr.hpp
+++ b/src/blockchain/test/block_index_bench/04-vector_aos_ptr.hpp
@@ -109,7 +109,7 @@ public:
         assert(reserved_ && "Must call preallocate() before add()");
         assert(blocks_.size() < blocks_.capacity() && "Vector would reallocate!");
 
-        uint32_t const idx = static_cast<uint32_t>(blocks_.size());
+        uint32_t const idx = uint32_t(blocks_.size());
 
         // Find parent
         block_index* parent_ptr = nullptr;

--- a/src/blockchain/test/block_index_bench/05-vector_aos_ptr_compact.hpp
+++ b/src/blockchain/test/block_index_bench/05-vector_aos_ptr_compact.hpp
@@ -129,7 +129,7 @@ public:
         assert(reserved_ && "Must call preallocate() before add()");
         assert(blocks_.size() < blocks_.capacity() && "Vector would reallocate!");
 
-        uint32_t const idx = static_cast<uint32_t>(blocks_.size());
+        uint32_t const idx = uint32_t(blocks_.size());
 
         block_index* parent_ptr = nullptr;
         int32_t height = 0;

--- a/src/blockchain/test/block_index_bench/06-vector_aos_ptr_prefetch.hpp
+++ b/src/blockchain/test/block_index_bench/06-vector_aos_ptr_prefetch.hpp
@@ -127,7 +127,7 @@ public:
         assert(reserved_ && "Must call preallocate() before add()");
         assert(blocks_.size() < blocks_.capacity() && "Vector would reallocate!");
 
-        uint32_t const idx = static_cast<uint32_t>(blocks_.size());
+        uint32_t const idx = uint32_t(blocks_.size());
 
         block_index* parent_ptr = nullptr;
         int32_t height = 0;

--- a/src/blockchain/test/block_index_bench/07-vector_aos_ptr_64.hpp
+++ b/src/blockchain/test/block_index_bench/07-vector_aos_ptr_64.hpp
@@ -59,7 +59,7 @@ public:
         assert(reserved_ && "Must call preallocate() before add()");
         assert(blocks_.size() < blocks_.capacity() && "Vector would reallocate!");
 
-        uint32_t const idx = static_cast<uint32_t>(blocks_.size());
+        uint32_t const idx = uint32_t(blocks_.size());
 
         block_index* parent_ptr = nullptr;
         int32_t height = 0;

--- a/src/blockchain/test/block_index_bench/10-soa_fully.hpp
+++ b/src/blockchain/test/block_index_bench/10-soa_fully.hpp
@@ -97,7 +97,7 @@ private:
             return it->second;
         }
 
-        uint32_t const idx = static_cast<uint32_t>(parent_indices_.size());
+        uint32_t const idx = uint32_t(parent_indices_.size());
 
         // Find parent
         uint32_t parent_idx = null_index;

--- a/src/blockchain/test/block_index_bench/11-soa_deque.hpp
+++ b/src/blockchain/test/block_index_bench/11-soa_deque.hpp
@@ -92,7 +92,7 @@ private:
             return it->second;
         }
 
-        uint32_t const idx = static_cast<uint32_t>(parent_indices_.size());
+        uint32_t const idx = uint32_t(parent_indices_.size());
 
         // Find parent
         uint32_t parent_idx = null_index;

--- a/src/blockchain/test/block_index_bench/15-tbb_cfm.hpp
+++ b/src/blockchain/test/block_index_bench/15-tbb_cfm.hpp
@@ -110,7 +110,7 @@ public:
             [&](auto& x) {
                 // Newly inserted - push to vector and get index
                 auto it = blocks_.push_back(entry);
-                x.second = static_cast<uint32_t>(it - blocks_.begin());
+                x.second = uint32_t(it - blocks_.begin());
                 result_idx = x.second;
             },
             [&](auto const& x) {

--- a/src/blockchain/test/block_index_bench/16-tbb_cfm_simple.hpp
+++ b/src/blockchain/test/block_index_bench/16-tbb_cfm_simple.hpp
@@ -108,7 +108,7 @@ public:
 
         // 1. First: insert into vector, get index
         auto it = blocks_.push_back(entry);
-        uint32_t idx = static_cast<uint32_t>(it - blocks_.begin());
+        uint32_t idx = uint32_t(it - blocks_.begin());
 
         // 2. Then: insert into map
         hash_to_idx_.insert({hash, idx});

--- a/src/blockchain/test/block_index_bench/benchmarks.cpp
+++ b/src/blockchain/test/block_index_bench/benchmarks.cpp
@@ -103,7 +103,7 @@ std::vector<kth::block_const_ptr> generate_kth_chain(size_t length) {
     kth::hash_digest prev_hash = kth::null_hash;  // Genesis has null prev hash
 
     for (size_t i = 0; i < length; ++i) {
-        auto block = create_kth_block(prev_hash, static_cast<uint32_t>(i));
+        auto block = create_kth_block(prev_hash, uint32_t(i));
         chain.push_back(block);
         prev_hash = block->hash();  // Next block points to this one
     }
@@ -912,7 +912,7 @@ void benchmark_daa_get_ancestor_skip() {
 
     //     std::vector<std::pair<vector_aos_ptr_compact::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -933,7 +933,7 @@ void benchmark_daa_get_ancestor_skip() {
 
     //     std::vector<std::pair<hash_digest, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(chain[h].first, static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(chain[h].first, int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -959,7 +959,7 @@ void benchmark_daa_get_ancestor_skip() {
 
         std::vector<std::pair<bchn_style::block_index*, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - daa_window);
+            queries.emplace_back(store.find(chain[h].first), int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -981,7 +981,7 @@ void benchmark_daa_get_ancestor_skip() {
 
     //     std::vector<std::pair<vector_aos_ptr_prefetch::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1003,7 +1003,7 @@ void benchmark_daa_get_ancestor_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1025,7 +1025,7 @@ void benchmark_daa_get_ancestor_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1046,7 +1046,7 @@ void benchmark_daa_get_ancestor_skip() {
 
     //     std::vector<std::pair<uint32_t, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(h, static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(h, int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1067,7 +1067,7 @@ void benchmark_daa_get_ancestor_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1089,7 +1089,7 @@ void benchmark_daa_get_ancestor_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1110,7 +1110,7 @@ void benchmark_daa_get_ancestor_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1131,7 +1131,7 @@ void benchmark_daa_get_ancestor_skip() {
 
     //     std::vector<std::pair<uint32_t, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(h, static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(h, int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1152,7 +1152,7 @@ void benchmark_daa_get_ancestor_skip() {
 
     //     std::vector<std::pair<uint32_t, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(h, static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(h, int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1191,7 +1191,7 @@ void benchmark_finalization_check_skip() {
 
     //     std::vector<std::pair<vector_aos_ptr_compact::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1212,7 +1212,7 @@ void benchmark_finalization_check_skip() {
 
     //     std::vector<std::pair<hash_digest, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(chain[h].first, static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(chain[h].first, int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1238,7 +1238,7 @@ void benchmark_finalization_check_skip() {
 
         std::vector<std::pair<bchn_style::block_index*, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(store.find(chain[h].first), int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1260,7 +1260,7 @@ void benchmark_finalization_check_skip() {
 
     //     std::vector<std::pair<vector_aos_ptr_prefetch::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1282,7 +1282,7 @@ void benchmark_finalization_check_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1304,7 +1304,7 @@ void benchmark_finalization_check_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1325,7 +1325,7 @@ void benchmark_finalization_check_skip() {
 
     //     std::vector<std::pair<uint32_t, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(h, int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1346,7 +1346,7 @@ void benchmark_finalization_check_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1368,7 +1368,7 @@ void benchmark_finalization_check_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1389,7 +1389,7 @@ void benchmark_finalization_check_skip() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1410,7 +1410,7 @@ void benchmark_finalization_check_skip() {
 
     //     std::vector<std::pair<uint32_t, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(h, int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1449,7 +1449,7 @@ void benchmark_daa_get_ancestor_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1471,7 +1471,7 @@ void benchmark_daa_get_ancestor_linear() {
 
     //     std::vector<std::pair<vector_aos_ptr_compact::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1493,7 +1493,7 @@ void benchmark_daa_get_ancestor_linear() {
 
     //     std::vector<std::pair<vector_aos_ptr_64::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1514,7 +1514,7 @@ void benchmark_daa_get_ancestor_linear() {
 
     //     std::vector<std::pair<hash_digest, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(chain[h].first, static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(chain[h].first, int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1540,7 +1540,7 @@ void benchmark_daa_get_ancestor_linear() {
 
         std::vector<std::pair<bchn_style::block_index*, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - daa_window);
+            queries.emplace_back(store.find(chain[h].first), int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1562,7 +1562,7 @@ void benchmark_daa_get_ancestor_linear() {
 
     //     std::vector<std::pair<vector_aos_ptr::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1584,7 +1584,7 @@ void benchmark_daa_get_ancestor_linear() {
 
     //     std::vector<std::pair<vector_aos_ptr_prefetch::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1605,7 +1605,7 @@ void benchmark_daa_get_ancestor_linear() {
 
         std::vector<std::pair<concurrent_node::block_index*, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - daa_window);
+            queries.emplace_back(store.find(chain[h].first), int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1627,7 +1627,7 @@ void benchmark_daa_get_ancestor_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1648,7 +1648,7 @@ void benchmark_daa_get_ancestor_linear() {
 
     //     std::vector<std::pair<uint32_t, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(h, static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(h, int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1669,7 +1669,7 @@ void benchmark_daa_get_ancestor_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1691,7 +1691,7 @@ void benchmark_daa_get_ancestor_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1712,7 +1712,7 @@ void benchmark_daa_get_ancestor_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - daa_window);
+            queries.emplace_back(h, int(h) - daa_window);
         }
 
         size_t sample_idx = 0;
@@ -1733,7 +1733,7 @@ void benchmark_daa_get_ancestor_linear() {
 
     //     std::vector<std::pair<uint32_t, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(h, static_cast<int>(h) - daa_window);
+    //         queries.emplace_back(h, int(h) - daa_window);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1772,7 +1772,7 @@ void benchmark_finalization_check_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1794,7 +1794,7 @@ void benchmark_finalization_check_linear() {
 
     //     std::vector<std::pair<vector_aos_ptr_compact::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1816,7 +1816,7 @@ void benchmark_finalization_check_linear() {
 
     //     std::vector<std::pair<vector_aos_ptr_64::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1837,7 +1837,7 @@ void benchmark_finalization_check_linear() {
 
     //     std::vector<std::pair<hash_digest, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(chain[h].first, static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(chain[h].first, int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1863,7 +1863,7 @@ void benchmark_finalization_check_linear() {
 
         std::vector<std::pair<bchn_style::block_index*, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(store.find(chain[h].first), int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1885,7 +1885,7 @@ void benchmark_finalization_check_linear() {
 
     //     std::vector<std::pair<vector_aos_ptr::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1907,7 +1907,7 @@ void benchmark_finalization_check_linear() {
 
     //     std::vector<std::pair<vector_aos_ptr_prefetch::block_index*, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(store.find(chain[h].first), int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1928,7 +1928,7 @@ void benchmark_finalization_check_linear() {
 
         std::vector<std::pair<concurrent_node::block_index*, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(store.find(chain[h].first), static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(store.find(chain[h].first), int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1950,7 +1950,7 @@ void benchmark_finalization_check_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -1971,7 +1971,7 @@ void benchmark_finalization_check_linear() {
 
     //     std::vector<std::pair<uint32_t, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(h, int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -1992,7 +1992,7 @@ void benchmark_finalization_check_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -2013,7 +2013,7 @@ void benchmark_finalization_check_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -2034,7 +2034,7 @@ void benchmark_finalization_check_linear() {
 
         std::vector<std::pair<uint32_t, int>> queries;
         for (uint32_t h : start_heights) {
-            queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+            queries.emplace_back(h, int(h) - max_reorg_depth);
         }
 
         size_t sample_idx = 0;
@@ -2055,7 +2055,7 @@ void benchmark_finalization_check_linear() {
 
     //     std::vector<std::pair<uint32_t, int>> queries;
     //     for (uint32_t h : start_heights) {
-    //         queries.emplace_back(h, static_cast<int>(h) - max_reorg_depth);
+    //         queries.emplace_back(h, int(h) - max_reorg_depth);
     //     }
 
     //     size_t sample_idx = 0;
@@ -2099,7 +2099,7 @@ void benchmark_find_common_ancestor() {
             std::vector<std::pair<uint32_t, uint32_t>> queries;
             for (uint32_t h : start_heights) {
                 uint32_t tip_idx = h;
-                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, static_cast<int>(h) - fork_depth);
+                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, int(h) - fork_depth);
                 queries.emplace_back(tip_idx, fork_idx);
             }
 
@@ -2124,7 +2124,7 @@ void benchmark_find_common_ancestor() {
         //     std::vector<std::pair<vector_aos_ptr_compact::block_index*, vector_aos_ptr_compact::block_index*>> queries;
         //     for (uint32_t h : start_heights) {
         //         auto* tip = store.find(chain[h].first);
-        //         auto* fork_point = vector_aos_ptr_compact::block_index_store::get_ancestor_skip(tip, static_cast<int>(h) - fork_depth);
+        //         auto* fork_point = vector_aos_ptr_compact::block_index_store::get_ancestor_skip(tip, int(h) - fork_depth);
         //         queries.emplace_back(tip, fork_point);
         //     }
 
@@ -2148,7 +2148,7 @@ void benchmark_find_common_ancestor() {
         //     // Cache hash pairs for lookup (not pointers!)
         //     std::vector<std::pair<hash_digest, int>> query_hashes;
         //     for (uint32_t h : start_heights) {
-        //         query_hashes.emplace_back(chain[h].first, static_cast<int>(h) - fork_depth);
+        //         query_hashes.emplace_back(chain[h].first, int(h) - fork_depth);
         //     }
 
         //     size_t sample_idx = 0;
@@ -2177,7 +2177,7 @@ void benchmark_find_common_ancestor() {
             std::vector<std::pair<bchn_style::block_index*, bchn_style::block_index*>> queries;
             for (uint32_t h : start_heights) {
                 auto* tip = store.find(chain[h].first);
-                auto* fork_point = bchn_style::get_ancestor_skip(tip, static_cast<int>(h) - fork_depth);
+                auto* fork_point = bchn_style::get_ancestor_skip(tip, int(h) - fork_depth);
                 queries.emplace_back(tip, fork_point);
             }
 
@@ -2202,7 +2202,7 @@ void benchmark_find_common_ancestor() {
         //     std::vector<std::pair<vector_aos_ptr::block_index*, vector_aos_ptr::block_index*>> queries;
         //     for (uint32_t h : start_heights) {
         //         auto* tip = store.find(chain[h].first);
-        //         auto* fork_point = vector_aos_ptr::block_index_store::get_ancestor_linear(tip, static_cast<int>(h) - fork_depth);
+        //         auto* fork_point = vector_aos_ptr::block_index_store::get_ancestor_linear(tip, int(h) - fork_depth);
         //         queries.emplace_back(tip, fork_point);
         //     }
 
@@ -2227,7 +2227,7 @@ void benchmark_find_common_ancestor() {
         //     std::vector<std::pair<vector_aos_ptr_prefetch::block_index*, vector_aos_ptr_prefetch::block_index*>> queries;
         //     for (uint32_t h : start_heights) {
         //         auto* tip = store.find(chain[h].first);
-        //         auto* fork_point = vector_aos_ptr_prefetch::block_index_store::get_ancestor_skip(tip, static_cast<int>(h) - fork_depth);
+        //         auto* fork_point = vector_aos_ptr_prefetch::block_index_store::get_ancestor_skip(tip, int(h) - fork_depth);
         //         queries.emplace_back(tip, fork_point);
         //     }
 
@@ -2251,7 +2251,7 @@ void benchmark_find_common_ancestor() {
             std::vector<std::pair<concurrent_node::block_index*, concurrent_node::block_index*>> queries;
             for (uint32_t h : start_heights) {
                 auto* tip = store.find(chain[h].first);
-                auto* fork_point = concurrent_node::block_index_store::get_ancestor_linear(tip, static_cast<int>(h) - fork_depth);
+                auto* fork_point = concurrent_node::block_index_store::get_ancestor_linear(tip, int(h) - fork_depth);
                 queries.emplace_back(tip, fork_point);
             }
 
@@ -2276,7 +2276,7 @@ void benchmark_find_common_ancestor() {
             std::vector<std::pair<uint32_t, uint32_t>> queries;
             for (uint32_t h : start_heights) {
                 uint32_t tip_idx = h;
-                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, static_cast<int>(h) - fork_depth);
+                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, int(h) - fork_depth);
                 queries.emplace_back(tip_idx, fork_idx);
             }
 
@@ -2300,7 +2300,7 @@ void benchmark_find_common_ancestor() {
         //     std::vector<std::pair<uint32_t, uint32_t>> queries;
         //     for (uint32_t h : start_heights) {
         //         uint32_t tip_idx = h;
-        //         uint32_t fork_idx = store.get_ancestor_linear(tip_idx, static_cast<int>(h) - fork_depth);
+        //         uint32_t fork_idx = store.get_ancestor_linear(tip_idx, int(h) - fork_depth);
         //         queries.emplace_back(tip_idx, fork_idx);
         //     }
 
@@ -2324,7 +2324,7 @@ void benchmark_find_common_ancestor() {
             std::vector<std::pair<uint32_t, uint32_t>> queries;
             for (uint32_t h : start_heights) {
                 uint32_t tip_idx = h;
-                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, static_cast<int>(h) - fork_depth);
+                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, int(h) - fork_depth);
                 queries.emplace_back(tip_idx, fork_idx);
             }
 
@@ -2348,7 +2348,7 @@ void benchmark_find_common_ancestor() {
             std::vector<std::pair<uint32_t, uint32_t>> queries;
             for (uint32_t h : start_heights) {
                 uint32_t tip_idx = h;
-                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, static_cast<int>(h) - fork_depth);
+                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, int(h) - fork_depth);
                 queries.emplace_back(tip_idx, fork_idx);
             }
 
@@ -2372,7 +2372,7 @@ void benchmark_find_common_ancestor() {
             std::vector<std::pair<uint32_t, uint32_t>> queries;
             for (uint32_t h : start_heights) {
                 uint32_t tip_idx = h;
-                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, static_cast<int>(h) - fork_depth);
+                uint32_t fork_idx = store.get_ancestor_linear(tip_idx, int(h) - fork_depth);
                 queries.emplace_back(tip_idx, fork_idx);
             }
 
@@ -2396,7 +2396,7 @@ void benchmark_find_common_ancestor() {
         //     std::vector<std::pair<uint32_t, uint32_t>> queries;
         //     for (uint32_t h : start_heights) {
         //         uint32_t tip_idx = h;
-        //         uint32_t fork_idx = store.get_ancestor_linear(tip_idx, static_cast<int>(h) - fork_depth);
+        //         uint32_t fork_idx = store.get_ancestor_linear(tip_idx, int(h) - fork_depth);
         //         queries.emplace_back(tip_idx, fork_idx);
         //     }
 
@@ -2420,7 +2420,7 @@ void benchmark_find_common_ancestor() {
         //     std::vector<std::pair<hash_digest, hash_digest>> queries;
         //     for (uint32_t h : start_heights) {
         //         hash_digest tip_hash = chain[h].first;
-        //         hash_digest fork_hash = store.get_ancestor_linear(tip_hash, static_cast<int>(h) - fork_depth);
+        //         hash_digest fork_hash = store.get_ancestor_linear(tip_hash, int(h) - fork_depth);
         //         queries.emplace_back(tip_hash, fork_hash);
         //     }
 
@@ -2858,7 +2858,7 @@ void run_tsan_test(
     // Readers
     for (size_t r = 0; r < cfg.num_readers; ++r) {
         threads.emplace_back([&, r] {
-            std::mt19937 rng(static_cast<unsigned>(r));
+            std::mt19937 rng(unsigned(r));
             std::uniform_int_distribution<size_t> dist(0, cached_starts.size() - 1);
             while (!start_flag.load(std::memory_order_acquire)) {
                 std::this_thread::yield();
@@ -3297,7 +3297,7 @@ void test_bchn_api_correct_usage() {
                 auto* block = store.lookup_block_index(hashes[dist(rng)]);
                 if (block) {
                     // SAFE: lock is held, can modify status
-                    block->status = static_cast<uint32_t>(w + 1);
+                    block->status = uint32_t(w + 1);
                     ++write_count;
                 }
             }
@@ -3379,7 +3379,7 @@ void test_bchn_api_incorrect_usage() {
                 auto* block = store.find(hashes[dist(rng)]);
                 if (block) {
                     // DATA RACE: lock was released, but we're still using the pointer!
-                    block->status = static_cast<uint32_t>(w + 1);
+                    block->status = uint32_t(w + 1);
                     ++write_count;
                 }
             }
@@ -3456,7 +3456,7 @@ void test_concurrent_node_api_correct_usage() {
             std::uniform_int_distribution<size_t> dist(0, hashes.size() - 1);
             while (!stop.load(std::memory_order_relaxed)) {
                 // CORRECT: Use set_status() which uses visit() internally
-                if (store.set_status(hashes[dist(rng)], static_cast<uint32_t>(w + 1))) {
+                if (store.set_status(hashes[dist(rng)], uint32_t(w + 1))) {
                     ++write_count;
                 }
             }
@@ -3530,7 +3530,7 @@ void test_concurrent_node_api_incorrect_usage() {
                 auto* block = store.find(hashes[dist(rng)]);
                 if (block) {
                     // DATA RACE: accessing block outside of visit()!
-                    block->status = static_cast<uint32_t>(w + 1);
+                    block->status = uint32_t(w + 1);
                     ++write_count;
                 }
             }
@@ -3960,7 +3960,7 @@ void test_soa_traversal_unlock_after_lookup() {
     for (size_t t = 0; t < num_traversers; ++t) {
         threads.emplace_back([&store, &cached_indices, &stop, &traverse_count, t, traversal_depth] {
             std::mt19937 rng(t);
-            std::uniform_int_distribution<size_t> dist(static_cast<size_t>(traversal_depth), cached_indices.size() - 1);
+            std::uniform_int_distribution<size_t> dist(size_t(traversal_depth), cached_indices.size() - 1);
             while (!stop.load(std::memory_order_relaxed)) {
                 // Use CACHED index - no lock, no synchronization with writers!
                 uint32_t start_idx = cached_indices[dist(rng)];
@@ -4036,7 +4036,7 @@ void test_soa_vector_race_unsafe() {
     // Multiple readers - read while writer is inserting
     for (size_t r = 0; r < num_readers; ++r) {
         threads.emplace_back([&store, &start_flag, &stop, &read_count, r] {
-            std::mt19937 rng(static_cast<unsigned>(r));
+            std::mt19937 rng(unsigned(r));
             while (!start_flag.load(std::memory_order_relaxed)) {
                 std::this_thread::yield();
             }
@@ -4046,7 +4046,7 @@ void test_soa_vector_race_unsafe() {
                 if (sz == 0) continue;
 
                 // Read random index (races with push_back and resize)
-                uint32_t idx = rng() % static_cast<uint32_t>(sz);
+                uint32_t idx = rng() % uint32_t(sz);
                 uint32_t parent = store.get_parent_idx(idx);
                 (void)parent;
 
@@ -4109,7 +4109,7 @@ void benchmark_memory_layout() {
 //         vec_store.add(hash, hdr);
 //     }
 
-//     uint32_t tip_idx = static_cast<uint32_t>(num_blocks - 1);
+//     uint32_t tip_idx = uint32_t(num_blocks - 1);
 
 //     fmt::print("Starting traversals...\n");
 

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -260,7 +260,7 @@ std::decay_t<T>* move_or_copy_and_leak(T&& x) {
 
 inline
 int bool_to_int(bool x) {
-    // return static_cast<int>(x);
+    // return int(x);
     return x;
 }
 

--- a/src/c-api/src/chain/transaction.cpp
+++ b/src/c-api/src/chain/transaction.cpp
@@ -41,7 +41,7 @@ void kth_chain_transaction_destruct(kth_transaction_t transaction) {
 }
 
 kth_bool_t kth_chain_transaction_is_valid(kth_transaction_t transaction) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_valid());
+    return int(kth_chain_transaction_const_cpp(transaction).is_valid());
 }
 
 uint32_t kth_chain_transaction_version(kth_transaction_t transaction) {
@@ -106,39 +106,39 @@ uint64_t kth_chain_transaction_total_output_value(kth_transaction_t transaction)
 }
 
 kth_bool_t kth_chain_transaction_is_coinbase(kth_transaction_t transaction) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_coinbase());
+    return int(kth_chain_transaction_const_cpp(transaction).is_coinbase());
 }
 
 kth_bool_t kth_chain_transaction_is_null_non_coinbase(kth_transaction_t transaction) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_null_non_coinbase());
+    return int(kth_chain_transaction_const_cpp(transaction).is_null_non_coinbase());
 }
 
 kth_bool_t kth_chain_transaction_is_oversized_coinbase(kth_transaction_t transaction) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_oversized_coinbase());
+    return int(kth_chain_transaction_const_cpp(transaction).is_oversized_coinbase());
 }
 
 kth_bool_t kth_chain_transaction_is_mature(kth_transaction_t transaction, kth_size_t target_height) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_mature(target_height));
+    return int(kth_chain_transaction_const_cpp(transaction).is_mature(target_height));
 }
 
 kth_bool_t kth_chain_transaction_is_overspent(kth_transaction_t transaction) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_overspent());
+    return int(kth_chain_transaction_const_cpp(transaction).is_overspent());
 }
 
 kth_bool_t kth_chain_transaction_is_double_spend(kth_transaction_t transaction, kth_bool_t include_unconfirmed) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_double_spend(kth::int_to_bool(include_unconfirmed)));
+    return int(kth_chain_transaction_const_cpp(transaction).is_double_spend(kth::int_to_bool(include_unconfirmed)));
 }
 
 kth_bool_t kth_chain_transaction_is_missing_previous_outputs(kth_transaction_t transaction) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_missing_previous_outputs());
+    return int(kth_chain_transaction_const_cpp(transaction).is_missing_previous_outputs());
 }
 
 kth_bool_t kth_chain_transaction_is_final(kth_transaction_t transaction, kth_size_t block_height, uint32_t kth_block_time) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_final(block_height, kth_block_time));
+    return int(kth_chain_transaction_const_cpp(transaction).is_final(block_height, kth_block_time));
 }
 
 kth_bool_t kth_chain_transaction_is_locktime_conflict(kth_transaction_t transaction) {
-    return static_cast<int>(kth_chain_transaction_const_cpp(transaction).is_locktime_conflict());
+    return int(kth_chain_transaction_const_cpp(transaction).is_locktime_conflict());
 }
 
 kth_output_list_t kth_chain_transaction_outputs(kth_transaction_t transaction) {

--- a/src/c-api/src/node.cpp
+++ b/src/c-api/src/node.cpp
@@ -100,7 +100,7 @@ int kth_node_close(kth_node_t node) {
 }
 
 int kth_node_stopped(kth_node_t node) {
-    return static_cast<int>(kth_node_cpp(node).stopped());
+    return int(kth_node_cpp(node).stopped());
 }
 
 kth_chain_t kth_node_get_chain(kth_node_t node) {

--- a/src/c-api/src/node/settings.cpp
+++ b/src/c-api/src/node/settings.cpp
@@ -21,7 +21,7 @@
 extern "C" {
 
 kth_currency_t kth_node_settings_get_currency() {
-    return static_cast<kth_currency_t>(static_cast<int>(kth::get_currency()));
+    return static_cast<kth_currency_t>(int(kth::get_currency()));
 }
 
 #if ! defined(__EMSCRIPTEN__)
@@ -34,7 +34,7 @@ kth_network_t kth_node_settings_get_network(kth_node_t exec) {
     auto id = sett.identifier;
     bool is_chipnet = sett.inbound_port == 48333;
 
-    return static_cast<kth_network_t>(static_cast<int>(kth::get_network(id, is_chipnet)));
+    return static_cast<kth_network_t>(int(kth::get_network(id, is_chipnet)));
 }
 #endif
 

--- a/src/c-api/src/vm/program.cpp
+++ b/src/c-api/src/vm/program.cpp
@@ -434,7 +434,7 @@ kth_size_t kth_vm_program_conditional_stack_size(kth_program_t program) {
 // }
 
 // kth_bool_t kth_wallet_payment_address_is_valid(kth_payment_address_t payment_address) {
-//     return kth::bool_to_int(static_cast<bool>(kth_wallet_payment_address_const_cpp(payment_address)));
+//     return kth::bool_to_int(bool(kth_wallet_payment_address_const_cpp(payment_address)));
 // }
 
 // // payment_address_list_t kth_wallet_payment_address_extract(chain::script_t const* script, uint8_t p2kh_version, uint8_t p2sh_version) {

--- a/src/c-api/src/wallet/ec_compressed_list.cpp
+++ b/src/c-api/src/wallet/ec_compressed_list.cpp
@@ -33,14 +33,6 @@ kth_ec_compressed_t kth_wallet_ec_compressed_list_nth(kth_ec_compressed_list_t l
     return detail::to_ec_compressed_t(x);
 }
 
-
-// template <typename HashCpp, typename HashC>
-// inline
-// void copy_c_hash(HashCpp const& in, HashC* out) {
-//     //precondition: size of out->hash is greater or equal than in.size()
-//     std::copy_n(in.begin(), in.size(), static_cast<uint8_t*>(out->hash));
-// }
-
 void kth_wallet_ec_compressed_list_nth_out(kth_ec_compressed_list_t l, kth_size_t n, kth_ec_compressed_t* out_elem) {
     auto const& x = kth_wallet_ec_compressed_list_cpp(l)[n];
     // kth::copy_c_hash(x, out_elem);

--- a/src/c-api/src/wallet/payment_address.cpp
+++ b/src/c-api/src/wallet/payment_address.cpp
@@ -98,7 +98,7 @@ uint8_t kth_wallet_payment_address_version(kth_payment_address_t payment_address
 }
 
 kth_bool_t kth_wallet_payment_address_is_valid(kth_payment_address_t payment_address) {
-    return kth::bool_to_int(static_cast<bool>(kth_wallet_payment_address_const_cpp(payment_address)));
+    return kth::bool_to_int(bool(kth_wallet_payment_address_const_cpp(payment_address)));
 }
 
 kth_payment_address_list_const_t kth_wallet_payment_address_extract(kth_script_t script, uint8_t p2kh_version, uint8_t p2sh_version) {

--- a/src/database/include/kth/database/databases/history_entry.hpp
+++ b/src/database/include/kth/database/databases/history_entry.hpp
@@ -53,7 +53,7 @@ struct KD_API history_entry {
     void factory_to_data(W& sink, uint64_t id, domain::chain::point const& point, domain::chain::point_kind kind, uint32_t height, uint32_t index, uint64_t value_or_checksum) {
         sink.write_8_bytes_little_endian(id);
         point.to_data(sink, false);
-        sink.write_byte(static_cast<uint8_t>(kind));
+        sink.write_byte(uint8_t(kind));
         sink.write_4_bytes_little_endian(height);
         sink.write_4_bytes_little_endian(index);
         sink.write_8_bytes_little_endian(value_or_checksum);

--- a/src/database/include/kth/database/databases/internal_database.ipp
+++ b/src/database/include/kth/database/databases/internal_database.ipp
@@ -71,7 +71,7 @@ bool internal_database_basis<Clock>::create_db_mode_property() {
 
     res = kth_db_put(db_txn, dbi_properties_, &key, &value, KTH_DB_NOOVERWRITE);
     if (res != KTH_DB_SUCCESS) {
-        spdlog::error("[database] Failed saving in DB Properties [create_db_mode_property] {}", static_cast<int32_t>(res));
+        spdlog::error("[database] Failed saving in DB Properties [create_db_mode_property] {}", int32_t(res));
         kth_db_txn_abort(db_txn);
         return false;
     }
@@ -131,7 +131,7 @@ bool internal_database_basis<Clock>::verify_db_mode_property() const {
 
     res = kth_db_get(db_txn, dbi_properties_, &key, &value);
     if (res != KTH_DB_SUCCESS) {
-        spdlog::error("[database] Failed getting DB Properties [verify_db_mode_property] {}", static_cast<int32_t>(res));
+        spdlog::error("[database] Failed getting DB Properties [verify_db_mode_property] {}", int32_t(res));
         kth_db_txn_abort(db_txn);
         return false;
     }
@@ -144,7 +144,7 @@ bool internal_database_basis<Clock>::verify_db_mode_property() const {
     }
 
     if (db_mode_ != db_mode_db) {
-        spdlog::error("[database] Error validating DB Mode, the node is compiled for another DB mode. Node DB Mode: {}, Actual DB Mode: {}", static_cast<uint32_t>(db_mode_), static_cast<uint32_t>(db_mode_db));
+        spdlog::error("[database] Error validating DB Mode, the node is compiled for another DB mode. Node DB Mode: {}, Actual DB Mode: {}", uint32_t(db_mode_), uint32_t(db_mode_db));
         return false;
     }
 
@@ -693,7 +693,7 @@ bool internal_database_basis<Clock>::create_and_open_environment() {
 
     auto res = kth_db_env_set_mapsize(env_, adjust_db_size(db_max_size_));
     if (res != KTH_DB_SUCCESS) {
-        spdlog::error("[database] Error setting max memory map size. Verify do you have enough free space. [create_and_open_environment] {}", static_cast<int32_t>(res));
+        spdlog::error("[database] Error setting max memory map size. Verify do you have enough free space. [create_and_open_environment] {}", int32_t(res));
         return false;
     }
 
@@ -747,7 +747,7 @@ bool internal_database_basis<Clock>::set_fast_flags_environment(bool enabled) {
     //KTH_DB_WRITEMAP |
     auto res = mdb_env_set_flags(env_, KTH_DB_MAPASYNC, enabled ? 1 : 0);
     if ( res != KTH_DB_SUCCESS ) {
-        spdlog::error("[database] Error setting LMDB Environmet flags. [set_fast_flags_environment] {}", static_cast<int32_t>(res));
+        spdlog::error("[database] Error setting LMDB Environmet flags. [set_fast_flags_environment] {}", int32_t(res));
         return false;
     }
 

--- a/src/database/include/kth/database/databases/transaction_unconfirmed_database.ipp
+++ b/src/database/include/kth/database/databases/transaction_unconfirmed_database.ipp
@@ -122,7 +122,7 @@ template <typename Clock>
 inline
 uint32_t internal_database_basis<Clock>::get_clock_now() const {
     auto const now = std::chrono::high_resolution_clock::now();
-    return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
+    return uint32_t(std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
 }
 
 #if ! defined(KTH_DB_READONLY)

--- a/src/database/test/internal_database.cpp
+++ b/src/database/test/internal_database.cpp
@@ -208,7 +208,7 @@ void print_db_entries_count(KTH_DB_env* env_, KTH_DB_dbi& dbi ) {
     MDB_stat db_stats;
     auto ret = mdb_stat(txn, dbi, &db_stats);
     if (ret != KTH_DB_SUCCESS) {
-        std::println("Error getting entries {}", static_cast<int32_t>(ret));
+        std::println("Error getting entries {}", int32_t(ret));
         kth_db_txn_commit(txn);
         return;
     }

--- a/src/domain/include/kth/domain/chain/point.hpp
+++ b/src/domain/include/kth/domain/chain/point.hpp
@@ -105,7 +105,7 @@ struct KD_API point {
             sink.write_4_bytes_little_endian(index_);
         } else {
             KTH_ASSERT(index_ == null_index || index_ < max_uint16);
-            sink.write_2_bytes_little_endian(static_cast<uint16_t>(index_));
+            sink.write_2_bytes_little_endian(uint16_t(index_));
         }
     }
 

--- a/src/domain/include/kth/domain/impl/machine/interpreter.ipp
+++ b/src/domain/include/kth/domain/impl/machine/interpreter.ipp
@@ -1706,7 +1706,7 @@ interpreter::result interpreter::op_active_bytecode(program& program) {
     auto const script_end = program.end();
     
     // Calculate the size of the active bytecode
-    auto const script_size = static_cast<size_t>(script_end - begin_code_hash);
+    auto const script_size = size_t(script_end - begin_code_hash);
     
     // Check maximum script element size constraint
     auto const max_script_element_size = program.max_script_element_size();

--- a/src/domain/include/kth/domain/impl/machine/operation.ipp
+++ b/src/domain/include/kth/domain/impl/machine/operation.ipp
@@ -138,7 +138,7 @@ data_chunk const& operation::data() const {
 // template <typename R>
 // inline
 // uint32_t operation::read_data_size(opcode code, R& source) {
-//     constexpr auto op_75 = static_cast<uint8_t>(opcode::push_size_75);
+//     constexpr auto op_75 = uint8_t(opcode::push_size_75);
 
 //     switch (code) {
 //         case opcode::push_one_size:
@@ -148,14 +148,14 @@ data_chunk const& operation::data() const {
 //         case opcode::push_four_size:
 //             return source.read_4_bytes_little_endian();
 //         default:
-//             auto const byte = static_cast<uint8_t>(code);
+//             auto const byte = uint8_t(code);
 //             return byte <= op_75 ? byte : 0;
 //     }
 // }
 
 inline
 expect<uint32_t> operation::read_data_size(opcode code, byte_reader& reader) {
-    constexpr auto op_75 = static_cast<uint8_t>(opcode::push_size_75);
+    constexpr auto op_75 = uint8_t(opcode::push_size_75);
 
     switch (code) {
         case opcode::push_one_size:
@@ -173,7 +173,7 @@ expect<uint32_t> operation::read_data_size(opcode code, byte_reader& reader) {
 inline
 opcode operation::opcode_from_size(size_t size) {
     KTH_ASSERT(size <= max_uint32);
-    constexpr auto op_75 = static_cast<uint8_t>(opcode::push_size_75);
+    constexpr auto op_75 = uint8_t(opcode::push_size_75);
 
     if (size <= op_75) {
         return static_cast<opcode>(size);
@@ -230,40 +230,40 @@ inline
 opcode operation::opcode_from_positive(uint8_t value) {
     KTH_ASSERT(value >= number::positive_1);
     KTH_ASSERT(value <= number::positive_16);
-    constexpr auto op_81 = static_cast<uint8_t>(opcode::push_positive_1);
+    constexpr auto op_81 = uint8_t(opcode::push_positive_1);
     return static_cast<opcode>(value + op_81 - 1);
 }
 
 inline
 uint8_t operation::opcode_to_positive(opcode code) {
     KTH_ASSERT(is_positive(code));
-    constexpr auto op_81 = static_cast<uint8_t>(opcode::push_positive_1);
-    return static_cast<uint8_t>(code) - op_81 + 1;
+    constexpr auto op_81 = uint8_t(opcode::push_positive_1);
+    return uint8_t(code) - op_81 + 1;
 }
 
 // opcode: [0..79, 81..96]
 inline
 bool operation::is_push(opcode code) {
-    constexpr auto op_80 = static_cast<uint8_t>(opcode::reserved_80);
-    constexpr auto op_96 = static_cast<uint8_t>(opcode::push_positive_16);
-    auto const value = static_cast<uint8_t>(code);
+    constexpr auto op_80 = uint8_t(opcode::reserved_80);
+    constexpr auto op_96 = uint8_t(opcode::push_positive_16);
+    auto const value = uint8_t(code);
     return value <= op_96 && value != op_80;
 }
 
 // opcode: [1..78]
 inline
 bool operation::is_payload(opcode code) {
-    constexpr auto op_1 = static_cast<uint8_t>(opcode::push_size_1);
-    constexpr auto op_78 = static_cast<uint8_t>(opcode::push_four_size);
-    auto const value = static_cast<uint8_t>(code);
+    constexpr auto op_1 = uint8_t(opcode::push_size_1);
+    constexpr auto op_78 = uint8_t(opcode::push_four_size);
+    auto const value = uint8_t(code);
     return value >= op_1 && value <= op_78;
 }
 
 // opcode: [97..255]
 inline
 bool operation::is_counted(opcode code) {
-    constexpr auto op_97 = static_cast<uint8_t>(opcode::nop);
-    auto const value = static_cast<uint8_t>(code);
+    constexpr auto op_97 = uint8_t(opcode::nop);
+    auto const value = uint8_t(code);
     return value >= op_97;
 }
 
@@ -282,17 +282,17 @@ bool operation::is_numeric(opcode code) {
 // stack: [1..16]
 inline
 bool operation::is_positive(opcode code) {
-    constexpr auto op_81 = static_cast<uint8_t>(opcode::push_positive_1);
-    constexpr auto op_96 = static_cast<uint8_t>(opcode::push_positive_16);
-    auto const value = static_cast<uint8_t>(code);
+    constexpr auto op_81 = uint8_t(opcode::push_positive_1);
+    constexpr auto op_96 = uint8_t(opcode::push_positive_16);
+    auto const value = uint8_t(code);
     return value >= op_81 && value <= op_96;
 }
 
 // opcode: [80, 98, 137, 138, 186..255]
 inline
 bool operation::is_reserved(opcode code) {
-    constexpr auto op_212 = static_cast<uint8_t>(opcode::reserved_212);
-    constexpr auto op_255 = static_cast<uint8_t>(opcode::reserved_255);
+    constexpr auto op_212 = uint8_t(opcode::reserved_212);
+    constexpr auto op_255 = uint8_t(opcode::reserved_255);
 
     switch (code) {
         case opcode::reserved_80:
@@ -384,8 +384,8 @@ bool operation::is_conditional(opcode code) {
 // opcode: [0..96]
 inline
 bool operation::is_relaxed_push(opcode code) {
-    constexpr auto op_96 = static_cast<uint8_t>(opcode::push_positive_16);
-    auto const value = static_cast<uint8_t>(code);
+    constexpr auto op_96 = uint8_t(opcode::push_positive_16);
+    auto const value = uint8_t(code);
     return value <= op_96;
 }
 

--- a/src/domain/include/kth/domain/machine/operation.hpp
+++ b/src/domain/include/kth/domain/machine/operation.hpp
@@ -75,17 +75,17 @@ struct KD_API operation {
     void to_data(W& sink) const {
         auto const size = data_.size();
 
-        sink.write_byte(static_cast<uint8_t>(code_));
+        sink.write_byte(uint8_t(code_));
 
         switch (code_) {
             case opcode::push_one_size:
-                sink.write_byte(static_cast<uint8_t>(size));
+                sink.write_byte(uint8_t(size));
                 break;
             case opcode::push_two_size:
-                sink.write_2_bytes_little_endian(static_cast<uint16_t>(size));
+                sink.write_2_bytes_little_endian(uint16_t(size));
                 break;
             case opcode::push_four_size:
-                sink.write_4_bytes_little_endian(static_cast<uint32_t>(size));
+                sink.write_4_bytes_little_endian(uint32_t(size));
                 break;
             default:
                 break;

--- a/src/domain/include/kth/domain/math/limits.hpp
+++ b/src/domain/include/kth/domain/math/limits.hpp
@@ -106,7 +106,7 @@ To safe_to_signed(From unsigned_value) {
     static_assert(sizeof(uint64_t) >= sizeof(To), "safe assign out of range");
     static auto const signed_maximum = (std::numeric_limits<To>::max)();
 
-    if (unsigned_value > static_cast<uint64_t>(signed_maximum))
+    if (unsigned_value > uint64_t(signed_maximum))
         throw std::range_error("to signed assignment out of range");
 
     return static_cast<To>(unsigned_value);
@@ -118,7 +118,7 @@ To safe_to_unsigned(From signed_value) {
     static auto const unsigned_maximum = (std::numeric_limits<To>::max)();
 
     if (signed_value < 0 ||
-        static_cast<uint64_t>(signed_value) > unsigned_maximum)
+        uint64_t(signed_value) > unsigned_maximum)
         throw std::range_error("to unsigned assignment out of range");
 
     return static_cast<To>(signed_value);

--- a/src/domain/include/kth/domain/message/send_compact.hpp
+++ b/src/domain/include/kth/domain/message/send_compact.hpp
@@ -55,7 +55,7 @@ struct KD_API send_compact {
 
     template <typename W>
     void to_data(uint32_t /*version*/, W& sink) const {
-        sink.write_byte(static_cast<uint8_t>(high_bandwidth_mode_));
+        sink.write_byte(uint8_t(high_bandwidth_mode_));
         sink.write_8_bytes_little_endian(this->version_);
     }
 

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -340,7 +340,7 @@ size_t block::locator_size(size_t top) {
     if (remaining < 2) {
         return top + size_t{1};
     }
-    return first_ten_or_top + static_cast<size_t>(std::log2(remaining) + 0.5) + size_t{1};
+    return first_ten_or_top + size_t(std::log2(remaining) + 0.5) + size_t{1};
 }
 
 // This algorithm is a network best practice, not a consensus rule.

--- a/src/domain/src/chain/block_basis.cpp
+++ b/src/domain/src/chain/block_basis.cpp
@@ -626,7 +626,7 @@ size_t locator_size(size_t top) {
     auto const first_ten_or_top = std::min(size_t(10), top);
     auto const remaining = top - first_ten_or_top;
     auto const back_off = remaining == 0 ? 0.0 : remaining == 1 ? 1.0 : std::log2(remaining);
-    auto const rounded_up_log = static_cast<size_t>(std::nearbyint(back_off));
+    auto const rounded_up_log = size_t(std::nearbyint(back_off));
     return first_ten_or_top + rounded_up_log + size_t(1);
 }
 

--- a/src/domain/src/chain/chain_state.cpp
+++ b/src/domain/src/chain/chain_state.cpp
@@ -415,7 +415,7 @@ chain_state::activations chain_state::activation(data const& values, uint32_t fo
     // performed this comparison using the signed integer version value.
     //*************************************************************************
     auto const ge = [](uint32_t value, size_t version) {
-        return static_cast<int32_t>(value) >= version;
+        return int32_t(value) >= version;
     };
 
     // Declare bip34-based version predicates.
@@ -906,7 +906,7 @@ auto timestamps_position(chain_state::timestamps const& times, size_t last_n = m
 
 std::vector<typename chain_state::timestamps::value_type> timestamps_subset(chain_state::timestamps const& times, size_t last_n = median_time_past_interval) {
     auto at = timestamps_position(times, last_n);
-    auto n = (std::min)(static_cast<size_t>(std::distance(at, times.end())), median_time_past_interval);
+    auto n = (std::min)(size_t(std::distance(at, times.end())), median_time_past_interval);
     std::vector<typename chain_state::timestamps::value_type> subset(n);
     std::copy_n(at, n, subset.begin());
     return subset;

--- a/src/domain/src/chain/compact.cpp
+++ b/src/domain/src/chain/compact.cpp
@@ -126,7 +126,7 @@ bool compact::from_compact(uint256_t& out, uint32_t compact) {
     auto mantissa = compact & mantissa_max;
 
     // Shift off the mantissa and sign to get the exponent byte.
-    auto const exponent = static_cast<uint8_t>(compact >> mantissa_bits);
+    auto const exponent = uint8_t(compact >> mantissa_bits);
 
     // Shift the mantissa into the big number.
     if (exponent <= 3) {
@@ -148,12 +148,12 @@ bool compact::from_compact(uint256_t& out, uint32_t compact) {
 
 uint32_t compact::from_big(uint256_t const& big) {
     // This value is limited to 32, so exponent cannot overflow.
-    auto exponent = static_cast<uint8_t>(logical_size(big));
+    auto exponent = uint8_t(logical_size(big));
 
     // Shift the big number significant digits into the mantissa.
-    auto const mantissa64 = exponent <= 3 ? static_cast<uint64_t>(big) << shift_low(exponent) : static_cast<uint64_t>(big >> shift_high(exponent));
+    auto const mantissa64 = exponent <= 3 ? uint64_t(big) << shift_low(exponent) : uint64_t(big >> shift_high(exponent));
 
-    auto mantissa = static_cast<uint32_t>(mantissa64);
+    auto mantissa = uint32_t(mantissa64);
 
     //*************************************************************************
     // CONSENSUS: Satoshi used a signed implementation to represent unsigned.
@@ -169,7 +169,7 @@ uint32_t compact::from_big(uint256_t const& big) {
     KTH_ASSERT_MSG((mantissa & mantissa_mask) == 0, "value exceess");
 
     // Assemble the compact notation.
-    return (static_cast<uint32_t>(exponent) << mantissa_bits) | mantissa;
+    return (uint32_t(exponent) << mantissa_bits) | mantissa;
 }
 
 } // namespace kth::domain::chain

--- a/src/domain/src/chain/point.cpp
+++ b/src/domain/src/chain/point.cpp
@@ -135,7 +135,7 @@ point_iterator point::begin() const {
 }
 
 point_iterator point::end() const {
-    return {*this, static_cast<unsigned>(store_point_size)};
+    return {*this, unsigned(store_point_size)};
 }
 
 // Properties.
@@ -195,7 +195,7 @@ uint64_t point::checksum() const {
     // of values into the front or back of tx hash (not a security feature).
     // Use most possible bits of tx hash to make intentional collision hard.
     auto const tx = from_little_endian_unsafe<uint64_t>(std::span{hash_}.subspan(12));
-    auto const index = static_cast<uint64_t>(index_);
+    auto const index = uint64_t(index_);
 
     auto const tx_upper_49_bits = tx & mask;
     auto const index_lower_15_bits = index & ~mask;

--- a/src/domain/src/chain/point_iterator.cpp
+++ b/src/domain/src/chain/point_iterator.cpp
@@ -19,8 +19,8 @@
 
 namespace kth::domain::chain {
 
-// static auto const point_size = static_cast<unsigned>(std::tuple_size<point>::value);
-constexpr auto point_size = static_cast<unsigned>(std::tuple_size<point>::value);
+// static auto const point_size = unsigned(std::tuple_size<point>::value);
+constexpr auto point_size = unsigned(std::tuple_size<point>::value);
 
 // Constructors.
 //-----------------------------------------------------------------------------
@@ -44,7 +44,7 @@ uint8_t point_iterator::current() const {
 
     // TODO(legacy): move the little-endian iterator into endian.hpp.
     auto const position = current_ - hash_size;
-    return static_cast<uint8_t>(point_->index() >> (position * byte_bits));
+    return uint8_t(point_->index() >> (position * byte_bits));
 }
 
 point_iterator::pointer point_iterator::operator->() const {
@@ -78,11 +78,11 @@ point_iterator::iterator point_iterator::operator--(int) {
 }
 
 point_iterator point_iterator::operator+(int value) const {
-    return value < 0 ? decrease(static_cast<unsigned>(std::abs(value))) : increase(value);
+    return value < 0 ? decrease(unsigned(std::abs(value))) : increase(value);
 }
 
 point_iterator point_iterator::operator-(int value) const {
-    return value < 0 ? increase(static_cast<unsigned>(std::abs(value))) : decrease(value);
+    return value < 0 ? increase(unsigned(std::abs(value))) : decrease(value);
 }
 
 bool point_iterator::operator==(point_iterator const& x) const {

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -307,7 +307,7 @@ sighash_algorithm to_sighash_enum(uint8_t sighash_type) {
 
 inline
 uint8_t is_sighash_enum(uint8_t sighash_type, sighash_algorithm value) {
-    return static_cast<uint8_t>(
+    return uint8_t(
         to_sighash_enum(sighash_type) == value
     );
 }
@@ -679,8 +679,8 @@ bool script::is_coinbase_pattern(operation::list const& ops, size_t height) {
     //Note(kth): Bitcoin core and derivatives do not follow the BIP34 specification.
     //  https://github.com/bitcoin/bitcoin/pull/14633
     if (height <= 16) {
-        static constexpr auto op_1 = static_cast<uint8_t>(opcode::push_positive_1);
-        auto const op_0 = static_cast<uint8_t>(ops[0].code());
+        static constexpr auto op_1 = uint8_t(opcode::push_positive_1);
+        auto const op_0 = uint8_t(ops[0].code());
         if (op_0 < op_1) return false;
         return height == op_0 - op_1 + 1;
     }
@@ -702,11 +702,11 @@ bool script::is_coinbase_pattern(operation::list const& ops, size_t height) {
 // It also allows any number of push ops and limits it to 0 value and 1 per tx.
 ////bool script::is_null_data_pattern(operation::list const& ops)
 ////{
-////    static constexpr auto op_76 = static_cast<uint8_t>(opcode::push_one_size);
+////    static constexpr auto op_76 = uint8_t(opcode::push_one_size);
 ////
 ////    return ops.size() >= 2
 ////        && ops[0].code() == opcode::return_
-////        && static_cast<uint8_t>(ops[1].code()) <= op_76
+////        && uint8_t(ops[1].code()) <= op_76
 ////        && ops[1].data().size() <= max_null_data_size;
 ////}
 
@@ -720,8 +720,8 @@ bool script::is_null_data_pattern(operation::list const& ops) {
 // multisig is not indexable and p2sh multisig is byte-limited to 15 sigs.
 // The satoshi client policy limit is 3 signatures for bare multisig.
 bool script::is_pay_multisig_pattern(operation::list const& ops) {
-    static constexpr auto op_1 = static_cast<uint8_t>(opcode::push_positive_1);
-    static constexpr auto op_16 = static_cast<uint8_t>(opcode::push_positive_16);
+    static constexpr auto op_1 = uint8_t(opcode::push_positive_1);
+    static constexpr auto op_16 = uint8_t(opcode::push_positive_16);
 
     auto const op_count = ops.size();
 
@@ -729,8 +729,8 @@ bool script::is_pay_multisig_pattern(operation::list const& ops) {
         return false;
     }
 
-    auto const op_m = static_cast<uint8_t>(ops[0].code());
-    auto const op_n = static_cast<uint8_t>(ops[op_count - 2].code());
+    auto const op_m = uint8_t(ops[0].code());
+    auto const op_n = uint8_t(ops[op_count - 2].code());
 
     if (op_m < op_1 || op_m > op_n || op_n < op_1 || op_n > op_16) {
         return false;
@@ -878,8 +878,8 @@ operation::list script::to_pay_multisig_pattern(uint8_t signatures, point_list c
 // The embedded script is limited to 520 bytes, an effective limit of 15 for
 // p2sh multisig, which can be as low as 7 when using all uncompressed keys.
 operation::list script::to_pay_multisig_pattern(uint8_t signatures, data_stack const& points) {
-    static constexpr auto op_81 = static_cast<uint8_t>(opcode::push_positive_1);
-    static constexpr auto op_96 = static_cast<uint8_t>(opcode::push_positive_16);
+    static constexpr auto op_81 = uint8_t(opcode::push_positive_1);
+    static constexpr auto op_96 = uint8_t(opcode::push_positive_16);
     static constexpr auto zero = op_81 - 1;
     static constexpr auto max = op_96 - zero;
 

--- a/src/domain/src/chain/script_basis.cpp
+++ b/src/domain/src/chain/script_basis.cpp
@@ -284,7 +284,7 @@ sighash_algorithm to_sighash_enum(uint8_t sighash_type) {
 
 inline
 uint8_t is_sighash_enum(uint8_t sighash_type, sighash_algorithm value) {
-    return static_cast<uint8_t>(
+    return uint8_t(
         to_sighash_enum(sighash_type) == value
     );
 }
@@ -436,8 +436,8 @@ bool script_basis::is_null_data_pattern(operation::list const& ops) {
 // multisig is not indexable and p2sh multisig is byte-limited to 15 sigs.
 // The satoshi client policy limit is 3 signatures for bare multisig.
 bool script_basis::is_pay_multisig_pattern(operation::list const& ops) {
-    static constexpr auto op_1 = static_cast<uint8_t>(opcode::push_positive_1);
-    static constexpr auto op_16 = static_cast<uint8_t>(opcode::push_positive_16);
+    static constexpr auto op_1 = uint8_t(opcode::push_positive_1);
+    static constexpr auto op_16 = uint8_t(opcode::push_positive_16);
 
     auto const op_count = ops.size();
 
@@ -445,8 +445,8 @@ bool script_basis::is_pay_multisig_pattern(operation::list const& ops) {
         return false;
     }
 
-    auto const op_m = static_cast<uint8_t>(ops[0].code());
-    auto const op_n = static_cast<uint8_t>(ops[op_count - 2].code());
+    auto const op_m = uint8_t(ops[0].code());
+    auto const op_n = uint8_t(ops[op_count - 2].code());
 
     if (op_m < op_1 || op_m > op_n || op_n < op_1 || op_n > op_16) {
         return false;
@@ -609,8 +609,8 @@ operation::list script_basis::to_pay_multisig_pattern(uint8_t signatures,
 // The embedded script is limited to 520 bytes, an effective limit of 15 for
 // p2sh multisig, which can be as low as 7 when using all uncompressed keys.
 operation::list script_basis::to_pay_multisig_pattern(uint8_t signatures, data_stack const& points) {
-    static constexpr auto op_81 = static_cast<uint8_t>(opcode::push_positive_1);
-    static constexpr auto op_96 = static_cast<uint8_t>(opcode::push_positive_16);
+    static constexpr auto op_81 = uint8_t(opcode::push_positive_1);
+    static constexpr auto op_96 = uint8_t(opcode::push_positive_16);
     static constexpr auto zero = op_81 - 1;
     static constexpr auto max = op_96 - zero;
 

--- a/src/domain/src/chain/transaction.cpp
+++ b/src/domain/src/chain/transaction.cpp
@@ -549,7 +549,7 @@ code transaction::connect_input(chain_state const& state, size_t input_index) co
     }
 
     auto const forks = state.enabled_forks();
-    auto const index32 = static_cast<uint32_t>(input_index);
+    auto const index32 = uint32_t(input_index);
 
     // Verify the transaction input script against the previous output.
     // return script::verify(*this, index32, forks);

--- a/src/domain/src/machine/opcode.cpp
+++ b/src/domain/src/machine/opcode.cpp
@@ -25,7 +25,7 @@ if (norm == text) { out_code = opcode::code; return true; }
 if (norm == text || norm == alias) { out_code = opcode::code; return true; }
 
 std::string opcode_to_string(opcode value, uint32_t active_forks) {
-    static auto const push_zero = static_cast<uint8_t>(opcode::reserved_80);
+    static auto const push_zero = uint8_t(opcode::reserved_80);
 
     switch (value) {
         // Prefer traditional aliases.
@@ -705,7 +705,7 @@ bool opcode_from_string(opcode& out_code, std::string const& value) {       //NO
 }
 
 std::string opcode_to_hexadecimal(opcode code) {
-    return "0x" + encode_base16(data_chunk{ static_cast<uint8_t>(code) });
+    return "0x" + encode_base16(data_chunk{ uint8_t(code) });
 }
 
 bool opcode_from_hexadecimal(opcode& out_code, std::string const& value) {

--- a/src/domain/src/machine/operation.cpp
+++ b/src/domain/src/machine/operation.cpp
@@ -29,8 +29,8 @@ inline bool is_text_token(std::string const& token) {
 }
 
 inline bool is_valid_data_size(opcode code, size_t size) {
-    constexpr auto op_75 = static_cast<uint8_t>(opcode::push_size_75);
-    auto const value = static_cast<uint8_t>(code);
+    constexpr auto op_75 = uint8_t(opcode::push_size_75);
+    auto const value = uint8_t(code);
     return value > op_75 || value == size;
 }
 
@@ -48,7 +48,7 @@ static
 bool opcode_from_data_prefix(opcode& out_code,
                                     std::string const& prefix,
                                     data_chunk const& data) {
-    constexpr auto op_75 = static_cast<uint8_t>(opcode::push_size_75);
+    constexpr auto op_75 = uint8_t(opcode::push_size_75);
     auto const size = data.size();
     out_code = operation::opcode_from_size(size);
 

--- a/src/domain/src/machine/script_execution_context.cpp
+++ b/src/domain/src/machine/script_execution_context.cpp
@@ -19,11 +19,11 @@ chain::transaction const& script_execution_context::transaction() const {
 }
 
 uint32_t script_execution_context::input_count() const {
-    return static_cast<uint32_t>(transaction_.inputs().size());
+    return uint32_t(transaction_.inputs().size());
 }
 
 uint32_t script_execution_context::output_count() const {
-    return static_cast<uint32_t>(transaction_.outputs().size());
+    return uint32_t(transaction_.outputs().size());
 }
 
 uint32_t script_execution_context::tx_version() const {

--- a/src/domain/src/message/inventory_vector.cpp
+++ b/src/domain/src/message/inventory_vector.cpp
@@ -14,7 +14,7 @@
 namespace kth::domain::message {
 
 uint32_t inventory_vector::to_number(type_id type) {
-    return static_cast<uint32_t>(type);
+    return uint32_t(type);
 }
 
 inventory_vector::type_id inventory_vector::to_type(uint32_t value) {

--- a/src/domain/src/wallet/stealth_address.cpp
+++ b/src/domain/src/wallet/stealth_address.cpp
@@ -187,7 +187,7 @@ stealth_address stealth_address::from_stealth(binary const& filter,
 
     // Coerce signatures to a valid range.
     auto const maximum = signatures == 0 || signatures > spend_keys_size;
-    auto const coerced = maximum ? static_cast<uint8_t>(spend_keys_size) : signatures;
+    auto const coerced = maximum ? uint8_t(spend_keys_size) : signatures;
 
     // Parameter order is used to change the constructor signature.
     return {version, filter, scan_key, spenders, coerced};
@@ -244,7 +244,7 @@ data_chunk stealth_address::to_chunk() const {
     extend_data(address, scan_key_);
 
     // Spend_pubkeys must have been guarded against a max size of 255.
-    auto number_spend_pubkeys = static_cast<uint8_t>(spend_keys_.size());
+    auto number_spend_pubkeys = uint8_t(spend_keys_.size());
 
     // Adjust for key reuse.
     if (reuse_key()) {
@@ -264,7 +264,7 @@ data_chunk stealth_address::to_chunk() const {
 
     // The prefix must be guarded against a size greater than 32
     // so that the bitfield can convert into uint32_t and sized by uint8_t.
-    auto const prefix_number_bits = static_cast<uint8_t>(filter_.size());
+    auto const prefix_number_bits = uint8_t(filter_.size());
 
     // Serialize the prefix bytes/blocks.
     address.push_back(prefix_number_bits);

--- a/src/domain/test/aserti3-2d/genenerate_test_vectors.cpp
+++ b/src/domain/test/aserti3-2d/genenerate_test_vectors.cpp
@@ -175,7 +175,7 @@ void produce_asert_test_vectors() {
         },
 
         { "run4 - from minimum target, a series of halflife schedule jumps, doubling target at each block",
-            0x01010000, 1ULL, 0ULL, 2ULL, 600 + static_cast<uint64_t>(time_incr_by_extra_halflife(0)), 256-31, height_incr_by_one, time_incr_by_extra_halflife
+            0x01010000, 1ULL, 0ULL, 2ULL, 600 + uint64_t(time_incr_by_extra_halflife(0)), 256-31, height_incr_by_one, time_incr_by_extra_halflife
         },
 
         { "run5 - from POW limit, a series of halflife block height jumps w/o time increment, halving target at each block",

--- a/src/domain/test/chain/header.cpp
+++ b/src/domain/test/chain/header.cpp
@@ -328,7 +328,7 @@ TEST_CASE("chain header  is valid timestamp  timestamp less than 2 hours from no
     chain::header instance;
     auto const now = std::chrono::system_clock::now();
     auto const now_time = std::chrono::system_clock::to_time_t(now);
-    instance.set_timestamp(static_cast<uint32_t>(now_time));
+    instance.set_timestamp(uint32_t(now_time));
     REQUIRE(instance.is_valid_timestamp());
 }
 
@@ -337,7 +337,7 @@ TEST_CASE("chain header  is valid timestamp  timestamp greater than 2 hours from
     auto const now = std::chrono::system_clock::now();
     auto const duration = std::chrono::hours(3);
     auto const future = std::chrono::system_clock::to_time_t(now + duration);
-    instance.set_timestamp(static_cast<uint32_t>(future));
+    instance.set_timestamp(uint32_t(future));
     REQUIRE( ! instance.is_valid_timestamp());
 }
 

--- a/src/domain/test/chain/point_iterator.cpp
+++ b/src/domain/test/chain/point_iterator.cpp
@@ -19,7 +19,7 @@ TEST_CASE("point iterator  operator bool  not at end  returns true", "[point ite
 
 TEST_CASE("point iterator  operator bool at end  returns false", "[point iterator]") {
     point value;
-    point_iterator instance(value, static_cast<unsigned>(value.serialized_size(false)));
+    point_iterator instance(value, unsigned(value.serialized_size(false)));
     REQUIRE( ! instance);
 }
 

--- a/src/domain/test/machine/operation.cpp
+++ b/src/domain/test/machine/operation.cpp
@@ -109,7 +109,7 @@ TEST_CASE("operation from data roundtrip push size 75  success", "[operation]") 
 }
 
 TEST_CASE("operation from data roundtrip push negative 1  success", "[operation]") {
-    static auto const op_79 = static_cast<uint8_t>(opcode::push_negative_1);
+    static auto const op_79 = uint8_t(opcode::push_negative_1);
     auto const data1 = data_chunk{op_79};
     auto const raw_operation = data1;
     operation instance;
@@ -136,7 +136,7 @@ TEST_CASE("operation from data roundtrip push negative 1  success", "[operation]
 }
 
 TEST_CASE("operation from data roundtrip push positive 1  success", "[operation]") {
-    static auto const op_81 = static_cast<uint8_t>(opcode::push_positive_1);
+    static auto const op_81 = uint8_t(opcode::push_positive_1);
     auto const data1 = data_chunk{op_81};
     auto const raw_operation = data1;
     operation instance;
@@ -163,7 +163,7 @@ TEST_CASE("operation from data roundtrip push positive 1  success", "[operation]
 }
 
 TEST_CASE("operation from data roundtrip push positive 16  success", "[operation]") {
-    static auto const op_96 = static_cast<uint8_t>(opcode::push_positive_16);
+    static auto const op_96 = uint8_t(opcode::push_positive_16);
     auto const data1 = data_chunk{op_96};
     auto const raw_operation = data1;
 

--- a/src/domain/test/math/limits.cpp
+++ b/src/domain/test/math/limits.cpp
@@ -26,7 +26,7 @@ TEST_CASE("limits cast add  uint32 to int64 maximum plus 0  returns maximum", "[
 }
 
 TEST_CASE("limits cast add  uint32 to int64 maximum plus maximum returns twice maximum", "[limits]") {
-    static int64_t const expected = 2 * static_cast<int64_t>(max_uint32);
+    static int64_t const expected = 2 * int64_t(max_uint32);
     REQUIRE(cast_add<int64_t>(max_uint32, max_uint32) == expected);
 }
 
@@ -39,7 +39,7 @@ TEST_CASE("limits cast subtract  uint32 to int64 0  returns 0", "[limits]") {
 }
 
 TEST_CASE("limits cast subtract  uint32 to int64 0 minus maximum returns negtive maximum", "[limits]") {
-    static int64_t const expected = -1 * static_cast<int64_t>(max_uint32);
+    static int64_t const expected = -1 * int64_t(max_uint32);
     REQUIRE(cast_subtract<int64_t>(uint32_t{0}, max_uint32) == expected);
 }
 

--- a/src/domain/test/message/send_compact.cpp
+++ b/src/domain/test/message/send_compact.cpp
@@ -60,7 +60,7 @@ TEST_CASE("send compact  from data 1  invalid mode byte  failure", "[send compac
     message::send_compact msg;
     byte_reader reader(raw_data);
     auto exp_result = message::send_compact::from_data(reader, message::send_compact::version_minimum);
-    bool result = static_cast<bool>(exp_result);
+    bool result = bool(exp_result);
     if (result) msg = std::move(*exp_result);
     REQUIRE( ! result);
 }
@@ -71,7 +71,7 @@ TEST_CASE("send compact  from data 1  insufficient version  failure", "[send com
     message::send_compact msg;
     byte_reader reader(raw_data);
     auto exp_result = message::send_compact::from_data(reader, message::send_compact::version_minimum - 1);
-    bool result = static_cast<bool>(exp_result);
+    bool result = bool(exp_result);
     if (result) msg = std::move(*exp_result);
     REQUIRE( ! result);
 }

--- a/src/domain/test/wallet/encrypted_keys.cpp
+++ b/src/domain/test/wallet/encrypted_keys.cpp
@@ -631,7 +631,7 @@ TEST_CASE("encrypted  create token lot  private and public compressed testnet  d
 //    auto const compressed = true;
 //    for (size_t version = 0x00; version <= 0xFF; ++version)
 //    {
-//        auto const byte = static_cast<uint8_t>(version);
+//        auto const byte = uint8_t(version);
 //       REQUIRE(encrypt(out_private_key, secret, "passphrase", byte, compressed));
 //
 //        auto key = encode_base58(out_private_key);
@@ -654,7 +654,7 @@ TEST_CASE("encrypted  create token lot  private and public compressed testnet  d
 //    auto const compressed = true;
 //    for (size_t version = 0x00; version <= 0xFF; ++version)
 //    {
-//        auto const byte = static_cast<uint8_t>(version);
+//        auto const byte = uint8_t(version);
 //       REQUIRE(create_key_pair(out_private_key, out_public_key, unused, token, seed, byte, compressed));
 //
 //        auto private_key = encode_base58(out_private_key);

--- a/src/infrastructure/include/kth/infrastructure/impl/machine/number.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/machine/number.ipp
@@ -64,13 +64,13 @@ bool number::set_data(data_chunk const& data, size_t max_size) {
 
     // This is "from little endian" with a variable buffer.
     for (size_t i = 0; i != data.size(); ++i) {
-        value_ |= static_cast<int64_t>(data[i]) << (8 * i);
+        value_ |= int64_t(data[i]) << (8 * i);
     }
 
     if (is_negative(data)) {
         auto const last_shift = 8 * (data.size() - 1);
         auto const mask = ~(negative_bit << last_shift);
-        value_ = -1 * (static_cast<int64_t>(value_ & mask));
+        value_ = -1 * (int64_t(value_ & mask));
     }
 
     return true;
@@ -89,7 +89,7 @@ data_chunk number::data() const {
 
     // This is "to little endian" with a minimal buffer.
     while (absolute != 0) {
-        data.push_back(static_cast<uint8_t>(absolute));
+        data.push_back(uint8_t(absolute));
         absolute >>= 8;
     }
 

--- a/src/infrastructure/include/kth/infrastructure/impl/utility/collection.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/utility/collection.ipp
@@ -42,7 +42,7 @@ int find_pair_position(std::vector<Pair> const& list, const Key& key) {
         return -1;
     }
 
-    return static_cast<int>(distance(list.begin(), it));
+    return int(distance(list.begin(), it));
 }
 
 template <typename T, typename Container>
@@ -53,7 +53,7 @@ int find_position(const Container& list, T const& value) {
         return -1;
     }
 
-    return static_cast<int>(std::distance(list.begin(), it));
+    return int(std::distance(list.begin(), it));
 }
 
 template <typename T, typename Predicate>

--- a/src/infrastructure/include/kth/infrastructure/impl/utility/serializer.ipp
+++ b/src/infrastructure/include/kth/infrastructure/impl/utility/serializer.ipp
@@ -73,13 +73,13 @@ void serializer<Iterator>::write_8_bytes_big_endian(uint64_t value) {
 template <typename Iterator>
 void serializer<Iterator>::write_variable_big_endian(uint64_t value) {
     if (value < varint_two_bytes) {
-        write_byte(static_cast<uint8_t>(value));
+        write_byte(uint8_t(value));
     } else if (value <= max_uint16) {
         write_byte(varint_two_bytes);
-        write_2_bytes_big_endian(static_cast<uint16_t>(value));
+        write_2_bytes_big_endian(uint16_t(value));
     } else if (value <= max_uint32) {
         write_byte(varint_four_bytes);
-        write_4_bytes_big_endian(static_cast<uint32_t>(value));
+        write_4_bytes_big_endian(uint32_t(value));
     } else {
         write_byte(varint_eight_bytes);
         write_8_bytes_big_endian(value);
@@ -96,7 +96,7 @@ void serializer<Iterator>::write_size_big_endian(size_t value) {
 
 template <typename Iterator>
 void serializer<Iterator>::write_error_code(code const& ec) {
-    write_4_bytes_little_endian(static_cast<uint32_t>(ec.value()));
+    write_4_bytes_little_endian(uint32_t(ec.value()));
 }
 
 template <typename Iterator>
@@ -117,13 +117,13 @@ void serializer<Iterator>::write_8_bytes_little_endian(uint64_t value) {
 template <typename Iterator>
 void serializer<Iterator>::write_variable_little_endian(uint64_t value) {
     if (value < varint_two_bytes) {
-        write_byte(static_cast<uint8_t>(value));
+        write_byte(uint8_t(value));
     } else if (value <= max_uint16) {
         write_byte(varint_two_bytes);
-        write_2_bytes_little_endian(static_cast<uint16_t>(value));
+        write_2_bytes_little_endian(uint16_t(value));
     } else if (value <= max_uint32) {
         write_byte(varint_four_bytes);
-        write_4_bytes_little_endian(static_cast<uint32_t>(value));
+        write_4_bytes_little_endian(uint32_t(value));
     } else {
         write_byte(varint_eight_bytes);
         write_8_bytes_little_endian(value);
@@ -228,7 +228,7 @@ size_t serializer<Iterator>::read_size_big_endian() {
     // This facilitates safely passing the size into a follow-on writer.
     // Return zero allows follow-on use before testing reader state.
     if (size <= max_size_t) {
-        return static_cast<size_t>(size);
+        return size_t(size);
     }
 
     valid_ = false;
@@ -259,7 +259,7 @@ size_t serializer<Iterator>::read_size_little_endian() {
     // This facilitates safely passing the size into a follow-on writer.
     // Return zero allows follow-on use before testing reader state.
     if (size <= max_size_t) {
-        return static_cast<size_t>(size);
+        return size_t(size);
     }
 
     valid_ = false;

--- a/src/infrastructure/include/kth/infrastructure/utility/limits.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/limits.hpp
@@ -112,7 +112,7 @@ I floor_subtract(I left, I right) {
 //     static_assert(sizeof(uint64_t) >= sizeof(To), "safe assign out of range");
 //     static auto const signed_maximum = (std::numeric_limits<To>::max)();
 
-//     if (unsigned_value > static_cast<uint64_t>(signed_maximum)) {
+//     if (unsigned_value > uint64_t(signed_maximum)) {
 //         throw std::range_error("to signed assignment out of range");
 //     }
 
@@ -124,7 +124,7 @@ I floor_subtract(I left, I right) {
 //     static_assert(sizeof(uint64_t) >= sizeof(To), "safe assign out of range");
 //     static auto const unsigned_maximum = (std::numeric_limits<To>::max)();
 
-//     if (signed_value < 0 || static_cast<uint64_t>(signed_value) > unsigned_maximum) {
+//     if (signed_value < 0 || uint64_t(signed_value) > unsigned_maximum) {
 //         throw std::range_error("to unsigned assignment out of range");
 //     }
 
@@ -193,7 +193,7 @@ expected<To, code> safe_to_signed(From unsigned_value) {
     static_assert(sizeof(uint64_t) >= sizeof(To), "safe assign out of range");
     static auto const signed_maximum = (std::numeric_limits<To>::max)();
 
-    if (unsigned_value > static_cast<uint64_t>(signed_maximum)) {
+    if (unsigned_value > uint64_t(signed_maximum)) {
         return std::unexpected(error::out_of_range);
     }
 
@@ -205,7 +205,7 @@ expected<To, code> safe_to_unsigned(From signed_value) {
     static_assert(sizeof(uint64_t) >= sizeof(To), "safe assign out of range");
     static auto const unsigned_maximum = (std::numeric_limits<To>::max());
 
-    if (signed_value < 0 || static_cast<uint64_t>(signed_value) > unsigned_maximum) {
+    if (signed_value < 0 || uint64_t(signed_value) > unsigned_maximum) {
         return std::unexpected(error::out_of_range);
     }
 

--- a/src/infrastructure/include/kth/infrastructure/utility/pseudo_random.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/pseudo_random.hpp
@@ -74,7 +74,7 @@ struct KI_API pseudo_random {
                 //TODO: replace exceptions with std::expected
                 throw std::runtime_error("getrandom() failed, errno=" + std::to_string(errno));
             }
-            offset += static_cast<size_t>(ret);
+            offset += size_t(ret);
         }
 #endif
     }

--- a/src/infrastructure/src/formats/base_16.cpp
+++ b/src/infrastructure/src/formats/base_16.cpp
@@ -28,7 +28,7 @@ std::string encode_base16(byte_span data) {
 }
 
 bool is_base16(char c) {
-    return hex_decode_table[static_cast<uint8_t>(c)] != 255;
+    return hex_decode_table[uint8_t(c)] != 255;
 }
 
 // Bitcoin hash format (these are all reversed):

--- a/src/infrastructure/src/unicode/unicode_streambuf.cpp
+++ b/src/infrastructure/src/unicode/unicode_streambuf.cpp
@@ -50,7 +50,7 @@ std::streambuf::int_type unicode_streambuf::underflow() {
     auto const size = static_cast<std::streamsize>(wide_size_);
 
     // Read from the wide input buffer.
-    auto const read = static_cast<size_t>(wide_buffer_->sgetn(wide_, size));
+    auto const read = size_t(wide_buffer_->sgetn(wide_, size));
 
     // Handle read termination.
     if (read == 0) {

--- a/src/infrastructure/src/utility/binary.cpp
+++ b/src/infrastructure/src/utility/binary.cpp
@@ -66,7 +66,7 @@ void binary::resize(size_type size) {
 
     if (offset > 0) {
         // This subtraction is guarded above.
-        final_block_excess_ = static_cast<uint8_t>(bits_per_block - offset);
+        final_block_excess_ = uint8_t(bits_per_block - offset);
         auto const last_ex = safe_subtract(blocks_.size(), size_t(1));
         if ( ! last_ex) {
             return;

--- a/src/infrastructure/src/utility/ostream_writer.cpp
+++ b/src/infrastructure/src/utility/ostream_writer.cpp
@@ -67,13 +67,13 @@ void ostream_writer::write_8_bytes_big_endian(uint64_t value) {
 
 void ostream_writer::write_variable_big_endian(uint64_t value) {
     if (value < varint_two_bytes) {
-        write_byte(static_cast<uint8_t>(value));
+        write_byte(uint8_t(value));
     } else if (value <= max_uint16) {
         write_byte(varint_two_bytes);
-        write_2_bytes_big_endian(static_cast<uint16_t>(value));
+        write_2_bytes_big_endian(uint16_t(value));
     } else if (value <= max_uint32) {
         write_byte(varint_four_bytes);
-        write_4_bytes_big_endian(static_cast<uint32_t>(value));
+        write_4_bytes_big_endian(uint32_t(value));
     } else {
         write_byte(varint_eight_bytes);
         write_8_bytes_big_endian(value);
@@ -88,7 +88,7 @@ void ostream_writer::write_size_big_endian(size_t value) {
 //-----------------------------------------------------------------------------
 
 void ostream_writer::write_error_code(code const& ec) {
-    write_4_bytes_little_endian(static_cast<uint32_t>(ec.value()));
+    write_4_bytes_little_endian(uint32_t(ec.value()));
 }
 
 void ostream_writer::write_2_bytes_little_endian(uint16_t value) {
@@ -105,13 +105,13 @@ void ostream_writer::write_8_bytes_little_endian(uint64_t value) {
 
 void ostream_writer::write_variable_little_endian(uint64_t value) {
     if (value < varint_two_bytes) {
-        write_byte(static_cast<uint8_t>(value));
+        write_byte(uint8_t(value));
     } else if (value <= max_uint16) {
         write_byte(varint_two_bytes);
-        write_2_bytes_little_endian(static_cast<uint16_t>(value));
+        write_2_bytes_little_endian(uint16_t(value));
     } else if (value <= max_uint32) {
         write_byte(varint_four_bytes);
-        write_4_bytes_little_endian(static_cast<uint32_t>(value));
+        write_4_bytes_little_endian(uint32_t(value));
     } else {
         write_byte(varint_eight_bytes);
         write_8_bytes_little_endian(value);

--- a/src/infrastructure/src/utility/png.cpp
+++ b/src/infrastructure/src/utility/png.cpp
@@ -23,7 +23,7 @@ bool png::write_png(byte_span data, uint32_t size, std::ostream& out) {
 
 extern "C" void sink_write(png_structp png_ptr, png_bytep data, png_size_t length) {
     static_assert(sizeof(length) <= sizeof(size_t), "png_size_t too large");
-    auto const size = static_cast<size_t>(length);
+    auto const size = size_t(length);
     auto& sink = *reinterpret_cast<ostream_writer*>(png_get_io_ptr(png_ptr));
     sink.write_bytes(reinterpret_cast<uint8_t const*>(data), size);
 }

--- a/src/infrastructure/src/utility/pseudo_random_broken_do_not_use.cpp
+++ b/src/infrastructure/src/utility/pseudo_random_broken_do_not_use.cpp
@@ -37,7 +37,7 @@ void pseudo_random_broken_do_not_use_fill(data_chunk& out) {
 static
 uint32_t get_clock_seed() {
     auto const now = high_resolution_clock::now();
-    return static_cast<uint32_t>(now.time_since_epoch().count());
+    return uint32_t(now.time_since_epoch().count());
 }
 
 std::mt19937& pseudo_random_broken_do_not_use::_get_twister_broken_do_not_use() {
@@ -90,7 +90,7 @@ asio::duration pseudo_random_broken_do_not_use::duration(asio::duration const& e
     }
 
     // [0..2^64) % 2500 => [0..2500]
-    auto const random_offset = static_cast<int>(pseudo_random_broken_do_not_use::next(0, limit));
+    auto const random_offset = int(pseudo_random_broken_do_not_use::next(0, limit));
 
     // (10000 - [0..2500]) => [7500..10000]
     auto const expires = max_expire - random_offset;

--- a/src/infrastructure/src/wallet/cashaddr.cpp
+++ b/src/infrastructure/src/wallet/cashaddr.cpp
@@ -163,7 +163,7 @@ data_chunk expand_prefix(std::string_view prefix) {
     data_chunk ret;
     ret.resize(prefix.size() + 1);
     for (size_t i = 0; i < prefix.size(); ++i) {
-        ret[i] = static_cast<uint8_t>(prefix[i]) & 0x1fu;
+        ret[i] = uint8_t(prefix[i]) & 0x1fu;
     }
 
     ret[prefix.size()] = 0;

--- a/src/infrastructure/src/wallet/hd_private.cpp
+++ b/src/infrastructure/src/wallet/hd_private.cpp
@@ -232,7 +232,7 @@ hd_private hd_private::derive_private(uint32_t index) const {
 
     hd_lineage const lineage {
         lineage_.prefixes,
-        static_cast<uint8_t>(lineage_.depth + 1),
+        uint8_t(lineage_.depth + 1),
         fingerprint(),
         index
     };

--- a/src/infrastructure/src/wallet/hd_public.cpp
+++ b/src/infrastructure/src/wallet/hd_public.cpp
@@ -211,7 +211,7 @@ hd_public hd_public::derive_public(uint32_t index) const {
 
     hd_lineage const lineage {
         lineage_.prefixes,
-        static_cast<uint8_t>(lineage_.depth + 1),
+        uint8_t(lineage_.depth + 1),
         fingerprint(),
         index
     };

--- a/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
+++ b/src/infrastructure/test/formats/base_encoding_benchmarks.cpp
@@ -15,7 +15,7 @@ using ankerl::nanobench::Bench;
 std::vector<uint8_t> generate_test_data(size_t size) {
     std::vector<uint8_t> data(size);
     for (size_t i = 0; i < size; ++i) {
-        data[i] = static_cast<uint8_t>(i * 137);  // Pseudo-random pattern
+        data[i] = uint8_t(i * 137);  // Pseudo-random pattern
     }
     return data;
 }

--- a/src/infrastructure/test/machine/number.cpp
+++ b/src/infrastructure/test/machine/number.cpp
@@ -283,7 +283,7 @@ static number_compare MakeCompare(int64_t const num1, int64_t const num2) {
 static
 void write_bytes(kth::data_chunk chunk, std::ostream& out) {
     for (auto const& byte : chunk)
-        out << fmt::format(" 0x%02x, ", static_cast<uint16_t>(byte));
+        out << fmt::format(" 0x%02x, ", uint16_t(byte));
 }
 
 static

--- a/src/infrastructure/test/unicode/unicode.cpp
+++ b/src/infrastructure/test/unicode/unicode.cpp
@@ -233,7 +233,7 @@ TEST_CASE("unicode  to utf8 environment  null termination  test", "[unicode test
     std::vector<const wchar_t*> wide_environment = { L"ascii", nullptr };
 
     auto variables = const_cast<wchar_t**>(&wide_environment[0]);
-    auto expected_count = static_cast<int>(wide_environment.size()) - 1;
+    auto expected_count = int(wide_environment.size()) - 1;
 
     auto environment = to_utf8(variables);
     auto narrow_environment = reinterpret_cast<char**>(&environment[0]);
@@ -252,7 +252,7 @@ TEST_CASE("unicode  to utf8 environment  null termination  test", "[unicode test
 //     std::vector<const wchar_t*> wide_args = { L"ascii", nullptr };
 
 //     auto argv = const_cast<wchar_t**>(&wide_args[0]);
-//     auto argc = static_cast<int>(wide_args.size()) - 1;
+//     auto argc = int(wide_args.size()) - 1;
 
 //     auto buffer = to_utf8(argc, argv);
 //     auto narrow_args = reinterpret_cast<char**>(&buffer[0]);
@@ -267,7 +267,7 @@ TEST_CASE("unicode  to utf8 environment  null termination  test", "[unicode test
 //     std::vector<const wchar_t*> wide_args = { L"ascii", non_literal_utf16, nullptr };
 
 //     auto argv = const_cast<wchar_t**>(&wide_args[0]);
-//     auto argc = static_cast<int>(wide_args.size()) - 1;
+//     auto argc = int(wide_args.size()) - 1;
 
 //     auto buffer = to_utf8(argc, argv);
 //     auto narrow_args = reinterpret_cast<char**>(&buffer[0]);
@@ -280,7 +280,7 @@ TEST_CASE("unicode  to utf8 main  null termination  test", "[unicode tests]") {
     std::vector<const wchar_t*> wide_args = { L"ascii", nullptr };
 
     auto argv = const_cast<wchar_t**>(&wide_args[0]);
-    auto argc = static_cast<int>(wide_args.size()) - 1;
+    auto argc = int(wide_args.size()) - 1;
 
     auto buffer = to_utf8(argc, argv);
     auto narrow_args = reinterpret_cast<char**>(&buffer[0]);

--- a/src/infrastructure/test/utility/byte_reader.cpp
+++ b/src/infrastructure/test/utility/byte_reader.cpp
@@ -247,7 +247,7 @@ TEST_CASE("byte_reader - read_string fixed size with null terminator", "[byte_re
 TEST_CASE("byte_reader - read_string with varint prefix", "[byte_reader tests]") {
     std::string const expected = "my string data";
     data_chunk buffer;
-    buffer.push_back(static_cast<uint8_t>(expected.length()));  // varint length
+    buffer.push_back(uint8_t(expected.length()));  // varint length
     buffer.insert(buffer.end(), expected.begin(), expected.end());
 
     byte_reader reader(buffer);

--- a/src/network/src/hosts.cpp
+++ b/src/network/src/hosts.cpp
@@ -19,8 +19,8 @@ using namespace kth::config;
 
 // TODO: change to network_address bimap hash table with services and age.
 hosts::hosts(settings const& settings)
-    : capacity_(std::min(max_address, static_cast<size_t>(settings.host_pool_capacity)))
-    , buffer_(std::max(capacity_, static_cast<size_t>(1u)))
+    : capacity_(std::min(max_address, size_t(settings.host_pool_capacity)))
+    , buffer_(std::max(capacity_, size_t(1u)))
     , stopped_(true)
     , file_path_(settings.hosts_file)
     , disabled_(capacity_ == 0)
@@ -63,7 +63,7 @@ code hosts::fetch(address& out) const {
 
     // Randomly select an address from the buffer.
     auto const random = pseudo_random_broken_do_not_use::next(0, buffer_.size() - 1);
-    auto const index = static_cast<size_t>(random);
+    auto const index = size_t(random);
     out = buffer_[index];
     return error::success;
     ///////////////////////////////////////////////////////////////////////////
@@ -87,7 +87,7 @@ code hosts::fetch(address::list& out) const {
             return error::not_found;
         }
 
-        auto const out_count = std::min(buffer_.size(), capacity_) / static_cast<size_t>(pseudo_random_broken_do_not_use::next(1, 20));
+        auto const out_count = std::min(buffer_.size(), capacity_) / size_t(pseudo_random_broken_do_not_use::next(1, 20));
 
         if (out_count == 0) {
             return error::success;
@@ -288,7 +288,7 @@ void hosts::store(address::list const& hosts, result_handler handler) {
     // Accept between 1 and all of this peer's addresses up to capacity.
     auto const capacity = buffer_.capacity();
     auto const usable = std::min(hosts.size(), capacity);
-    auto const random = static_cast<size_t>(pseudo_random_broken_do_not_use::next(1, usable));
+    auto const random = size_t(pseudo_random_broken_do_not_use::next(1, usable));
 
     // But always accept at least the amount we are short if available.
     auto const gap = capacity - buffer_.size();

--- a/src/network/src/protocols/protocol_reject_70002.cpp
+++ b/src/network/src/protocols/protocol_reject_70002.cpp
@@ -61,7 +61,7 @@ bool protocol_reject_70002::handle_receive_reject(code const& ec, reject_const_p
     }
 
     auto const code = reject->code();
-    spdlog::debug("[network] Received {} reject ({}) from [{}] '{}'{}", message, static_cast<uint16_t>(code), authority(), reject->reason(), hash);
+    spdlog::debug("[network] Received {} reject ({}) from [{}] '{}'{}", message, uint16_t(code), authority(), reject->reason(), hash);
     return true;
 }
 

--- a/src/network/src/protocols/protocol_version_31402.cpp
+++ b/src/network/src/protocols/protocol_version_31402.cpp
@@ -71,13 +71,13 @@ domain::message::version protocol_version_31402::version_factory() const {
     domain::message::version version;
     version.set_value(own_version_);
     version.set_services(own_services_);
-    version.set_timestamp(static_cast<uint64_t>(zulu_time()));
+    version.set_timestamp(uint64_t(zulu_time()));
     version.set_address_receiver(authority().to_network_address());
     version.set_address_sender(settings.self.to_network_address());
     version.set_nonce(nonce());
     // version.set_user_agent(get_user_agent());
     version.set_user_agent(user_agent_);
-    version.set_start_height(static_cast<uint32_t>(height));
+    version.set_start_height(uint32_t(height));
 
     // The peer's services cannot be reflected, so zero it.
     version.address_receiver().set_services(version::service::none);

--- a/src/node/src/protocols/protocol_block_in.cpp
+++ b/src/node/src/protocols/protocol_block_in.cpp
@@ -710,12 +710,12 @@ bool enabled(size_t height) {
 inline
 float difference(const asio::time_point& start, const asio::time_point& end) {
     auto const elapsed = duration_cast<asio::microseconds>(end - start);
-    return static_cast<float>(elapsed.count());
+    return float(elapsed.count());
 }
 
 inline
 size_t unit_cost(const asio::time_point& start, const asio::time_point& end, size_t value) {
-    return static_cast<size_t>(std::round(difference(start, end) / value));
+    return size_t(std::round(difference(start, end) / value));
 }
 
 inline

--- a/src/node/src/protocols/protocol_header_sync.cpp
+++ b/src/node/src/protocols/protocol_header_sync.cpp
@@ -121,7 +121,7 @@ void protocol_header_sync::handle_event(code const& ec, event_handler complete) 
     // TODO: replace rate backoff with peer competition.
     //=========================================================================
     // It was a timeout so another expiry period has passed (overflow ok here).
-    current_second_ += static_cast<size_t>(expiry_interval.count());
+    current_second_ += size_t(expiry_interval.count());
     auto rate = (headers_->previous_height() - start_size_) / current_second_;
     //=========================================================================
 

--- a/src/node/src/protocols/protocol_transaction_in.cpp
+++ b/src/node/src/protocols/protocol_transaction_in.cpp
@@ -31,7 +31,7 @@ inline
 uint64_t to_relay_fee(float minimum_byte_fee) {
     // Spending one standard prevout with one output is nominally 189 bytes.
     static size_t const small_transaction_size = 189;
-    return static_cast<uint64_t>(minimum_byte_fee * small_transaction_size);
+    return uint64_t(minimum_byte_fee * small_transaction_size);
 }
 
 protocol_transaction_in::protocol_transaction_in(full_node& node, channel::ptr channel, safe_chain& chain)

--- a/src/node/src/sessions/session_header_sync.cpp
+++ b/src/node/src/sessions/session_header_sync.cpp
@@ -155,7 +155,7 @@ void session_header_sync::attach_protocols(channel::ptr channel, header_list::pt
 void session_header_sync::handle_complete(code const& ec, header_list::ptr row, result_handler handler) {
     if (ec) {
         // Reduce the rate minimum so that we don't get hung up.
-        minimum_rate_ = static_cast<uint32_t>(minimum_rate_ * back_off_factor);
+        minimum_rate_ = uint32_t(minimum_rate_ * back_off_factor);
 
         // There is no failure scenario, we ignore the result code here.
         new_connection(row, handler);

--- a/src/node/src/utility/performance.cpp
+++ b/src/node/src/utility/performance.cpp
@@ -10,7 +10,7 @@ namespace kth::node {
 
 double performance::normal() const {
     // If numerator is small we can overflow (infinity).
-    return divide<double>(events, static_cast<double>(window) - database);
+    return divide<double>(events, double(window) - database);
 }
 
 double performance::total() const {

--- a/src/node/src/utility/reservation.cpp
+++ b/src/node/src/utility/reservation.cpp
@@ -160,7 +160,7 @@ void reservation::update_rate(size_t events, microseconds const& database) {
     for (auto it = history_.begin(); it != history_.end() && it->time < start; it = history_.erase(it));
 
     auto const window_full = history_count > history_.size();
-    auto const event_cost = static_cast<uint64_t>(database.count());
+    auto const event_cost = uint64_t(database.count());
     history_.push_back({ events, event_cost, event_start });
 
     // We can't set the rate until we have a period (two or more data points).
@@ -181,7 +181,7 @@ void reservation::update_rate(size_t events, microseconds const& database) {
     // Calculate the duration of the rate window.
     auto window = window_full ? rate_window() : (end - history_.front().time);
     auto count = duration_cast<microseconds>(window).count();
-    rate.window = static_cast<uint64_t>(count);
+    rate.window = uint64_t(count);
 
     history_mutex_.unlock();
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

- Replace `static_cast<T>(x)` with `T(x)` for simple types throughout the codebase
- Function-style casts are more concise while being equivalent for non-pointer types
- Update `.gitignore` to exclude runtime files (`banlist.dat`, `hosts.cache`)

## Motivation

Reduce noise in future PRs by applying these style changes to master first, then rebasing feature branches.

## Files changed

85 files with consistent style updates.