### PR TITLE
refactor(c-api): unify and harden chain/header bindings

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -204,6 +204,7 @@ set(kth_sources
 # if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   set(kth_sources
     ${kth_sources}
+        src/primitives.cpp
         src/hash.cpp
         src/hash_list.cpp
         src/binary.cpp
@@ -495,9 +496,16 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     enable_testing()
     find_package(Catch2 3 REQUIRED)
 
-    # add_executable(queries
-    #   test/dummy.cpp)
-    # target_link_libraries(queries PUBLIC ${PROJECT_NAME})
+    add_executable(kth_capi_test
+        test/chain/header.cpp
+    )
+
+    target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})
+    target_link_libraries(kth_capi_test PRIVATE Catch2::Catch2WithMain)
+
+    include(CTest)
+    include(Catch)
+    catch_discover_tests(kth_capi_test)
 endif()
 
 

--- a/src/c-api/include/kth/capi/chain/header.h
+++ b/src/c-api/include/kth/capi/chain/header.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,85 +10,130 @@
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// Constructors
+
+/** @return Owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_header_mut_t kth_chain_header_construct_default(void);
+
+/** @param[out] out On success, owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_header_t kth_chain_header_factory_from_data(uint8_t* data, kth_size_t n);
+kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_header_mut_t* out);
+
+/** @return Owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_header_mut_t kth_chain_header_construct(uint32_t version, uint8_t const* previous_block_hash, uint8_t const* merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce);
+
+
+// Destructor
 
 KTH_EXPORT
-kth_size_t kth_chain_header_satoshi_fixed_size();
+void kth_chain_header_destruct(kth_header_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_header_mut_t kth_chain_header_copy(kth_header_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-void kth_chain_header_reset(kth_header_t header);
+kth_bool_t kth_chain_header_equals(kth_header_const_t self, kth_header_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_header_to_data(kth_header_const_t self, kth_bool_t wire, kth_size_t* out_size);
 
 KTH_EXPORT
-kth_size_t kth_chain_header_serialized_size(kth_header_t header);
+kth_size_t kth_chain_header_serialized_size(kth_header_const_t self, kth_bool_t wire);
+
+
+// Getters
 
 KTH_EXPORT
-uint8_t const* kth_chain_header_to_data(kth_header_t header, kth_size_t* out_size);
+kth_hash_t kth_chain_header_hash_pow(kth_header_const_t self);
 
 KTH_EXPORT
-kth_header_t kth_chain_header_construct_default(void);
+uint32_t kth_chain_header_version(kth_header_const_t self);
 
 KTH_EXPORT
-kth_header_t kth_chain_header_construct(uint32_t version, uint8_t* previous_block_hash, uint8_t* merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce);
+kth_hash_t kth_chain_header_previous_block_hash(kth_header_const_t self);
 
 KTH_EXPORT
-void kth_chain_header_destruct(kth_header_t header);
+kth_hash_t kth_chain_header_merkle(kth_header_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_chain_header_is_valid(kth_header_t header);
+uint32_t kth_chain_header_timestamp(kth_header_const_t self);
 
 KTH_EXPORT
-uint32_t kth_chain_header_version(kth_header_t header);
+uint32_t kth_chain_header_bits(kth_header_const_t self);
 
 KTH_EXPORT
-void kth_chain_header_set_version(kth_header_t header, uint32_t version);
+uint32_t kth_chain_header_nonce(kth_header_const_t self);
+
+
+// Setters
 
 KTH_EXPORT
-uint32_t kth_chain_header_timestamp(kth_header_t header);
+void kth_chain_header_set_version(kth_header_mut_t self, uint32_t value);
 
 KTH_EXPORT
-void kth_chain_header_set_timestamp(kth_header_t header, uint32_t timestamp);
+void kth_chain_header_set_previous_block_hash(kth_header_mut_t self, uint8_t const* value);
 
 KTH_EXPORT
-uint32_t kth_chain_header_bits(kth_header_t header);
+void kth_chain_header_set_merkle(kth_header_mut_t self, uint8_t const* value);
 
 KTH_EXPORT
-char const* kth_chain_header_proof_str(kth_header_t header);
+void kth_chain_header_set_timestamp(kth_header_mut_t self, uint32_t value);
 
 KTH_EXPORT
-void kth_chain_header_set_bits(kth_header_t header, uint32_t bits);
+void kth_chain_header_set_bits(kth_header_mut_t self, uint32_t value);
 
 KTH_EXPORT
-uint32_t kth_chain_header_nonce(kth_header_t header);
+void kth_chain_header_set_nonce(kth_header_mut_t self, uint32_t value);
+
+
+// Predicates
 
 KTH_EXPORT
-void kth_chain_header_set_nonce(kth_header_t header, uint32_t nonce);
+kth_bool_t kth_chain_header_is_valid_proof_of_work(kth_header_const_t self, kth_bool_t retarget);
 
 KTH_EXPORT
-kth_hash_t kth_chain_header_previous_block_hash(kth_header_t header);
+kth_bool_t kth_chain_header_is_valid(kth_header_const_t self);
 
 KTH_EXPORT
-void kth_chain_header_previous_block_hash_out(kth_header_t header, kth_hash_t* out_previous_block_hash);
+kth_bool_t kth_chain_header_is_valid_timestamp(kth_header_const_t self);
+
+
+// Operations
 
 KTH_EXPORT
-kth_hash_t kth_chain_header_merkle(kth_header_t header);
+kth_error_code_t kth_chain_header_check(kth_header_const_t self, kth_bool_t retarget);
 
 KTH_EXPORT
-void kth_chain_header_merkle_out(kth_header_t header, kth_hash_t* out_merkle);
+kth_error_code_t kth_chain_header_accept(kth_header_const_t self, kth_chain_state_const_t state);
 
 KTH_EXPORT
-kth_hash_t kth_chain_header_hash(kth_header_t header);
+void kth_chain_header_reset(kth_header_mut_t self);
+
+
+// Static utilities
 
 KTH_EXPORT
-void kth_chain_header_hash_out(kth_header_t header, kth_hash_t* out_hash);
+kth_size_t kth_chain_header_satoshi_fixed_size(void);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_HEADER_H_ */
+#endif // KTH_CAPI_CHAIN_HEADER_H_

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -29,7 +29,19 @@
 // #endif
 
 KTH_CONV_DECLARE(chain, kth_block_t, kth::domain::chain::block, block)
-KTH_CONV_DECLARE(chain, kth_header_t, kth::domain::chain::header, header)
+// header conversion functions take const/mut handle types directly. Defined
+// in src/chain/header.cpp.
+kth::domain::chain::header const& kth_chain_header_const_cpp(kth_header_const_t o);
+kth::domain::chain::header&       kth_chain_header_mut_cpp(kth_header_mut_t o);
+
+// chain_state is not yet a first-class C-API type but header::accept needs it,
+// so we expose lightweight inline conversions over the opaque handle.
+inline kth::domain::chain::chain_state const& kth_chain_chain_state_const_cpp(kth_chain_state_const_t o) {
+    return *static_cast<kth::domain::chain::chain_state const*>(o);
+}
+inline kth::domain::chain::chain_state& kth_chain_chain_state_mut_cpp(kth_chain_state_mut_t o) {
+    return *static_cast<kth::domain::chain::chain_state*>(o);
+}
 KTH_CONV_DECLARE(chain, kth_input_t, kth::domain::chain::input, input)
 KTH_CONV_DECLARE(chain, kth_output_t, kth::domain::chain::output, output)
 KTH_CONV_DECLARE(chain, kth_outputpoint_t, kth::domain::chain::output_point, output_point)

--- a/src/c-api/include/kth/capi/error.h
+++ b/src/c-api/include/kth/capi/error.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-typedef enum error_code {
+typedef enum kth_error_code {
 
     // general codes
     kth_ec_success = 0,

--- a/src/c-api/include/kth/capi/hash.h
+++ b/src/c-api/include/kth/capi/hash.h
@@ -5,6 +5,8 @@
 #ifndef KTH_CAPI_HASH_H_
 #define KTH_CAPI_HASH_H_
 
+#include <string.h>
+
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
 #include <kth/capi/wallet/primitives.h>
@@ -12,6 +14,32 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Equality and null-check helpers for the value-struct hash types. These are
+// inline so they have no link-time presence and can be safely consumed from
+// any translation unit (and from non-C language backends that import this
+// header).
+
+static inline
+kth_bool_t kth_hash_equal(kth_hash_t a, kth_hash_t b) {
+    return memcmp(a.hash, b.hash, KTH_BITCOIN_HASH_SIZE) == 0;
+}
+
+static inline
+kth_bool_t kth_hash_is_null(kth_hash_t h) {
+    kth_hash_t const null_h = {{0}};
+    return memcmp(h.hash, null_h.hash, KTH_BITCOIN_HASH_SIZE) == 0;
+}
+
+static inline
+kth_bool_t kth_shorthash_equal(kth_shorthash_t a, kth_shorthash_t b) {
+    return memcmp(a.hash, b.hash, KTH_BITCOIN_SHORT_HASH_SIZE) == 0;
+}
+
+static inline
+kth_bool_t kth_longhash_equal(kth_longhash_t a, kth_longhash_t b) {
+    return memcmp(a.hash, b.hash, KTH_BITCOIN_LONG_HASH_SIZE) == 0;
+}
 
 KTH_EXPORT
 kth_hash_t kth_sha256_hash(uint8_t const* data, kth_size_t size);

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -6,13 +6,50 @@
 #define KTH_CAPI_PRIMITIVES_H_
 
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <kth/capi/error.h>
 #include <kth/capi/visibility.h>
 
+#define KTH_PRECONDITION(expr) do { if (!(expr)) { abort(); } } while(0)
+
+// Marks a function whose return value (or one of its out-parameters) transfers
+// ownership to the caller. The caller is then responsible for releasing the
+// returned object via the matching destructor (`kth_<group>_<obj>_destruct`
+// for handles, `kth_core_destruct_array` for raw byte buffers,
+// `kth_core_destruct_string` for C strings).
+//
+// On compilers that support it, this also raises a warning when the result of
+// such a call is silently discarded, which would otherwise leak memory.
+#if defined(__GNUC__) || defined(__clang__)
+#define KTH_OWNED __attribute__((warn_unused_result))
+#else
+#define KTH_OWNED
+#endif
+
+// Parameter-level companion to KTH_OWNED. Marks an out-parameter that, on
+// successful completion, is filled with an object the caller now owns and
+// must release with the matching destructor. The marker is purely informative
+// at the C level (it expands to nothing) but is visible at the declaration
+// site and is greppable for non-C language backends.
+#define KTH_OUT_OWNED
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Releases an owned byte buffer returned by a C-API function (e.g. the
+// payload of `kth_chain_*_to_data`). Internally a thin wrapper around
+// free(); kept as a dedicated entry point so the API does not commit to a
+// specific allocator and so language backends can wire it through their
+// SafeHandle / Drop equivalents.
+KTH_EXPORT
+void kth_core_destruct_array(uint8_t* arr);
+
+// Releases an owned C string returned by a C-API function. Same rationale
+// as kth_core_destruct_array.
+KTH_EXPORT
+void kth_core_destruct_string(char* str);
 
 #define KTH_BITCOIN_SHORT_HASH_SIZE 20
 #define KTH_BITCOIN_HASH_SIZE 32
@@ -63,6 +100,10 @@ typedef void* kth_double_spend_proof_t;
 typedef void* kth_double_spend_proof_spender_t;
 typedef void const* kth_double_spend_proof_spender_const_t;
 typedef void* kth_header_t;
+typedef void* kth_header_mut_t;
+typedef void const* kth_header_const_t;
+typedef void* kth_chain_state_mut_t;
+typedef void const* kth_chain_state_const_t;
 typedef void* kth_history_compact_t;
 typedef void* kth_history_compact_list_t;
 typedef void* kth_input_t;

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,126 +7,209 @@
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/domain/chain/header.hpp>
 
-KTH_CONV_DEFINE(chain, kth_header_t, kth::domain::chain::header, header)
+// Conversion functions
+kth::domain::chain::header& kth_chain_header_mut_cpp(kth_header_mut_t o) {
+    return *static_cast<kth::domain::chain::header*>(o);
+}
+kth::domain::chain::header const& kth_chain_header_const_cpp(kth_header_const_t o) {
+    return *static_cast<kth::domain::chain::header const*>(o);
+}
 
+// ---------------------------------------------------------------------------
 extern "C" {
 
-kth_header_t kth_chain_header_factory_from_data(uint8_t* data, kth_size_t n) {
-    kth::data_chunk data_cpp(data, std::next(data, n));
-    kth::byte_reader reader(data_cpp);
-    auto res = kth::domain::chain::header::from_data(reader);
-    if ( ! res) {
-        return kth::move_or_copy_and_leak(kth::domain::chain::header{});
-    }
-    return kth::move_or_copy_and_leak(std::move(*res));
-}
+// Constructors
 
-kth_size_t kth_chain_header_satoshi_fixed_size() {
-    return kth::domain::chain::header::satoshi_fixed_size();
-}
-
-//Note: It is the responsability of the user to release/destruct the array
-uint8_t const* kth_chain_header_to_data(kth_header_t header, kth_size_t* out_size) {
-    auto const& header_cpp = kth_chain_header_const_cpp(header);
-    auto data = header_cpp.to_data();
-    return kth::create_c_array(data, *out_size);
-}
-
-void kth_chain_header_reset(kth_header_t header) {
-    return kth_chain_header_cpp(header).reset();
-}
-
-kth_size_t kth_chain_header_serialized_size(kth_header_t header) {
-    return kth_chain_header_const_cpp(header).serialized_size();
-}
-
-kth_header_t kth_chain_header_construct_default() {
+kth_header_mut_t kth_chain_header_construct_default(void) {
     return new kth::domain::chain::header();
 }
 
-kth_header_t kth_chain_header_construct(uint32_t version, uint8_t* previous_block_hash, uint8_t* merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce) {
-    //precondition: [previous_block_hash, 32) is a valid range
-    //              && [merkle, 32) is a valid range
+kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_header_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, n));
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto result = kth::domain::chain::header::from_data(data_cpp, wire_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::chain::header(std::move(*result));
+    return kth_ec_success;
+}
 
+kth_header_mut_t kth_chain_header_construct(uint32_t version, uint8_t const* previous_block_hash, uint8_t const* merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce) {
+    KTH_PRECONDITION(previous_block_hash != nullptr);
+    KTH_PRECONDITION(merkle != nullptr);
     auto previous_block_hash_cpp = kth::hash_to_cpp(previous_block_hash);
     auto merkle_cpp = kth::hash_to_cpp(merkle);
     return new kth::domain::chain::header(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce);
 }
 
-void kth_chain_header_destruct(kth_header_t header) {
-    delete &kth_chain_header_cpp(header);
+
+// Destructor
+
+void kth_chain_header_destruct(kth_header_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_header_mut_cpp(self);
 }
 
-kth_bool_t kth_chain_header_is_valid(kth_header_t header) {
-    return kth::bool_to_int(kth_chain_header_const_cpp(header).is_valid());
+
+// Copy
+
+kth_header_mut_t kth_chain_header_copy(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::chain::header(kth_chain_header_const_cpp(self));
 }
 
-uint32_t kth_chain_header_version(kth_header_t header) {
-    return kth_chain_header_const_cpp(header).version();
+
+// Equality
+
+kth_bool_t kth_chain_header_equals(kth_header_const_t self, kth_header_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_header_const_cpp(self) == kth_chain_header_const_cpp(other));
 }
 
-void kth_chain_header_set_version(kth_header_t header, uint32_t version) {
-    return kth_chain_header_cpp(header).set_version(version);
+
+// Serialization
+
+uint8_t* kth_chain_header_to_data(kth_header_const_t self, kth_bool_t wire, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto data = kth_chain_header_const_cpp(self).to_data(wire_cpp);
+    return kth::create_c_array(data, *out_size);
 }
 
-uint32_t kth_chain_header_timestamp(kth_header_t header) {
-    return kth_chain_header_const_cpp(header).timestamp();
+kth_size_t kth_chain_header_serialized_size(kth_header_const_t self, kth_bool_t wire) {
+    KTH_PRECONDITION(self != nullptr);
+    auto wire_cpp = kth::int_to_bool(wire);
+    return kth_chain_header_const_cpp(self).serialized_size(wire_cpp);
 }
 
-void kth_chain_header_set_timestamp(kth_header_t header, uint32_t timestamp) {
-    return kth_chain_header_cpp(header).set_timestamp(timestamp);
+
+// Getters
+
+kth_hash_t kth_chain_header_hash_pow(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto value_cpp = kth_chain_header_const_cpp(self).hash_pow();
+    return kth::to_hash_t(value_cpp);
 }
 
-uint32_t kth_chain_header_bits(kth_header_t header) {
-    return kth_chain_header_const_cpp(header).bits();
+uint32_t kth_chain_header_version(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_header_const_cpp(self).version();
 }
 
-char const* kth_chain_header_proof_str(kth_header_t header) {
-    std::string proof_str = kth_chain_header_const_cpp(header).proof().str();
-    return kth::create_c_str(proof_str);
+kth_hash_t kth_chain_header_previous_block_hash(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto value_cpp = kth_chain_header_const_cpp(self).previous_block_hash();
+    return kth::to_hash_t(value_cpp);
 }
 
-void kth_chain_header_set_bits(kth_header_t header, uint32_t bits) {
-    return kth_chain_header_cpp(header).set_bits(bits);
+kth_hash_t kth_chain_header_merkle(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto value_cpp = kth_chain_header_const_cpp(self).merkle();
+    return kth::to_hash_t(value_cpp);
 }
 
-uint32_t kth_chain_header_nonce(kth_header_t header) {
-    return kth_chain_header_const_cpp(header).nonce();
+uint32_t kth_chain_header_timestamp(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_header_const_cpp(self).timestamp();
 }
 
-void kth_chain_header_set_nonce(kth_header_t header, uint32_t nonce) {
-    return kth_chain_header_cpp(header).set_nonce(nonce);
+uint32_t kth_chain_header_bits(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_header_const_cpp(self).bits();
 }
 
-kth_hash_t kth_chain_header_previous_block_hash(kth_header_t header) {
-    auto const& hash_cpp = kth_chain_header_const_cpp(header).previous_block_hash();
-    return kth::to_hash_t(hash_cpp);
+uint32_t kth_chain_header_nonce(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_header_const_cpp(self).nonce();
 }
 
-void kth_chain_header_previous_block_hash_out(kth_header_t header, kth_hash_t* out_previous_block_hash) {
-    auto const& previous_block_hash_cpp = kth_chain_header_const_cpp(header).previous_block_hash();
-    kth::copy_c_hash(previous_block_hash_cpp, out_previous_block_hash);
+
+// Setters
+
+void kth_chain_header_set_version(kth_header_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_header_mut_cpp(self).set_version(value);
 }
 
-kth_hash_t kth_chain_header_merkle(kth_header_t header) {
-    auto const& hash_cpp = kth_chain_header_const_cpp(header).merkle();
-    return kth::to_hash_t(hash_cpp);
+void kth_chain_header_set_previous_block_hash(kth_header_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto value_cpp = kth::hash_to_cpp(value);
+    kth_chain_header_mut_cpp(self).set_previous_block_hash(value_cpp);
 }
 
-void kth_chain_header_merkle_out(kth_header_t header, kth_hash_t* out_merkle) {
-    auto const& merkle_hash_cpp = kth_chain_header_const_cpp(header).merkle();
-    kth::copy_c_hash(merkle_hash_cpp, out_merkle);
+void kth_chain_header_set_merkle(kth_header_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto value_cpp = kth::hash_to_cpp(value);
+    kth_chain_header_mut_cpp(self).set_merkle(value_cpp);
 }
 
-kth_hash_t kth_chain_header_hash(kth_header_t header) {
-    auto const& hash_cpp = kth_chain_header_const_cpp(header).hash();
-    return kth::to_hash_t(hash_cpp);
+void kth_chain_header_set_timestamp(kth_header_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_header_mut_cpp(self).set_timestamp(value);
 }
 
-void kth_chain_header_hash_out(kth_header_t header, kth_hash_t* out_hash) {
-    auto const& hash_cpp = kth_chain_header_const_cpp(header).hash();
-    kth::copy_c_hash(hash_cpp, out_hash);
+void kth_chain_header_set_bits(kth_header_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_header_mut_cpp(self).set_bits(value);
+}
+
+void kth_chain_header_set_nonce(kth_header_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_header_mut_cpp(self).set_nonce(value);
+}
+
+
+// Predicates
+
+kth_bool_t kth_chain_header_is_valid_proof_of_work(kth_header_const_t self, kth_bool_t retarget) {
+    KTH_PRECONDITION(self != nullptr);
+    auto retarget_cpp = kth::int_to_bool(retarget);
+    return kth::bool_to_int(kth_chain_header_const_cpp(self).is_valid_proof_of_work(retarget_cpp));
+}
+
+kth_bool_t kth_chain_header_is_valid(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_header_const_cpp(self).is_valid());
+}
+
+kth_bool_t kth_chain_header_is_valid_timestamp(kth_header_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_header_const_cpp(self).is_valid_timestamp());
+}
+
+
+// Operations
+
+kth_error_code_t kth_chain_header_check(kth_header_const_t self, kth_bool_t retarget) {
+    KTH_PRECONDITION(self != nullptr);
+    auto retarget_cpp = kth::int_to_bool(retarget);
+    return static_cast<kth_error_code_t>((kth_chain_header_const_cpp(self).check(retarget_cpp)).value());
+}
+
+kth_error_code_t kth_chain_header_accept(kth_header_const_t self, kth_chain_state_const_t state) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(state != nullptr);
+    auto const& state_cpp = kth_chain_chain_state_const_cpp(state);
+    return static_cast<kth_error_code_t>((kth_chain_header_const_cpp(self).accept(state_cpp)).value());
+}
+
+void kth_chain_header_reset(kth_header_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_header_mut_cpp(self).reset();
+}
+
+
+// Static utilities
+
+kth_size_t kth_chain_header_satoshi_fixed_size(void) {
+    return kth::domain::chain::header::satoshi_fixed_size();
 }
 
 } // extern "C"

--- a/src/c-api/src/primitives.cpp
+++ b/src/c-api/src/primitives.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/primitives.h>
+
+#include <stdlib.h>
+
+extern "C" {
+
+void kth_core_destruct_array(uint8_t* arr) {
+    free(arr);
+}
+
+void kth_core_destruct_string(char* str) {
+    free(str);
+}
+
+} // extern "C"

--- a/src/c-api/test/chain/header.cpp
+++ b/src/c-api/test/chain/header.cpp
@@ -1,0 +1,292 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include <kth/capi/chain/header.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+static uint32_t const kVersion   = 10u;
+static uint32_t const kTimestamp = 531234u;
+static uint32_t const kBits      = 6523454u;
+static uint32_t const kNonce     = 68644u;
+
+// 32-byte hashes used throughout the suite, written here as raw byte arrays
+// so the tests do not depend on any C++ helper.
+static uint8_t const kPrevHash[32] = {
+    0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72,
+    0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7, 0x4f,
+    0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c,
+    0x68, 0xd6, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+static uint8_t const kMerkle[32] = {
+    0x3b, 0xa3, 0xed, 0xfd, 0x7a, 0x7b, 0x12, 0xb2,
+    0x7a, 0xc7, 0x2c, 0x3e, 0x67, 0x76, 0x8f, 0x61,
+    0x7f, 0xc8, 0x1b, 0xc3, 0x88, 0x8a, 0x51, 0x32,
+    0x3a, 0x9f, 0xb8, 0xaa, 0x4b, 0x1e, 0x5e, 0x4a
+};
+
+static kth_hash_t make_hash(uint8_t const* bytes) {
+    kth_hash_t h;
+    memcpy(h.hash, bytes, KTH_BITCOIN_HASH_SIZE);
+    return h;
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Header - default construct is invalid", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    REQUIRE(kth_chain_header_is_valid(header) == 0);
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - field constructor preserves all fields", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct(
+        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+
+    REQUIRE(kth_chain_header_is_valid(header) != 0);
+    REQUIRE(kth_chain_header_version(header)   == kVersion);
+    REQUIRE(kth_chain_header_timestamp(header) == kTimestamp);
+    REQUIRE(kth_chain_header_bits(header)      == kBits);
+    REQUIRE(kth_chain_header_nonce(header)     == kNonce);
+
+    kth_hash_t prev = kth_chain_header_previous_block_hash(header);
+    REQUIRE(kth_hash_equal(prev, make_hash(kPrevHash)) != 0);
+
+    kth_hash_t merkle = kth_chain_header_merkle(header);
+    REQUIRE(kth_hash_equal(merkle, make_hash(kMerkle)) != 0);
+
+    kth_chain_header_destruct(header);
+}
+
+// ---------------------------------------------------------------------------
+// from_data / to_data round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Header - from_data insufficient bytes fails", "[C-API Header]") {
+    uint8_t data[10];
+    memset(data, 0, sizeof(data));
+    kth_header_mut_t out = NULL;
+    kth_error_code_t ec = kth_chain_header_construct_from_data(data, 10, 1, &out);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(out == NULL);
+}
+
+TEST_CASE("C-API Header - to_data / from_data roundtrip", "[C-API Header]") {
+    kth_header_mut_t expected = kth_chain_header_construct(
+        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+
+    kth_size_t size = 0;
+    uint8_t* raw = kth_chain_header_to_data(expected, 1, &size);
+    REQUIRE(size == 80u);
+    REQUIRE(raw != NULL);
+
+    kth_header_mut_t parsed = NULL;
+    kth_error_code_t ec = kth_chain_header_construct_from_data(raw, size, 1, &parsed);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(parsed != NULL);
+
+    REQUIRE(kth_chain_header_is_valid(parsed) != 0);
+    REQUIRE(kth_chain_header_equals(expected, parsed) != 0);
+
+    kth_core_destruct_array(raw);
+    kth_chain_header_destruct(parsed);
+    kth_chain_header_destruct(expected);
+}
+
+// ---------------------------------------------------------------------------
+// Getters / setters
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Header - version setter roundtrip", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    REQUIRE(kth_chain_header_version(header) != 4521u);
+    kth_chain_header_set_version(header, 4521u);
+    REQUIRE(kth_chain_header_version(header) == 4521u);
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - previous_block_hash setter roundtrip", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    REQUIRE(kth_hash_is_null(kth_chain_header_previous_block_hash(header)) != 0);
+
+    kth_chain_header_set_previous_block_hash(header, kPrevHash);
+    REQUIRE(kth_hash_equal(kth_chain_header_previous_block_hash(header),
+                           make_hash(kPrevHash)) != 0);
+
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - merkle setter roundtrip", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    REQUIRE(kth_hash_is_null(kth_chain_header_merkle(header)) != 0);
+
+    kth_chain_header_set_merkle(header, kMerkle);
+    REQUIRE(kth_hash_equal(kth_chain_header_merkle(header),
+                           make_hash(kMerkle)) != 0);
+
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - timestamp setter roundtrip", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    REQUIRE(kth_chain_header_timestamp(header) != 4521u);
+    kth_chain_header_set_timestamp(header, 4521u);
+    REQUIRE(kth_chain_header_timestamp(header) == 4521u);
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - bits setter roundtrip", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    REQUIRE(kth_chain_header_bits(header) != 4521u);
+    kth_chain_header_set_bits(header, 4521u);
+    REQUIRE(kth_chain_header_bits(header) == 4521u);
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - nonce setter roundtrip", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    REQUIRE(kth_chain_header_nonce(header) != 4521u);
+    kth_chain_header_set_nonce(header, 4521u);
+    REQUIRE(kth_chain_header_nonce(header) == 4521u);
+    kth_chain_header_destruct(header);
+}
+
+// ---------------------------------------------------------------------------
+// Predicates
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Header - is_valid_timestamp now true", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    time_t now = time(NULL);
+    kth_chain_header_set_timestamp(header, (uint32_t)now);
+    REQUIRE(kth_chain_header_is_valid_timestamp(header) != 0);
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - is_valid_timestamp 3h in future false", "[C-API Header]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    time_t future = time(NULL) + 3 * 60 * 60;
+    kth_chain_header_set_timestamp(header, (uint32_t)future);
+    REQUIRE(kth_chain_header_is_valid_timestamp(header) == 0);
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - is_valid_proof_of_work bits exceed max false", "[C-API Header]") {
+    // Any bits value above the proof-of-work limit should make the header
+    // fail validation. Use a sentinel value larger than any plausible target.
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    kth_chain_header_set_bits(header, 0xFFFFFFFFu);
+    REQUIRE(kth_chain_header_is_valid_proof_of_work(header, 1) == 0);
+    kth_chain_header_destruct(header);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equals
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Header - copy preserves all fields", "[C-API Header]") {
+    kth_header_mut_t original = kth_chain_header_construct(
+        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+    kth_header_mut_t copy = kth_chain_header_copy(original);
+
+    REQUIRE(kth_chain_header_is_valid(copy) != 0);
+    REQUIRE(kth_chain_header_equals(original, copy) != 0);
+    REQUIRE(kth_chain_header_version(copy)   == kVersion);
+    REQUIRE(kth_chain_header_timestamp(copy) == kTimestamp);
+    REQUIRE(kth_chain_header_bits(copy)      == kBits);
+    REQUIRE(kth_chain_header_nonce(copy)     == kNonce);
+
+    kth_chain_header_destruct(copy);
+    kth_chain_header_destruct(original);
+}
+
+TEST_CASE("C-API Header - equals duplicates", "[C-API Header]") {
+    kth_header_mut_t a = kth_chain_header_construct(
+        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+    kth_header_mut_t b = kth_chain_header_construct(
+        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+    kth_header_mut_t c = kth_chain_header_construct_default();
+
+    REQUIRE(kth_chain_header_equals(a, b) != 0);
+    REQUIRE(kth_chain_header_equals(a, c) == 0);
+
+    kth_chain_header_destruct(a);
+    kth_chain_header_destruct(b);
+    kth_chain_header_destruct(c);
+}
+
+// ---------------------------------------------------------------------------
+// Static utilities
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Header - satoshi_fixed_size is 80", "[C-API Header]") {
+    REQUIRE(kth_chain_header_satoshi_fixed_size() == 80u);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions (death tests via fork)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Header - construct_from_data null data aborts",
+          "[C-API Header][precondition]") {
+    KTH_EXPECT_ABORT({
+        kth_header_mut_t out = NULL;
+        kth_chain_header_construct_from_data(NULL, 0, 1, &out);
+    });
+}
+
+TEST_CASE("C-API Header - construct null previous_block_hash aborts",
+          "[C-API Header][precondition]") {
+    KTH_EXPECT_ABORT(
+        kth_chain_header_construct(kVersion, NULL, kMerkle,
+                                   kTimestamp, kBits, kNonce));
+}
+
+TEST_CASE("C-API Header - construct null merkle aborts",
+          "[C-API Header][precondition]") {
+    KTH_EXPECT_ABORT(
+        kth_chain_header_construct(kVersion, kPrevHash, NULL,
+                                   kTimestamp, kBits, kNonce));
+}
+
+TEST_CASE("C-API Header - to_data null out_size aborts",
+          "[C-API Header][precondition]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_header_to_data(header, 1, NULL));
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - set_previous_block_hash null aborts",
+          "[C-API Header][precondition]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_header_set_previous_block_hash(header, NULL));
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - set_merkle null aborts",
+          "[C-API Header][precondition]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_header_set_merkle(header, NULL));
+    kth_chain_header_destruct(header);
+}

--- a/src/c-api/test/test_helpers.hpp
+++ b/src/c-api/test/test_helpers.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_TEST_HELPERS_HPP_
+#define KTH_CAPI_TEST_HELPERS_HPP_
+
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+// Verify that a statement triggers KTH_PRECONDITION (abort).
+// Forks a child process to run the statement; if the child does not abort,
+// the test fails. Catch2-friendly: uses REQUIRE for assertions.
+//
+// Note: POSIX-only (uses fork/waitpid).
+#define KTH_EXPECT_ABORT(stmt) do {                                  \
+    pid_t _pid = fork();                                             \
+    REQUIRE(_pid >= 0);                                              \
+    if (_pid == 0) {                                                 \
+        /* child: silence stderr to avoid abort() messages */        \
+        freopen("/dev/null", "w", stderr);                           \
+        stmt;                                                        \
+        _exit(0);  /* did not abort */                               \
+    }                                                                \
+    int _status = 0;                                                 \
+    REQUIRE(waitpid(_pid, &_status, 0) == _pid);                     \
+    REQUIRE(WIFSIGNALED(_status));                                   \
+    REQUIRE(WTERMSIG(_status) == SIGABRT);                           \
+} while(0)
+
+#endif /* KTH_CAPI_TEST_HELPERS_HPP_ */

--- a/src/domain/include/kth/domain/version.hpp
+++ b/src/domain/include/kth/domain/version.hpp
@@ -15,7 +15,7 @@
 namespace kth {
 
 // Version string from build system (conan -> cmake -> C++)
-inline constexpr std::string_view version = "0.78.0";
+inline constexpr std::string_view version = "0.80.0";
 
 // Currency identifier
 #if defined(KTH_CURRENCY_BCH)

--- a/src/domain/src/chain/header.cpp
+++ b/src/domain/src/chain/header.cpp
@@ -123,7 +123,6 @@ hash_digest header::litecoin_proof_of_work_hash() const {
 }
 #endif  //KTH_CURRENCY_LTC
 
-inline
 hash_digest header::hash_pow() const {
 #if defined(KTH_CURRENCY_LTC)
     return litecoin_proof_of_work_hash();


### PR DESCRIPTION
## Summary

Reworks the chain/header C bindings to bring them in line with the rest of the const/mut migration and to make ownership semantics explicit at the API surface.

### Type system

- Public functions now use `kth_header_const_t` / `kth_header_mut_t` instead of the legacy unqualified `kth_header_t`. Read-only operations take a const handle, mutating operations take a mut handle. The legacy alias remains in `primitives.h` for callers that have not yet migrated.
- Local conversion helpers are renamed for symmetry: `kth_chain_header_cpp` → `kth_chain_header_mut_cpp`, paired with the existing `kth_chain_header_const_cpp`.

### Constructors and lifecycle

- `factory_from_data` is replaced by `construct_from_data`, which now returns a `kth_error_code_t` and writes the constructed header into an out-parameter. The error from the underlying `expect<header>` is propagated instead of silently producing a default-constructed header on failure.
- The field constructor `(version, prev_hash, merkle, timestamp, bits, nonce)` is preserved with the same shape but takes `uint8_t const*` for the two hash arguments and validates them with `KTH_PRECONDITION`.
- `destruct` is null-safe.
- `copy` is exposed via a dedicated `kth_chain_header_copy` entry point.

### Ownership annotations

- New `KTH_OWNED` marker (defined in `primitives.h`) tags every function whose return value or out-parameter transfers ownership to the caller. Owned returns are `kth_<x>_mut_t` handles, owned heap byte buffers (`uint8_t*`), and owned C strings (`char*`). Borrowed views (`kth_<x>_const_t`) and scalar returns are not marked.
- On compilers that support it, `KTH_OWNED` expands to `__attribute__((warn_unused_result))`, so silently discarding the result of a constructor or `to_data` call is now a compiler warning instead of a silent leak.
- Each owned function carries a one-line doc comment naming the matching destructor (`kth_chain_header_destruct`, `kth_core_destruct_array`, `kth_core_destruct_string`), so callers have the lifetime contract documented at the declaration site.

### Surface changes

- Setters now uniformly take a `kth_header_mut_t self` plus a value parameter (no in-place mutation through const handles).
- Adds bindings that the previous file was missing relative to the underlying C++ class: `serialized_size(wire)`, `is_valid_proof_of_work`, `is_valid_timestamp`, `check`, `accept`.
- Hash returns use `kth_hash_t` by value. The companion `*_out` variants for languages that cannot accept user-defined types by value will be added in a separate change.

### Methods intentionally not exposed at this layer

- `header(header_basis const&)` — the `header_basis` type is not part of the public C surface.
- `to_data(data_sink&)` — stream-based overload; the `data_chunk`-returning variant is exposed instead.
- `proof()` / `static proof(uint32_t)` — returns `boost::multiprecision` `uint256_t`, which has no current C representation. The legacy `proof_str` helper is also dropped here; it can be reintroduced as a dedicated entry point if needed.

## Test plan

- [ ] Build the c-api target on Linux
- [ ] Run any existing c-api tests for `chain/header`
- [ ] Verify `KTH_OWNED` triggers `-Wunused-result` when a `_construct*` / `_copy` / `to_data` result is discarded
- [ ] Spot-check downstream language bindings (Python / NodeJS) for the renamed `factory_from_data` → `construct_from_data` and the new error-code signature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public C-API signatures for `chain/header` change (const/mut handle split, new constructors, removed legacy entrypoints), which is a breaking surface-area change for downstream bindings. The new ownership/precondition semantics and added validation/accept paths could expose new aborts or integration issues if callers don’t follow the updated contracts.
> 
> **Overview**
> Refactors the C bindings for `chain/header` to use explicit `kth_header_const_t`/`kth_header_mut_t` handles, adds `KTH_OWNED`/`KTH_OUT_OWNED` ownership annotations, and introduces `KTH_PRECONDITION` aborting guards plus explicit destructors for returned buffers/strings (`kth_core_destruct_array`, `kth_core_destruct_string`).
> 
> Replaces the old `factory_from_data` behavior with `kth_chain_header_construct_from_data` that returns `kth_error_code_t` and only produces a header on success, expands the header surface (wire-aware `to_data`/`serialized_size`, `equals`, `copy`, PoW/timestamp predicates, `check`/`accept`), and updates conversions to support the new handle types (including `chain_state` passthrough for `accept`).
> 
> Adds Catch2/CTest integration and a focused `chain/header` C-API test suite (including precondition death tests), adds inline hash equality/null helpers in `hash.h`, renames the error enum to `kth_error_code`, and bumps the domain version string to `0.80.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff9753a3a4ace676b2abb7d31093bbca03acb631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * C API for block headers reworked to explicit mutable/const handles with owned lifecycle and wire-aware serialization.

* **New Features**
  * Added validation predicates and explicit check/accept operations that return error codes; getter/setter ergonomics improved; owned-buffer/string destructors exposed.

* **Tests**
  * New comprehensive tests covering construction, serialization round-trip, getters/setters, validation, equality and abort preconditions.

* **Chores**
  * Added ownership/annotation macros, inline hash comparison helpers, error-code typedef rename, test integration, and a library version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->