### PR TITLE
feat: add wallet utilities and C-API improvements

### DIFF
--- a/scripts/build-create-ems.sh
+++ b/scripts/build-create-ems.sh
@@ -12,9 +12,9 @@ echo "Building version: ${VERSION}"
 rm -rf build
 rm -rf conan-wasm.lock
 
-conan lock create conanfile.py --version="${VERSION}" --lockfile=conan-wasm.lock --update -pr ems2
+conan lock create conanfile.py --version="${VERSION}" --lockfile=conan-wasm.lock --update -pr ems2 -o consensus=False -o tests=False
 
-conan lock create conanfile.py --version "${VERSION}" --lockfile=conan-wasm.lock --lockfile-out=build/conan.lock -pr ems2 -o consensus=False
-conan create conanfile.py --version "${VERSION}" --lockfile=build/conan.lock --build=missing  -pr ems2 -o consensus=False
+conan lock create conanfile.py --version "${VERSION}" --lockfile=conan-wasm.lock --lockfile-out=build/conan.lock -pr ems2 -o consensus=False -o tests=False
+conan create conanfile.py --version "${VERSION}" --lockfile=build/conan.lock --build=missing  -pr ems2 -o consensus=False -o tests=False
 
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,11 @@ fi
 # conan lock create conanfile.py --version "${VERSION}" $MARCH_OPT --lockfile=conan.lock --lockfile-out=build/conan.lock
 # conan install conanfile.py $MARCH_OPT --lockfile=build/conan.lock -of build --build=missing
 
+CCACHE_OPT=""
+if command -v ccache &>/dev/null; then
+    CCACHE_OPT="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+fi
+
 # Only configure if not already configured or if explicitly requested
 if [ ! -f "build/build/Release/CMakeCache.txt" ] || [ "$RECONFIGURE" = "1" ]; then
     echo "Configuring CMake..."
@@ -37,7 +42,8 @@ if [ ! -f "build/build/Release/CMakeCache.txt" ] || [ "$RECONFIGURE" = "1" ]; th
              -DCMAKE_VERBOSE_MAKEFILE=ON \
              -DGLOBAL_BUILD=ON \
              -DENABLE_TEST=ON \
-             -DCMAKE_BUILD_TYPE=Release
+             -DCMAKE_BUILD_TYPE=Release \
+             $CCACHE_OPT
 
     if [ $? -ne 0 ]; then
         echo "CMake configuration failed"

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -30,11 +30,17 @@ conan lock create conanfile.py --version="${VERSION}" $MARCH_OPT --update || exi
 conan lock create conanfile.py --version "${VERSION}" $MARCH_OPT --lockfile=conan.lock --lockfile-out=build/conan.lock || exit 1
 conan install conanfile.py --version="${VERSION}" $MARCH_OPT --lockfile=build/conan.lock -of build --build=missing || exit 1
 
+CCACHE_OPT=""
+if command -v ccache &>/dev/null; then
+    CCACHE_OPT="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+fi
+
 cmake --preset conan-release \
          -DCMAKE_VERBOSE_MAKEFILE=ON \
          -DGLOBAL_BUILD=ON \
          -DENABLE_TEST=ON \
-         -DCMAKE_BUILD_TYPE=Release
+         -DCMAKE_BUILD_TYPE=Release \
+         $CCACHE_OPT
 
 if [ $? -ne 0 ]; then
     echo "CMake configuration failed"

--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -237,6 +237,7 @@ set(kth_sources
         src/chain/output_point.cpp
         src/chain/point.cpp
         src/chain/point_list.cpp
+        src/chain/outputpoint_list.cpp
         src/chain/mempool_transaction.cpp
 
         src/chain/token_data.cpp
@@ -378,6 +379,7 @@ set(kth_headers
     include/kth/capi/chain/history_compact.h
     include/kth/capi/chain/output.h
     include/kth/capi/chain/output_list.h
+    include/kth/capi/chain/outputpoint_list.h
     include/kth/capi/chain/get_blocks.h
     include/kth/capi/chain/double_spend_proof_spender.h
     include/kth/capi/chain/point.h

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -28,6 +28,7 @@
 #include <kth/capi/chain/output.h>
 #include <kth/capi/chain/output_list.h>
 #include <kth/capi/chain/output_point.h>
+#include <kth/capi/chain/outputpoint_list.h>
 #include <kth/capi/wallet/payment_address.h>
 #include <kth/capi/chain/point.h>
 #include <kth/capi/chain/point_list.h>

--- a/src/c-api/include/kth/capi/chain/outputpoint_list.h
+++ b/src/c-api/include/kth/capi/chain/outputpoint_list.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_OUTPUTPOINT_LIST_H_
+#define KTH_CAPI_CHAIN_OUTPUTPOINT_LIST_H_
+
+#include <stdint.h>
+
+#include <kth/capi/list_creator.h>
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+KTH_LIST_DECLARE(chain, kth_outputpoint_list_t, kth_outputpoint_t, outputpoint_list)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_CHAIN_OUTPUTPOINT_LIST_H_ */

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -63,6 +63,7 @@ KTH_LIST_DECLARE_CONSTRUCT_FROM_CPP_CONST(chain, kth_operation_list_t, kth::doma
 
 KTH_LIST_DECLARE_CONVERTERS(chain, kth_block_list_t, kth::domain::chain::block, block_list)
 KTH_LIST_DECLARE_CONVERTERS(chain, kth_point_list_t, kth::domain::chain::point, point_list)
+KTH_LIST_DECLARE_CONVERTERS(chain, kth_outputpoint_list_t, kth::domain::chain::output_point, outputpoint_list)
 KTH_LIST_DECLARE_CONVERTERS(chain, kth_input_list_t, kth::domain::chain::input, input_list)
 KTH_LIST_DECLARE_CONVERTERS(chain, kth_output_list_t, kth::domain::chain::output, output_list)
 KTH_LIST_DECLARE_CONVERTERS(chain, kth_utxo_list_t, kth::domain::chain::utxo, utxo_list)

--- a/src/c-api/include/kth/capi/hash.h
+++ b/src/c-api/include/kth/capi/hash.h
@@ -20,6 +20,9 @@ KTH_EXPORT
 kth_hash_t kth_sha256_hash_reversed(uint8_t const* data, kth_size_t size);
 
 KTH_EXPORT
+kth_shorthash_t kth_ripemd160_hash(uint8_t const* data, kth_size_t size);
+
+KTH_EXPORT
 char* kth_sha256_hash_reversed_str(uint8_t const* data, kth_size_t size);
 
 KTH_EXPORT

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -85,6 +85,7 @@ typedef void* kth_utxo_t;
 typedef void const* kth_outputpoint_const_t;
 typedef void* kth_point_t;
 typedef void* kth_point_list_t;
+typedef void* kth_outputpoint_list_t;
 typedef void* kth_transaction_t;
 typedef void const* kth_transaction_const_t;
 typedef void* kth_transaction_list_t;

--- a/src/c-api/include/kth/capi/wallet/payment_address.h
+++ b/src/c-api/include/kth/capi/wallet/payment_address.h
@@ -48,6 +48,9 @@ char* kth_wallet_payment_address_encoded_legacy(kth_payment_address_t payment_ad
 #if defined(KTH_CURRENCY_BCH)
 KTH_EXPORT
 char* kth_wallet_payment_address_encoded_cashaddr(kth_payment_address_t payment_address, kth_bool_t token_aware);
+
+KTH_EXPORT
+char* kth_wallet_payment_address_encoded_token(kth_payment_address_t payment_address);
 #endif //KTH_CURRENCY_BCH
 
 KTH_EXPORT

--- a/src/c-api/src/chain/outputpoint_list.cpp
+++ b/src/c-api/src/chain/outputpoint_list.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/domain/chain/output_point.hpp>
+
+#include <kth/capi/chain/outputpoint_list.h>
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/list_creator.h>
+
+KTH_LIST_DEFINE_CONVERTERS(chain, kth_outputpoint_list_t, kth::domain::chain::output_point, outputpoint_list)
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+KTH_LIST_DEFINE(chain, kth_outputpoint_list_t, kth_outputpoint_t, outputpoint_list, kth::domain::chain::output_point, kth_chain_output_point_const_cpp)
+
+} // extern "C"

--- a/src/c-api/src/hash.cpp
+++ b/src/c-api/src/hash.cpp
@@ -56,6 +56,11 @@ kth_hash_t kth_sha256_hash_reversed(uint8_t const* data, kth_size_t size) {
     return kth::to_hash_t(hash);
 }
 
+kth_shorthash_t kth_ripemd160_hash(uint8_t const* data, kth_size_t size) {
+    auto hash = kth::ripemd160_hash({data, size});
+    return kth::to_shorthash_t(hash);
+}
+
 char* kth_sha256_hash_reversed_str(uint8_t const* data, kth_size_t size) {
     auto hash = kth_sha256_hash(data, size);
     return kth_hash_to_str(hash); // this function reverses the hash when encoding to string

--- a/src/c-api/src/wallet/payment_address.cpp
+++ b/src/c-api/src/wallet/payment_address.cpp
@@ -71,6 +71,12 @@ char* kth_wallet_payment_address_encoded_cashaddr(kth_payment_address_t payment_
     std::string str = kth_wallet_payment_address_const_cpp(payment_address).encoded_cashaddr(token_aware);
     return kth::create_c_str(str);
 }
+
+//User is responsible for releasing return value memory
+char* kth_wallet_payment_address_encoded_token(kth_payment_address_t payment_address) {
+    std::string str = kth_wallet_payment_address_const_cpp(payment_address).encoded_token();
+    return kth::create_c_str(str);
+}
 #endif //KTH_CURRENCY_BCH
 
 kth_shorthash_t kth_wallet_payment_address_hash20(kth_payment_address_t payment_address) {

--- a/src/domain/include/kth/domain/chain/script.hpp
+++ b/src/domain/include/kth/domain/chain/script.hpp
@@ -247,6 +247,9 @@ public:
     operation::list to_pay_public_key_hash_pattern_unlocking_placeholder(size_t endorsement_size, size_t pubkey_size);
 
     static
+    operation::list to_pay_script_hash_pattern_unlocking_placeholder(size_t script_size, bool multisig);
+
+    static
     operation::list to_pay_script_hash_pattern(short_hash const& hash);
 
     static

--- a/src/domain/include/kth/domain/chain/script_basis.hpp
+++ b/src/domain/include/kth/domain/chain/script_basis.hpp
@@ -183,6 +183,9 @@ struct KD_API script_basis {
     operation::list to_pay_public_key_hash_pattern_unlocking_placeholder(size_t endorsement_size, size_t pubkey_size);
 
     static
+    operation::list to_pay_script_hash_pattern_unlocking_placeholder(size_t script_size, bool multisig);
+
+    static
     operation::list to_pay_script_hash_pattern(short_hash const& hash);
 
     static

--- a/src/domain/include/kth/domain/chain/token_data.hpp
+++ b/src/domain/include/kth/domain/chain/token_data.hpp
@@ -133,7 +133,7 @@ struct non_fungible {
 using both_kinds = std::pair<fungible, non_fungible>;
 
 struct token_data_t {
-    token_id_t id;
+    token_id_t id; // id or category
     std::variant<fungible, non_fungible, both_kinds> data;
 
     // friend constexpr

--- a/src/domain/include/kth/domain/wallet/payment_address.hpp
+++ b/src/domain/include/kth/domain/wallet/payment_address.hpp
@@ -102,6 +102,9 @@ struct KD_API payment_address {
 #if defined(KTH_CURRENCY_BCH)
     [[nodiscard]]
     std::string encoded_cashaddr(bool token_aware) const;
+
+    [[nodiscard]]
+    std::string encoded_token() const;
 #endif  //KTH_CURRENCY_BCH
 
     /// Accessors.

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -849,6 +849,10 @@ operation::list script::to_pay_public_key_hash_pattern_unlocking_placeholder(siz
     return script_basis::to_pay_public_key_hash_pattern_unlocking_placeholder(endorsement_size, pubkey_size);
 }
 
+operation::list script::to_pay_script_hash_pattern_unlocking_placeholder(size_t script_size, bool multisig) {
+    return script_basis::to_pay_script_hash_pattern_unlocking_placeholder(script_size, multisig);
+}
+
 operation::list script::to_pay_script_hash_pattern(short_hash const& hash) {
     return operation::list{
         {opcode::hash160},

--- a/src/domain/src/chain/script_basis.cpp
+++ b/src/domain/src/chain/script_basis.cpp
@@ -577,6 +577,20 @@ operation::list script_basis::to_pay_public_key_hash_pattern_unlocking_placehold
     };
 }
 
+operation::list script_basis::to_pay_script_hash_pattern_unlocking_placeholder(size_t script_size, bool multisig) {
+    data_chunk placeholder_script(script_size, 0);
+    if (multisig) {
+        // OP_0 dummy required by CHECKMULTISIG (historic off-by-one bug in Bitcoin).
+        return operation::list {
+            operation(opcode::push_size_0),
+            operation(std::move(placeholder_script))
+        };
+    }
+    return operation::list {
+        operation(std::move(placeholder_script))
+    };
+}
+
 operation::list script_basis::to_pay_script_hash_pattern(short_hash const& hash) {
     return operation::list{
         {opcode::hash160},

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -383,6 +383,10 @@ std::string payment_address::encoded_cashaddr(bool token_aware) const {
     return encode_cashaddr_(*this, token_aware);
 }
 
+std::string payment_address::encoded_token() const {
+    return encode_cashaddr_(*this, true);
+}
+
 #endif  //KTH_CURRENCY_BCH
 
 // Accessors.


### PR DESCRIPTION
## Summary
- Add P2SH unlocking script placeholder for transaction size estimation
- Add `encoded_token()` method on `payment_address` for CashToken-aware addresses
- Expose `kth_ripemd160_hash()` in C-API
- Add `outputpoint_list` type to C-API
- Skip tests in Emscripten WASM builds (`build-create-ems.sh`)
- Clarify `token_data` id field documentation

## Test plan
- [ ] Verify WASM build with `build-create-ems.sh`
- [ ] Verify native build compiles cleanly
- [ ] Test `encoded_token()` returns correct CashToken address format
- [ ] Test `kth_ripemd160_hash()` produces correct hashes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new wallet address encoding and script-construction helpers that affect transaction sizing/serialization, plus expands the public C-API surface. Changes are mostly additive, but downstream integrations may need updates and outputs should be validated for correctness.
> 
> **Overview**
> Adds several **new C-API capabilities**: `kth_ripemd160_hash()`, a new `kth_outputpoint_list_t` list type (wired into `CMakeLists.txt`, `primitives.h`, `capi.h`, and conversion helpers), and a BCH-only `kth_wallet_payment_address_encoded_token()` wrapper.
> 
> Extends domain wallet/script utilities by adding `payment_address::encoded_token()` (CashToken-aware CashAddr) and a new `script(_basis)::to_pay_script_hash_pattern_unlocking_placeholder(script_size, multisig)` helper for building placeholder P2SH unlocking scripts (with optional CHECKMULTISIG dummy) useful for size estimation. Build tooling is updated to **skip tests** in Emscripten Conan builds and to auto-enable `ccache` in native `build.sh`/`rebuild.sh`; `token_data_t::id` is clarified with a comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91308d6989dbee0c50ce1bc2fe73c2a2463e3d77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * C API: support for output-point lists with conversion utilities.
  * C API: RIPEMD-160 hashing exposed for byte-span inputs.
  * Domain: script pattern generator for pay-to-script-hash unlocking placeholders.
  * Wallet (BCH): token-aware address encoding accessor and corresponding C API.

* **Chores**
  * Build tooling: option to disable tests during package/lock creation and optional use of ccache for faster builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->