### PR TITLE
ci: add ccache to build workflows

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -121,6 +121,19 @@ jobs:
         with:
           new-version: ${{ inputs.build-version }}
 
+      - name: 🗄️ Setup ccache
+        if: ${{ inputs.upload != true }}
+        run: |
+          apt-get update -qq && apt-get install -y -qq ccache > /dev/null 2>&1 || true
+          ccache --version || true
+
+      - name: 🗄️ Restore ccache
+        if: ${{ inputs.upload != true }}
+        uses: actions/cache@v4
+        with:
+          path: /github/home/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-
 
       - name: 🔨 Build
         working-directory: .
@@ -175,13 +188,25 @@ jobs:
             conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh
             conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh -o tests=True
             
+            CCACHE_OPT=""
+            if command -v ccache &>/dev/null; then
+              export PATH="/usr/lib/ccache:$PATH"
+              ccache --zero-stats
+              CCACHE_OPT="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+            fi
+
             cmake --preset conan-release \
                  -DCMAKE_VERBOSE_MAKEFILE=ON \
                  -DGLOBAL_BUILD=ON \
                  -DENABLE_TEST=ON \
-                 -DCMAKE_BUILD_TYPE=Release
-                 
+                 -DCMAKE_BUILD_TYPE=Release \
+                 $CCACHE_OPT
+
             cmake --build --preset conan-release -j4
+
+            if command -v ccache &>/dev/null; then
+              ccache --show-stats
+            fi
           fi
 
       - name: 📊 Build summary

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -113,6 +113,19 @@ jobs:
         with:
           new-version: ${{ inputs.build-version }}
 
+      - name: 🗄️ Setup ccache
+        if: ${{ inputs.upload != true }}
+        run: |
+          brew install ccache 2>/dev/null || true
+          ccache --version || true
+
+      - name: 🗄️ Restore ccache
+        if: ${{ inputs.upload != true }}
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-
 
       - name: 🔨 Build
         working-directory: .
@@ -167,13 +180,24 @@ jobs:
             conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b general-ci-cd -pr:h general-ci-cd
             conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -pr:b general-ci-cd -pr:h general-ci-cd -o tests=True
             
+            CCACHE_OPT=""
+            if command -v ccache &>/dev/null; then
+              ccache --zero-stats
+              CCACHE_OPT="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+            fi
+
             cmake --preset conan-release \
                  -DCMAKE_VERBOSE_MAKEFILE=ON \
                  -DGLOBAL_BUILD=ON \
                  -DENABLE_TEST=ON \
-                 -DCMAKE_BUILD_TYPE=Release
-                 
+                 -DCMAKE_BUILD_TYPE=Release \
+                 $CCACHE_OPT
+
             cmake --build --preset conan-release -j4
+
+            if command -v ccache &>/dev/null; then
+              ccache --show-stats
+            fi
           fi
 
       - name: 📊 Build summary


### PR DESCRIPTION
## Summary
- Add ccache to `build-with-container.yml` (Linux) and `build-without-container.yml` (macOS) workflows
- Cache ccache directory between CI runs using `actions/cache@v4`
- Auto-detect ccache availability — no-op if not installed

## Changes
- **build-with-container.yml**: Install ccache via apt, cache at `/github/home/.cache/ccache`, add `CMAKE_C/CXX_COMPILER_LAUNCHER=ccache`
- **build-without-container.yml**: Install ccache via brew, cache at `~/Library/Caches/ccache`, same CMake flags
- Both show ccache stats after build

## Expected impact
- First run: no speedup (cold cache)
- Subsequent runs on same branch: significant speedup for unchanged translation units
- Cache keyed by compiler + version + commit SHA, with fallback to compiler + version prefix

## Context
`coverage.yml` already uses ccache. This extends it to the main build workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only changes that add optional caching and `ccache` compiler launchers for non-upload builds; main risk is cache key/path or tool-install differences causing slower builds or unexpected CI failures.
> 
> **Overview**
> Speeds up non-release CI builds by adding `ccache` to both `build-with-container.yml` (apt in container) and `build-without-container.yml` (brew on macOS), with automatic no-op behavior when `ccache` isn’t available.
> 
> Adds `actions/cache@v4` persistence for the ccache directory and wires ccache into CMake via `-DCMAKE_*_COMPILER_LAUNCHER=ccache`, including resetting and printing ccache stats around the build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a713afedd1a393f8db776039c67af5644805d921. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development CI builds now use compiler caching to speed up iterative builds (including macOS); cache stats are collected and reported.
  * Release/upload build path remains unchanged; no caching is applied to release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->