### PR TITLE
fix: generate version.hpp during release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build_debug/
 build_release/
 CMakeUserPresets.json
 build-asan/
+build-release-*/
 test_runner/
 doc/release-notes/*.backup
 src/domain/CMakeLists.txt

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -145,6 +145,51 @@ else
     echo "📝 No lockfile changes detected"
 fi
 
+# Generate version.hpp via conan install + cmake configure (no build needed)
+echo "📦 Generating version.hpp for ${VERSION}..."
+BUILD_RELEASE_DIR="build-release-${VERSION}"
+rm -rf "${BUILD_RELEASE_DIR}"
+
+conan lock create conanfile.py --version "${VERSION}" --lockfile=conan.lock --lockfile-out="${BUILD_RELEASE_DIR}/conan.lock"
+conan install conanfile.py --version="${VERSION}" --lockfile="${BUILD_RELEASE_DIR}/conan.lock" -of "${BUILD_RELEASE_DIR}" --build=missing
+
+# Temporarily point CMakeUserPresets.json to the release build directory
+PRESETS_BAK=""
+if [ -f CMakeUserPresets.json ]; then
+    PRESETS_BAK=$(cat CMakeUserPresets.json)
+fi
+cat > CMakeUserPresets.json <<PRESETS_EOF
+{
+    "version": 4,
+    "vendor": { "conan": {} },
+    "include": [
+        "${BUILD_RELEASE_DIR}/build/Release/generators/CMakePresets.json"
+    ]
+}
+PRESETS_EOF
+
+cmake --preset conan-release \
+    -DGLOBAL_BUILD=ON \
+    -DCMAKE_BUILD_TYPE=Release
+
+# Restore CMakeUserPresets.json
+if [ -n "$PRESETS_BAK" ]; then
+    echo "$PRESETS_BAK" > CMakeUserPresets.json
+else
+    rm -f CMakeUserPresets.json
+fi
+
+# Note: ${BUILD_RELEASE_DIR} is left for inspection. Clean up in post-release.sh or manually.
+
+# Check if version.hpp was updated
+VERSION_HPP="src/domain/include/kth/domain/version.hpp"
+if git status --porcelain | grep -q "version.hpp"; then
+    echo "📝 version.hpp updated to ${VERSION}"
+    CHANGES_MADE=true
+else
+    echo "📝 version.hpp already has version ${VERSION}"
+fi
+
 # Commit everything in a single commit
 if [ "$CHANGES_MADE" = true ]; then
     echo "📝 Creating single commit with all changes..."
@@ -152,7 +197,8 @@ if [ "$CHANGES_MADE" = true ]; then
     git commit -m "release: prepare version ${VERSION}
 
 - Update README versions to ${VERSION}
-- Generate conan.lock and conan-wasm.lock for ${VERSION}"
+- Generate conan.lock and conan-wasm.lock for ${VERSION}
+- Update version.hpp to ${VERSION}"
 else
     echo "📝 No changes to commit"
 fi


### PR DESCRIPTION
## Summary

- `release.sh` now runs `conan install` + `cmake configure` (no build) to generate `version.hpp` from `version.hpp.in` before committing
- Uses a dedicated `build-release-<version>/` directory to avoid interfering with the normal `build/` directory
- The release build directory is kept for inspection (can be cleaned up in `post-release.sh` or manually)
- Adds `build-release-*/` to `.gitignore`

## Context

`version.hpp` is generated by CMake's `configure_file()` from `version.hpp.in`, with the version string coming from conan → cmake. The release script never ran cmake, so `version.hpp` was never updated during releases (e.g., 0.76.0 still showed 0.75.0).

## Test plan

- [ ] Run `release.sh` for next version and verify `version.hpp` is updated and committed
- [ ] Verify `build-release-<version>/` directory is created and not picked up by `git add`
- [ ] Verify `CMakeUserPresets.json` is restored after the configure step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the automated release pipeline and temporarily overwrites `CMakeUserPresets.json`, so failures could disrupt local dev setups or produce incorrect release artifacts if the configure step misbehaves.
> 
> **Overview**
> Ensures releases update `src/domain/include/kth/domain/version.hpp` by extending `scripts/release.sh` to run a `conan install` + `cmake --preset conan-release` configure step (no build) in a fresh `build-release-<version>/` directory, temporarily rewriting/restoring `CMakeUserPresets.json` to point at the generated presets.
> 
> Adds `build-release-*/` to `.gitignore`, and updates the release commit message to include the `version.hpp` update alongside README and lockfile generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1052243690c8731d5823e3f5c5148ba6f1d07d42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release tooling configuration and updated build exclusion patterns to streamline the version generation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->