### PR TITLE
fix: increase default db_max_size for block-indexed mode to 400 GiB

### DIFF
--- a/src/database/src/settings.cpp
+++ b/src/database/src/settings.cpp
@@ -12,7 +12,7 @@ using namespace std::filesystem;
 
 //TODO(fernando): look for good defaults
 constexpr auto db_size_pruned_mainnet  = 100 * (uint64_t(1) << 30); //100 GiB
-constexpr auto db_size_default_mainnet = 200 * (uint64_t(1) << 30); //200 GiB
+constexpr auto db_size_default_mainnet = 400 * (uint64_t(1) << 30); //400 GiB
 constexpr auto db_size_full_mainnet    = 600 * (uint64_t(1) << 30); //600 GiB
 
 constexpr auto db_size_pruned_testnet4  =  5 * (uint64_t(1) << 30); // 5 GiB


### PR DESCRIPTION
## Summary

- Increases the default LMDB map size for block-indexed mode (`db_mode=blocks`) from 200 GiB to 400 GiB on mainnet
- The previous default was insufficient at ~805K blocks, causing `MDB_MAP_FULL` (-30792) errors during IBD

## Test plan

- [x] Full IBD on mainnet with native VM completed successfully with 400 GiB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single default-configuration change that increases LMDB map size, with the main impact being higher default disk/memory-map reservation for mainnet `db_mode=blocks`.
> 
> **Overview**
> Increases the default mainnet `db_max_size` used for LMDB map sizing in block-indexed mode (`db_mode=blocks`) from **200 GiB to 400 GiB** to reduce `MDB_MAP_FULL` failures during sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f302dbaae22d21dce3c84c96b9e9a98e49e56c46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased default database storage capacity for mainnet deployments from 200 GB to 400 GB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->