### PR TITLE
refactor(c-api): unify and harden chain/point bindings

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -498,6 +498,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 
     add_executable(kth_capi_test
         test/chain/header.cpp
+        test/chain/point.cpp
     )
 
     target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})

--- a/src/c-api/include/kth/capi/chain/header.h
+++ b/src/c-api/include/kth/capi/chain/header.h
@@ -20,7 +20,7 @@ extern "C" {
 KTH_EXPORT KTH_OWNED
 kth_header_mut_t kth_chain_header_construct_default(void);
 
-/** @param[out] out On success, owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`. Untouched on error. */
+/** @param[out] out Must point to a null `kth_header_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_header_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_header_mut_t* out);
 

--- a/src/c-api/include/kth/capi/chain/point.h
+++ b/src/c-api/include/kth/capi/chain/point.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,23 +14,100 @@
 extern "C" {
 #endif
 
+// Constructors
+
+/** @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_point_mut_t kth_chain_point_construct_default(void);
+
+/** @param[out] out Must point to a null `kth_point_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_point_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_hash_t kth_chain_point_get_hash(kth_point_t point);
+kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_point_mut_t* out);
+
+/** @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_point_mut_t kth_chain_point_construct(uint8_t const* hash, uint32_t index);
+
+
+// Static factories
+
+/** @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_point_mut_t kth_chain_point_null(void);
+
+
+// Destructor
 
 KTH_EXPORT
-void kth_chain_point_get_hash_out(kth_point_t point, kth_hash_t* out_hash);
+void kth_chain_point_destruct(kth_point_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_point_mut_t kth_chain_point_copy(kth_point_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-kth_bool_t kth_chain_point_is_valid(kth_point_t point);
+kth_bool_t kth_chain_point_equals(kth_point_const_t self, kth_point_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_point_to_data(kth_point_const_t self, kth_bool_t wire, kth_size_t* out_size);
 
 KTH_EXPORT
-uint32_t kth_chain_point_get_index(kth_point_t point);
+kth_size_t kth_chain_point_serialized_size(kth_point_const_t self, kth_bool_t wire);
+
+
+// Getters
 
 KTH_EXPORT
-uint64_t kth_chain_point_get_checksum(kth_point_t point);
+kth_hash_t kth_chain_point_hash(kth_point_const_t self);
+
+KTH_EXPORT
+uint32_t kth_chain_point_index(kth_point_const_t self);
+
+KTH_EXPORT
+uint64_t kth_chain_point_checksum(kth_point_const_t self);
+
+
+// Setters
+
+KTH_EXPORT
+void kth_chain_point_set_hash(kth_point_mut_t self, uint8_t const* value);
+
+KTH_EXPORT
+void kth_chain_point_set_index(kth_point_mut_t self, uint32_t value);
+
+
+// Predicates
+
+KTH_EXPORT
+kth_bool_t kth_chain_point_is_valid(kth_point_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_point_is_null(kth_point_const_t self);
+
+
+// Operations
+
+KTH_EXPORT
+void kth_chain_point_reset(kth_point_mut_t self);
+
+
+// Static utilities
+
+KTH_EXPORT
+kth_size_t kth_chain_point_satoshi_fixed_size(void);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_POINT_H_ */
+#endif // KTH_CAPI_CHAIN_POINT_H_

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -48,7 +48,10 @@ KTH_CONV_DECLARE(chain, kth_outputpoint_t, kth::domain::chain::output_point, out
 KTH_CONV_DECLARE(chain, kth_script_t, kth::domain::chain::script, script)
 KTH_CONV_DECLARE(chain, kth_transaction_t, kth::domain::chain::transaction, transaction)
 // KTH_CONV_DECLARE(chain, kth_transaction_t, kth::domain::chain::transaction, transaction)
-KTH_CONV_DECLARE(chain, kth_point_t, kth::domain::chain::point, point)
+// point conversion functions take const/mut handle types directly. Defined
+// in src/chain/point.cpp.
+kth::domain::chain::point const& kth_chain_point_const_cpp(kth_point_const_t o);
+kth::domain::chain::point&       kth_chain_point_mut_cpp(kth_point_mut_t o);
 KTH_CONV_DECLARE(chain, kth_utxo_t, kth::domain::chain::utxo, utxo)
 KTH_CONV_DECLARE(chain, kth_token_data_t, kth::domain::chain::token_data_t, token_data)
 

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -125,6 +125,8 @@ typedef void* kth_outputpoint_t;
 typedef void* kth_utxo_t;
 typedef void const* kth_outputpoint_const_t;
 typedef void* kth_point_t;
+typedef void* kth_point_mut_t;
+typedef void const* kth_point_const_t;
 typedef void* kth_point_list_t;
 typedef void* kth_outputpoint_list_t;
 typedef void* kth_transaction_t;

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -29,6 +29,7 @@ kth_header_mut_t kth_chain_header_construct_default(void) {
 kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_header_mut_t* out) {
     KTH_PRECONDITION(data != nullptr);
     KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
     auto data_cpp = kth::byte_reader(kth::byte_span(data, n));
     auto wire_cpp = kth::int_to_bool(wire);
     auto result = kth::domain::chain::header::from_data(data_cpp, wire_cpp);

--- a/src/c-api/src/chain/point.cpp
+++ b/src/c-api/src/chain/point.cpp
@@ -1,41 +1,158 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <kth/capi/chain/point.h>
 
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/domain/chain/point.hpp>
 
-#include <kth/capi/helpers.hpp>
-#include <kth/capi/type_conversions.h>
-
-
-KTH_CONV_DEFINE(chain, kth_point_t, kth::domain::chain::point, point)
+// Conversion functions
+kth::domain::chain::point& kth_chain_point_mut_cpp(kth_point_mut_t o) {
+    return *static_cast<kth::domain::chain::point*>(o);
+}
+kth::domain::chain::point const& kth_chain_point_const_cpp(kth_point_const_t o) {
+    return *static_cast<kth::domain::chain::point const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_hash_t kth_chain_point_get_hash(kth_point_t point) {
-    auto const& hash_cpp = kth_chain_point_const_cpp(point).hash();
-    return kth::to_hash_t(hash_cpp);
+// Constructors
+
+kth_point_mut_t kth_chain_point_construct_default(void) {
+    return new kth::domain::chain::point();
 }
 
-void kth_chain_point_get_hash_out(kth_point_t point, kth_hash_t* out_hash) {
-    auto const& hash_cpp = kth_chain_point_const_cpp(point).hash();
-    kth::copy_c_hash(hash_cpp, out_hash);
+kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_point_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, n));
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto result = kth::domain::chain::point::from_data(data_cpp, wire_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::chain::point(std::move(*result));
+    return kth_ec_success;
 }
 
-kth_bool_t kth_chain_point_is_valid(kth_point_t point) {
-    return kth::bool_to_int(kth_chain_point_const_cpp(point).is_valid());
+kth_point_mut_t kth_chain_point_construct(uint8_t const* hash, uint32_t index) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto hash_cpp = kth::hash_to_cpp(hash);
+    return new kth::domain::chain::point(hash_cpp, index);
 }
 
-uint32_t kth_chain_point_get_index(kth_point_t point) {
-    return kth_chain_point_const_cpp(point).index();
+
+// Static factories
+
+kth_point_mut_t kth_chain_point_null(void) {
+    return new kth::domain::chain::point(kth::domain::chain::point::null());
 }
 
-uint64_t kth_chain_point_get_checksum(kth_point_t point) {
-    return kth_chain_point_const_cpp(point).checksum();
+
+// Destructor
+
+void kth_chain_point_destruct(kth_point_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_point_mut_cpp(self);
+}
+
+
+// Copy
+
+kth_point_mut_t kth_chain_point_copy(kth_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::chain::point(kth_chain_point_const_cpp(self));
+}
+
+
+// Equality
+
+kth_bool_t kth_chain_point_equals(kth_point_const_t self, kth_point_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_point_const_cpp(self) == kth_chain_point_const_cpp(other));
+}
+
+
+// Serialization
+
+uint8_t* kth_chain_point_to_data(kth_point_const_t self, kth_bool_t wire, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto data = kth_chain_point_const_cpp(self).to_data(wire_cpp);
+    return kth::create_c_array(data, *out_size);
+}
+
+kth_size_t kth_chain_point_serialized_size(kth_point_const_t self, kth_bool_t wire) {
+    KTH_PRECONDITION(self != nullptr);
+    auto wire_cpp = kth::int_to_bool(wire);
+    return kth_chain_point_const_cpp(self).serialized_size(wire_cpp);
+}
+
+
+// Getters
+
+kth_hash_t kth_chain_point_hash(kth_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto value_cpp = kth_chain_point_const_cpp(self).hash();
+    return kth::to_hash_t(value_cpp);
+}
+
+uint32_t kth_chain_point_index(kth_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_point_const_cpp(self).index();
+}
+
+uint64_t kth_chain_point_checksum(kth_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_point_const_cpp(self).checksum();
+}
+
+
+// Setters
+
+void kth_chain_point_set_hash(kth_point_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto value_cpp = kth::hash_to_cpp(value);
+    kth_chain_point_mut_cpp(self).set_hash(value_cpp);
+}
+
+void kth_chain_point_set_index(kth_point_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_point_mut_cpp(self).set_index(value);
+}
+
+
+// Predicates
+
+kth_bool_t kth_chain_point_is_valid(kth_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_point_const_cpp(self).is_valid());
+}
+
+kth_bool_t kth_chain_point_is_null(kth_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_point_const_cpp(self).is_null());
+}
+
+
+// Operations
+
+void kth_chain_point_reset(kth_point_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_point_mut_cpp(self).reset();
+}
+
+
+// Static utilities
+
+kth_size_t kth_chain_point_satoshi_fixed_size(void) {
+    return kth::domain::chain::point::satoshi_fixed_size();
 }
 
 } // extern "C"
-

--- a/src/c-api/test/chain/point.cpp
+++ b/src/c-api/test/chain/point.cpp
@@ -1,0 +1,231 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/chain/point.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+static uint8_t const kHash[32] = {
+    0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72,
+    0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7, 0x4f,
+    0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c,
+    0x68, 0xd6, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+static uint8_t const kAllOnes[32] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+};
+
+static kth_hash_t make_hash(uint8_t const* bytes) {
+    kth_hash_t h;
+    memcpy(h.hash, bytes, KTH_BITCOIN_HASH_SIZE);
+    return h;
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Point - default construct is invalid", "[C-API Point]") {
+    kth_point_mut_t point = kth_chain_point_construct_default();
+    REQUIRE(kth_chain_point_is_valid(point) == 0);
+    kth_chain_point_destruct(point);
+}
+
+TEST_CASE("C-API Point - field constructor preserves hash and index", "[C-API Point]") {
+    kth_point_mut_t point = kth_chain_point_construct(kHash, 1234u);
+    REQUIRE(kth_chain_point_is_valid(point) != 0);
+    REQUIRE(kth_chain_point_index(point) == 1234u);
+    REQUIRE(kth_hash_equal(kth_chain_point_hash(point), make_hash(kHash)) != 0);
+    kth_chain_point_destruct(point);
+}
+
+// ---------------------------------------------------------------------------
+// from_data / to_data round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Point - from_data insufficient bytes fails", "[C-API Point]") {
+    uint8_t data[10];
+    memset(data, 0, sizeof(data));
+    kth_point_mut_t out = NULL;
+    kth_error_code_t ec = kth_chain_point_construct_from_data(data, 10, 1, &out);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(out == NULL);
+}
+
+TEST_CASE("C-API Point - to_data / from_data roundtrip", "[C-API Point]") {
+    kth_point_mut_t expected = kth_chain_point_construct(kHash, 53213u);
+
+    kth_size_t size = 0;
+    uint8_t* raw = kth_chain_point_to_data(expected, 1, &size);
+    REQUIRE(size == 36u);
+    REQUIRE(raw != NULL);
+
+    kth_point_mut_t parsed = NULL;
+    kth_error_code_t ec = kth_chain_point_construct_from_data(raw, size, 1, &parsed);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(parsed != NULL);
+
+    REQUIRE(kth_chain_point_is_valid(parsed) != 0);
+    REQUIRE(kth_chain_point_equals(expected, parsed) != 0);
+    REQUIRE(kth_chain_point_index(parsed) == 53213u);
+    REQUIRE(kth_hash_equal(kth_chain_point_hash(parsed), make_hash(kHash)) != 0);
+
+    kth_core_destruct_array(raw);
+    kth_chain_point_destruct(parsed);
+    kth_chain_point_destruct(expected);
+}
+
+// ---------------------------------------------------------------------------
+// Getters / setters
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Point - hash setter roundtrip", "[C-API Point]") {
+    kth_point_mut_t point = kth_chain_point_construct_default();
+    REQUIRE(kth_hash_is_null(kth_chain_point_hash(point)) != 0);
+
+    kth_chain_point_set_hash(point, kHash);
+    REQUIRE(kth_hash_equal(kth_chain_point_hash(point), make_hash(kHash)) != 0);
+
+    kth_chain_point_destruct(point);
+}
+
+TEST_CASE("C-API Point - index setter roundtrip", "[C-API Point]") {
+    kth_point_mut_t point = kth_chain_point_construct_default();
+    REQUIRE(kth_chain_point_index(point) != 1254u);
+    kth_chain_point_set_index(point, 1254u);
+    REQUIRE(kth_chain_point_index(point) == 1254u);
+    kth_chain_point_destruct(point);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equals
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Point - copy preserves fields", "[C-API Point]") {
+    kth_point_mut_t original = kth_chain_point_construct(kHash, 524342u);
+    kth_point_mut_t copy = kth_chain_point_copy(original);
+
+    REQUIRE(kth_chain_point_is_valid(copy) != 0);
+    REQUIRE(kth_chain_point_equals(original, copy) != 0);
+    REQUIRE(kth_chain_point_index(copy) == 524342u);
+
+    kth_chain_point_destruct(copy);
+    kth_chain_point_destruct(original);
+}
+
+TEST_CASE("C-API Point - equals duplicates", "[C-API Point]") {
+    kth_point_mut_t a = kth_chain_point_construct(kHash, 524342u);
+    kth_point_mut_t b = kth_chain_point_construct(kHash, 524342u);
+    kth_point_mut_t c = kth_chain_point_construct_default();
+
+    REQUIRE(kth_chain_point_equals(a, b) != 0);
+    REQUIRE(kth_chain_point_equals(a, c) == 0);
+
+    kth_chain_point_destruct(a);
+    kth_chain_point_destruct(b);
+    kth_chain_point_destruct(c);
+}
+
+// ---------------------------------------------------------------------------
+// Checksum
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Point - checksum all ones returns all ones", "[C-API Point]") {
+    kth_point_mut_t point = kth_chain_point_construct(kAllOnes, 0xffffffffu);
+    REQUIRE(kth_chain_point_checksum(point) == 0xffffffffffffffffull);
+    kth_chain_point_destruct(point);
+}
+
+TEST_CASE("C-API Point - checksum all zeros returns zero", "[C-API Point]") {
+    uint8_t zero[32];
+    memset(zero, 0, sizeof(zero));
+    kth_point_mut_t point = kth_chain_point_construct(zero, 0u);
+    REQUIRE(kth_chain_point_checksum(point) == 0ull);
+    kth_chain_point_destruct(point);
+}
+
+// ---------------------------------------------------------------------------
+// Static utilities
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Point - satoshi_fixed_size is 36", "[C-API Point]") {
+    REQUIRE(kth_chain_point_satoshi_fixed_size() == 36u);
+}
+
+TEST_CASE("C-API Point - null factory returns is_null", "[C-API Point]") {
+    kth_point_mut_t point = kth_chain_point_null();
+    REQUIRE(kth_chain_point_is_null(point) != 0);
+    kth_chain_point_destruct(point);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions (death tests via fork)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Point - construct_from_data null data aborts",
+          "[C-API Point][precondition]") {
+    KTH_EXPECT_ABORT({
+        kth_point_mut_t out = NULL;
+        kth_chain_point_construct_from_data(NULL, 0, 1, &out);
+    });
+}
+
+TEST_CASE("C-API Point - construct_from_data null out aborts",
+          "[C-API Point][precondition]") {
+    uint8_t data[10];
+    memset(data, 0, sizeof(data));
+    KTH_EXPECT_ABORT(kth_chain_point_construct_from_data(data, 10, 1, NULL));
+}
+
+TEST_CASE("C-API Point - construct null hash aborts",
+          "[C-API Point][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_point_construct(NULL, 0));
+}
+
+TEST_CASE("C-API Point - to_data null out_size aborts",
+          "[C-API Point][precondition]") {
+    kth_point_mut_t point = kth_chain_point_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_point_to_data(point, 1, NULL));
+    kth_chain_point_destruct(point);
+}
+
+TEST_CASE("C-API Point - copy null self aborts",
+          "[C-API Point][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_point_copy(NULL));
+}
+
+TEST_CASE("C-API Point - set_hash null aborts",
+          "[C-API Point][precondition]") {
+    kth_point_mut_t point = kth_chain_point_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_point_set_hash(point, NULL));
+    kth_chain_point_destruct(point);
+}
+
+TEST_CASE("C-API Point - equals null self aborts",
+          "[C-API Point][precondition]") {
+    kth_point_mut_t other = kth_chain_point_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_point_equals(NULL, other));
+    kth_chain_point_destruct(other);
+}

--- a/src/c-api/test/test_helpers.hpp
+++ b/src/c-api/test/test_helpers.hpp
@@ -12,18 +12,40 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+// Helper macros that locally suppress -Wunused-result around a single
+// statement. Used by KTH_EXPECT_ABORT below to allow death tests to call
+// KTH_OWNED functions without capturing their return value (the child
+// process is about to abort, so any leak is irrelevant). Guarded so the
+// pragmas are only emitted on toolchains that understand them.
+#if defined(__GNUC__) || defined(__clang__)
+#define KTH_TEST_PUSH_NO_UNUSED_RESULT \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wunused-result\"")
+#define KTH_TEST_POP_DIAG _Pragma("GCC diagnostic pop")
+#else
+#define KTH_TEST_PUSH_NO_UNUSED_RESULT
+#define KTH_TEST_POP_DIAG
+#endif
+
 // Verify that a statement triggers KTH_PRECONDITION (abort).
 // Forks a child process to run the statement; if the child does not abort,
 // the test fails. Catch2-friendly: uses REQUIRE for assertions.
 //
 // Note: POSIX-only (uses fork/waitpid).
+//
+// The `stmt` argument may be a call to a KTH_OWNED function whose return
+// value would normally trigger -Wunused-result. Death-test bodies are
+// allowed to discard those results (the process is about to abort anyway),
+// so we suppress the warning locally around the call site.
 #define KTH_EXPECT_ABORT(stmt) do {                                  \
     pid_t _pid = fork();                                             \
     REQUIRE(_pid >= 0);                                              \
     if (_pid == 0) {                                                 \
         /* child: silence stderr to avoid abort() messages */        \
         freopen("/dev/null", "w", stderr);                           \
+        KTH_TEST_PUSH_NO_UNUSED_RESULT                               \
         stmt;                                                        \
+        KTH_TEST_POP_DIAG                                            \
         _exit(0);  /* did not abort */                               \
     }                                                                \
     int _status = 0;                                                 \


### PR DESCRIPTION
## Summary

Reworks the chain/point C bindings in line with the const/mut migration applied to chain/header (#216), and exposes ownership semantics at the API surface so language backends can wire owned objects through their own smart-handle equivalents.

### Type system

- Public functions now use `kth_point_const_t` / `kth_point_mut_t` instead of the legacy unqualified `kth_point_t`. Read-only operations take a const handle, mutating operations take a mut handle. The legacy alias remains in `primitives.h` for callers that have not yet migrated.
- Local conversion helpers follow the symmetric naming: `kth_chain_point_const_cpp` / `kth_chain_point_mut_cpp`.

### Constructors and lifecycle

- `construct_from_data` returns a `kth_error_code_t` and writes the parsed point through an out-parameter; the underlying `expect<point>` error is propagated instead of silently producing a default-constructed point on failure.
- The field constructor `(hash, index)` takes `uint8_t const*` for the hash argument and validates it with `KTH_PRECONDITION`.
- `destruct` is null-safe.
- `copy` is exposed via a dedicated `kth_chain_point_copy` entry point.

### Ownership annotations

- Owned returns are tagged with `KTH_OWNED` (`warn_unused_result` on GCC/Clang). Owned out-parameters are tagged with `KTH_OUT_OWNED`.
- Each owned function carries a one-line doc comment naming the matching destructor (`kth_chain_point_destruct`, `kth_core_destruct_array`).

### Surface changes

- Setters take a `kth_point_mut_t self` plus a value parameter.
- Adds bindings that the previous file was missing relative to the underlying C++ class: `serialized_size(wire)`, `checksum`, `is_null`, `null` factory, `equals`.
- Hash returns use `kth_hash_t` by value.

### Tests

- Adds `src/c-api/test/chain/point.cpp` covering: ctors, `from_data` / `to_data` roundtrip, getters/setters, `copy`, `equals`, `checksum`, `is_null`, `satoshi_fixed_size`, and 7 `KTH_PRECONDITION` death tests (fork-based).

### Methods intentionally not exposed

- `to_data(data_sink&)` — stream-based overload; the `data_chunk` variant is exposed instead.
- `begin()` / `end()` — return `point_iterator`, which is not part of the C-API surface.

## Test plan

- [ ] Build the c-api target on Linux
- [ ] Run the new \`kth_capi_test\` suite for \`[C-API Point]\`
- [ ] Verify \`KTH_OWNED\` triggers \`-Wunused-result\` when a \`_construct*\` / \`_copy\` / \`to_data\` result is discarded

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is an API-shaping change to the public C bindings for `chain/point` (new handle types, new entry points, and changed construction semantics), so downstream consumers may break or misuse ownership if not updated. Runtime risk is moderate but mainly around FFI integration and memory/ABI expectations, mitigated by added preconditions and new tests.
> 
> **Overview**
> Refactors the `chain/point` C-API to mirror the const/mut + ownership model used elsewhere: introduces `kth_point_const_t`/`kth_point_mut_t`, updates conversion helpers, and tightens `*_construct_from_data` to return an error code and require a null out-slot.
> 
> Expands the `point` surface with explicit lifecycle (`destruct`, `copy`), equality, serialization helpers (`to_data`, `serialized_size`), full getters/setters, null/valid predicates, `reset`, and fixed-size utility; and wires in a new Catch2 test suite (including fork-based precondition death tests) plus CMake test target updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29fd5077b0d4c8076c7220f6b3005633cb136000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned C‑API for chain points: ownership-aware handles, constructors, copy/equality, serialization, getters/setters, reset, and size utility.

* **Breaking Changes**
  * Old point getter functions removed and replaced by the new handle-based API; callers must switch to the new functions.

* **Tests**
  * Added comprehensive C‑API tests covering construction, serialization round‑trip, getters/setters, equality, checksum, null handling, and argument-abort cases.

* **Documentation**
  * Strengthened contract for header-from-data output parameter to require a null slot before call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->