### PR TITLE
release: 0.77.0

### DIFF
--- a/src/c-api/README.md
+++ b/src/c-api/README.md
@@ -20,7 +20,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=c-api/0.76.0 --update
+$ conan install --requires=c-api/0.77.0 --update
 ```
 
 ### "Hello, Knuth!":

--- a/src/consensus/README.md
+++ b/src/consensus/README.md
@@ -19,7 +19,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=consensus/0.76.0 --update
+$ conan install --requires=consensus/0.77.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -16,7 +16,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=database/0.76.0 --update
+$ conan install --requires=database/0.77.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/domain/README.md
+++ b/src/domain/README.md
@@ -16,7 +16,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=domain/0.76.0 --update
+$ conan install --requires=domain/0.77.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/domain/include/kth/domain/version.hpp
+++ b/src/domain/include/kth/domain/version.hpp
@@ -15,7 +15,7 @@
 namespace kth {
 
 // Version string from build system (conan -> cmake -> C++)
-inline constexpr std::string_view version = "0.75.0";
+inline constexpr std::string_view version = "0.77.0";
 
 // Currency identifier
 #if defined(KTH_CURRENCY_BCH)

--- a/src/infrastructure/README.md
+++ b/src/infrastructure/README.md
@@ -16,7 +16,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=infrastructure/0.76.0 --update
+$ conan install --requires=infrastructure/0.77.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -16,7 +16,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=network/0.76.0 --update
+$ conan install --requires=network/0.77.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/node-exe/README.md
+++ b/src/node-exe/README.md
@@ -47,7 +47,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate node executable:
 
 ```
-$ conan install --requires=kth/0.76.0 --update --deploy=direct_deploy
+$ conan install --requires=kth/0.77.0 --update --deploy=direct_deploy
 
 ```
 

--- a/src/node/README.md
+++ b/src/node/README.md
@@ -18,7 +18,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=node/0.76.0 --update
+$ conan install --requires=node/0.77.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).


### PR DESCRIPTION
release: 0.77.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates version strings and install instructions, with no functional code changes beyond the exported version constant.
> 
> **Overview**
> Updates the release/version references across the repo to `0.77.0`.
> 
> Documentation install commands in multiple module READMEs now point to the `0.77.0` Conan packages, and `kth::version` in `src/domain/include/kth/domain/version.hpp` is bumped to `0.77.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ae176a0166c48d733e6d007947dd14e798c86a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions across multiple modules with dependency version updates.

* **Chores**
  * Bumped version constants to reflect new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->