### PR TITLE
refactor(c-api): unify and harden chain/output_point bindings

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -499,6 +499,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     add_executable(kth_capi_test
         test/chain/header.cpp
         test/chain/point.cpp
+        test/chain/output_point.cpp
     )
 
     target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})

--- a/src/c-api/include/kth/capi/chain/output_point.h
+++ b/src/c-api/include/kth/capi/chain/output_point.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,39 +14,96 @@
 extern "C" {
 #endif
 
-KTH_EXPORT
-kth_outputpoint_t kth_chain_output_point_construct(void);
+// Constructors
+
+/** @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_point_mut_t kth_chain_output_point_construct_default(void);
+
+/** @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(uint8_t const* hash, uint32_t index);
+
+/** @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_point_mut_t kth_chain_output_point_construct_from_point(kth_point_const_t x);
+
+
+// Destructor
 
 KTH_EXPORT
-kth_outputpoint_t kth_chain_output_point_construct_from_hash_index(kth_hash_t const* hash, uint32_t index);
+void kth_chain_output_point_destruct(kth_output_point_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_point_mut_t kth_chain_output_point_copy(kth_output_point_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-void kth_chain_output_point_destruct(kth_outputpoint_t op);
+kth_bool_t kth_chain_output_point_equals(kth_output_point_const_t self, kth_output_point_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_output_point_to_data(kth_output_point_const_t self, kth_bool_t wire, kth_size_t* out_size);
 
 KTH_EXPORT
-kth_hash_t kth_chain_output_point_get_hash(kth_outputpoint_t op);
+kth_size_t kth_chain_output_point_serialized_size(kth_output_point_const_t self, kth_bool_t wire);
+
+
+// Getters
 
 KTH_EXPORT
-void kth_chain_output_point_get_hash_out(kth_outputpoint_t op, kth_hash_t* out_hash);
+kth_hash_t kth_chain_output_point_hash(kth_output_point_const_t self);
 
 KTH_EXPORT
-uint32_t kth_chain_output_point_get_index(kth_outputpoint_t op);
+uint32_t kth_chain_output_point_index(kth_output_point_const_t self);
 
 KTH_EXPORT
-kth_output_t kth_chain_output_point_get_cached_output(kth_outputpoint_t op);
+uint64_t kth_chain_output_point_checksum(kth_output_point_const_t self);
+
+
+// Setters
 
 KTH_EXPORT
-void kth_chain_output_point_set_hash(kth_outputpoint_t op, kth_hash_t const* hash);
+void kth_chain_output_point_set_hash(kth_output_point_mut_t self, uint8_t const* value);
 
 KTH_EXPORT
-void kth_chain_output_point_set_index(kth_outputpoint_t op, uint32_t index);
+void kth_chain_output_point_set_index(kth_output_point_mut_t self, uint32_t value);
+
+
+// Predicates
 
 KTH_EXPORT
-void kth_chain_output_point_set_cached_output(kth_outputpoint_t op, kth_output_t output);
+kth_bool_t kth_chain_output_point_is_mature(kth_output_point_const_t self, kth_size_t height);
 
+KTH_EXPORT
+kth_bool_t kth_chain_output_point_is_valid(kth_output_point_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_output_point_is_null(kth_output_point_const_t self);
+
+
+// Operations
+
+KTH_EXPORT
+void kth_chain_output_point_reset(kth_output_point_mut_t self);
+
+
+// Static utilities
+
+KTH_EXPORT
+kth_size_t kth_chain_output_point_satoshi_fixed_size(void);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_OUTPUT_POINT_H_ */
+#endif // KTH_CAPI_CHAIN_OUTPUT_POINT_H_

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -44,7 +44,10 @@ inline kth::domain::chain::chain_state& kth_chain_chain_state_mut_cpp(kth_chain_
 }
 KTH_CONV_DECLARE(chain, kth_input_t, kth::domain::chain::input, input)
 KTH_CONV_DECLARE(chain, kth_output_t, kth::domain::chain::output, output)
-KTH_CONV_DECLARE(chain, kth_outputpoint_t, kth::domain::chain::output_point, output_point)
+// output_point conversion functions take const/mut handle types directly.
+// Defined in src/chain/output_point.cpp.
+kth::domain::chain::output_point const& kth_chain_output_point_const_cpp(kth_output_point_const_t o);
+kth::domain::chain::output_point&       kth_chain_output_point_mut_cpp(kth_output_point_mut_t o);
 KTH_CONV_DECLARE(chain, kth_script_t, kth::domain::chain::script, script)
 KTH_CONV_DECLARE(chain, kth_transaction_t, kth::domain::chain::transaction, transaction)
 // KTH_CONV_DECLARE(chain, kth_transaction_t, kth::domain::chain::transaction, transaction)

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -122,6 +122,8 @@ typedef void* kth_operation_t;
 typedef void* kth_output_list_t;
 typedef void* kth_output_t;
 typedef void* kth_outputpoint_t;
+typedef void* kth_output_point_mut_t;
+typedef void const* kth_output_point_const_t;
 typedef void* kth_utxo_t;
 typedef void const* kth_outputpoint_const_t;
 typedef void* kth_point_t;

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,63 +6,144 @@
 
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
+#include <kth/domain/chain/output_point.hpp>
 
-KTH_CONV_DEFINE(chain, kth_outputpoint_t, kth::domain::chain::output_point, output_point)
+// Conversion functions
+kth::domain::chain::output_point& kth_chain_output_point_mut_cpp(kth_output_point_mut_t o) {
+    return *static_cast<kth::domain::chain::output_point*>(o);
+}
+kth::domain::chain::output_point const& kth_chain_output_point_const_cpp(kth_output_point_const_t o) {
+    return *static_cast<kth::domain::chain::output_point const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_outputpoint_t kth_chain_output_point_construct() {
-    // return std::make_unique<kth::domain::chain::output_point>().release();
-    return new kth::domain::chain::output_point;
+// Constructors
+
+kth_output_point_mut_t kth_chain_output_point_construct_default(void) {
+    return new kth::domain::chain::output_point();
+}
+
+kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(uint8_t const* hash, uint32_t index) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto hash_cpp = kth::hash_to_cpp(hash);
+    return new kth::domain::chain::output_point(hash_cpp, index);
+}
+
+kth_output_point_mut_t kth_chain_output_point_construct_from_point(kth_point_const_t x) {
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth_chain_point_const_cpp(x);
+    return new kth::domain::chain::output_point(x_cpp);
 }
 
 
-kth_outputpoint_t kth_chain_output_point_construct_from_hash_index(kth_hash_t const* hash, uint32_t index) {
-    auto hash_cpp = kth::to_array(hash->hash);
-    auto ret = new kth::domain::chain::output_point(hash_cpp, index);
-    return ret;
+// Destructor
+
+void kth_chain_output_point_destruct(kth_output_point_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_output_point_mut_cpp(self);
 }
 
-void kth_chain_output_point_destruct(kth_outputpoint_t op) {
-    delete &kth_chain_output_point_cpp(op);
+
+// Copy
+
+kth_output_point_mut_t kth_chain_output_point_copy(kth_output_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::chain::output_point(kth_chain_output_point_const_cpp(self));
 }
 
-//kth_hash_t kth_chain_output_point_get_hash(kth_outputpoint_t op) {
-//    auto const& hash_cpp = kth_chain_output_point_const_cpp(op).hash();
-//    return hash_cpp.data();
-//}
 
-kth_hash_t kth_chain_output_point_get_hash(kth_outputpoint_t op) {
-    auto const& hash_cpp = kth_chain_output_point_const_cpp(op).hash();
-    return kth::to_hash_t(hash_cpp);
+// Equality
+
+kth_bool_t kth_chain_output_point_equals(kth_output_point_const_t self, kth_output_point_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_output_point_const_cpp(self) == kth_chain_output_point_const_cpp(other));
 }
 
-void kth_chain_output_point_get_hash_out(kth_outputpoint_t op, kth_hash_t* out_hash) {
-    auto const& hash_cpp = kth_chain_output_point_const_cpp(op).hash();
-    kth::copy_c_hash(hash_cpp, out_hash);
+
+// Serialization
+
+uint8_t* kth_chain_output_point_to_data(kth_output_point_const_t self, kth_bool_t wire, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto data = kth_chain_output_point_const_cpp(self).to_data(wire_cpp);
+    return kth::create_c_array(data, *out_size);
 }
 
-uint32_t kth_chain_output_point_get_index(kth_outputpoint_t op) {
-    return kth_chain_output_point_const_cpp(op).index();
+kth_size_t kth_chain_output_point_serialized_size(kth_output_point_const_t self, kth_bool_t wire) {
+    KTH_PRECONDITION(self != nullptr);
+    auto wire_cpp = kth::int_to_bool(wire);
+    return kth_chain_output_point_const_cpp(self).serialized_size(wire_cpp);
 }
 
-kth_output_t kth_chain_output_point_get_cached_output(kth_outputpoint_t op) {
-    auto& output = kth_chain_output_point_const_cpp(op).validation.cache;
-    return &output;
+
+// Getters
+
+kth_hash_t kth_chain_output_point_hash(kth_output_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto value_cpp = kth_chain_output_point_const_cpp(self).hash();
+    return kth::to_hash_t(value_cpp);
 }
 
-void kth_chain_output_point_set_hash(kth_outputpoint_t op, kth_hash_t const* hash) {
-    auto hash_cpp = kth::to_array(hash->hash);
-    kth_chain_output_point_cpp(op).set_hash(hash_cpp);
+uint32_t kth_chain_output_point_index(kth_output_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_output_point_const_cpp(self).index();
 }
 
-void kth_chain_output_point_set_index(kth_outputpoint_t op, uint32_t index) {
-    kth_chain_output_point_cpp(op).set_index(index);
+uint64_t kth_chain_output_point_checksum(kth_output_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_output_point_const_cpp(self).checksum();
 }
 
-void kth_chain_output_point_set_cached_output(kth_outputpoint_t op, kth_output_t output) {
-    kth_chain_output_point_cpp(op).validation.cache = kth_chain_output_const_cpp(output);
+
+// Setters
+
+void kth_chain_output_point_set_hash(kth_output_point_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto value_cpp = kth::hash_to_cpp(value);
+    kth_chain_output_point_mut_cpp(self).set_hash(value_cpp);
+}
+
+void kth_chain_output_point_set_index(kth_output_point_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_output_point_mut_cpp(self).set_index(value);
+}
+
+
+// Predicates
+
+kth_bool_t kth_chain_output_point_is_mature(kth_output_point_const_t self, kth_size_t height) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_output_point_const_cpp(self).is_mature(height));
+}
+
+kth_bool_t kth_chain_output_point_is_valid(kth_output_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_output_point_const_cpp(self).is_valid());
+}
+
+kth_bool_t kth_chain_output_point_is_null(kth_output_point_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_output_point_const_cpp(self).is_null());
+}
+
+
+// Operations
+
+void kth_chain_output_point_reset(kth_output_point_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_output_point_mut_cpp(self).reset();
+}
+
+
+// Static utilities
+
+kth_size_t kth_chain_output_point_satoshi_fixed_size(void) {
+    return kth::domain::chain::output_point::satoshi_fixed_size();
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/output_point.cpp
+++ b/src/c-api/test/chain/output_point.cpp
@@ -1,0 +1,220 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/chain/output_point.h>
+#include <kth/capi/chain/point.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+static uint8_t const kHash[32] = {
+    0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72,
+    0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7, 0x4f,
+    0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c,
+    0x68, 0xd6, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+static uint8_t const kAllOnes[32] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+};
+
+static kth_hash_t make_hash(uint8_t const* bytes) {
+    kth_hash_t h;
+    memcpy(h.hash, bytes, KTH_BITCOIN_HASH_SIZE);
+    return h;
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API OutputPoint - default construct is invalid", "[C-API OutputPoint]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
+    REQUIRE(kth_chain_output_point_is_valid(op) == 0);
+    kth_chain_output_point_destruct(op);
+}
+
+TEST_CASE("C-API OutputPoint - construct from hash and index", "[C-API OutputPoint]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHash, 1234u);
+    REQUIRE(kth_chain_output_point_is_valid(op) != 0);
+    REQUIRE(kth_chain_output_point_index(op) == 1234u);
+    REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op), make_hash(kHash)) != 0);
+    kth_chain_output_point_destruct(op);
+}
+
+TEST_CASE("C-API OutputPoint - construct from point preserves fields", "[C-API OutputPoint]") {
+    kth_point_mut_t pt = kth_chain_point_construct(kHash, 42u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_point(pt);
+
+    REQUIRE(kth_chain_output_point_is_valid(op) != 0);
+    REQUIRE(kth_chain_output_point_index(op) == 42u);
+    REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op), make_hash(kHash)) != 0);
+
+    kth_chain_output_point_destruct(op);
+    kth_chain_point_destruct(pt);
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API OutputPoint - serialized_size is fixed 36", "[C-API OutputPoint]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHash, 7u);
+    REQUIRE(kth_chain_output_point_serialized_size(op, 1) == 36u);
+    kth_chain_output_point_destruct(op);
+}
+
+TEST_CASE("C-API OutputPoint - to_data fixed-size payload", "[C-API OutputPoint]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHash, 7u);
+
+    kth_size_t size = 0;
+    uint8_t* raw = kth_chain_output_point_to_data(op, 1, &size);
+    REQUIRE(raw != NULL);
+    REQUIRE(size == 36u);
+
+    // Last 4 bytes are the index in little-endian.
+    REQUIRE(raw[32] == 0x07);
+    REQUIRE(raw[33] == 0x00);
+    REQUIRE(raw[34] == 0x00);
+    REQUIRE(raw[35] == 0x00);
+
+    kth_core_destruct_array(raw);
+    kth_chain_output_point_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Getters / setters
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API OutputPoint - hash setter roundtrip", "[C-API OutputPoint]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
+    REQUIRE(kth_hash_is_null(kth_chain_output_point_hash(op)) != 0);
+
+    kth_chain_output_point_set_hash(op, kHash);
+    REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op), make_hash(kHash)) != 0);
+
+    kth_chain_output_point_destruct(op);
+}
+
+TEST_CASE("C-API OutputPoint - index setter roundtrip", "[C-API OutputPoint]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
+    REQUIRE(kth_chain_output_point_index(op) != 9999u);
+    kth_chain_output_point_set_index(op, 9999u);
+    REQUIRE(kth_chain_output_point_index(op) == 9999u);
+    kth_chain_output_point_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equals
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API OutputPoint - copy preserves fields", "[C-API OutputPoint]") {
+    kth_output_point_mut_t original = kth_chain_output_point_construct_from_hash_index(kHash, 524342u);
+    kth_output_point_mut_t copy = kth_chain_output_point_copy(original);
+
+    REQUIRE(kth_chain_output_point_is_valid(copy) != 0);
+    REQUIRE(kth_chain_output_point_equals(original, copy) != 0);
+    REQUIRE(kth_chain_output_point_index(copy) == 524342u);
+
+    kth_chain_output_point_destruct(copy);
+    kth_chain_output_point_destruct(original);
+}
+
+TEST_CASE("C-API OutputPoint - equals duplicates", "[C-API OutputPoint]") {
+    kth_output_point_mut_t a = kth_chain_output_point_construct_from_hash_index(kHash, 524342u);
+    kth_output_point_mut_t b = kth_chain_output_point_construct_from_hash_index(kHash, 524342u);
+    kth_output_point_mut_t c = kth_chain_output_point_construct_default();
+
+    REQUIRE(kth_chain_output_point_equals(a, b) != 0);
+    REQUIRE(kth_chain_output_point_equals(a, c) == 0);
+
+    kth_chain_output_point_destruct(a);
+    kth_chain_output_point_destruct(b);
+    kth_chain_output_point_destruct(c);
+}
+
+// ---------------------------------------------------------------------------
+// Checksum
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API OutputPoint - checksum all ones", "[C-API OutputPoint]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kAllOnes, 0xffffffffu);
+    REQUIRE(kth_chain_output_point_checksum(op) == 0xffffffffffffffffull);
+    kth_chain_output_point_destruct(op);
+}
+
+TEST_CASE("C-API OutputPoint - checksum all zeros", "[C-API OutputPoint]") {
+    uint8_t zero[32];
+    memset(zero, 0, sizeof(zero));
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(zero, 0u);
+    REQUIRE(kth_chain_output_point_checksum(op) == 0ull);
+    kth_chain_output_point_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Static utilities
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API OutputPoint - satoshi_fixed_size is 36", "[C-API OutputPoint]") {
+    REQUIRE(kth_chain_output_point_satoshi_fixed_size() == 36u);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions (death tests via fork)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API OutputPoint - construct null hash aborts",
+          "[C-API OutputPoint][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_output_point_construct_from_hash_index(NULL, 0));
+}
+
+TEST_CASE("C-API OutputPoint - construct from null point aborts",
+          "[C-API OutputPoint][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_output_point_construct_from_point(NULL));
+}
+
+TEST_CASE("C-API OutputPoint - to_data null out_size aborts",
+          "[C-API OutputPoint][precondition]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_output_point_to_data(op, 1, NULL));
+    kth_chain_output_point_destruct(op);
+}
+
+TEST_CASE("C-API OutputPoint - copy null self aborts",
+          "[C-API OutputPoint][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_output_point_copy(NULL));
+}
+
+TEST_CASE("C-API OutputPoint - set_hash null aborts",
+          "[C-API OutputPoint][precondition]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_output_point_set_hash(op, NULL));
+    kth_chain_output_point_destruct(op);
+}
+
+TEST_CASE("C-API OutputPoint - equals null self aborts",
+          "[C-API OutputPoint][precondition]") {
+    kth_output_point_mut_t other = kth_chain_output_point_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_output_point_equals(NULL, other));
+    kth_chain_output_point_destruct(other);
+}


### PR DESCRIPTION
## Summary

Reworks the chain/output_point C bindings in line with the const/mut migration applied to chain/header (#216) and chain/point (#217), and exposes ownership semantics at the API surface so language backends can wire owned objects through their own smart-handle equivalents.

### Type system

- Public functions now use \`kth_output_point_const_t\` / \`kth_output_point_mut_t\` instead of the legacy unqualified \`kth_outputpoint_t\`. Read-only operations take a const handle, mutating operations take a mut handle. The legacy alias remains in \`primitives.h\` for callers that have not yet migrated.
- Local conversion helpers follow the symmetric naming: \`kth_chain_output_point_const_cpp\` / \`kth_chain_output_point_mut_cpp\`.

### Constructors and lifecycle

- Two field constructors are exposed:
  - \`construct_from_hash_index(hash, index)\`
  - \`construct_from_point(point)\`
  Both validate their pointer arguments with \`KTH_PRECONDITION\`.
- \`destruct\` is null-safe.
- \`copy\` is exposed via a dedicated \`kth_chain_output_point_copy\` entry point.

### Ownership annotations

- Owned returns are tagged with \`KTH_OWNED\` (\`warn_unused_result\` on GCC/Clang). Owned out-parameters are tagged with \`KTH_OUT_OWNED\`.
- Each owned function carries a one-line doc comment naming the matching destructor (\`kth_chain_output_point_destruct\`, \`kth_core_destruct_array\`).

### Surface changes

- Setters take a \`kth_output_point_mut_t self\` plus a value parameter.
- Adds bindings that the previous file was missing relative to the underlying C++ class: \`serialized_size(wire)\`, \`checksum\`, \`is_null\`, \`equals\`, \`satoshi_fixed_size\`, \`is_mature\`.
- Hash returns use \`kth_hash_t\` by value.

### Tests

- Adds \`src/c-api/test/chain/output_point.cpp\` covering: ctors, serialization, getters/setters, \`copy\`, \`equals\`, \`checksum\`, \`satoshi_fixed_size\`, and 6 \`KTH_PRECONDITION\` death tests (fork-based).

### Methods intentionally not exposed

- The inherited \`point::from_data\` static factory: it returns \`expect<point>\` at the C++ level, so exposing it on \`output_point\` would deliver a base-typed handle the caller cannot safely use.
- The inherited \`point::null\` static factory: same reason — it fabricates a base \`point\`, not an \`output_point\`.
- \`to_data(data_sink&)\`: stream-based overload; the \`data_chunk\` variant is exposed instead.
- \`begin()\` / \`end()\`: return \`point_iterator\`, which is not part of the C-API surface.

## Test plan

- [ ] Build the c-api target on Linux
- [ ] Run the new \`kth_capi_test\` suite for \`[C-API OutputPoint]\`
- [ ] Verify \`KTH_OWNED\` triggers \`-Wunused-result\` when a \`_construct*\` / \`_copy\` / \`to_data\` result is discarded

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the public C API surface for `output_point` (new handle types, renamed/added functions), which can break downstream consumers and requires careful ABI/API compatibility. Logic is straightforward but touches memory ownership, pointer preconditions, and serialization helpers.
> 
> **Overview**
> Refactors the `chain/output_point` C bindings to the const/mut handle model (`kth_output_point_const_t`/`kth_output_point_mut_t`) with explicit ownership annotations (`KTH_OWNED`) and null-safe destruction.
> 
> Expands the `output_point` API surface with copy/equality, serialization helpers (`to_data`, `serialized_size`), additional getters (`checksum`), predicates (`is_mature`, `is_null`), `reset`, and `satoshi_fixed_size`, while updating the C++ conversion layer to use dedicated const/mut conversion helpers.
> 
> Adds a new Catch2 test file for `output_point` (including precondition/death tests) and wires it into the `kth_capi_test` target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f3df05066738e36c8285b72f3f5fb491af521a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation methods for output points (maturity checking, validity testing, null state detection).
  * Added serialization support with size calculation.
  * Introduced checksum computation capability.

* **Refactor**
  * Redesigned output point API with improved type safety for mutable and immutable operations.
  * Enhanced constructor options including default initialization and copy functionality.
  * Improved setter and getter semantics with better parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->