### PR TITLE
fix: pass height instead of forks bitmask to populate_pooled

### DIFF
--- a/src/blockchain/include/kth/blockchain/pools/branch.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/branch.hpp
@@ -25,10 +25,10 @@ struct KB_API branch {
     using const_ptr = std::shared_ptr<const branch>;
 
     /// Establish a branch with the given parent height.
-    branch(size_t height = 0);
+    branch(uint32_t height = 0);
 
     /// Set the height of the parent of this branch (fork point).
-    void set_height(size_t height);
+    void set_height(uint32_t height);
 
     /// Push the block onto the branch, true if successfully chains to parent.
     bool push_front(block_const_ptr block);
@@ -37,7 +37,7 @@ struct KB_API branch {
     block_const_ptr top() const;
 
     /// The top block of the branch, if it exists.
-    size_t top_height() const;
+    uint32_t top_height() const;
 
     /////// Populate unspent duplicate state in the context of the branch.
     ////void populate_duplicate(const domain::chain::transaction& tx) const;
@@ -65,30 +65,30 @@ struct KB_API branch {
     hash_digest hash() const;
 
     /// The height of the parent of this branch (branch point).
-    size_t height() const;
+    uint32_t height() const;
 
     /// A checkpoint of the fork point, identical to { hash(), height() }.
     infrastructure::config::checkpoint fork_point() const;
 
     /// The bits of the block at the given height in the branch.
-    bool get_bits(uint32_t& out_bits, size_t height) const;
+    bool get_bits(uint32_t& out_bits, uint32_t height) const;
 
     /// The bits of the block at the given height in the branch.
-    bool get_version(uint32_t& out_version, size_t height) const;
+    bool get_version(uint32_t& out_version, uint32_t height) const;
 
     /// The bits of the block at the given height in the branch.
-    bool get_timestamp(uint32_t& out_timestamp, size_t height) const;
+    bool get_timestamp(uint32_t& out_timestamp, uint32_t height) const;
 
     /// The hash of the block at the given height if it exists in the branch.
-    bool get_block_hash(hash_digest& out_hash, size_t height) const;
+    bool get_block_hash(hash_digest& out_hash, uint32_t height) const;
 
 protected:
-    size_t index_of(size_t height) const;
-    size_t height_at(size_t index) const;
+    size_t index_of(uint32_t height) const;
+    uint32_t height_at(size_t index) const;
     uint32_t median_time_past_at(size_t index) const;
 
 private:
-    size_t height_;
+    uint32_t height_;
 
     /// The chain of blocks in the branch.
     block_const_ptr_list_ptr blocks_;

--- a/src/blockchain/include/kth/blockchain/populate/populate_base.hpp
+++ b/src/blockchain/include/kth/blockchain/populate/populate_base.hpp
@@ -23,7 +23,7 @@ protected:
     populate_base(dispatcher& dispatch, fast_chain const& chain);
 
     void populate_duplicate(size_t maximum_height, const domain::chain::transaction& tx, bool require_confirmed) const;
-    void populate_pooled(domain::chain::transaction const& tx, uint32_t forks) const;
+    void populate_pooled(domain::chain::transaction const& tx, uint32_t height) const;
     void populate_prevout(size_t maximum_height, domain::chain::output_point const& outpoint, bool require_confirmed) const;
 
     // This is thread safe.

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -270,7 +270,7 @@ void block_chain::push(transaction_const_ptr tx, dispatcher&, result_handler han
     //last_transaction_.store(tx);
 
     // Transaction push is currently sequential so dispatch is not used.
-    handler(database_.push(*tx, chain_state()->enabled_forks()));
+    handler(database_.push(*tx, chain_state()->height()));
 }
 
 #endif // ! defined(KTH_DB_READONLY)

--- a/src/blockchain/src/pools/block_organizer.cpp
+++ b/src/blockchain/src/pools/block_organizer.cpp
@@ -488,7 +488,7 @@ bool block_organizer::set_branch_height(branch::ptr branch) {
         return false;
     }
 
-    branch->set_height(height);
+    branch->set_height(static_cast<uint32_t>(height));
     return true;
 }
 

--- a/src/blockchain/src/pools/branch.cpp
+++ b/src/blockchain/src/pools/branch.cpp
@@ -53,12 +53,12 @@ local_utxo_set_t create_branch_utxo_set(branch::const_ptr const& branch) {
 
 
 // This will be eliminated once weak block headers are moved to the store.
-branch::branch(size_t height)
+branch::branch(uint32_t height)
     : height_(height)
     , blocks_(std::make_shared<block_const_ptr_list>())
 {}
 
-void branch::set_height(size_t height) {
+void branch::set_height(uint32_t height) {
     height_ = height;
 }
 
@@ -81,8 +81,8 @@ block_const_ptr branch::top() const {
     return empty() ? nullptr : blocks_->back();
 }
 
-size_t branch::top_height() const {
-    return height() + size();
+uint32_t branch::top_height() const {
+    return height() + static_cast<uint32_t>(size());
 }
 
 block_const_ptr_list_const_ptr branch::blocks() const {
@@ -97,7 +97,7 @@ size_t branch::size() const {
     return blocks_->size();
 }
 
-size_t branch::height() const {
+uint32_t branch::height() const {
     return height_;
 }
 
@@ -110,15 +110,15 @@ infrastructure::config::checkpoint branch::fork_point() const {
 }
 
 // private
-size_t branch::index_of(size_t height) const {
+size_t branch::index_of(uint32_t height) const {
     // The member height_ is the height of the fork point, not the first block.
-    return *safe_subtract(*safe_subtract(height, height_), size_t(1));
+    return *safe_subtract(size_t(*safe_subtract(height, height_)), size_t(1));
 }
 
 // private
-size_t branch::height_at(size_t index) const {
+uint32_t branch::height_at(size_t index) const {
     // The height of the blockchain branch point plus zero-based index.
-    return *safe_add(*safe_add(index, height_), size_t(1));
+    return *safe_add(*safe_add(uint32_t(index), height_), uint32_t(1));
 }
 
 // private
@@ -314,7 +314,7 @@ void branch::populate_prevout(output_point const& outpoint, std::vector<std::uno
 
 // TODO(legacy): absorb into the main chain for speed and code consolidation.
 // The bits of the block at the given height in the branch.
-bool branch::get_bits(uint32_t& out_bits, size_t height) const {
+bool branch::get_bits(uint32_t& out_bits, uint32_t height) const {
     if (height <= height_) {
         return false;
     }
@@ -330,7 +330,7 @@ bool branch::get_bits(uint32_t& out_bits, size_t height) const {
 
 // TODO(legacy): absorb into the main chain for speed and code consolidation.
 // The version of the block at the given height in the branch.
-bool branch::get_version(uint32_t& out_version, size_t height) const {
+bool branch::get_version(uint32_t& out_version, uint32_t height) const {
     if (height <= height_) {
         return false;
     }
@@ -347,7 +347,7 @@ bool branch::get_version(uint32_t& out_version, size_t height) const {
 
 // TODO(legacy): absorb into the main chain for speed and code consolidation.
 // The timestamp of the block at the given height in the branch.
-bool branch::get_timestamp(uint32_t& out_timestamp, size_t height) const {
+bool branch::get_timestamp(uint32_t& out_timestamp, uint32_t height) const {
     if (height <= height_) {
         return false;
     }
@@ -364,7 +364,7 @@ bool branch::get_timestamp(uint32_t& out_timestamp, size_t height) const {
 
 // TODO(legacy): convert to a direct block pool query when the branch goes away.
 // The hash of the block at the given height if it exists in the branch.
-bool branch::get_block_hash(hash_digest& out_hash, size_t height) const {
+bool branch::get_block_hash(hash_digest& out_hash, uint32_t height) const {
     if (height <= height_) {
         return false;
     }

--- a/src/blockchain/src/populate/populate_base.cpp
+++ b/src/blockchain/src/populate/populate_base.cpp
@@ -33,16 +33,16 @@ void populate_base::populate_duplicate(size_t branch_height, const domain::chain
     tx.validation.duplicate = false;
 }
 
-void populate_base::populate_pooled(const domain::chain::transaction& tx, uint32_t forks) const {
-    size_t height;
+void populate_base::populate_pooled(const domain::chain::transaction& tx, uint32_t height) const {
+    size_t stored_height;
     size_t position;
 
-    if (fast_chain_.get_transaction_position(height, position, tx.hash(), false)
+    if (fast_chain_.get_transaction_position(stored_height, position, tx.hash(), false)
 
         && (position == position_max)) {
 
         tx.validation.pooled = true;
-        tx.validation.current = (height == forks);
+        tx.validation.current = (stored_height == height);
         return;
     }
 

--- a/src/blockchain/src/populate/populate_block.cpp
+++ b/src/blockchain/src/populate/populate_block.cpp
@@ -183,9 +183,8 @@ void populate_block::populate_transactions(branch::const_ptr branch, size_t buck
         // unless tx relay is disabled. In that case duplication is unlikely.
         //---------------------------------------------------------------------
 
-        //TODO(fernando): check again why this is not implemented?
         if (relay_transactions_) {
-            populate_base::populate_pooled(tx, forks);
+            populate_base::populate_pooled(tx, state->height());
         }
 
         //*********************************************************************

--- a/src/database/include/kth/database/data_base.hpp
+++ b/src/database/include/kth/database/data_base.hpp
@@ -69,7 +69,7 @@ public:
 
     /// Add an unconfirmed tx to the store (without indexing).
     /// Returns unspent_duplicate if existing unspent hash duplicate exists.
-    code push(domain::chain::transaction const& tx, uint32_t forks);
+    code push(domain::chain::transaction const& tx, uint32_t height);
 
     /// Returns store_block_missing_parent if not linked.
     /// Returns store_block_invalid_height if height is not the current top + 1.

--- a/src/database/src/data_base.cpp
+++ b/src/database/src/data_base.cpp
@@ -195,13 +195,13 @@ code data_base::insert(domain::chain::block const& block, size_t height) {
 #if ! defined(KTH_DB_READONLY)
 
 // This is designed for write exclusivity and read concurrency.
-code data_base::push(domain::chain::transaction const& tx, uint32_t forks) {
+code data_base::push(domain::chain::transaction const& tx, uint32_t height) {
     if (settings_.db_mode != db_mode_type::full) {
         return error::success;
     }
 
     //We insert only in transaction unconfirmed here
-    internal_db_->push_transaction_unconfirmed(tx, forks);
+    internal_db_->push_transaction_unconfirmed(tx, height);
     return error::success;  //TODO(fernando): store the transactions in a new mempool
 }
 

--- a/src/domain/include/kth/domain/chain/chain_state.hpp
+++ b/src/domain/include/kth/domain/chain/chain_state.hpp
@@ -165,7 +165,7 @@ struct KD_API chain_state {
     domain::config::network network() const;
 
     [[nodiscard]]
-    size_t height() const;
+    uint32_t height() const;
 
     [[nodiscard]]
     abla::state const& abla_state() const;

--- a/src/domain/src/chain/chain_state.cpp
+++ b/src/domain/src/chain/chain_state.cpp
@@ -1363,7 +1363,7 @@ bool chain_state::is_valid() const {
 // Properties.
 //-----------------------------------------------------------------------------
 
-size_t chain_state::height() const {
+uint32_t chain_state::height() const {
     return data_.height;
 }
 


### PR DESCRIPTION
## Summary

- `populate_pooled` was comparing a stored fork bitmask against current forks to determine if a pooled transaction was still current. The `height` field in `transaction_unconfirmed_entry` was being abused to store forks since its introduction in 2018.
- Now the actual block height is stored and compared, which is the correct semantic for determining transaction currency.
- Changes `chain_state::height()` and `branch::height()` return types from `size_t` to `uint32_t`.

Fixes #190

## Test plan

- [ ] Verify CI passes (build + tests)
- [ ] Verify mempool transaction validation cache works correctly with height comparison

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction-pool validation and unconfirmed-tx persistence semantics, so incorrect height plumbing could cause mempool “current/pooled” misclassification or regressions in callers expecting `size_t` heights.
> 
> **Overview**
> Fixes pooled-transaction “current” detection by changing `populate_pooled` and the unconfirmed-tx write path to use *block height* rather than the enabled-forks bitmask (plumbed from `block_chain::push` through `data_base::push` into `push_transaction_unconfirmed`).
> 
> Standardizes height typing in the affected APIs by switching `chain_state::height()` and `branch` height-related members/methods (and `branch` height-based getters) from `size_t` to `uint32_t`, adding casts where needed (e.g., branch height initialization).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e5650339ae4c423f4ccda16a1c0f1a19c4c54f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized all blockchain height-related APIs and storage to use 32-bit unsigned integers (uint32_t), including public accessors and transaction/block pooling interfaces.
  * Adjusted related calls to pass block height (uint32_t) consistently; no behavioral changes expected, only type and signature updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->