### PR TITLE
ci: add code coverage with Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,97 @@
+name: Code Coverage
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    container:
+      image: kthnode/gcc15-ubuntu24.04
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: 🔧 Setup Conan
+        uses: ./ci_utils/.github/actions/setup-conan
+
+      - name: 🔧 Setup kthbuild
+        uses: ./ci_utils/.github/actions/setup-kthbuild
+
+      - name: 🗄️ Setup ccache
+        run: |
+          apt-get update -qq && apt-get install -y -qq ccache > /dev/null 2>&1 || true
+          ccache --version || true
+
+      - name: 🗄️ Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: /github/home/.cache/ccache
+          key: ccache-coverage-${{ github.sha }}
+          restore-keys: ccache-coverage-
+
+      - name: 📦 Install dependencies
+        run: |
+          conan install conanfile.py --version 0.0.0 -of build --build=missing \
+            -pr:b linux-ci-cd -pr:h linux-ci-cd \
+            -o march_id=ZLm9Pjh -o tests=True
+
+      - name: 🔨 Build with coverage
+        run: |
+          export PATH="/usr/lib/ccache:$PATH"
+          ccache --zero-stats
+
+          cmake --preset conan-release \
+            -DCMAKE_VERBOSE_MAKEFILE=OFF \
+            -DGLOBAL_BUILD=ON \
+            -DENABLE_TEST=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_FLAGS="--coverage -O0" \
+            -DCMAKE_CXX_FLAGS="--coverage -O0" \
+            -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+          cmake --build --preset conan-release -j$(nproc)
+          ccache --show-stats
+
+      - name: 🧪 Run tests
+        run: |
+          ctest --preset conan-release --output-on-failure -j$(nproc)
+
+      - name: 📊 Generate coverage report
+        if: always()
+        run: |
+          python3 -m pip install gcovr
+          mkdir -p coverage-report
+          gcovr --root . \
+            --filter 'src/domain/' \
+            --filter 'src/infrastructure/' \
+            --filter 'src/blockchain/' \
+            --exclude '.*test.*' \
+            --xml coverage.xml \
+            --html-details coverage-report/index.html \
+            --print-summary
+
+      - name: ☁️ Upload to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
+
+      - name: 📎 Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-report/


### PR DESCRIPTION
## Summary
- Add `coverage.yml` GitHub Actions workflow
- Builds with `--coverage` flags using GCC 15
- Generates coverage reports with gcovr
- Uploads to Codecov for PR annotations and tracking

## Prerequisites
- `CODECOV_TOKEN` secret must be configured in the repo

## Test plan
- [ ] Verify workflow runs on push to master
- [ ] Verify Codecov receives the report
- [ ] Check coverage HTML artifact is downloadable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new GitHub Actions workflow and does not change production code, but it can affect CI time and introduce failures if coverage/tooling setup breaks.
> 
> **Overview**
> Adds a new `coverage.yml` GitHub Actions workflow that builds and runs tests with GCC coverage instrumentation, then generates XML + HTML reports via `gcovr`.
> 
> The workflow uploads `coverage.xml` to Codecov (using `CODECOV_TOKEN` when present) and publishes the HTML report as a GitHub Actions artifact, with `ccache` enabled to speed up repeated runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 352c06c266aea23f5460528db137a22e9e90346e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated code coverage workflow triggered on push, pull request, and manual runs.
  * Builds and runs tests with coverage instrumentation and generates XML and HTML coverage reports.
  * Uploads the XML coverage report to an external coverage service and publishes the HTML report as a downloadable artifact.
  * Publishes a summary coverage output to aid review and tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->