### PR TITLE
fix: always assign gmp to secp256k1 component requires

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -349,9 +349,7 @@ class KthRecipe(KnuthConanFileV2):
         self.cpp_info.components["secp256k1"].names["cmake_find_package"] = "secp256k1"
         self.cpp_info.components["secp256k1"].names["cmake_find_package_multi"] = "secp256k1"
         # secp256k1 requires GMP for big number operations
-        # if secp256k1_enable_bignum is enabled:
-        if self.options.secp256k1_enable_bignum:
-            self.cpp_info.components["secp256k1"].requires = ["gmp::gmp"]
+        self.cpp_info.components["secp256k1"].requires = ["gmp::gmp"]
 
         # Core infrastructure component
         self.cpp_info.components["infrastructure"].libs = ["infrastructure"]


### PR DESCRIPTION
## Summary
- `gmp` is declared as a top-level `self.requires()` unconditionally (line 157), but was only assigned to the `secp256k1` component's `requires` when `secp256k1_enable_bignum=True`
- Since the default is `secp256k1_enable_bignum=False`, building with `consensus=False` triggers: `ERROR: kth/x.y.z: package_info(): The direct dependency 'gmp' is not used by any '(cpp_info/components).requires'`
- Fix: always assign `gmp::gmp` to the `secp256k1` component regardless of `secp256k1_enable_bignum`

## Test plan
- [ ] Build with `consensus=False` and `secp256k1_enable_bignum=False` (default) — should no longer error
- [ ] Build with `consensus=True` — should still work as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Conan metadata change only; it adjusts component dependency wiring to avoid unused-direct-dependency errors and shouldn’t affect runtime behavior.
> 
> **Overview**
> Fixes Conan component metadata by **always** declaring `gmp::gmp` as a requirement of the `secp256k1` component in `conanfile.py`, instead of only doing so when `secp256k1_enable_bignum` is enabled.
> 
> This prevents Conan from erroring on builds (e.g., `consensus=False` with default options) where `gmp` is a direct requirement but was not referenced by any component `requires`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 889c072446c4772491cdd32affe8b9bbfe2ba68d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The secp256k1 component now unconditionally requires GMP as a dependency, ensuring proper library linkage regardless of configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->