### PR TITLE
refactor(c-api): unify and harden chain/script bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ peers.dat
 build_asan/
 Testing/
 utxo-z/
+
+# Local working notes (not for upstream)
+TODO.md

--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -500,6 +500,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/header.cpp
         test/chain/point.cpp
         test/chain/output_point.cpp
+        test/chain/script.cpp
     )
 
     target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})

--- a/src/c-api/include/kth/capi/chain/output_point.h
+++ b/src/c-api/include/kth/capi/chain/output_point.h
@@ -20,6 +20,10 @@ extern "C" {
 KTH_EXPORT KTH_OWNED
 kth_output_point_mut_t kth_chain_output_point_construct_default(void);
 
+/** @param[out] out Must point to a null `kth_output_point_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_output_point_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_output_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_output_point_mut_t* out);
+
 /** @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(uint8_t const* hash, uint32_t index);

--- a/src/c-api/include/kth/capi/chain/script.h
+++ b/src/c-api/include/kth/capi/chain/script.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,225 +11,232 @@
 #include <kth/capi/visibility.h>
 #include <kth/capi/chain/script_flags.h>
 #include <kth/capi/chain/script_pattern.h>
-#include <kth/capi/chain/script_version.h>
-#include <kth/capi/wallet/primitives.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-KTH_EXPORT
-kth_script_t kth_chain_script_construct_default(void);
+// Constructors
 
-KTH_EXPORT
-kth_script_t kth_chain_script_construct_from_bytes(uint8_t* encoded, kth_size_t n, kth_bool_t prefix);
+/** @return Owned `kth_script_mut_t`. Caller must release with `kth_chain_script_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_script_mut_t kth_chain_script_construct_default(void);
 
+/** @param[out] out Must point to a null `kth_script_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_script_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_script_t kth_chain_script_construct_from_string(char const* str);
+kth_error_code_t kth_chain_script_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_script_mut_t* out);
 
-KTH_EXPORT
-kth_script_t kth_chain_script_construct_from_operations(kth_operation_list_t operations);
+/** @return Owned `kth_script_mut_t`. Caller must release with `kth_chain_script_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_script_mut_t kth_chain_script_construct_from_operations(kth_operation_list_const_t ops);
 
-KTH_EXPORT
-void kth_chain_script_destruct(kth_script_t script);
+/** @return Owned `kth_script_mut_t`. Caller must release with `kth_chain_script_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_script_mut_t kth_chain_script_construct_from_encoded_prefix(uint8_t const* encoded, kth_size_t encoded_n, kth_bool_t prefix);
 
-KTH_EXPORT
-kth_bool_t kth_chain_script_is_valid(kth_script_t script);
 
-KTH_EXPORT
-kth_bool_t kth_chain_script_is_valid_operations(kth_script_t script);
-
-KTH_EXPORT
-kth_size_t kth_chain_script_satoshi_content_size(kth_script_t script);
+// Destructor
 
 KTH_EXPORT
-kth_size_t kth_chain_script_serialized_size(kth_script_t script, kth_bool_t prefix);
+void kth_chain_script_destruct(kth_script_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_script_mut_t`. Caller must release with `kth_chain_script_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_script_mut_t kth_chain_script_copy(kth_script_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-char const* kth_chain_script_to_string(kth_script_t script, uint64_t active_flags);
+kth_bool_t kth_chain_script_equals(kth_script_const_t self, kth_script_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_script_to_data(kth_script_const_t self, kth_bool_t prefix, kth_size_t* out_size);
 
 KTH_EXPORT
-char const* kth_chain_script_type(kth_script_t script);
+kth_size_t kth_chain_script_serialized_size(kth_script_const_t self, kth_bool_t prefix);
+
+
+// Getters
 
 KTH_EXPORT
-uint8_t const* kth_chain_script_to_data(kth_script_t script, kth_bool_t prefix, kth_size_t* out_size);
-
-// KTH_EXPORT
-// kth_size_t kth_chain_script_sigops(kth_script_t script, kth_bool_t embedded);
+kth_bool_t kth_chain_script_empty(kth_script_const_t self);
 
 KTH_EXPORT
-kth_operation_list_const_t kth_chain_script_operations(kth_script_t script);
+kth_size_t kth_chain_script_size(kth_script_const_t self);
 
 KTH_EXPORT
-uint8_t const* kth_chain_script_to_bytes(kth_script_t script, kth_size_t* out_size);
-
-// Static functions
-
-/// Determine if the fork is enabled in the active forks set.
-KTH_EXPORT
-kth_bool_t kth_chain_script_is_enabled(uint64_t active_flags, kth_script_flags_t flag);
-
-/// Consensus patterns
-KTH_EXPORT
-kth_bool_t  kth_chain_script_is_push_only(kth_operation_list_t ops);
+kth_operation_const_t kth_chain_script_front(kth_script_const_t self);
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_relaxed_push(kth_operation_list_t ops);
+kth_operation_const_t kth_chain_script_back(kth_script_const_t self);
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_coinbase_pattern(kth_operation_list_t ops, kth_size_t height);
+kth_operation_list_const_t kth_chain_script_operations(kth_script_const_t self);
 
-/// Common output patterns (psh and pwsh are also consensus).
-KTH_EXPORT
-kth_bool_t  kth_chain_script_is_null_data_pattern(kth_operation_list_t ops);
-
-KTH_EXPORT
-kth_bool_t  kth_chain_script_is_pay_multisig_pattern(kth_operation_list_t ops);
+/** @return Owned `kth_operation_mut_t`. Caller must release with `kth_chain_operation_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_mut_t kth_chain_script_first_operation(kth_script_const_t self);
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_pay_public_key_pattern(kth_operation_list_t ops);
+kth_script_pattern_t kth_chain_script_pattern(kth_script_const_t self);
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_pay_public_key_hash_pattern(kth_operation_list_t ops);
+kth_script_pattern_t kth_chain_script_output_pattern(kth_script_const_t self);
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_pay_script_hash_pattern(kth_operation_list_t ops);
+kth_script_pattern_t kth_chain_script_input_pattern(kth_script_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_script_bytes(kth_script_const_t self, kth_size_t* out_size);
+
+
+// Predicates
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_pay_script_hash_32_pattern(kth_operation_list_t ops);
-
-/// Common input patterns (skh is also consensus).
-KTH_EXPORT
-kth_bool_t  kth_chain_script_is_sign_multisig_pattern(kth_operation_list_t ops);
+kth_bool_t kth_chain_script_is_valid_operations(kth_script_const_t self);
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_sign_public_key_pattern(kth_operation_list_t ops);
+kth_bool_t kth_chain_script_is_push_only(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_sign_public_key_hash_pattern(kth_operation_list_t ops);
+kth_bool_t kth_chain_script_is_relaxed_push(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_sign_script_hash_pattern(kth_operation_list_t ops);
-
-/// Stack factories.
-KTH_EXPORT
-kth_operation_list_const_t kth_chain_script_to_null_data_pattern(uint8_t const* data, kth_size_t n);
+kth_bool_t kth_chain_script_is_coinbase_pattern(kth_operation_list_const_t ops, kth_size_t height);
 
 KTH_EXPORT
-kth_operation_list_const_t kth_chain_script_to_pay_public_key_pattern(uint8_t const* point, kth_size_t n);
+kth_bool_t kth_chain_script_is_null_data_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_operation_list_const_t kth_chain_script_to_pay_public_key_hash_pattern(kth_shorthash_t const* chash);
+kth_bool_t kth_chain_script_is_pay_multisig_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_operation_list_const_t kth_chain_script_to_pay_script_hash_pattern(kth_shorthash_t const* hash);
+kth_bool_t kth_chain_script_is_pay_public_key_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_operation_list_const_t kth_chain_script_to_pay_script_hash_32_pattern(kth_hash_t const* hash);
+kth_bool_t kth_chain_script_is_pay_public_key_hash_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_operation_list_const_t kth_chain_script_to_pay_multisig_pattern(uint8_t signatures, kth_ec_compressed_list_t points);
-
-// TODO: add this
-// KTH_EXPORT
-// kth_operation_list_const_t kth_chain_script_to_pay_multisig_pattern(uint8_t signatures, data_stack const& points);
-
-
-// Utilities (non-static).
-//-------------------------------------------------------------------------
-
-/// Common pattern detection.
+kth_bool_t kth_chain_script_is_pay_script_hash_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_script_pattern_t kth_chain_script_pattern(kth_script_t script);
+kth_bool_t kth_chain_script_is_pay_script_hash_32_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_script_pattern_t kth_chain_script_output_pattern(kth_script_t script);
+kth_bool_t kth_chain_script_is_sign_multisig_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_script_pattern_t kth_chain_script_input_pattern(kth_script_t script);
-
-/// Consensus computations.
-KTH_EXPORT
-kth_size_t kth_chain_script_sigops(kth_script_t script, kth_bool_t accurate);
+kth_bool_t kth_chain_script_is_sign_public_key_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_bool_t kth_chain_script_is_unspendable(kth_script_t script);
+kth_bool_t kth_chain_script_is_sign_public_key_hash_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-void kth_chain_script_reset(kth_script_t script);
-
-
-// Signing.
-//-------------------------------------------------------------------------
+kth_bool_t kth_chain_script_is_sign_script_hash_pattern(kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_hash_t generate_signature_hash(
-    kth_transaction_t tx,
-    uint32_t input_index,
-    kth_script_t script_code,
-    uint8_t sighash_type,
-    uint64_t active_flags,
-#if ! defined(KTH_CURRENCY_BCH)
-    kth_script_version_t version,
-#endif // ! KTH_CURRENCY_BCH
-    uint64_t value,
-    kth_size_t* out_hashed_bytes
-);
+kth_bool_t kth_chain_script_is_unspendable(kth_script_const_t self);
 
 KTH_EXPORT
-kth_bool_t check_signature(
-    kth_ec_signature_t signature,
-    uint8_t sighash_type,
-    uint8_t const* public_key,
-    kth_size_t public_key_size,
-    kth_script_t script_code,
-    kth_transaction_t tx,
-    uint32_t input_index,
-    uint64_t active_flags,
-#if ! defined(KTH_CURRENCY_BCH)
-    kth_script_version_t version,
-#endif // ! KTH_CURRENCY_BCH
-    uint64_t value,
-    kth_size_t* out_hashed_bytes
-);
+kth_bool_t kth_chain_script_is_pay_to_script_hash(kth_script_const_t self, kth_script_flags_t flags);
 
 KTH_EXPORT
-uint8_t const* kth_chain_script_create_endorsement(
-    kth_ec_secret_t const* secret,
-    kth_script_t prevout_script,
-    kth_transaction_t tx,
-    uint32_t input_index,
-    uint8_t sighash_type,
-    uint64_t active_flags,
-#if ! defined(KTH_CURRENCY_BCH)
-    kth_script_version_t version,
-#endif // ! KTH_CURRENCY_BCH
-    uint64_t value,
-    kth_endorsement_type_t type,
-    kth_size_t* out_size
-);
-
-// Validation.
-//-----------------------------------------------------------------------------
+kth_bool_t kth_chain_script_is_pay_to_script_hash_32(kth_script_const_t self, kth_script_flags_t flags);
 
 KTH_EXPORT
-kth_error_code_t kth_chain_script_verify(kth_transaction_t tx, uint32_t input_index, uint64_t forks, kth_script_t input_script, kth_script_t prevout_script, uint64_t value);
+kth_bool_t kth_chain_script_is_valid(kth_script_const_t self);
 
 KTH_EXPORT
-kth_error_code_t kth_chain_script_verify_transaction(kth_transaction_t tx, uint32_t input, uint64_t forks);
+kth_bool_t kth_chain_script_is_enabled(kth_script_flags_t active_flags, kth_script_flags_t fork);
 
 
-#if defined(KTH_SEGWIT_ENABLED)
-KTH_EXPORT
-kth_bool_t  kth_chain_script_is_commitment_pattern(kth_operation_list_t ops);
+// Operations
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_witness_program_pattern(kth_operation_list_t ops);
+void kth_chain_script_from_operations(kth_script_mut_t self, kth_operation_list_const_t ops);
 
 KTH_EXPORT
-kth_bool_t  kth_chain_script_is_pay_witness_script_hash_pattern(kth_operation_list_t ops);
-#endif
+kth_bool_t kth_chain_script_from_string(kth_script_mut_t self, char const* mnemonic);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_chain_script_to_string(kth_script_const_t self, kth_script_flags_t active_flags);
+
+KTH_EXPORT
+void kth_chain_script_clear(kth_script_mut_t self);
+
+KTH_EXPORT
+kth_size_t kth_chain_script_sigops(kth_script_const_t self, kth_bool_t accurate);
+
+KTH_EXPORT
+void kth_chain_script_reset(kth_script_mut_t self);
+
+
+// Static utilities
+
+/** @param[out] out Must point to a null `kth_script_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_script_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_script_from_data_with_size(uint8_t const* data, kth_size_t n, kth_size_t size, KTH_OUT_OWNED kth_script_mut_t* out);
+
+KTH_EXPORT
+kth_hash_t kth_chain_script_generate_signature_hash(kth_transaction_const_t tx, uint32_t input_index, kth_script_const_t script_code, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size);
+
+KTH_EXPORT
+kth_bool_t kth_chain_script_check_signature(uint8_t const* signature, uint8_t sighash_type, uint8_t const* public_key, kth_size_t public_key_n, kth_script_const_t script_code, kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size);
+
+KTH_EXPORT
+kth_error_code_t kth_chain_script_create_endorsement(uint8_t const* secret, kth_script_const_t prevout_script, kth_transaction_const_t tx, uint32_t input_index, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_endorsement_type_t type, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_null_data_pattern(uint8_t const* data, kth_size_t data_n);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_pattern(uint8_t const* point, kth_size_t point_n);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern(uint8_t const* hash);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocking_placeholder(kth_size_t endorsement_size, kth_size_t pubkey_size);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern_unlocking_placeholder(kth_size_t script_size, kth_bool_t multisig);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern(uint8_t const* hash);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_32_pattern(uint8_t const* hash);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_pay_multisig_pattern_ec_compressed_list(uint8_t signatures, kth_ec_compressed_list_const_t points);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_pay_multisig_pattern_data_stack(uint8_t signatures, kth_data_stack_const_t points);
+
+KTH_EXPORT
+kth_error_code_t kth_chain_script_verify(kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t flags, kth_script_const_t input_script, kth_script_const_t prevout_script, uint64_t arg5);
+
+KTH_EXPORT
+kth_error_code_t kth_chain_script_verify_simple(kth_transaction_const_t tx, uint32_t input, kth_script_flags_t flags);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -42,13 +42,64 @@ inline kth::domain::chain::chain_state const& kth_chain_chain_state_const_cpp(kt
 inline kth::domain::chain::chain_state& kth_chain_chain_state_mut_cpp(kth_chain_state_mut_t o) {
     return *static_cast<kth::domain::chain::chain_state*>(o);
 }
+
+// The following types are not migrated to const/mut yet (their existing
+// converters via KTH_CONV_DECLARE / KTH_LIST_DECLARE_CONVERTERS take the
+// legacy `_t = void*` form). The migrated C-API uses the matching
+// `_const_t` / `_mut_t` aliases for read-only and mutable handles, so we
+// add inline overloads here that bridge the two until each type migrates.
+
+inline std::vector<kth::domain::machine::operation> const&
+kth_chain_operation_list_const_cpp(kth_operation_list_const_t l) {
+    return *static_cast<std::vector<kth::domain::machine::operation> const*>(l);
+}
+inline std::vector<kth::domain::machine::operation>&
+kth_chain_operation_list_mut_cpp(kth_operation_list_mut_t l) {
+    return *static_cast<std::vector<kth::domain::machine::operation>*>(l);
+}
+
+inline kth::domain::chain::transaction const&
+kth_chain_transaction_const_cpp(kth_transaction_const_t o) {
+    return *static_cast<kth::domain::chain::transaction const*>(o);
+}
+inline kth::domain::chain::transaction&
+kth_chain_transaction_mut_cpp(kth_transaction_mut_t o) {
+    return *static_cast<kth::domain::chain::transaction*>(o);
+}
+
+// std::vector<std::array<uint8_t, 33>> matches the existing
+// `ec_compressed_cpp_t` alias used by the legacy converters further down.
+// We spell it out here to keep the const/mut shim self-contained.
+inline std::vector<std::array<uint8_t, 33>> const&
+kth_wallet_ec_compressed_list_const_cpp(kth_ec_compressed_list_const_t l) {
+    return *static_cast<std::vector<std::array<uint8_t, 33>> const*>(l);
+}
+inline std::vector<std::array<uint8_t, 33>>&
+kth_wallet_ec_compressed_list_mut_cpp(kth_ec_compressed_list_mut_t l) {
+    return *static_cast<std::vector<std::array<uint8_t, 33>>*>(l);
+}
+
+// data_stack — vector of variable-length byte buffers (the script runtime
+// stack). Exposed only as an opaque handle for now; ownership and element
+// access live on the user side until we wire a proper data_stack module.
+inline std::vector<std::vector<uint8_t>> const&
+kth_chain_data_stack_const_cpp(kth_data_stack_const_t s) {
+    return *static_cast<std::vector<std::vector<uint8_t>> const*>(s);
+}
+inline std::vector<std::vector<uint8_t>>&
+kth_chain_data_stack_mut_cpp(kth_data_stack_mut_t s) {
+    return *static_cast<std::vector<std::vector<uint8_t>>*>(s);
+}
 KTH_CONV_DECLARE(chain, kth_input_t, kth::domain::chain::input, input)
 KTH_CONV_DECLARE(chain, kth_output_t, kth::domain::chain::output, output)
 // output_point conversion functions take const/mut handle types directly.
 // Defined in src/chain/output_point.cpp.
 kth::domain::chain::output_point const& kth_chain_output_point_const_cpp(kth_output_point_const_t o);
 kth::domain::chain::output_point&       kth_chain_output_point_mut_cpp(kth_output_point_mut_t o);
-KTH_CONV_DECLARE(chain, kth_script_t, kth::domain::chain::script, script)
+// script conversion functions take const/mut handle types directly. Defined
+// in src/chain/script.cpp.
+kth::domain::chain::script const& kth_chain_script_const_cpp(kth_script_const_t o);
+kth::domain::chain::script&       kth_chain_script_mut_cpp(kth_script_mut_t o);
 KTH_CONV_DECLARE(chain, kth_transaction_t, kth::domain::chain::transaction, transaction)
 // KTH_CONV_DECLARE(chain, kth_transaction_t, kth::domain::chain::transaction, transaction)
 // point conversion functions take const/mut handle types directly. Defined

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -184,6 +184,13 @@ kth::short_hash short_hash_to_cpp(uint8_t const* x) {
     return ret;
 }
 
+inline
+kth::long_hash long_hash_to_cpp(uint8_t const* x) {
+    kth::long_hash ret;
+    std::copy_n(x, ret.size(), std::begin(ret));
+    return ret;
+}
+
 template <typename T>
 inline
 T* mnew(std::size_t n = 1) {

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -112,12 +112,17 @@ typedef void* kth_utxo_list_t;
 typedef void* kth_inputpoint_t;
 typedef void* kth_merkleblock_t;
 typedef void* kth_script_t;
+typedef void* kth_script_mut_t;
+typedef void const* kth_script_const_t;
 typedef void* kth_token_data_t;
 typedef void const* kth_token_data_const_t;
 
 typedef void* kth_operation_list_t;
+typedef void* kth_operation_list_mut_t;
 typedef void const* kth_operation_list_const_t;
 typedef void* kth_operation_t;
+typedef void* kth_operation_mut_t;
+typedef void const* kth_operation_const_t;
 
 typedef void* kth_output_list_t;
 typedef void* kth_output_t;
@@ -132,6 +137,7 @@ typedef void const* kth_point_const_t;
 typedef void* kth_point_list_t;
 typedef void* kth_outputpoint_list_t;
 typedef void* kth_transaction_t;
+typedef void* kth_transaction_mut_t;
 typedef void const* kth_transaction_const_t;
 typedef void* kth_transaction_list_t;
 typedef void* kth_mempool_transaction_t;
@@ -157,6 +163,14 @@ typedef void* kth_u64_list_t;
 typedef void* kth_wallet_data_t;
 
 typedef void* kth_ec_compressed_list_t;
+typedef void* kth_ec_compressed_list_mut_t;
+typedef void const* kth_ec_compressed_list_const_t;
+
+// Vector of byte buffers — used by Bitcoin script's runtime stack and by
+// `to_pay_multisig_pattern` for the signature variant. The owning C-API
+// type is opaque; element accessors are not exposed yet.
+typedef void* kth_data_stack_mut_t;
+typedef void const* kth_data_stack_const_t;
 
 
 // VM

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -27,7 +27,7 @@ kth_header_mut_t kth_chain_header_construct_default(void) {
 }
 
 kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_header_mut_t* out) {
-    KTH_PRECONDITION(data != nullptr);
+    KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
     auto data_cpp = kth::byte_reader(kth::byte_span(data, n));

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -6,6 +6,7 @@
 
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/domain/chain/output_point.hpp>
 
 // Conversion functions
@@ -23,6 +24,18 @@ extern "C" {
 
 kth_output_point_mut_t kth_chain_output_point_construct_default(void) {
     return new kth::domain::chain::output_point();
+}
+
+kth_error_code_t kth_chain_output_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_output_point_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, n));
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto result = kth::domain::chain::output_point::from_data(data_cpp, wire_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::chain::output_point(std::move(*result));
+    return kth_ec_success;
 }
 
 kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(uint8_t const* hash, uint32_t index) {

--- a/src/c-api/src/chain/point.cpp
+++ b/src/c-api/src/chain/point.cpp
@@ -27,7 +27,7 @@ kth_point_mut_t kth_chain_point_construct_default(void) {
 }
 
 kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_point_mut_t* out) {
-    KTH_PRECONDITION(data != nullptr);
+    KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
     auto data_cpp = kth::byte_reader(kth::byte_span(data, n));

--- a/src/c-api/src/chain/script.cpp
+++ b/src/c-api/src/chain/script.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,438 +6,421 @@
 
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
-#include <kth/capi/wallet/conversions.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/domain/chain/script.hpp>
 
-KTH_CONV_DEFINE(chain, kth_script_t, kth::domain::chain::script, script)
+// Conversion functions
+kth::domain::chain::script& kth_chain_script_mut_cpp(kth_script_mut_t o) {
+    return *static_cast<kth::domain::chain::script*>(o);
+}
+kth::domain::chain::script const& kth_chain_script_const_cpp(kth_script_const_t o) {
+    return *static_cast<kth::domain::chain::script const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_script_t kth_chain_script_construct_default() {
+// Constructors
+
+kth_script_mut_t kth_chain_script_construct_default(void) {
     return new kth::domain::chain::script();
 }
 
-// script::script(const data_chunk& encoded, bool prefix)
-kth_script_t kth_chain_script_construct_from_bytes(uint8_t* encoded, kth_size_t n, kth_bool_t prefix) {
-    kth::data_chunk encoded_cpp(encoded, std::next(encoded, n));
-    return new kth::domain::chain::script(encoded_cpp, kth::int_to_bool(prefix));
+kth_error_code_t kth_chain_script_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_script_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, n));
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto result = kth::domain::chain::script::from_data(data_cpp, wire_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::chain::script(std::move(*result));
+    return kth_ec_success;
 }
 
-kth_script_t kth_chain_script_construct_from_string(char const* str) {
-    kth::domain::chain::script script;
-    auto const res = script.from_string(std::string(str));
-    if ( ! res) {
-        return new kth::domain::chain::script();
-    }
-    return kth::move_or_copy_and_leak(std::move(script));
-}
-
-kth_script_t kth_chain_script_construct_from_operations(kth_operation_list_t operations) {
-    auto const& ops_cpp = kth_chain_operation_list_const_cpp(operations);
+kth_script_mut_t kth_chain_script_construct_from_operations(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
+    auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return new kth::domain::chain::script(ops_cpp);
 }
 
-void kth_chain_script_destruct(kth_script_t script) {
-    delete &kth_chain_script_cpp(script);
+kth_script_mut_t kth_chain_script_construct_from_encoded_prefix(uint8_t const* encoded, kth_size_t encoded_n, kth_bool_t prefix) {
+    KTH_PRECONDITION(encoded != nullptr || encoded_n == 0);
+    auto encoded_cpp = kth::data_chunk(encoded, encoded + encoded_n);
+    auto prefix_cpp = kth::int_to_bool(prefix);
+    return new kth::domain::chain::script(encoded_cpp, prefix_cpp);
 }
 
-kth_bool_t kth_chain_script_is_valid(kth_script_t script) {
-    return kth::bool_to_int(kth_chain_script_const_cpp(script).is_valid());
+
+// Destructor
+
+void kth_chain_script_destruct(kth_script_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_script_mut_cpp(self);
 }
 
-kth_bool_t kth_chain_script_is_valid_operations(kth_script_t script) {
-    return kth::bool_to_int(kth_chain_script_const_cpp(script).is_valid_operations());
+
+// Copy
+
+kth_script_mut_t kth_chain_script_copy(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::chain::script(kth_chain_script_const_cpp(self));
 }
 
-kth_size_t kth_chain_script_satoshi_content_size(kth_script_t script) {
-    return kth_chain_script_const_cpp(script).serialized_size(false);
+
+// Equality
+
+kth_bool_t kth_chain_script_equals(kth_script_const_t self, kth_script_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_script_const_cpp(self) == kth_chain_script_const_cpp(other));
 }
 
-kth_size_t kth_chain_script_serialized_size(kth_script_t script, kth_bool_t prefix) {
-    return kth_chain_script_const_cpp(script).serialized_size(kth::int_to_bool(prefix));
+
+// Serialization
+
+uint8_t* kth_chain_script_to_data(kth_script_const_t self, kth_bool_t prefix, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto prefix_cpp = kth::int_to_bool(prefix);
+    auto data = kth_chain_script_const_cpp(self).to_data(prefix_cpp);
+    return kth::create_c_array(data, *out_size);
 }
 
-char const* kth_chain_script_to_string(kth_script_t script, uint64_t active_flags) {
-    auto str = kth_chain_script_const_cpp(script).to_string(active_flags);
-    return kth::create_c_str(str);
+kth_size_t kth_chain_script_serialized_size(kth_script_const_t self, kth_bool_t prefix) {
+    KTH_PRECONDITION(self != nullptr);
+    auto prefix_cpp = kth::int_to_bool(prefix);
+    return kth_chain_script_const_cpp(self).serialized_size(prefix_cpp);
 }
 
-// TODO(fernando): Move this logic elsewhere (this does not go in a wrapper like c-api)
-char const* kth_chain_script_type(kth_script_t script) {
-    auto script_pattern = kth_chain_script_const_cpp(script).pattern();
-    std::string type = "non_standard";
-    switch(script_pattern) {
-        case kth::infrastructure::machine::script_pattern::null_data: type = "nulldata"; break;
-        case kth::infrastructure::machine::script_pattern::pay_multisig: type = "pay_multisig"; break;
-        case kth::infrastructure::machine::script_pattern::pay_public_key: type = "pay_public_key"; break;
-        case kth::infrastructure::machine::script_pattern::pay_public_key_hash: type = "pay_public_key_hash"; break;
-        case kth::infrastructure::machine::script_pattern::pay_script_hash: type = "pay_script_hash"; break;
-        case kth::infrastructure::machine::script_pattern::pay_script_hash_32: type = "pay_script_hash_32"; break;
-        case kth::infrastructure::machine::script_pattern::sign_multisig: type = "sign_multisig"; break;
-        case kth::infrastructure::machine::script_pattern::sign_public_key: type = "sign_public_key"; break;
-        case kth::infrastructure::machine::script_pattern::sign_public_key_hash: type = "sign_public_key_hash"; break;
-        case kth::infrastructure::machine::script_pattern::sign_script_hash: type = "sign_script_hash"; break;
-        default: type = "non_standard"; break;
-    }
 
-    return kth::create_c_str(type);
+// Getters
+
+kth_bool_t kth_chain_script_empty(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_script_const_cpp(self).empty());
 }
 
-uint8_t const* kth_chain_script_to_data(kth_script_t script, kth_bool_t prefix, kth_size_t* out_size) {
-    auto script_data = kth_chain_script_const_cpp(script).to_data(kth::int_to_bool(prefix));
-    return kth::create_c_array(script_data, *out_size);
+kth_size_t kth_chain_script_size(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_script_const_cpp(self).size();
 }
 
-// kth_size_t kth_chain_script_sigops(kth_script_t script, kth_bool_t embedded) {
-//     return kth_chain_script_const_cpp(script).sigops(kth::int_to_bool(embedded));
-// }
-
-kth_operation_list_const_t kth_chain_script_operations(kth_script_t script) {
-    auto& script_cpp = kth_chain_script_cpp(script);
-    return kth_chain_operation_list_construct_from_cpp(script_cpp.operations());
+kth_operation_const_t kth_chain_script_front(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION( ! kth_chain_script_const_cpp(self).empty());
+    return &(kth_chain_script_const_cpp(self).front());
 }
 
-uint8_t const* kth_chain_script_to_bytes(kth_script_t script, kth_size_t* out_size) {
-    auto script_data = kth_chain_script_const_cpp(script).bytes();
-    return kth::create_c_array(script_data, *out_size);
+kth_operation_const_t kth_chain_script_back(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION( ! kth_chain_script_const_cpp(self).empty());
+    return &(kth_chain_script_const_cpp(self).back());
 }
 
-kth_bool_t kth_chain_script_is_enabled(uint64_t active_flags, kth_script_flags_t flag) {
-    auto flag_cpp = kth::script_flags_to_cpp(flag);
-    return kth::bool_to_int(kth::domain::chain::script::is_enabled(active_flags, flag_cpp));
+kth_operation_list_const_t kth_chain_script_operations(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth_chain_script_const_cpp(self).operations());
 }
 
-kth_bool_t  kth_chain_script_is_push_only(kth_operation_list_t ops) {
+kth_operation_mut_t kth_chain_script_first_operation(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::machine::operation(kth_chain_script_const_cpp(self).first_operation());
+}
+
+kth_script_pattern_t kth_chain_script_pattern(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return static_cast<kth_script_pattern_t>(kth_chain_script_const_cpp(self).pattern());
+}
+
+kth_script_pattern_t kth_chain_script_output_pattern(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return static_cast<kth_script_pattern_t>(kth_chain_script_const_cpp(self).output_pattern());
+}
+
+kth_script_pattern_t kth_chain_script_input_pattern(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return static_cast<kth_script_pattern_t>(kth_chain_script_const_cpp(self).input_pattern());
+}
+
+uint8_t* kth_chain_script_bytes(kth_script_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto data = kth_chain_script_const_cpp(self).bytes();
+    return kth::create_c_array(data, *out_size);
+}
+
+
+// Predicates
+
+kth_bool_t kth_chain_script_is_valid_operations(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_script_const_cpp(self).is_valid_operations());
+}
+
+kth_bool_t kth_chain_script_is_push_only(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_push_only(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_relaxed_push(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_relaxed_push(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_relaxed_push(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_coinbase_pattern(kth_operation_list_t ops, kth_size_t height) {
+kth_bool_t kth_chain_script_is_coinbase_pattern(kth_operation_list_const_t ops, kth_size_t height) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_coinbase_pattern(ops_cpp, height));
 }
 
-kth_bool_t  kth_chain_script_is_null_data_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_null_data_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_null_data_pattern(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_pay_multisig_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_pay_multisig_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_pay_multisig_pattern(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_pay_public_key_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_pay_public_key_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_pay_public_key_pattern(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_pay_public_key_hash_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_pay_public_key_hash_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_pay_public_key_hash_pattern(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_pay_script_hash_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_pay_script_hash_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_pay_script_hash_pattern(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_pay_script_hash_32_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_pay_script_hash_32_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_pay_script_hash_32_pattern(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_sign_multisig_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_sign_multisig_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_sign_multisig_pattern(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_sign_public_key_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_sign_public_key_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_sign_public_key_pattern(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_sign_public_key_hash_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_sign_public_key_hash_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_sign_public_key_hash_pattern(ops_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_sign_script_hash_pattern(kth_operation_list_t ops) {
+kth_bool_t kth_chain_script_is_sign_script_hash_pattern(kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
     return kth::bool_to_int(kth::domain::chain::script::is_sign_script_hash_pattern(ops_cpp));
 }
 
-kth_operation_list_const_t kth_chain_script_to_null_data_pattern(uint8_t const* data, kth_size_t n) {
-    // printf("kth_chain_script_to_null_data_pattern: data: %p, n: %u\n", data, n);
-    kth::byte_span data_cpp(data, data + n);
-    auto res = kth::domain::chain::script::to_null_data_pattern(data_cpp);
-    return kth::move_or_copy_and_leak(std::move(res));
+kth_bool_t kth_chain_script_is_unspendable(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_script_const_cpp(self).is_unspendable());
 }
 
-kth_operation_list_const_t kth_chain_script_to_pay_public_key_pattern(uint8_t const* point, kth_size_t n) {
-    kth::byte_span point_cpp(point, point + n);
-    auto res = kth::domain::chain::script::to_pay_public_key_pattern(point_cpp);
-    return kth::move_or_copy_and_leak(std::move(res));
+kth_bool_t kth_chain_script_is_pay_to_script_hash(kth_script_const_t self, kth_script_flags_t flags) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_script_const_cpp(self).is_pay_to_script_hash(flags));
 }
 
-kth_operation_list_const_t kth_chain_script_to_pay_public_key_hash_pattern(kth_shorthash_t const* hash) {
-    auto const hash_cpp = kth::short_hash_to_cpp(hash->hash);
-    auto res = kth::domain::chain::script::to_pay_public_key_hash_pattern(hash_cpp);
-    return kth::move_or_copy_and_leak(std::move(res));
+kth_bool_t kth_chain_script_is_pay_to_script_hash_32(kth_script_const_t self, kth_script_flags_t flags) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_script_const_cpp(self).is_pay_to_script_hash_32(flags));
 }
 
-kth_operation_list_const_t kth_chain_script_to_pay_script_hash_pattern(kth_shorthash_t const* hash) {
-    auto const hash_cpp = kth::short_hash_to_cpp(hash->hash);
-    auto res = kth::domain::chain::script::to_pay_script_hash_pattern(hash_cpp);
-    return kth::move_or_copy_and_leak(std::move(res));
+kth_bool_t kth_chain_script_is_valid(kth_script_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_script_const_cpp(self).is_valid());
 }
 
-kth_operation_list_const_t kth_chain_script_to_pay_script_hash_32_pattern(kth_hash_t const* hash) {
-    auto const hash_cpp = kth::hash_to_cpp(hash->hash);
-    auto res = kth::domain::chain::script::to_pay_script_hash_32_pattern(hash_cpp);
-    return kth::move_or_copy_and_leak(std::move(res));
+kth_bool_t kth_chain_script_is_enabled(kth_script_flags_t active_flags, kth_script_flags_t fork) {
+    return kth::bool_to_int(kth::domain::chain::script::is_enabled(active_flags, fork));
 }
 
-kth_operation_list_const_t kth_chain_script_to_pay_multisig_pattern(uint8_t signatures, kth_ec_compressed_list_t points) {
-    auto const& points_cpp = kth_wallet_ec_compressed_list_const_cpp(points);
-    auto res = kth::domain::chain::script::to_pay_multisig_pattern(signatures, points_cpp);
-    return kth::move_or_copy_and_leak(std::move(res));
-}
 
-// TODO: add this
-// kth_operation_list_const_t kth_chain_script_to_pay_multisig_pattern(uint8_t signatures, data_stack const& points) {
-//     auto res = kth::domain::chain::script::to_pay_multisig_pattern(signatures, points);
-//     return kth::move_or_copy_and_leak(std::move(res));
-// }
+// Operations
 
-#if defined(KTH_SEGWIT_ENABLED)
-kth_bool_t  kth_chain_script_is_commitment_pattern(kth_operation_list_t ops) {
+void kth_chain_script_from_operations(kth_script_mut_t self, kth_operation_list_const_t ops) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
-    return kth::bool_to_int(kth::domain::chain::script::is_commitment_pattern(ops_cpp));
+    kth_chain_script_mut_cpp(self).from_operations(ops_cpp);
 }
 
-kth_bool_t  kth_chain_script_is_witness_program_pattern(kth_operation_list_t ops) {
-    auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
-    return kth::bool_to_int(kth::domain::chain::script::is_witness_program_pattern(ops_cpp));
+kth_bool_t kth_chain_script_from_string(kth_script_mut_t self, char const* mnemonic) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(mnemonic != nullptr);
+    auto mnemonic_cpp = std::string(mnemonic);
+    return kth::bool_to_int(kth_chain_script_mut_cpp(self).from_string(mnemonic_cpp));
 }
 
-kth_bool_t  kth_chain_script_is_pay_witness_script_hash_pattern(kth_operation_list_t ops) {
-    auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
-    return kth::bool_to_int(kth::domain::chain::script::is_pay_witness_script_hash_pattern(ops_cpp));
-}
-#endif
-
-// Utilities (non-static).
-//-------------------------------------------------------------------------
-
-/// Common pattern detection.
-
-
-kth_script_pattern_t kth_chain_script_pattern(kth_script_t script) {
-    auto const& script_cpp = kth_chain_script_const_cpp(script);
-    return kth::script_pattern_to_c(script_cpp.pattern());
+char* kth_chain_script_to_string(kth_script_const_t self, kth_script_flags_t active_flags) {
+    KTH_PRECONDITION(self != nullptr);
+    auto s = kth_chain_script_const_cpp(self).to_string(active_flags);
+    return kth::create_c_str(s);
 }
 
-kth_script_pattern_t kth_chain_script_output_pattern(kth_script_t script) {
-    auto const& script_cpp = kth_chain_script_const_cpp(script);
-    return kth::script_pattern_to_c(script_cpp.output_pattern());
+void kth_chain_script_clear(kth_script_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_script_mut_cpp(self).clear();
 }
 
-kth_script_pattern_t kth_chain_script_input_pattern(kth_script_t script) {
-    auto const& script_cpp = kth_chain_script_const_cpp(script);
-    return kth::script_pattern_to_c(script_cpp.input_pattern());
+kth_size_t kth_chain_script_sigops(kth_script_const_t self, kth_bool_t accurate) {
+    KTH_PRECONDITION(self != nullptr);
+    auto accurate_cpp = kth::int_to_bool(accurate);
+    return kth_chain_script_const_cpp(self).sigops(accurate_cpp);
 }
 
-/// Consensus computations.
-kth_size_t kth_chain_script_sigops(kth_script_t script, kth_bool_t accurate) {
-    auto const& script_cpp = kth_chain_script_const_cpp(script);
-    return script_cpp.sigops(kth::int_to_bool(accurate));
-}
-
-kth_bool_t kth_chain_script_is_unspendable(kth_script_t script) {
-    auto const& script_cpp = kth_chain_script_const_cpp(script);
-    return kth::bool_to_int(script_cpp.is_unspendable());
-}
-
-void kth_chain_script_reset(kth_script_t script) {
-    auto& script_cpp = kth_chain_script_cpp(script);
-    script_cpp.reset();
+void kth_chain_script_reset(kth_script_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_script_mut_cpp(self).reset();
 }
 
 
-// Signing.
-//-------------------------------------------------------------------------
+// Static utilities
 
-// static
-// std::pair<hash_digest, size_t> generate_signature_hash(transaction const& tx,
-//                                     uint32_t input_index,
-//                                     script const& script_code,
-//                                     uint8_t sighash_type,
-//                                     script_version version = script_version::unversioned,
-//                                     uint64_t value = max_uint64);
+kth_error_code_t kth_chain_script_from_data_with_size(uint8_t const* data, kth_size_t n, kth_size_t size, KTH_OUT_OWNED kth_script_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, n));
+    auto result = kth::domain::chain::script::from_data_with_size(data_cpp, size);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::chain::script(std::move(*result));
+    return kth_ec_success;
+}
 
-// static
-// std::pair<bool, size_t> check_signature(ec_signature const& signature,
-//                         uint8_t sighash_type,
-//                         data_chunk const& public_key,
-//                         script const& script_code,
-//                         transaction const& tx,
-//                         uint32_t input_index,
-//                         script_version version = script_version::unversioned,
-//                         uint64_t value = max_uint64);
-
-// static
-// bool create_endorsement(endorsement& out, ec_secret const& secret, script const& prevout_script, transaction const& tx, uint32_t input_index, uint8_t sighash_type, script_version version = script_version::unversioned, uint64_t value = max_uint64);
-
-// kth_hash_t kth_chain_block_hash(kth_block_t block) {
-//     auto const& hash_cpp = kth_chain_block_const_cpp(block).hash();
-//     return kth::to_hash_t(hash_cpp);
-// }
-
-kth_hash_t generate_signature_hash(
-    kth_transaction_t tx,
-    uint32_t input_index,
-    kth_script_t script_code,
-    uint8_t sighash_type,
-    uint64_t active_flags,
-#if ! defined(KTH_CURRENCY_BCH)
-    kth_script_version_t version,
-#endif // ! KTH_CURRENCY_BCH
-    uint64_t value,
-    kth_size_t* out_hashed_bytes
-) {
+kth_hash_t kth_chain_script_generate_signature_hash(kth_transaction_const_t tx, uint32_t input_index, kth_script_const_t script_code, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size) {
+    KTH_PRECONDITION(tx != nullptr);
+    KTH_PRECONDITION(script_code != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
     auto const& tx_cpp = kth_chain_transaction_const_cpp(tx);
     auto const& script_code_cpp = kth_chain_script_const_cpp(script_code);
-#if ! defined(KTH_CURRENCY_BCH)
-    auto const& version_cpp = kth::script_version_to_cpp(version);
-#endif // ! KTH_CURRENCY_BCH
-
-    auto res = kth::domain::chain::script::generate_signature_hash(
-        tx_cpp,
-        input_index,
-        script_code_cpp,
-        sighash_type,
-        active_flags,
-
-#if ! defined(KTH_CURRENCY_BCH)
-        version_cpp,
-#endif // ! KTH_CURRENCY_BCH
-        value
-    );
-
-    *out_hashed_bytes = res.second;
-    return kth::to_hash_t(res.first);
+    auto pair_cpp = kth::domain::chain::script::generate_signature_hash(tx_cpp, input_index, script_code_cpp, sighash_type, active_flags, value);
+    *out_size = pair_cpp.second;
+    return kth::to_hash_t(pair_cpp.first);
 }
 
-kth_bool_t check_signature(
-    kth_ec_signature_t signature,
-    uint8_t sighash_type,
-    uint8_t const* public_key,
-    kth_size_t public_key_size,
-    kth_script_t script_code,
-    kth_transaction_t tx,
-    uint32_t input_index,
-    uint64_t active_flags,
-#if ! defined(KTH_CURRENCY_BCH)
-    kth_script_version_t version,
-#endif // ! KTH_CURRENCY_BCH
-    uint64_t value,
-    kth_size_t* out_hashed_bytes
-) {
-    auto const signature_cpp = detail::from_ec_signature_t(signature);
-    auto const& public_key_cpp = kth::data_chunk(public_key, public_key + public_key_size);
+kth_bool_t kth_chain_script_check_signature(uint8_t const* signature, uint8_t sighash_type, uint8_t const* public_key, kth_size_t public_key_n, kth_script_const_t script_code, kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size) {
+    KTH_PRECONDITION(signature != nullptr);
+    KTH_PRECONDITION(public_key != nullptr || public_key_n == 0);
+    KTH_PRECONDITION(script_code != nullptr);
+    KTH_PRECONDITION(tx != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto signature_cpp = kth::long_hash_to_cpp(signature);
+    auto public_key_cpp = kth::data_chunk(public_key, public_key + public_key_n);
     auto const& script_code_cpp = kth_chain_script_const_cpp(script_code);
     auto const& tx_cpp = kth_chain_transaction_const_cpp(tx);
-
-#if ! defined(KTH_CURRENCY_BCH)
-    auto const& version_cpp = kth::script_version_to_cpp(version);
-#endif // ! KTH_CURRENCY_BCH
-    auto res = kth::domain::chain::script::check_signature(
-        signature_cpp,
-        sighash_type,
-        public_key_cpp,
-        script_code_cpp,
-        tx_cpp,
-        input_index,
-        active_flags,
-#if ! defined(KTH_CURRENCY_BCH)
-        version_cpp,
-#endif // ! KTH_CURRENCY_BCH
-        value
-    );
-    *out_hashed_bytes = res.second;
-    return kth::bool_to_int(res.first);
+    auto pair_cpp = kth::domain::chain::script::check_signature(signature_cpp, sighash_type, public_key_cpp, script_code_cpp, tx_cpp, input_index, active_flags, value);
+    *out_size = pair_cpp.second;
+    return kth::bool_to_int(pair_cpp.first);
 }
 
-uint8_t const* kth_chain_script_create_endorsement(
-    kth_ec_secret_t const* secret,
-    kth_script_t prevout_script,
-    kth_transaction_t tx,
-    uint32_t input_index,
-    uint8_t sighash_type,
-    uint64_t active_flags,
-#if ! defined(KTH_CURRENCY_BCH)
-    kth_script_version_t version,
-#endif // ! KTH_CURRENCY_BCH
-    uint64_t value,
-    kth_endorsement_type_t type,
-    kth_size_t* out_size
-) {
-
-    auto const& secret_cpp = detail::from_ec_secret_t(*secret);
+kth_error_code_t kth_chain_script_create_endorsement(uint8_t const* secret, kth_script_const_t prevout_script, kth_transaction_const_t tx, uint32_t input_index, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_endorsement_type_t type, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size) {
+    KTH_PRECONDITION(secret != nullptr);
+    KTH_PRECONDITION(prevout_script != nullptr);
+    KTH_PRECONDITION(tx != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto secret_cpp = kth::hash_to_cpp(secret);
     auto const& prevout_script_cpp = kth_chain_script_const_cpp(prevout_script);
     auto const& tx_cpp = kth_chain_transaction_const_cpp(tx);
-#if ! defined(KTH_CURRENCY_BCH)
-    auto const version_cpp = kth::script_version_to_cpp(version);
-#endif // ! KTH_CURRENCY_BCH
-    auto const endorsement_type_cpp = kth::endorsement_type_to_cpp(type);
-
-    auto res = kth::domain::chain::script::create_endorsement(
-        secret_cpp,
-        prevout_script_cpp,
-        tx_cpp,
-        input_index,
-        sighash_type,
-        active_flags,
-#if ! defined(KTH_CURRENCY_BCH)
-        version_cpp,
-#endif // ! KTH_CURRENCY_BCH
-        value,
-        endorsement_type_cpp
-    );
-
-    if ( ! res) {
-        *out_size = 0;
-        return nullptr;
-    }
-    return kth::create_c_array(res.value(), *out_size);
+    auto type_cpp = static_cast<kth::domain::chain::endorsement_type>(type);
+    auto result = kth::domain::chain::script::create_endorsement(secret_cpp, prevout_script_cpp, tx_cpp, input_index, sighash_type, active_flags, value, type_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = kth::create_c_array(*result, *out_size);
+    return kth_ec_success;
 }
 
-// Validation.
-//-----------------------------------------------------------------------------
+kth_operation_list_mut_t kth_chain_script_to_null_data_pattern(uint8_t const* data, kth_size_t data_n) {
+    KTH_PRECONDITION(data != nullptr || data_n == 0);
+    auto data_cpp = kth::byte_span(data, data_n);
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_null_data_pattern(data_cpp));
+}
 
-// static
-// code verify(transaction const& tx, uint32_t input_index, uint64_t forks, script const& input_script, script const& prevout_script, uint64_t /*value*/);
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_pattern(uint8_t const* point, kth_size_t point_n) {
+    KTH_PRECONDITION(point != nullptr || point_n == 0);
+    auto point_cpp = kth::byte_span(point, point_n);
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_public_key_pattern(point_cpp));
+}
 
-// static
-// code verify(transaction const& tx, uint32_t input, uint64_t forks);
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern(uint8_t const* hash) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto hash_cpp = kth::short_hash_to_cpp(hash);
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_public_key_hash_pattern(hash_cpp));
+}
 
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocking_placeholder(kth_size_t endorsement_size, kth_size_t pubkey_size) {
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_public_key_hash_pattern_unlocking_placeholder(endorsement_size, pubkey_size));
+}
 
-kth_error_code_t kth_chain_script_verify(kth_transaction_t tx, uint32_t input_index, uint64_t forks, kth_script_t input_script, kth_script_t prevout_script, uint64_t value) {
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern_unlocking_placeholder(kth_size_t script_size, kth_bool_t multisig) {
+    auto multisig_cpp = kth::int_to_bool(multisig);
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_script_hash_pattern_unlocking_placeholder(script_size, multisig_cpp));
+}
+
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern(uint8_t const* hash) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto hash_cpp = kth::short_hash_to_cpp(hash);
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_script_hash_pattern(hash_cpp));
+}
+
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_32_pattern(uint8_t const* hash) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto hash_cpp = kth::hash_to_cpp(hash);
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_script_hash_32_pattern(hash_cpp));
+}
+
+kth_operation_list_mut_t kth_chain_script_to_pay_multisig_pattern_ec_compressed_list(uint8_t signatures, kth_ec_compressed_list_const_t points) {
+    KTH_PRECONDITION(points != nullptr);
+    auto const& points_cpp = kth_wallet_ec_compressed_list_const_cpp(points);
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_multisig_pattern(signatures, points_cpp));
+}
+
+kth_operation_list_mut_t kth_chain_script_to_pay_multisig_pattern_data_stack(uint8_t signatures, kth_data_stack_const_t points) {
+    KTH_PRECONDITION(points != nullptr);
+    auto const& points_cpp = kth_chain_data_stack_const_cpp(points);
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_multisig_pattern(signatures, points_cpp));
+}
+
+kth_error_code_t kth_chain_script_verify(kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t flags, kth_script_const_t input_script, kth_script_const_t prevout_script, uint64_t arg5) {
+    KTH_PRECONDITION(tx != nullptr);
+    KTH_PRECONDITION(input_script != nullptr);
+    KTH_PRECONDITION(prevout_script != nullptr);
     auto const& tx_cpp = kth_chain_transaction_const_cpp(tx);
     auto const& input_script_cpp = kth_chain_script_const_cpp(input_script);
     auto const& prevout_script_cpp = kth_chain_script_const_cpp(prevout_script);
-    return kth::to_c_err(kth::domain::chain::script::verify(tx_cpp, input_index, forks, input_script_cpp, prevout_script_cpp, value));
+    return static_cast<kth_error_code_t>((kth::domain::chain::script::verify(tx_cpp, input_index, flags, input_script_cpp, prevout_script_cpp, arg5)).value());
 }
 
-kth_error_code_t kth_chain_script_verify_transaction(kth_transaction_t tx, uint32_t input, uint64_t forks) {
+kth_error_code_t kth_chain_script_verify_simple(kth_transaction_const_t tx, uint32_t input, kth_script_flags_t flags) {
+    KTH_PRECONDITION(tx != nullptr);
     auto const& tx_cpp = kth_chain_transaction_const_cpp(tx);
-    return kth::to_c_err(kth::domain::chain::script::verify(tx_cpp, input, forks));
+    return static_cast<kth_error_code_t>((kth::domain::chain::script::verify(tx_cpp, input, flags)).value());
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/header.cpp
+++ b/src/c-api/test/chain/header.cpp
@@ -248,12 +248,23 @@ TEST_CASE("C-API Header - satoshi_fixed_size is 80", "[C-API Header]") {
 // Preconditions (death tests via fork)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Header - construct_from_data null data aborts",
+TEST_CASE("C-API Header - construct_from_data null data with non-zero size aborts",
           "[C-API Header][precondition]") {
     KTH_EXPECT_ABORT({
         kth_header_mut_t out = NULL;
-        kth_chain_header_construct_from_data(NULL, 0, 1, &out);
+        kth_chain_header_construct_from_data(NULL, 1, 1, &out);
     });
+}
+
+TEST_CASE("C-API Header - construct_from_data NULL data with zero size returns error",
+          "[C-API Header]") {
+    // (NULL, 0) is a valid empty input; the function should not abort. The
+    // header parser will fail because zero bytes are insufficient, but it
+    // must do so gracefully via an error code.
+    kth_header_mut_t out = NULL;
+    kth_error_code_t ec = kth_chain_header_construct_from_data(NULL, 0, 1, &out);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(out == NULL);
 }
 
 TEST_CASE("C-API Header - construct null previous_block_hash aborts",

--- a/src/c-api/test/chain/output_point.cpp
+++ b/src/c-api/test/chain/output_point.cpp
@@ -75,6 +75,58 @@ TEST_CASE("C-API OutputPoint - construct from point preserves fields", "[C-API O
 }
 
 // ---------------------------------------------------------------------------
+// from_data / to_data round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API OutputPoint - from_data insufficient bytes fails", "[C-API OutputPoint]") {
+    uint8_t data[10];
+    memset(data, 0, sizeof(data));
+    kth_output_point_mut_t out = NULL;
+    kth_error_code_t ec = kth_chain_output_point_construct_from_data(data, 10, 1, &out);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(out == NULL);
+}
+
+TEST_CASE("C-API OutputPoint - to_data / from_data roundtrip", "[C-API OutputPoint]") {
+    kth_output_point_mut_t expected =
+        kth_chain_output_point_construct_from_hash_index(kHash, 53213u);
+
+    kth_size_t size = 0;
+    uint8_t* raw = kth_chain_output_point_to_data(expected, 1, &size);
+    REQUIRE(size == 36u);
+    REQUIRE(raw != NULL);
+
+    // The factory we just exposed wraps point::from_data through the
+    // output_point(point const&) conversion ctor, so the resulting handle
+    // is genuinely an output_point and the round-trip preserves the wire
+    // bytes (the layout matches because output_point has no extra wire
+    // members on top of point).
+    kth_output_point_mut_t parsed = NULL;
+    kth_error_code_t ec = kth_chain_output_point_construct_from_data(raw, size, 1, &parsed);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(parsed != NULL);
+
+    REQUIRE(kth_chain_output_point_is_valid(parsed) != 0);
+    REQUIRE(kth_chain_output_point_index(parsed) == 53213u);
+    REQUIRE(kth_hash_equal(kth_chain_output_point_hash(parsed), make_hash(kHash)) != 0);
+
+    kth_core_destruct_array(raw);
+    kth_chain_output_point_destruct(parsed);
+    kth_chain_output_point_destruct(expected);
+}
+
+TEST_CASE("C-API OutputPoint - construct_from_data NULL data with zero size returns error",
+          "[C-API OutputPoint]") {
+    // (NULL, 0) is a valid empty input — no abort. The parser will fail
+    // because zero bytes are insufficient, but it must do so gracefully.
+    kth_output_point_mut_t out = NULL;
+    kth_error_code_t ec =
+        kth_chain_output_point_construct_from_data(NULL, 0, 1, &out);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(out == NULL);
+}
+
+// ---------------------------------------------------------------------------
 // Serialization
 // ---------------------------------------------------------------------------
 
@@ -182,6 +234,21 @@ TEST_CASE("C-API OutputPoint - satoshi_fixed_size is 36", "[C-API OutputPoint]")
 // ---------------------------------------------------------------------------
 // Preconditions (death tests via fork)
 // ---------------------------------------------------------------------------
+
+TEST_CASE("C-API OutputPoint - construct_from_data null data with non-zero size aborts",
+          "[C-API OutputPoint][precondition]") {
+    KTH_EXPECT_ABORT({
+        kth_output_point_mut_t out = NULL;
+        kth_chain_output_point_construct_from_data(NULL, 1, 1, &out);
+    });
+}
+
+TEST_CASE("C-API OutputPoint - construct_from_data null out aborts",
+          "[C-API OutputPoint][precondition]") {
+    uint8_t data[10];
+    memset(data, 0, sizeof(data));
+    KTH_EXPECT_ABORT(kth_chain_output_point_construct_from_data(data, 10, 1, NULL));
+}
 
 TEST_CASE("C-API OutputPoint - construct null hash aborts",
           "[C-API OutputPoint][precondition]") {

--- a/src/c-api/test/chain/point.cpp
+++ b/src/c-api/test/chain/point.cpp
@@ -184,12 +184,22 @@ TEST_CASE("C-API Point - null factory returns is_null", "[C-API Point]") {
 // Preconditions (death tests via fork)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Point - construct_from_data null data aborts",
+TEST_CASE("C-API Point - construct_from_data null data with non-zero size aborts",
           "[C-API Point][precondition]") {
     KTH_EXPECT_ABORT({
         kth_point_mut_t out = NULL;
-        kth_chain_point_construct_from_data(NULL, 0, 1, &out);
+        kth_chain_point_construct_from_data(NULL, 1, 1, &out);
     });
+}
+
+TEST_CASE("C-API Point - construct_from_data NULL data with zero size returns error",
+          "[C-API Point]") {
+    // (NULL, 0) is a valid empty input; the function must not abort and
+    // should report the parse failure via an error code.
+    kth_point_mut_t out = NULL;
+    kth_error_code_t ec = kth_chain_point_construct_from_data(NULL, 0, 1, &out);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(out == NULL);
 }
 
 TEST_CASE("C-API Point - construct_from_data null out aborts",

--- a/src/c-api/test/chain/script.cpp
+++ b/src/c-api/test/chain/script.cpp
@@ -1,0 +1,286 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/chain/operation_list.h>
+#include <kth/capi/chain/script.h>
+#include <kth/capi/chain/script_pattern.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// A trivial OP_RETURN script (one byte: 0x6a). Lets us round-trip a small
+// known-valid payload through `from_data` / `to_data` without depending on
+// the operation_list constructor (which we can not call from C-API yet).
+//
+// Wire layout: prefix byte (0x01 = length 1) followed by the OP_RETURN
+// opcode (0x6a). With prefix=true, the parser reads the length first.
+static uint8_t const kOpReturnPrefixed[2] = { 0x01, 0x6a };
+static uint8_t const kOpReturnRaw[1]      = { 0x6a };
+
+// 20-byte short hash (used for pay_script_hash patterns).
+static uint8_t const kShortHash[20] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13
+};
+
+// 32-byte hash (used for pay_script_hash_32 patterns).
+static uint8_t const kHash32[32] = {
+    0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72,
+    0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7, 0x4f,
+    0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c,
+    0x68, 0xd6, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+// ---------------------------------------------------------------------------
+// Constructors / lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Script - default construct is empty", "[C-API Script]") {
+    kth_script_mut_t script = kth_chain_script_construct_default();
+    REQUIRE(kth_chain_script_empty(script) != 0);
+    REQUIRE(kth_chain_script_size(script) == 0u);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Script - destruct null is safe", "[C-API Script]") {
+    kth_chain_script_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// from_data / to_data round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Script - from_data prefixed roundtrip", "[C-API Script]") {
+    kth_script_mut_t script = NULL;
+    kth_error_code_t ec = kth_chain_script_construct_from_data(
+        kOpReturnPrefixed, sizeof(kOpReturnPrefixed), 1, &script);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(script != NULL);
+    REQUIRE(kth_chain_script_is_valid(script) != 0);
+    REQUIRE(kth_chain_script_size(script) == 1u);
+    REQUIRE(kth_chain_script_empty(script) == 0);
+
+    kth_size_t out_size = 0;
+    uint8_t* raw = kth_chain_script_to_data(script, 1, &out_size);
+    REQUIRE(raw != NULL);
+    REQUIRE(out_size == sizeof(kOpReturnPrefixed));
+    REQUIRE(memcmp(raw, kOpReturnPrefixed, sizeof(kOpReturnPrefixed)) == 0);
+
+    kth_core_destruct_array(raw);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Script - serialized_size matches to_data length",
+          "[C-API Script]") {
+    kth_script_mut_t script = NULL;
+    REQUIRE(kth_chain_script_construct_from_data(
+        kOpReturnPrefixed, sizeof(kOpReturnPrefixed), 1, &script) == kth_ec_success);
+
+    kth_size_t expected_with_prefix    = kth_chain_script_serialized_size(script, 1);
+    kth_size_t expected_without_prefix = kth_chain_script_serialized_size(script, 0);
+    REQUIRE(expected_with_prefix    == 2u);  // length byte + opcode
+    REQUIRE(expected_without_prefix == 1u);  // opcode only
+
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// Container accessors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Script - non-empty script has size 1", "[C-API Script]") {
+    kth_script_mut_t script = NULL;
+    REQUIRE(kth_chain_script_construct_from_data(
+        kOpReturnPrefixed, sizeof(kOpReturnPrefixed), 1, &script) == kth_ec_success);
+    REQUIRE(kth_chain_script_size(script) == 1u);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Script - clear empties a non-empty script", "[C-API Script]") {
+    kth_script_mut_t script = NULL;
+    REQUIRE(kth_chain_script_construct_from_data(
+        kOpReturnPrefixed, sizeof(kOpReturnPrefixed), 1, &script) == kth_ec_success);
+    REQUIRE(kth_chain_script_empty(script) == 0);
+    kth_chain_script_clear(script);
+    REQUIRE(kth_chain_script_empty(script) != 0);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// from_string round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Script - from_string empty mnemonic", "[C-API Script]") {
+    kth_script_mut_t script = kth_chain_script_construct_default();
+    REQUIRE(kth_chain_script_from_string(script, "") != 0);
+    REQUIRE(kth_chain_script_empty(script) != 0);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equals
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Script - copy preserves equality", "[C-API Script]") {
+    kth_script_mut_t original = NULL;
+    REQUIRE(kth_chain_script_construct_from_data(
+        kOpReturnPrefixed, sizeof(kOpReturnPrefixed), 1, &original) == kth_ec_success);
+
+    kth_script_mut_t copy = kth_chain_script_copy(original);
+    REQUIRE(kth_chain_script_is_valid(copy) != 0);
+    REQUIRE(kth_chain_script_equals(original, copy) != 0);
+    REQUIRE(kth_chain_script_size(copy) == kth_chain_script_size(original));
+
+    kth_chain_script_destruct(copy);
+    kth_chain_script_destruct(original);
+}
+
+TEST_CASE("C-API Script - equals different scripts", "[C-API Script]") {
+    kth_script_mut_t a = NULL;
+    REQUIRE(kth_chain_script_construct_from_data(
+        kOpReturnPrefixed, sizeof(kOpReturnPrefixed), 1, &a) == kth_ec_success);
+    kth_script_mut_t b = kth_chain_script_construct_default();
+
+    REQUIRE(kth_chain_script_equals(a, b) == 0);
+
+    kth_chain_script_destruct(a);
+    kth_chain_script_destruct(b);
+}
+
+// ---------------------------------------------------------------------------
+// Static pattern factories
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Script - to_pay_script_hash_pattern returns operation list",
+          "[C-API Script]") {
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_pay_script_hash_pattern(kShortHash);
+    REQUIRE(ops != NULL);
+    // We can't introspect operation_list element-by-element from the C-API
+    // yet, but constructing a script from it should yield a valid script.
+    kth_script_mut_t script = kth_chain_script_construct_from_operations(ops);
+    REQUIRE(kth_chain_script_is_valid(script) != 0);
+    REQUIRE(kth_chain_script_empty(script) == 0);
+    kth_chain_script_destruct(script);
+    kth_chain_operation_list_destruct(ops);
+}
+
+TEST_CASE("C-API Script - to_pay_script_hash_32_pattern returns operation list",
+          "[C-API Script]") {
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_pay_script_hash_32_pattern(kHash32);
+    REQUIRE(ops != NULL);
+    kth_script_mut_t script = kth_chain_script_construct_from_operations(ops);
+    REQUIRE(kth_chain_script_is_valid(script) != 0);
+    REQUIRE(kth_chain_script_empty(script) == 0);
+    kth_chain_script_destruct(script);
+    kth_chain_operation_list_destruct(ops);
+}
+
+// ---------------------------------------------------------------------------
+// Static utilities
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Script - is_enabled bit test", "[C-API Script]") {
+    kth_size_t flags = 0x05;  // bits 0 and 2 set
+    REQUIRE(kth_chain_script_is_enabled(flags, 0x01) != 0);
+    REQUIRE(kth_chain_script_is_enabled(flags, 0x04) != 0);
+    REQUIRE(kth_chain_script_is_enabled(flags, 0x02) == 0);
+}
+
+// ---------------------------------------------------------------------------
+// Pattern detection
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Script - pattern of empty script is non standard",
+          "[C-API Script]") {
+    kth_script_mut_t script = kth_chain_script_construct_default();
+    kth_script_pattern_t p = kth_chain_script_pattern(script);
+    REQUIRE(p == kth_script_pattern_non_standard);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Script - bare OP_RETURN is non_standard",
+          "[C-API Script]") {
+    // A single OP_RETURN with no payload does not match the canonical
+    // null_data pattern (which requires a data push). The classifier
+    // should fall through to non_standard.
+    kth_script_mut_t script = NULL;
+    REQUIRE(kth_chain_script_construct_from_data(
+        kOpReturnPrefixed, sizeof(kOpReturnPrefixed), 1, &script) == kth_ec_success);
+    kth_script_pattern_t p = kth_chain_script_output_pattern(script);
+    REQUIRE(p == kth_script_pattern_non_standard);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions (death tests via fork)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Script - construct_from_data null data with non-zero size aborts",
+          "[C-API Script][precondition]") {
+    KTH_EXPECT_ABORT({
+        kth_script_mut_t out = NULL;
+        kth_chain_script_construct_from_data(NULL, 1, 1, &out);
+    });
+}
+
+TEST_CASE("C-API Script - construct_from_data NULL data with zero size succeeds",
+          "[C-API Script]") {
+    // Empty script is a valid input. (NULL, 0) should not abort and should
+    // produce an empty, valid script.
+    kth_script_mut_t out = NULL;
+    kth_error_code_t ec = kth_chain_script_construct_from_data(NULL, 0, 0, &out);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(out != NULL);
+    REQUIRE(kth_chain_script_empty(out) != 0);
+    kth_chain_script_destruct(out);
+}
+
+TEST_CASE("C-API Script - construct_from_data null out aborts",
+          "[C-API Script][precondition]") {
+    uint8_t data[2] = { 0x00, 0x00 };
+    KTH_EXPECT_ABORT(kth_chain_script_construct_from_data(data, 2, 1, NULL));
+}
+
+TEST_CASE("C-API Script - to_data null out_size aborts",
+          "[C-API Script][precondition]") {
+    kth_script_mut_t script = kth_chain_script_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_script_to_data(script, 1, NULL));
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Script - copy null self aborts",
+          "[C-API Script][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_script_copy(NULL));
+}
+
+TEST_CASE("C-API Script - equals null self aborts",
+          "[C-API Script][precondition]") {
+    kth_script_mut_t other = kth_chain_script_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_script_equals(NULL, other));
+    kth_chain_script_destruct(other);
+}
+
+TEST_CASE("C-API Script - to_pay_script_hash_pattern null hash aborts",
+          "[C-API Script][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_script_to_pay_script_hash_pattern(NULL));
+}

--- a/src/c-api/test/test_helpers.hpp
+++ b/src/c-api/test/test_helpers.hpp
@@ -43,6 +43,14 @@
     if (_pid == 0) {                                                 \
         /* child: silence stderr to avoid abort() messages */        \
         freopen("/dev/null", "w", stderr);                           \
+        /* Catch2 installs its own SIGABRT handler in the test       \
+         * driver. When our child inherits it, the handler           \
+         * intercepts the abort(), prints a FAILED line into the     \
+         * shared stdout, and exits the child normally — so the      \
+         * parent then sees WIFSIGNALED == false and the death       \
+         * test misfires. Reset SIGABRT to the default handler so    \
+         * abort() actually terminates the child via the signal. */  \
+        signal(SIGABRT, SIG_DFL);                                    \
         KTH_TEST_PUSH_NO_UNUSED_RESULT                               \
         stmt;                                                        \
         KTH_TEST_POP_DIAG                                            \

--- a/src/domain/include/kth/domain/chain/script.hpp
+++ b/src/domain/include/kth/domain/chain/script.hpp
@@ -214,8 +214,10 @@ public:
     static
     bool is_pay_script_hash_32_pattern(operation::list const& ops);
 
+#if defined(KTH_SEGWIT_ENABLED)
     static
     bool is_pay_witness_script_hash_pattern(operation::list const& ops);
+#endif // KTH_SEGWIT_ENABLED
 
     /// Common input patterns (skh is also consensus).
     static
@@ -264,7 +266,9 @@ public:
     //-------------------------------------------------------------------------
 
     /// Common pattern detection.
+#if defined(KTH_SEGWIT_ENABLED)
     data_chunk witness_program() const;
+#endif // KTH_SEGWIT_ENABLED
 
 #if ! defined(KTH_CURRENCY_BCH)
     script_version version() const;

--- a/src/infrastructure/include/kth/infrastructure/machine/script_pattern.hpp
+++ b/src/infrastructure/include/kth/infrastructure/machine/script_pattern.hpp
@@ -5,12 +5,13 @@
 #ifndef KTH_INFRASTUCTURE_MACHINE_SCRIPT_PATTERN_HPP
 #define KTH_INFRASTUCTURE_MACHINE_SCRIPT_PATTERN_HPP
 
+#include <string_view>
+
 namespace kth::infrastructure::machine {
 
 /// Script patterms.
 /// Comments from: bitcoin.org/en/developer-guide#signature-hash-types
-enum class script_pattern
-{
+enum class script_pattern {
     /// Null Data
     /// Pubkey Script: OP_RETURN <0 to 80 bytes of data> (formerly 40 bytes)
     /// Null data scripts cannot be spent, so there's no signature script.
@@ -61,6 +62,33 @@ enum class script_pattern
     /// transactions with uncommon scripts may not be forwarded by peers.
     non_standard
 };
+
+/// String representation of a script_pattern enumerator. Used by the C-API
+/// (and any other consumer that needs a stable textual name) so the
+/// enum-to-string mapping lives next to the enum definition itself instead
+/// of being duplicated in wrappers.
+///
+/// TODO(C++26 reflection): replace the hand-written switch with a generic
+/// enum_to_string<E> built on top of P2996 reflection (`std::meta::*`),
+/// applied uniformly to every enum in the codebase.
+constexpr
+std::string_view to_string(script_pattern p) {
+    switch (p) {
+        case script_pattern::null_data:             return "null_data";
+        case script_pattern::pay_multisig:          return "pay_multisig";
+        case script_pattern::pay_public_key:        return "pay_public_key";
+        case script_pattern::pay_public_key_hash:   return "pay_public_key_hash";
+        case script_pattern::pay_script_hash:       return "pay_script_hash";
+        case script_pattern::pay_script_hash_32:    return "pay_script_hash_32";
+        case script_pattern::sign_multisig:         return "sign_multisig";
+        case script_pattern::sign_public_key:       return "sign_public_key";
+        case script_pattern::sign_public_key_hash:  return "sign_public_key_hash";
+        case script_pattern::sign_script_hash:      return "sign_script_hash";
+        case script_pattern::witness_reservation:   return "witness_reservation";
+        case script_pattern::non_standard:          return "non_standard";
+    }
+    return "non_standard";
+}
 
 } // namespace kth::infrastructure::machine
 


### PR DESCRIPTION
## Summary

Reworks the chain/script C bindings in line with the const/mut migration applied to chain/header (#216), chain/point (#217), and chain/output_point (#218), and exposes ownership semantics at the API surface so language backends can wire owned objects through their own smart-handle equivalents.

### Type system

- Public functions now use \`kth_script_const_t\` / \`kth_script_mut_t\` instead of the legacy unqualified \`kth_script_t\`. Read-only operations take a const handle, mutating operations take a mut handle. The legacy alias remains in \`primitives.h\` for callers that have not yet migrated.
- Local conversion helpers follow the symmetric naming: \`kth_chain_script_const_cpp\` / \`kth_chain_script_mut_cpp\`.

### Constructors and lifecycle

- \`construct_from_data\` returns a \`kth_error_code_t\` and writes the parsed script into an out-parameter; the underlying \`expect<script>\` error is propagated instead of silently producing a default-constructed script on failure. The same shape is exposed for \`from_data_with_size\`.
- Two field constructors are exposed: \`construct_from_operations(operation_list)\` and \`construct_from_encoded_prefix(uint8_t const*, size_t, bool prefix)\`.
- \`destruct\` is null-safe.
- \`copy\` is exposed via a dedicated \`kth_chain_script_copy\` entry point.

### Ownership annotations

- Owned returns are tagged with \`KTH_OWNED\` (\`warn_unused_result\` on GCC/Clang). Owned out-parameters are tagged with \`KTH_OUT_OWNED\`.
- Each owned function carries a one-line doc comment naming the matching destructor (\`kth_chain_script_destruct\`, \`kth_core_destruct_array\`, \`kth_core_destruct_string\`).

### Surface changes

- Pattern accessors (\`pattern\`, \`output_pattern\`, \`input_pattern\`) now return a strongly-typed \`kth_script_pattern_t\` enum.
- Hash-derived results returned via \`std::pair\` (\`generate_signature_hash\`, \`check_signature\`) now expose the first element as the C return value and write the second element through a new out-parameter.
- \`create_endorsement\` returns a \`kth_error_code_t\` and writes the resulting byte buffer through a \`uint8_t**\` + size pair.
- The two \`verify\` overloads are both exposed: the canonical signature keeps the bare name (\`kth_chain_script_verify\`), the simpler three-argument variant gets the \`_simple\` suffix.
- Both \`to_pay_multisig_pattern\` overloads are exposed and disambiguated by the differing list element type: \`..._ec_compressed_list\` and \`..._data_stack\`.
- Adds bindings that the previous file was missing: \`bytes\`, \`clear\`, \`empty\`, \`size\`, \`back\`, \`front\`, \`first_operation\`, \`from_string\`, \`from_operations\`, \`witness_program\` (when SegWit is enabled), \`is_pay_to_script_hash\`, \`is_pay_to_script_hash_32\`, plus the \`*_unlocking_placeholder\` helpers.

### Domain header hygiene

- \`script.hpp\` had two declarations (\`witness_program\` and \`is_pay_witness_script_hash_pattern\`) that lived outside the \`KTH_SEGWIT_ENABLED\` guard while their callers and definitions live inside it. The declarations are now wrapped in the matching guard so non-SegWit builds (BCH) no longer expose dangling symbols.

### Infrastructure

- \`script_pattern.hpp\` now ships a \`constexpr to_string(script_pattern)\` overload alongside the enum so the textual representation lives next to the definition (and not duplicated inside C-API wrappers).
- \`helpers.hpp\` gains a \`long_hash_to_cpp\` companion to the existing \`hash_to_cpp\` / \`short_hash_to_cpp\` helpers, used by the script bindings that need to forward 64-byte \`ec_signature\` parameters.
- \`primitives.h\` declares \`kth_data_stack_const_t\` / \`kth_data_stack_mut_t\` so the \`data_stack\` overload of \`to_pay_multisig_pattern\` can take an opaque handle.
- \`conversions.hpp\` gains inline const/mut shims for \`transaction\`, \`operation_list\`, \`ec_compressed_list\`, \`data_stack\` and \`chain_state\` so the migrated script API can call into legacy types that still use the pre-const/mut converter macros.

### Tests

- Adds \`src/c-api/test/chain/script.cpp\` covering: construct, destruct, \`from_data\`/\`to_data\` round-trip, \`serialized_size\`, container queries (\`size\`, \`empty\`, \`clear\`), \`copy\`, \`equals\`, the \`to_pay_script_hash_*\` pattern factories, the static \`is_enabled\` bit test, the \`pattern\` / \`output_pattern\` accessors, and seven \`KTH_PRECONDITION\` death tests.
- The \`KTH_EXPECT_ABORT\` helper now resets the \`SIGABRT\` handler to the default disposition inside the forked child. Catch2 installs its own \`SIGABRT\` handler in the test driver, and without the reset the handler intercepted the child's \`abort()\` — printing a spurious failure into the shared output stream and letting the child exit normally, which made the death test misfire in the parent.

### Methods intentionally not exposed

- \`script(script_basis const&)\` / \`script(script_basis&&)\`: the base type is not part of the public C surface.
- \`to_data(data_sink&)\`: stream-based overload; the \`data_chunk\` variant is exposed instead.
- \`begin()\` / \`end()\` / \`operator[]\`: STL iterator and indexing — out of scope for the C surface.
- \`to_pay_public_key_hash_pattern_unlocking\`: param \`wallet::ec_public\` is not yet registered in the type system.
- \`is_commitment_pattern\` / \`is_witness_program_pattern\`: SegWit-only (\`#if defined(KTH_SEGWIT_ENABLED)\`) — not visible in the BCH build.

## Test plan

- [ ] Build the c-api target on Linux
- [ ] Run the new \`kth_capi_test\` suite for \`[C-API Script]\`
- [ ] Verify \`KTH_OWNED\` triggers \`-Wunused-result\` when a \`_construct*\` / \`_copy\` / \`to_data\` result is discarded

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches C-API surface for `script` (new signatures, ownership, and error handling) and adds new parsing factories, so downstream bindings may need updates and serialization/validation paths could regress if mismatched.
> 
> **Overview**
> **Refactors the C-API `chain/script` surface to the const/mut handle model** and makes ownership explicit via `KTH_OWNED` / `KTH_OUT_OWNED`, including out-param constructors that return `kth_error_code_t` instead of silently defaulting on parse failure.
> 
> **Expands script functionality exposed to C consumers**, adding copy/equality, serialization helpers, accessors/mutators (`empty`, `size`, `clear`, `reset`, operations access), pattern factories, and signing/verification helpers (including updated signature-hash/check-signature APIs with out-size reporting and endorsement creation via owned out buffers).
> 
> **Hardens and rounds out related bindings and build/test coverage**: adds `output_point` `construct_from_data`, relaxes `*_construct_from_data` preconditions to allow `(NULL, 0)` without aborting, introduces const/mut conversion shims and new opaque primitives (`data_stack`, const/mut list handles), fixes SegWit-only declarations behind `KTH_SEGWIT_ENABLED`, adds `script_pattern` enum `to_string`, updates the death-test helper for Catch2 SIGABRT handling, and adds new Catch2 tests (including a new `script` suite) wired into `kth_capi_test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee7d95483c8656b4b0bcaf8532f11aac1885633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revised script C API: explicit mutable/const handles, richer serialization/inspection, pattern builders, signing/verification and SegWit-aware pattern access (conditional).
  * Added new constructor for output-point-from-data; relaxed header/point-from-data precondition for empty input.
  * Added stable string conversion for script pattern enum.

* **Tests**
  * New comprehensive C-API tests for scripts, output points, headers/points, patterns and abort preconditions.

* **Chores**
  * Ignore local TODO notes via .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->