### PR TITLE
refactor(c-api): unify and harden chain/output bindings

### DIFF
--- a/scripts/build-create.sh
+++ b/scripts/build-create.sh
@@ -9,16 +9,20 @@ VERSION="$1"
 
 echo "Building version: ${VERSION}"
 
-rm -rf build
+# Use a workspace separate from build.sh's `build/` so the two scripts can
+# run side-by-side without trampling each other's intermediate files.
+WORKDIR="build-create"
+
+rm -rf "${WORKDIR}"
 rm -rf conan.lock
 
 conan lock create conanfile.py --version="${VERSION}" --update
 
-conan lock create conanfile.py --version="${VERSION}" --lockfile=conan.lock --lockfile-out=build/conan.lock
-conan create conanfile.py --version "${VERSION}" --lockfile=build/conan.lock --build=missing -o tests=False
+conan lock create conanfile.py --version="${VERSION}" --lockfile=conan.lock --lockfile-out="${WORKDIR}/conan.lock"
+conan create conanfile.py --version "${VERSION}" --lockfile="${WORKDIR}/conan.lock" --build=missing -o tests=False
 
 # Run tests after create
 echo "Running tests..."
-conan test test_package kth/${VERSION} 
+conan test test_package "kth/${VERSION}"
 
 

--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -501,6 +501,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/point.cpp
         test/chain/output_point.cpp
         test/chain/script.cpp
+        test/chain/output.cpp
     )
 
     target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})

--- a/src/c-api/include/kth/capi/chain/output.h
+++ b/src/c-api/include/kth/capi/chain/output.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,68 +10,109 @@
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
 
-#include <kth/capi/chain/token_capability.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// Constructors
+
+/** @return Owned `kth_output_mut_t`. Caller must release with `kth_chain_output_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_mut_t kth_chain_output_construct_default(void);
+
+/** @param[out] out Must point to a null `kth_output_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_output_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_output_t kth_chain_output_construct_default(void);
+kth_error_code_t kth_chain_output_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_output_mut_t* out);
+
+/** @return Owned `kth_output_mut_t`. Caller must release with `kth_chain_output_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_mut_t kth_chain_output_construct(uint64_t value, kth_script_const_t script, kth_token_data_const_t token_data);
+
+
+// Destructor
 
 KTH_EXPORT
-kth_output_t kth_chain_output_construct(uint64_t value, kth_script_t script);
+void kth_chain_output_destruct(kth_output_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_output_mut_t`. Caller must release with `kth_chain_output_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_mut_t kth_chain_output_copy(kth_output_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-kth_output_t kth_chain_output_construct_with_token_fungible(uint64_t value, kth_script_t script, kth_hash_t const* token_category, int64_t token_amount);
+kth_bool_t kth_chain_output_equals(kth_output_const_t self, kth_output_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_output_to_data(kth_output_const_t self, kth_bool_t wire, kth_size_t* out_size);
 
 KTH_EXPORT
-kth_output_t kth_chain_output_construct_with_token_non_fungible(uint64_t value, kth_script_t script, kth_hash_t const* token_category, kth_token_capability_t capability, uint8_t* commitment_data, kth_size_t commitment_n);
+kth_size_t kth_chain_output_serialized_size(kth_output_const_t self, kth_bool_t wire);
+
+
+// Getters
 
 KTH_EXPORT
-kth_output_t kth_chain_output_construct_with_token_both(uint64_t value, kth_script_t script, kth_hash_t const* token_category, int64_t token_amount, kth_token_capability_t capability, uint8_t* commitment_data, kth_size_t commitment_n);
+uint64_t kth_chain_output_value(kth_output_const_t self);
 
 KTH_EXPORT
-kth_output_t kth_chain_output_construct_with_token_data(uint64_t value, kth_script_t script, kth_token_data_t token_data);
+kth_script_const_t kth_chain_output_script(kth_output_const_t self);
 
 KTH_EXPORT
-void kth_chain_output_destruct(kth_output_t output);
+kth_token_data_const_t kth_chain_output_token_data(kth_output_const_t self);
+
+
+// Setters
 
 KTH_EXPORT
-kth_output_t kth_chain_output_factory_from_data(uint8_t* data, kth_size_t n);
+void kth_chain_output_set_script(kth_output_mut_t self, kth_script_const_t value);
 
 KTH_EXPORT
-kth_bool_t kth_chain_output_is_valid(kth_output_t output);
+void kth_chain_output_set_value(kth_output_mut_t self, uint64_t value);
 
 KTH_EXPORT
-kth_size_t kth_chain_output_serialized_size(kth_output_t output, kth_bool_t wire); //wire = true
+void kth_chain_output_set_token_data(kth_output_mut_t self, kth_token_data_const_t value);
+
+
+// Predicates
 
 KTH_EXPORT
-uint64_t kth_chain_output_value(kth_output_t output);
+kth_bool_t kth_chain_output_is_valid(kth_output_const_t self);
 
 KTH_EXPORT
-kth_size_t kth_chain_output_signature_operations(kth_output_t output);
+kth_bool_t kth_chain_output_is_dust(kth_output_const_t self, uint64_t minimum_output_value);
+
+
+// Operations
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_chain_output_address_simple(kth_output_const_t self, kth_bool_t testnet);
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_chain_output_address(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version);
+
+/** @return Owned `kth_payment_address_list_mut_t`. Caller must release with `kth_wallet_payment_address_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_list_mut_t kth_chain_output_addresses(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version);
 
 KTH_EXPORT
-kth_script_t kth_chain_output_script(kth_output_t output);
+kth_size_t kth_chain_output_signature_operations(kth_output_const_t self, kth_bool_t bip141);
 
 KTH_EXPORT
-kth_payment_address_t kth_chain_output_payment_address(kth_output_t output, kth_bool_t use_testnet_rules);
-
-KTH_EXPORT
-uint8_t const* kth_chain_output_to_data(kth_output_t output, kth_bool_t wire, kth_size_t* out_size);
-
-//uint32_t kth_chain_output_get_index(kth_output_t output);
-
-// Cash Tokens ---------------------------------------------------------------
-KTH_EXPORT
-kth_bool_t kth_chain_output_has_token_data(kth_output_t output);
-
-KTH_EXPORT
-kth_token_data_t kth_chain_output_token_data(kth_output_t output);
+void kth_chain_output_reset(kth_output_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_OUTPUT_H_ */
+#endif // KTH_CAPI_CHAIN_OUTPUT_H_

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -79,6 +79,19 @@ kth_wallet_ec_compressed_list_mut_cpp(kth_ec_compressed_list_mut_t l) {
     return *static_cast<std::vector<std::array<uint8_t, 33>>*>(l);
 }
 
+// token_data is not migrated to const/mut yet. The legacy
+// KTH_CONV_DECLARE(chain, kth_token_data_t, ...) declares the converter
+// taking a non-const void*; the migrated chain/output API needs the const
+// view, so we add an inline shim here.
+inline kth::domain::chain::token_data_t const&
+kth_chain_token_data_const_cpp(kth_token_data_const_t o) {
+    return *static_cast<kth::domain::chain::token_data_t const*>(o);
+}
+inline kth::domain::chain::token_data_t&
+kth_chain_token_data_mut_cpp(kth_token_data_mut_t o) {
+    return *static_cast<kth::domain::chain::token_data_t*>(o);
+}
+
 // data_stack — vector of variable-length byte buffers (the script runtime
 // stack). Exposed only as an opaque handle for now; ownership and element
 // access live on the user side until we wire a proper data_stack module.
@@ -91,7 +104,10 @@ kth_chain_data_stack_mut_cpp(kth_data_stack_mut_t s) {
     return *static_cast<std::vector<std::vector<uint8_t>>*>(s);
 }
 KTH_CONV_DECLARE(chain, kth_input_t, kth::domain::chain::input, input)
-KTH_CONV_DECLARE(chain, kth_output_t, kth::domain::chain::output, output)
+// output conversion functions take const/mut handle types directly. Defined
+// in src/chain/output.cpp.
+kth::domain::chain::output const& kth_chain_output_const_cpp(kth_output_const_t o);
+kth::domain::chain::output&       kth_chain_output_mut_cpp(kth_output_mut_t o);
 // output_point conversion functions take const/mut handle types directly.
 // Defined in src/chain/output_point.cpp.
 kth::domain::chain::output_point const& kth_chain_output_point_const_cpp(kth_output_point_const_t o);

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -115,6 +115,7 @@ typedef void* kth_script_t;
 typedef void* kth_script_mut_t;
 typedef void const* kth_script_const_t;
 typedef void* kth_token_data_t;
+typedef void* kth_token_data_mut_t;
 typedef void const* kth_token_data_const_t;
 
 typedef void* kth_operation_list_t;
@@ -126,6 +127,8 @@ typedef void const* kth_operation_const_t;
 
 typedef void* kth_output_list_t;
 typedef void* kth_output_t;
+typedef void* kth_output_mut_t;
+typedef void const* kth_output_const_t;
 typedef void* kth_outputpoint_t;
 typedef void* kth_output_point_mut_t;
 typedef void const* kth_output_point_const_t;
@@ -147,7 +150,10 @@ typedef void* kth_get_blocks_ptr_t;
 typedef void* kth_get_headers_t;
 typedef void* kth_get_headers_ptr_t;
 typedef void* kth_payment_address_t;
+typedef void* kth_payment_address_mut_t;
+typedef void const* kth_payment_address_const_t;
 typedef void* kth_payment_address_list_t;
+typedef void* kth_payment_address_list_mut_t;
 typedef void const* kth_payment_address_list_const_t;
 typedef void* kth_binary_t;
 typedef void* kth_stealth_compact_t;

--- a/src/c-api/src/chain/output.cpp
+++ b/src/c-api/src/chain/output.cpp
@@ -1,158 +1,173 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <kth/capi/chain/output.h>
 
-#include <kth/capi/chain/script.h>
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/domain/chain/output.hpp>
 
-KTH_CONV_DEFINE(chain, kth_output_t, kth::domain::chain::output, output)
+// Conversion functions
+kth::domain::chain::output& kth_chain_output_mut_cpp(kth_output_mut_t o) {
+    return *static_cast<kth::domain::chain::output*>(o);
+}
+kth::domain::chain::output const& kth_chain_output_const_cpp(kth_output_const_t o) {
+    return *static_cast<kth::domain::chain::output const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_output_t kth_chain_output_construct_default() {
+// Constructors
+
+kth_output_mut_t kth_chain_output_construct_default(void) {
     return new kth::domain::chain::output();
 }
 
-//kth_output_t kth_chain_output_construct(uint64_t value, kth_script_t script, kth_token_data_t token_data) {
-kth_output_t kth_chain_output_construct(uint64_t value, kth_script_t script) {
-    // return new kth::domain::chain::output(value, kth_chain_script_const_cpp(script), kth_chain_token_data_const_cpp(token_data));
-    return new kth::domain::chain::output(value, kth_chain_script_const_cpp(script), std::nullopt);
+kth_error_code_t kth_chain_output_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_output_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, n));
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto result = kth::domain::chain::output::from_data(data_cpp, wire_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::chain::output(std::move(*result));
+    return kth_ec_success;
 }
 
-kth_output_t kth_chain_output_construct_with_token_fungible(uint64_t value, kth_script_t script, kth_hash_t const* token_category, int64_t token_amount) {
-    using kth::domain::chain::amount_t;
-
-    auto token_category_cpp = kth::to_array(token_category->hash);
-
-    kth::domain::chain::token_data_t token_data = {
-        token_category_cpp,
-        kth::domain::chain::fungible{amount_t{token_amount}}
-    };
-
-    return new kth::domain::chain::output(
-        value,
-        kth_chain_script_const_cpp(script),
-        std::move(token_data)
-    );
+kth_output_mut_t kth_chain_output_construct(uint64_t value, kth_script_const_t script, kth_token_data_const_t token_data) {
+    KTH_PRECONDITION(script != nullptr);
+    auto const& script_cpp = kth_chain_script_const_cpp(script);
+    auto token_data_cpp = (token_data == nullptr ? std::nullopt : std::optional<kth::domain::chain::token_data_t>(kth_chain_token_data_const_cpp(token_data)));
+    return new kth::domain::chain::output(value, script_cpp, token_data_cpp);
 }
 
-kth_output_t kth_chain_output_construct_with_token_non_fungible(uint64_t value, kth_script_t script, kth_hash_t const* token_category, kth_token_capability_t capability, uint8_t* commitment_data, kth_size_t commitment_n) {
-    auto token_category_cpp = kth::to_array(token_category->hash);
-    auto capability_cpp = kth::token_capability_to_cpp(capability);
-    kth::data_chunk commitment_cpp(commitment_data, std::next(commitment_data, commitment_n));
 
-    kth::domain::chain::token_data_t token_data = {
-        token_category_cpp,
-        kth::domain::chain::non_fungible{capability_cpp, std::move(commitment_cpp)}
-    };
+// Destructor
 
-    return new kth::domain::chain::output(
-        value,
-        kth_chain_script_const_cpp(script),
-        std::move(token_data)
-    );
+void kth_chain_output_destruct(kth_output_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_output_mut_cpp(self);
 }
 
-kth_output_t kth_chain_output_construct_with_token_both(uint64_t value, kth_script_t script, kth_hash_t const* token_category, int64_t token_amount, kth_token_capability_t capability, uint8_t* commitment_data, kth_size_t commitment_n) {
-    using kth::domain::chain::amount_t;
 
-    auto token_category_cpp = kth::to_array(token_category->hash);
-    auto capability_cpp = kth::token_capability_to_cpp(capability);
-    kth::data_chunk commitment_cpp(commitment_data, std::next(commitment_data, commitment_n));
+// Copy
 
-    kth::domain::chain::token_data_t token_data = {
-        token_category_cpp,
-        kth::domain::chain::both_kinds{
-            kth::domain::chain::fungible{
-                amount_t{token_amount}
-            },
-            kth::domain::chain::non_fungible{
-                capability_cpp,
-                std::move(commitment_cpp)
-            }
-        }
-    };
-
-    return new kth::domain::chain::output(
-        value,
-        kth_chain_script_const_cpp(script),
-        std::move(token_data)
-    );
+kth_output_mut_t kth_chain_output_copy(kth_output_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::chain::output(kth_chain_output_const_cpp(self));
 }
 
-kth_output_t kth_chain_output_construct_with_token_data(uint64_t value, kth_script_t script, kth_token_data_t token_data) {
-    return new kth::domain::chain::output(
-        value,
-        kth_chain_script_const_cpp(script),
-        kth_chain_token_data_const_cpp(token_data)
-    );
+
+// Equality
+
+kth_bool_t kth_chain_output_equals(kth_output_const_t self, kth_output_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_output_const_cpp(self) == kth_chain_output_const_cpp(other));
 }
 
-void kth_chain_output_destruct(kth_output_t output) {
-    delete &kth_chain_output_cpp(output);
+
+// Serialization
+
+uint8_t* kth_chain_output_to_data(kth_output_const_t self, kth_bool_t wire, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto data = kth_chain_output_const_cpp(self).to_data(wire_cpp);
+    return kth::create_c_array(data, *out_size);
 }
 
-kth_output_t kth_chain_output_factory_from_data(uint8_t* data, kth_size_t n) {
-    kth::data_chunk data_cpp(data, std::next(data, n));
-    kth::byte_reader reader(data_cpp);
-    auto res = kth::domain::chain::output::from_data(reader);
-    if ( ! res) {
-        return kth::move_or_copy_and_leak(kth::domain::chain::output{});
-    }
-    return kth::move_or_copy_and_leak(std::move(*res));
+kth_size_t kth_chain_output_serialized_size(kth_output_const_t self, kth_bool_t wire) {
+    KTH_PRECONDITION(self != nullptr);
+    auto wire_cpp = kth::int_to_bool(wire);
+    return kth_chain_output_const_cpp(self).serialized_size(wire_cpp);
 }
 
-kth_bool_t kth_chain_output_is_valid(kth_output_t output) {
-    return kth::bool_to_int(kth_chain_output_const_cpp(output).is_valid());
+
+// Getters
+
+uint64_t kth_chain_output_value(kth_output_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_output_const_cpp(self).value();
 }
 
-kth_size_t kth_chain_output_serialized_size(kth_output_t output, kth_bool_t wire /* = true */) {
-    return kth_chain_output_const_cpp(output).serialized_size(kth::int_to_bool(wire));
+kth_script_const_t kth_chain_output_script(kth_output_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth_chain_output_const_cpp(self).script());
 }
 
-uint64_t kth_chain_output_value(kth_output_t output) {
-    return kth_chain_output_const_cpp(output).value();
+kth_token_data_const_t kth_chain_output_token_data(kth_output_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const& opt = kth_chain_output_const_cpp(self).token_data();
+    return opt.has_value() ? &(*opt) : nullptr;
 }
 
-kth_size_t kth_chain_output_signature_operations(kth_output_t output) {
-#if defined(KTH_CURRENCY_BCH)
-    kth_bool_t bip141_active = 0;
-#else
-    kth_bool_t bip141_active = 1;
-#endif
-    return kth_chain_output_const_cpp(output).signature_operations(kth::int_to_bool(bip141_active));
+
+// Setters
+
+void kth_chain_output_set_script(kth_output_mut_t self, kth_script_const_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const& value_cpp = kth_chain_script_const_cpp(value);
+    kth_chain_output_mut_cpp(self).set_script(value_cpp);
 }
 
-kth_script_t kth_chain_output_script(kth_output_t output) {
-    return &(kth_chain_output_cpp(output).script());
+void kth_chain_output_set_value(kth_output_mut_t self, uint64_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_output_mut_cpp(self).set_value(value);
 }
 
-kth_payment_address_t kth_chain_output_payment_address(kth_output_t output, kth_bool_t use_testnet_rules) {
-    auto payment_address = kth_chain_output_cpp(output).address(kth::int_to_bool(use_testnet_rules));
-    return new kth::domain::wallet::payment_address(payment_address);
+void kth_chain_output_set_token_data(kth_output_mut_t self, kth_token_data_const_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    auto value_cpp = (value == nullptr ? std::nullopt : std::optional<kth::domain::chain::token_data_t>(kth_chain_token_data_const_cpp(value)));
+    kth_chain_output_mut_cpp(self).set_token_data(value_cpp);
 }
 
-uint8_t const* kth_chain_output_to_data(kth_output_t output, kth_bool_t wire, kth_size_t* out_size) {
-    auto output_data = kth_chain_output_const_cpp(output).to_data(kth::int_to_bool(wire));
-    return kth::create_c_array(output_data, *out_size);
+
+// Predicates
+
+kth_bool_t kth_chain_output_is_valid(kth_output_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_output_const_cpp(self).is_valid());
 }
 
-// Cash Tokens ---------------------------------------------------------------
-
-kth_bool_t kth_chain_output_has_token_data(kth_output_t output) {
-    return kth::bool_to_int(kth_chain_output_const_cpp(output).token_data().has_value());
+kth_bool_t kth_chain_output_is_dust(kth_output_const_t self, uint64_t minimum_output_value) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_output_const_cpp(self).is_dust(minimum_output_value));
 }
 
-kth_token_data_t kth_chain_output_token_data(kth_output_t output) {
-    if ( ! kth_chain_output_cpp(output).token_data().has_value()) {
-        return nullptr;
-    }
-    return &kth_chain_output_cpp(output).token_data().value();
+
+// Operations
+
+kth_payment_address_mut_t kth_chain_output_address_simple(kth_output_const_t self, kth_bool_t testnet) {
+    KTH_PRECONDITION(self != nullptr);
+    auto testnet_cpp = kth::int_to_bool(testnet);
+    return new kth::domain::wallet::payment_address(kth_chain_output_const_cpp(self).address(testnet_cpp));
+}
+
+kth_payment_address_mut_t kth_chain_output_address(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::wallet::payment_address(kth_chain_output_const_cpp(self).address(p2kh_version, p2sh_version));
+}
+
+kth_payment_address_list_mut_t kth_chain_output_addresses(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version) {
+    KTH_PRECONDITION(self != nullptr);
+    return new std::vector<kth::domain::wallet::payment_address>(kth_chain_output_const_cpp(self).addresses(p2kh_version, p2sh_version));
+}
+
+kth_size_t kth_chain_output_signature_operations(kth_output_const_t self, kth_bool_t bip141) {
+    KTH_PRECONDITION(self != nullptr);
+    auto bip141_cpp = kth::int_to_bool(bip141);
+    return kth_chain_output_const_cpp(self).signature_operations(bip141_cpp);
+}
+
+void kth_chain_output_reset(kth_output_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_output_mut_cpp(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/output.cpp
+++ b/src/c-api/test/chain/output.cpp
@@ -1,0 +1,239 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/chain/output.h>
+#include <kth/capi/chain/script.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+static uint64_t const kValue = 523542ull;
+
+// 20-byte payload that the C++ tests use as a script body. With wire=false
+// the script parser just reads the raw operations from the buffer.
+static uint8_t const kScriptBody[20] = {
+    0xec, 0xe4, 0x24, 0xa6, 0xbb, 0x6d, 0xdf, 0x4d,
+    0xb5, 0x92, 0xc0, 0xfa, 0xed, 0x60, 0x68, 0x50,
+    0x47, 0xa3, 0x61, 0xb1
+};
+
+static kth_script_mut_t make_script(void) {
+    kth_script_mut_t script = NULL;
+    kth_error_code_t ec = kth_chain_script_construct_from_data(
+        kScriptBody, sizeof(kScriptBody), 0, &script);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(script != NULL);
+    return script;
+}
+
+// ---------------------------------------------------------------------------
+// Constructors / lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Output - default construct is invalid", "[C-API Output]") {
+    kth_output_mut_t op = kth_chain_output_construct_default();
+    REQUIRE(kth_chain_output_is_valid(op) == 0);
+    kth_chain_output_destruct(op);
+}
+
+TEST_CASE("C-API Output - field constructor preserves value and script",
+          "[C-API Output]") {
+    kth_script_mut_t script = make_script();
+    kth_output_mut_t op = kth_chain_output_construct(kValue, script, NULL);
+    REQUIRE(kth_chain_output_is_valid(op) != 0);
+    REQUIRE(kth_chain_output_value(op) == kValue);
+    // No token data was provided → token_data() returns NULL.
+    REQUIRE(kth_chain_output_token_data(op) == NULL);
+    kth_chain_output_destruct(op);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Output - destruct null is safe", "[C-API Output]") {
+    kth_chain_output_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// from_data / to_data round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Output - from_data insufficient bytes fails",
+          "[C-API Output]") {
+    uint8_t data[5];
+    memset(data, 0, sizeof(data));
+    kth_output_mut_t out = NULL;
+    kth_error_code_t ec = kth_chain_output_construct_from_data(
+        data, sizeof(data), 1, &out);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(out == NULL);
+}
+
+TEST_CASE("C-API Output - to_data / from_data roundtrip", "[C-API Output]") {
+    kth_script_mut_t script = make_script();
+    kth_output_mut_t expected = kth_chain_output_construct(kValue, script, NULL);
+
+    kth_size_t size = 0;
+    uint8_t* raw = kth_chain_output_to_data(expected, 1, &size);
+    REQUIRE(raw != NULL);
+    REQUIRE(size > 0);
+
+    kth_output_mut_t parsed = NULL;
+    kth_error_code_t ec = kth_chain_output_construct_from_data(raw, size, 1, &parsed);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(parsed != NULL);
+    REQUIRE(kth_chain_output_is_valid(parsed) != 0);
+    REQUIRE(kth_chain_output_value(parsed) == kValue);
+    REQUIRE(kth_chain_output_equals(expected, parsed) != 0);
+
+    kth_core_destruct_array(raw);
+    kth_chain_output_destruct(parsed);
+    kth_chain_output_destruct(expected);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// Getters / setters
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Output - value setter roundtrip", "[C-API Output]") {
+    kth_output_mut_t op = kth_chain_output_construct_default();
+    REQUIRE(kth_chain_output_value(op) != kValue);
+    kth_chain_output_set_value(op, kValue);
+    REQUIRE(kth_chain_output_value(op) == kValue);
+    kth_chain_output_destruct(op);
+}
+
+TEST_CASE("C-API Output - script setter roundtrip", "[C-API Output]") {
+    kth_output_mut_t op = kth_chain_output_construct_default();
+    kth_script_mut_t script = make_script();
+    kth_chain_output_set_script(op, script);
+    // Borrowed view back; just exercise the path.
+    REQUIRE(kth_chain_output_script(op) != NULL);
+    kth_chain_output_destruct(op);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Output - default token_data is NULL", "[C-API Output]") {
+    kth_output_mut_t op = kth_chain_output_construct_default();
+    REQUIRE(kth_chain_output_token_data(op) == NULL);
+    kth_chain_output_destruct(op);
+}
+
+TEST_CASE("C-API Output - set_token_data NULL clears the optional",
+          "[C-API Output]") {
+    kth_output_mut_t op = kth_chain_output_construct_default();
+    // Already NULL by default; setting NULL must remain a no-op (no abort).
+    kth_chain_output_set_token_data(op, NULL);
+    REQUIRE(kth_chain_output_token_data(op) == NULL);
+    kth_chain_output_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Predicates / computations
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Output - is_dust below minimum is true", "[C-API Output]") {
+    kth_output_mut_t op = kth_chain_output_construct_default();
+    kth_chain_output_set_value(op, 100);
+    REQUIRE(kth_chain_output_is_dust(op, 1000) != 0);
+    kth_chain_output_destruct(op);
+}
+
+TEST_CASE("C-API Output - is_dust above minimum is false", "[C-API Output]") {
+    kth_output_mut_t op = kth_chain_output_construct_default();
+    kth_chain_output_set_value(op, 100000);
+    REQUIRE(kth_chain_output_is_dust(op, 1000) == 0);
+    kth_chain_output_destruct(op);
+}
+
+TEST_CASE("C-API Output - signature_operations on default is zero",
+          "[C-API Output]") {
+    kth_output_mut_t op = kth_chain_output_construct_default();
+    REQUIRE(kth_chain_output_signature_operations(op, 0) == 0);
+    kth_chain_output_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equals
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Output - copy preserves fields", "[C-API Output]") {
+    kth_script_mut_t script = make_script();
+    kth_output_mut_t original = kth_chain_output_construct(kValue, script, NULL);
+    kth_output_mut_t copy = kth_chain_output_copy(original);
+
+    REQUIRE(kth_chain_output_is_valid(copy) != 0);
+    REQUIRE(kth_chain_output_equals(original, copy) != 0);
+    REQUIRE(kth_chain_output_value(copy) == kValue);
+
+    kth_chain_output_destruct(copy);
+    kth_chain_output_destruct(original);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Output - equals different values", "[C-API Output]") {
+    kth_script_mut_t script = make_script();
+    kth_output_mut_t a = kth_chain_output_construct(kValue, script, NULL);
+    kth_output_mut_t b = kth_chain_output_construct(kValue, script, NULL);
+    kth_output_mut_t c = kth_chain_output_construct_default();
+
+    REQUIRE(kth_chain_output_equals(a, b) != 0);
+    REQUIRE(kth_chain_output_equals(a, c) == 0);
+
+    kth_chain_output_destruct(a);
+    kth_chain_output_destruct(b);
+    kth_chain_output_destruct(c);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions (death tests via fork)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Output - construct_from_data null data with non-zero size aborts",
+          "[C-API Output][precondition]") {
+    KTH_EXPECT_ABORT({
+        kth_output_mut_t out = NULL;
+        kth_chain_output_construct_from_data(NULL, 1, 1, &out);
+    });
+}
+
+TEST_CASE("C-API Output - construct_from_data null out aborts",
+          "[C-API Output][precondition]") {
+    uint8_t data[10];
+    memset(data, 0, sizeof(data));
+    KTH_EXPECT_ABORT(kth_chain_output_construct_from_data(data, 10, 1, NULL));
+}
+
+TEST_CASE("C-API Output - to_data null out_size aborts",
+          "[C-API Output][precondition]") {
+    kth_output_mut_t op = kth_chain_output_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_output_to_data(op, 1, NULL));
+    kth_chain_output_destruct(op);
+}
+
+TEST_CASE("C-API Output - copy null self aborts",
+          "[C-API Output][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_output_copy(NULL));
+}
+
+TEST_CASE("C-API Output - construct null script aborts",
+          "[C-API Output][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_output_construct(kValue, NULL, NULL));
+}


### PR DESCRIPTION
## Summary

Reworks the chain/output C bindings in line with the const/mut migration applied to chain/header (#216), chain/point (#217), chain/output_point (#218), and chain/script (#219), and exposes ownership semantics at the API surface so language backends can wire owned objects through their own smart-handle equivalents.

### Type system

- Public functions now use \`kth_output_const_t\` / \`kth_output_mut_t\` instead of the legacy unqualified \`kth_output_t\`. Read-only operations take a const handle, mutating operations take a mut handle. The legacy alias remains in \`primitives.h\` for callers that have not yet migrated.
- Local conversion helpers follow the symmetric naming: \`kth_chain_output_const_cpp\` / \`kth_chain_output_mut_cpp\`.
- \`kth_payment_address_*_t\` and \`kth_payment_address_list_*_t\` gain the matching const/mut typedefs so the new accessors can refer to them.
- \`kth_token_data_mut_t\` is added; \`conversions.hpp\` gains inline shims that bridge the legacy macro-based converter to the const/mut handles the migrated chain/output API consumes.

### Constructors and lifecycle

- \`construct_from_data\` returns a \`kth_error_code_t\` and writes the parsed output into an out-parameter; the underlying \`expect<output>\` error is propagated instead of silently producing a default-constructed output on failure.
- The field constructor exposes the inherited \`output_basis(value, script, token_data)\` variant. The \`token_data\` parameter is the new \`std::optional<token_data>\` mapped to a nullable C handle: pass \`NULL\` for \`nullopt\`, a non-null \`kth_token_data_const_t\` to attach a token.
- \`destruct\` is null-safe.
- \`copy\` is exposed via a dedicated \`kth_chain_output_copy\` entry point.

### \`std::optional\` support in the type registry

- The classifier learns a new \`optional\` kind for \`std::optional<T>\`. Today only \`optional<opaque_handle>\` is supported: \`NULL\` on the C side means \`nullopt\`, a non-null handle means the optional is engaged. \`set_token_data(NULL)\` clears the token, \`token_data()\` returns \`NULL\` when the output has none.

### Surface changes

- Setters take a \`kth_output_mut_t self\` plus a value parameter.
- Adds bindings the previous file was missing relative to the underlying C++ class: \`copy\`, \`equals\`, \`is_dust\`, \`reset\`, \`set_script\`, \`set_value\`, \`set_token_data\`, \`address\` (full), \`address_simple\` (testnet shortcut), \`addresses\` (returning the address list).

### Tests

- Adds \`src/c-api/test/chain/output.cpp\` covering: construct, destruct, \`from_data\` / \`to_data\` round-trip, getters / setters, default \`token_data\` is \`NULL\`, \`set_token_data NULL\` clears the optional, \`is_dust\` below / above minimum, \`signature_operations\`, \`copy\`, \`equals\`, and five \`KTH_PRECONDITION\` death tests (fork-based).

### Build script hygiene

- \`scripts/build-create.sh\` now uses a separate \`build-create/\` workspace instead of \`build/\` so it can run side-by-side with \`build.sh\` without trampling each other's intermediate files.

### Methods intentionally not exposed

- \`output(output_basis const&)\` and \`output(output_basis&&)\`: the base type is not part of the public C surface.
- \`to_data(data_sink&)\`: stream-based overload; the \`data_chunk\` variant is exposed instead.

### Convenience functions removed in this PR (will be revisited)

- \`construct_with_token_fungible\` / \`construct_with_token_non_fungible\` / \`construct_with_token_both\`: hand-coded factories that built up a \`token_data\` from raw primitives. They live downstream in higher-level bindings; we will recover the equivalent flow once the \`token_data\` class itself is exposed through the migrated C-API surface (so callers can construct the \`token_data\` first and pass it through the regular \`construct(value, script, token_data)\` entry point).
- \`construct_with_token_data\`: semantically identical to the new \`construct(value, script, token_data)\` — simply renamed.
- \`has_token_data\`: deprecated convenience predicate; callers can test \`token_data() != NULL\` directly through the new nullable-handle binding.

## Test plan

- [ ] Build the c-api target on Linux
- [ ] Run the new \`kth_capi_test\` suite for \`[C-API Output]\`
- [ ] Verify \`KTH_OWNED\` triggers \`-Wunused-result\` when a \`_construct*\` / \`_copy\` / \`to_data\` result is discarded

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public C-API surface for `chain/output` changes significantly (new handle types, new constructors, removed token factories), so downstream bindings may need updates and could see ABI/API breakage. Logic is mostly thin wrappers with added precondition aborts and improved error propagation, lowering functional risk but raising integration risk.
> 
> **Overview**
> Refactors the `chain/output` C-API to the const/mut handle model (`kth_output_const_t`/`kth_output_mut_t`) and makes ownership explicit via `KTH_OWNED`/`KTH_OUT_OWNED`, including a new `construct_from_data` that returns `kth_error_code_t` instead of silently producing a default output on parse failure.
> 
> Expands the surface to include `copy`, `equals`, `is_dust`, `reset`, setters (`set_value/script/token_data`), and richer address helpers (`address_simple`, `address`, `addresses`), while removing the older token-convenience constructors and related helpers.
> 
> Adds new typedefs needed by the migrated API (`kth_output_*`, `kth_payment_address_*`, `kth_token_data_mut_t`), introduces conversion shims for `token_data`, adds a new Catch2 test suite for `output`, and updates `build-create.sh` to use a separate `build-create/` workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16acf6c4140f3ffa92a5f0b15ca249cb8939c8da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced mutable/const handle variants and richer output APIs (copy, equality, reset, setters/getters)
  * Added improved serialization/deserialization and address extraction options
  * Added signature-op and dust predicate controls

* **Tests**
  * Added comprehensive tests covering construction, lifecycle, serialization round-trips, predicates, copy/equality, and error conditions

* **Chores**
  * Adjusted build workspace invocation and lockfile handling in build scripts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->