### PR TITLE
fix: use portable shebangs in shell scripts

### DIFF
--- a/scripts/backfill_release_notes.sh
+++ b/scripts/backfill_release_notes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to backfill missing release notes from GitHub
 # This script handles the multi-repo versioning complexity

--- a/scripts/build-create-ems.sh
+++ b/scripts/build-create-ems.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 if [ -z "$1" ]; then

--- a/scripts/build-create.sh
+++ b/scripts/build-create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 if [ -z "$1" ]; then

--- a/scripts/build-ems.sh
+++ b/scripts/build-ems.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 if [ -z "$1" ]; then

--- a/scripts/build-ninja.sh
+++ b/scripts/build-ninja.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 if [ -z "$1" ]; then

--- a/scripts/build-sanitizer.sh
+++ b/scripts/build-sanitizer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to build locally with sanitizers enabled
 # Based on scripts/build.sh but with sanitizer support

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 if [ -z "$1" ]; then

--- a/scripts/check-cppcheck.sh
+++ b/scripts/check-cppcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to run cppcheck analysis on C++ code
 # This mirrors the same check that runs in GitHub Actions

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to check C++ code formatting with clang-format
 # This mirrors the same check that runs in GitHub Actions

--- a/scripts/check-iwyu.sh
+++ b/scripts/check-iwyu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to run include-what-you-use analysis on C++ code
 # This helps optimize #include dependencies and reduce compile times

--- a/scripts/check-tidy.sh
+++ b/scripts/check-tidy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to run clang-tidy analysis on C++ code
 # This mirrors the same check that runs in GitHub Actions

--- a/scripts/east_const.sh
+++ b/scripts/east_const.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # East const conversion script
 # Usage: ./scripts/east_const.sh

--- a/scripts/local_build_test.sh
+++ b/scripts/local_build_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Local Build and Test Script
 # Based on GitHub Actions build-without-container.yml workflow

--- a/scripts/lock.sh
+++ b/scripts/lock.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # VERSION=$(cat conanfile.py | grep "version" | cut -d '"' -f 2)
 VERSION="0.68.0"

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Colors for output

--- a/scripts/prepare_version_sync.sh
+++ b/scripts/prepare_version_sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to prepare version synchronization across all Knuth repositories
 # Usage: ./scripts/prepare_version_sync.sh <new_version>

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 if [ -z "$1" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 # Error handling - rollback on failure

--- a/scripts/rollback-release.sh
+++ b/scripts/rollback-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Colors for output

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "Running existing tests..."

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Pretty Test Runner for KTH Project
 # Uses Catch2 reporters for beautiful output

--- a/scripts/sync_release_notes.sh
+++ b/scripts/sync_release_notes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to sync release notes from GitHub Releases to local markdown file
 # Usage: ./sync_release_notes.sh

--- a/scripts/test-sanitizers.sh
+++ b/scripts/test-sanitizers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to test sanitizer builds locally
 # This mirrors the sanitizer functionality in GitHub Actions build workflows

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ -z "$1" ]; then

--- a/scripts/update_readme_versions.sh
+++ b/scripts/update_readme_versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to update version numbers in README files
 # Usage: ./update_readme_versions.sh <new_version>


### PR DESCRIPTION
## Summary
- Change `#!/bin/bash` to `#!/usr/bin/env bash` for better portability

## Motivation
Scripts fail on NixOS and other distributions where bash is not at `/bin/bash`.

## Changes
- Updated 25 shell scripts to use portable shebangs