### PR TITLE
refactor(c-api): unify and harden chain/block bindings

### DIFF
--- a/src/c-api/include/kth/capi/chain/block.h
+++ b/src/c-api/include/kth/capi/chain/block.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,98 +9,209 @@
 
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
+#include <kth/capi/chain/script_flags.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// Constructors
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_construct_default(void);
+
+/** @param[out] out Must point to a null `kth_block_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_block_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_block_t kth_chain_block_construct_default(void);
+kth_error_code_t kth_chain_block_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_block_mut_t* out);
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transaction_list_const_t transactions);
+
+
+// Static factories
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_genesis_mainnet(void);
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_genesis_testnet(void);
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_genesis_regtest(void);
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_genesis_testnet4(void);
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_genesis_scalenet(void);
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_genesis_chipnet(void);
+
+
+// Destructor
 
 KTH_EXPORT
-kth_block_t kth_chain_block_construct(kth_header_t header, kth_transaction_list_t transactions);
+void kth_chain_block_destruct(kth_block_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_mut_t kth_chain_block_copy(kth_block_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-kth_block_t kth_chain_block_factory_from_data(uint8_t* data, kth_size_t n);
+kth_bool_t kth_chain_block_equals(kth_block_const_t self, kth_block_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_block_to_data_simple(kth_block_const_t self, kth_size_t* out_size);
 
 KTH_EXPORT
-void kth_chain_block_destruct(kth_block_t block);
+kth_size_t kth_chain_block_serialized_size(kth_block_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_block_to_data(kth_block_const_t self, kth_size_t serialized_size, kth_size_t* out_size);
+
+
+// Getters
 
 KTH_EXPORT
-kth_bool_t kth_chain_block_is_valid(kth_block_t block);
+kth_size_t kth_chain_block_signature_operations_simple(kth_block_const_t self);
 
 KTH_EXPORT
-kth_header_t kth_chain_block_header(kth_block_t block);
+kth_error_code_t kth_chain_block_check(kth_block_const_t self);
 
 KTH_EXPORT
-kth_hash_t kth_chain_block_hash(kth_block_t block);
+kth_error_code_t kth_chain_block_connect(kth_block_const_t self);
+
+/** @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_block_to_hashes(kth_block_const_t self);
+
+/** @return Borrowed `kth_header_const_t` view into `self`. Do not destruct; the parent object retains ownership. */
+KTH_EXPORT
+kth_header_const_t kth_chain_block_header(kth_block_const_t self);
+
+/** @return Borrowed `kth_transaction_list_const_t` view into `self`. Do not destruct; the parent object retains ownership. */
+KTH_EXPORT
+kth_transaction_list_const_t kth_chain_block_transactions(kth_block_const_t self);
 
 KTH_EXPORT
-void kth_chain_block_hash_out(kth_block_t block, kth_hash_t* out_hash);
+kth_hash_t kth_chain_block_hash(kth_block_const_t self);
 
 KTH_EXPORT
-char const* kth_chain_block_proof_str(kth_block_t block);
+uint64_t kth_chain_block_fees(kth_block_const_t self);
 
 KTH_EXPORT
-kth_transaction_list_t kth_chain_block_transactions(kth_block_t block);
+uint64_t kth_chain_block_claim(kth_block_const_t self);
 
 KTH_EXPORT
-kth_size_t kth_chain_block_serialized_size(kth_block_t block);
-
-/*static*/
-KTH_EXPORT
-uint64_t kth_chain_block_subsidy(kth_size_t height);
+kth_hash_t kth_chain_block_generate_merkle_root(kth_block_const_t self);
 
 KTH_EXPORT
-uint64_t kth_chain_block_fees(kth_block_t block);
+kth_error_code_t kth_chain_block_check_transactions(kth_block_const_t self);
 
 KTH_EXPORT
-uint64_t kth_chain_block_claim(kth_block_t block);
+kth_size_t kth_chain_block_non_coinbase_input_count(kth_block_const_t self);
+
+
+// Setters
 
 KTH_EXPORT
-uint64_t kth_chain_block_reward(kth_block_t block, kth_size_t height);
+void kth_chain_block_set_transactions(kth_block_mut_t self, kth_transaction_list_const_t value);
 
 KTH_EXPORT
-kth_hash_t kth_chain_block_generate_merkle_root(kth_block_t block);
+void kth_chain_block_set_header(kth_block_mut_t self, kth_header_const_t value);
+
+
+// Predicates
 
 KTH_EXPORT
-void kth_chain_block_generate_merkle_root_out(kth_block_t block, kth_hash_t* out_merkle);
+kth_bool_t kth_chain_block_is_valid(kth_block_const_t self);
 
 KTH_EXPORT
-kth_size_t kth_chain_block_signature_operations(kth_block_t block);
+kth_bool_t kth_chain_block_is_extra_coinbases(kth_block_const_t self);
 
 KTH_EXPORT
-kth_size_t kth_chain_block_signature_operations_bip16_active(kth_block_t block, kth_bool_t bip16_active);
+kth_bool_t kth_chain_block_is_final(kth_block_const_t self, kth_size_t height, uint32_t block_time);
 
 KTH_EXPORT
-kth_size_t kth_chain_block_total_inputs(kth_block_t block, kth_bool_t with_coinbase); //with_coinbase = true
+kth_bool_t kth_chain_block_is_distinct_transaction_set(kth_block_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_chain_block_is_extra_coinbases(kth_block_t block);
+kth_bool_t kth_chain_block_is_valid_coinbase_claim(kth_block_const_t self, kth_size_t height);
 
 KTH_EXPORT
-kth_bool_t kth_chain_block_is_final(kth_block_t block, kth_size_t height, uint32_t kth_block_time);
+kth_bool_t kth_chain_block_is_valid_coinbase_script(kth_block_const_t self, kth_size_t height);
 
 KTH_EXPORT
-kth_bool_t kth_chain_block_is_distinct_transaction_set(kth_block_t block);
+kth_bool_t kth_chain_block_is_forward_reference(kth_block_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_chain_block_is_valid_coinbase_claim(kth_block_t block, kth_size_t height);
+kth_bool_t kth_chain_block_is_canonical_ordered(kth_block_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_chain_block_is_valid_coinbase_script(kth_block_t block, kth_size_t height);
+kth_bool_t kth_chain_block_is_internal_double_spend(kth_block_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_chain_block_is_internal_double_spend(kth_block_t block);
+kth_bool_t kth_chain_block_is_valid_merkle_root(kth_block_const_t self);
+
+
+// Operations
 
 KTH_EXPORT
-kth_bool_t kth_chain_block_is_valid_merkle_root(kth_block_t block);
+kth_size_t kth_chain_block_total_inputs(kth_block_const_t self, kth_bool_t with_coinbase);
 
 KTH_EXPORT
-uint8_t const* kth_chain_block_to_data(kth_block_t block, kth_bool_t wire, kth_size_t* out_size);
+kth_error_code_t kth_chain_block_accept(kth_block_const_t self, kth_script_flags_t flags, kth_size_t height, uint32_t median_time_past, kth_size_t max_block_size_dynamic, kth_size_t max_sigops, kth_bool_t is_under_checkpoint, kth_bool_t transactions);
+
+KTH_EXPORT
+uint64_t kth_chain_block_reward(kth_block_const_t self, kth_size_t height);
+
+KTH_EXPORT
+kth_size_t kth_chain_block_signature_operations(kth_block_const_t self, kth_bool_t bip16, kth_bool_t bip141);
+
+KTH_EXPORT
+kth_error_code_t kth_chain_block_accept_transactions(kth_block_const_t self, kth_script_flags_t flags, kth_size_t height, uint32_t median_time_past, kth_size_t max_sigops, kth_bool_t is_under_checkpoint);
+
+KTH_EXPORT
+kth_error_code_t kth_chain_block_connect_transactions(kth_block_const_t self, kth_chain_state_const_t state);
+
+KTH_EXPORT
+void kth_chain_block_reset(kth_block_mut_t self);
+
+
+// Static utilities
+
+KTH_EXPORT
+kth_size_t kth_chain_block_locator_size(kth_size_t top);
+
+/** @return Owned `kth_block_indexes_mut_t`. Caller must release with `kth_chain_block_indexes_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_indexes_mut_t kth_chain_block_locator_heights(kth_size_t top);
+
+KTH_EXPORT
+uint64_t kth_chain_block_subsidy(kth_size_t height, kth_bool_t retarget);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_BLOCK_H_ */
+#endif // KTH_CAPI_CHAIN_BLOCK_H_

--- a/src/c-api/include/kth/capi/chain/block_list.h
+++ b/src/c-api/include/kth/capi/chain/block_list.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,7 +7,6 @@
 
 #include <stdint.h>
 
-#include <kth/capi/list_creator.h>
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
 
@@ -15,7 +14,28 @@
 extern "C" {
 #endif
 
-KTH_LIST_DECLARE(chain, kth_block_list_t, kth_block_t, block_list)
+/** @return Owned `kth_block_list_mut_t`. Caller must release with `kth_chain_block_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_block_list_mut_t kth_chain_block_list_construct_default(void);
+
+KTH_EXPORT
+void kth_chain_block_list_push_back(kth_block_list_mut_t list, kth_block_const_t elem);
+
+KTH_EXPORT
+void kth_chain_block_list_destruct(kth_block_list_mut_t list);
+
+KTH_EXPORT
+kth_size_t kth_chain_block_list_count(kth_block_list_const_t list);
+
+/** @return Borrowed `kth_block_const_t` view into the list. Do not destruct; the list retains ownership. Invalidated by any mutation of the list. */
+KTH_EXPORT
+kth_block_const_t kth_chain_block_list_nth(kth_block_list_const_t list, kth_size_t index);
+
+KTH_EXPORT
+void kth_chain_block_list_assign_at(kth_block_list_mut_t list, kth_size_t index, kth_block_const_t elem);
+
+KTH_EXPORT
+void kth_chain_block_list_erase(kth_block_list_mut_t list, kth_size_t index);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -28,7 +28,11 @@
 #include <kth/blockchain/interface/safe_chain.hpp>
 // #endif
 
-KTH_CONV_DECLARE(chain, kth_block_t, kth::domain::chain::block, block)
+// block conversion functions take const/mut handle types directly. Defined
+// in src/chain/block.cpp.
+kth::domain::chain::block const& kth_chain_block_const_cpp(kth_block_const_t o);
+kth::domain::chain::block&       kth_chain_block_mut_cpp(kth_block_mut_t o);
+
 // header conversion functions take const/mut handle types directly. Defined
 // in src/chain/header.cpp.
 kth::domain::chain::header const& kth_chain_header_const_cpp(kth_header_const_t o);
@@ -130,6 +134,14 @@ inline std::vector<kth::domain::chain::output>&
 kth_chain_output_list_mut_cpp(kth_output_list_mut_t l) {
     return *static_cast<std::vector<kth::domain::chain::output>*>(l);
 }
+inline std::vector<kth::domain::chain::transaction> const&
+kth_chain_transaction_list_const_cpp(kth_transaction_list_const_t l) {
+    return *static_cast<std::vector<kth::domain::chain::transaction> const*>(l);
+}
+inline std::vector<kth::domain::chain::transaction>&
+kth_chain_transaction_list_mut_cpp(kth_transaction_list_mut_t l) {
+    return *static_cast<std::vector<kth::domain::chain::transaction>*>(l);
+}
 // output conversion functions take const/mut handle types directly. Defined
 // in src/chain/output.cpp.
 kth::domain::chain::output const& kth_chain_output_const_cpp(kth_output_const_t o);
@@ -174,7 +186,6 @@ KTH_LIST_DECLARE_CONSTRUCT_FROM_CPP(chain, kth_transaction_list_t, kth::domain::
 KTH_LIST_DECLARE_CONSTRUCT_FROM_CPP(core, kth_hash_list_t, kth::hash_digest, hash_list)
 KTH_LIST_DECLARE_CONSTRUCT_FROM_CPP_CONST(chain, kth_operation_list_t, kth::domain::machine::operation, operation_list)
 
-KTH_LIST_DECLARE_CONVERTERS(chain, kth_block_list_t, kth::domain::chain::block, block_list)
 KTH_LIST_DECLARE_CONVERTERS(chain, kth_point_list_t, kth::domain::chain::point, point_list)
 KTH_LIST_DECLARE_CONVERTERS(chain, kth_outputpoint_list_t, kth::domain::chain::output_point, outputpoint_list)
 KTH_LIST_DECLARE_CONVERTERS(chain, kth_input_list_t, kth::domain::chain::input, input_list)

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -93,8 +93,14 @@ typedef void* kth_p2p_t;
 
 // TODO(fernando): check if we can encapsulate the pointer into a struct to make them more "type safe"
 typedef void* kth_block_t;
+typedef void* kth_block_mut_t;
+typedef void const* kth_block_const_t;
 typedef void* kth_block_indexes_t;
+typedef void* kth_block_indexes_mut_t;
+typedef void const* kth_block_indexes_const_t;
 typedef void* kth_block_list_t;
+typedef void* kth_block_list_mut_t;
+typedef void const* kth_block_list_const_t;
 typedef void* kth_compact_block_t;
 typedef void* kth_double_spend_proof_t;
 typedef void* kth_double_spend_proof_spender_t;
@@ -151,6 +157,8 @@ typedef void* kth_transaction_t;
 typedef void* kth_transaction_mut_t;
 typedef void const* kth_transaction_const_t;
 typedef void* kth_transaction_list_t;
+typedef void* kth_transaction_list_mut_t;
+typedef void const* kth_transaction_list_const_t;
 typedef void* kth_mempool_transaction_t;
 typedef void* kth_mempool_transaction_list_t;
 typedef void* kth_get_blocks_t;

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,162 +7,327 @@
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/domain/chain/block.hpp>
 
-#include <kth/domain/chain/transaction.hpp>
-
-KTH_CONV_DEFINE(chain, kth_block_t, kth::domain::chain::block, block)
+// Conversion functions
+kth::domain::chain::block& kth_chain_block_mut_cpp(kth_block_mut_t o) {
+    return *static_cast<kth::domain::chain::block*>(o);
+}
+kth::domain::chain::block const& kth_chain_block_const_cpp(kth_block_const_t o) {
+    return *static_cast<kth::domain::chain::block const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_block_t kth_chain_block_construct_default() {
+// Constructors
+
+kth_block_mut_t kth_chain_block_construct_default(void) {
     return new kth::domain::chain::block();
 }
 
-kth_block_t kth_chain_block_construct(kth_header_t header, kth_transaction_list_t transactions) {
+kth_error_code_t kth_chain_block_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_block_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, n));
+    auto wire_cpp = kth::int_to_bool(wire);
+    auto result = kth::domain::chain::block::from_data(data_cpp, wire_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::chain::block(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transaction_list_const_t transactions) {
+    KTH_PRECONDITION(header != nullptr);
+    KTH_PRECONDITION(transactions != nullptr);
     auto const& header_cpp = kth_chain_header_const_cpp(header);
-    auto const& txs_cpp = kth_chain_transaction_list_const_cpp(transactions);
-    return new kth::domain::chain::block(header_cpp, txs_cpp);
+    auto const& transactions_cpp = kth_chain_transaction_list_const_cpp(transactions);
+    return new kth::domain::chain::block(header_cpp, transactions_cpp);
 }
 
-kth_block_t kth_chain_block_factory_from_data(uint8_t* data, kth_size_t n) {
-    kth::data_chunk data_cpp(data, std::next(data, n));
-    kth::byte_reader reader(data_cpp);
-    auto res = kth::domain::chain::block::from_data(reader);
-    if ( ! res) {
-        return kth::move_or_copy_and_leak(kth::domain::chain::block{});
-    }
-    return kth::move_or_copy_and_leak(std::move(*res));
+
+// Static factories
+
+kth_block_mut_t kth_chain_block_genesis_mainnet(void) {
+    return new kth::domain::chain::block(kth::domain::chain::block::genesis_mainnet());
 }
 
-void kth_chain_block_destruct(kth_block_t block) {
-    delete &kth_chain_block_cpp(block);
+kth_block_mut_t kth_chain_block_genesis_testnet(void) {
+    return new kth::domain::chain::block(kth::domain::chain::block::genesis_testnet());
 }
 
-kth_bool_t kth_chain_block_is_valid(kth_block_t block) {
-    return kth::bool_to_int(kth_chain_block_const_cpp(block).is_valid());
+kth_block_mut_t kth_chain_block_genesis_regtest(void) {
+    return new kth::domain::chain::block(kth::domain::chain::block::genesis_regtest());
 }
 
-kth_header_t kth_chain_block_header(kth_block_t block) {
-    return &kth_chain_block_cpp(block).header();
+kth_block_mut_t kth_chain_block_genesis_testnet4(void) {
+    return new kth::domain::chain::block(kth::domain::chain::block::genesis_testnet4());
 }
 
-kth_hash_t kth_chain_block_hash(kth_block_t block) {
-    auto const& hash_cpp = kth_chain_block_const_cpp(block).hash();
-    return kth::to_hash_t(hash_cpp);
+kth_block_mut_t kth_chain_block_genesis_scalenet(void) {
+    return new kth::domain::chain::block(kth::domain::chain::block::genesis_scalenet());
 }
 
-void kth_chain_block_hash_out(kth_block_t block, kth_hash_t* out_hash) {
-    auto const& hash_cpp = kth_chain_block_const_cpp(block).hash();
-    kth::copy_c_hash(hash_cpp, out_hash);
+kth_block_mut_t kth_chain_block_genesis_chipnet(void) {
+    return new kth::domain::chain::block(kth::domain::chain::block::genesis_chipnet());
 }
 
-char const* kth_chain_block_proof_str(kth_block_t block) {
-    auto proof_str = kth_chain_block_const_cpp(block).proof().str();
-    return kth::create_c_str(proof_str);
+
+// Destructor
+
+void kth_chain_block_destruct(kth_block_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_block_mut_cpp(self);
 }
 
-kth_transaction_list_t kth_chain_block_transactions(kth_block_t block) {
-    auto& block_cpp = kth_chain_block_cpp(block);
-    return kth_chain_transaction_list_construct_from_cpp(block_cpp.transactions()); // TODO(fernando): block::transactions() is deprecated... check how to do it better...
+
+// Copy
+
+kth_block_mut_t kth_chain_block_copy(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::chain::block(kth_chain_block_const_cpp(self));
 }
 
-// -----------------------
 
-kth_size_t kth_chain_block_serialized_size(kth_block_t block) {
-    return kth_chain_block_const_cpp(block).serialized_size();
+// Equality
+
+kth_bool_t kth_chain_block_equals(kth_block_const_t self, kth_block_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self) == kth_chain_block_const_cpp(other));
 }
 
-/*static*/
-uint64_t kth_chain_block_subsidy(kth_size_t height) {
-    return kth::domain::chain::block::subsidy(height);
+
+// Serialization
+
+uint8_t* kth_chain_block_to_data_simple(kth_block_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto data = kth_chain_block_const_cpp(self).to_data();
+    return kth::create_c_array(data, *out_size);
 }
 
-//static uint256_t kth_chain_block_proof(uint32_t bits) {}
-
-///*static*/
-
-uint64_t kth_chain_block_fees(kth_block_t block) {
-    return kth_chain_block_const_cpp(block).fees();
+kth_size_t kth_chain_block_serialized_size(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_block_const_cpp(self).serialized_size();
 }
 
-uint64_t kth_chain_block_claim(kth_block_t block) {
-    return kth_chain_block_const_cpp(block).claim();
+uint8_t* kth_chain_block_to_data(kth_block_const_t self, kth_size_t serialized_size, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto serialized_size_cpp = static_cast<size_t>(serialized_size);
+    auto data = kth_chain_block_const_cpp(self).to_data(serialized_size_cpp);
+    return kth::create_c_array(data, *out_size);
 }
 
-uint64_t kth_chain_block_reward(kth_block_t block, kth_size_t height) {
-    return kth_chain_block_const_cpp(block).reward(height);
+
+// Getters
+
+kth_size_t kth_chain_block_signature_operations_simple(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_block_const_cpp(self).signature_operations();
 }
 
-//uint256_t kth_chain_block_proof(kth_block_t block) {}
-//hash_digest kth_chain_block_generate_merkle_root(kth_block_t block) {}
-
-//kth_hash_t kth_chain_block_generate_merkle_root(kth_block_t block) {
-//    auto hash_cpp = kth_chain_block_const_cpp(block).generate_merkle_root();
-//    uint8_t* ret = (uint8_t*)malloc(hash_cpp.size() * sizeof(uint8_t));
-//    std::copy_n(std::begin(hash_cpp), hash_cpp.size(), ret);
-//    return ret;
-//}
-
-kth_hash_t kth_chain_block_generate_merkle_root(kth_block_t block) {
-    auto hash_cpp = kth_chain_block_const_cpp(block).generate_merkle_root();
-    return kth::to_hash_t(hash_cpp);
+kth_error_code_t kth_chain_block_check(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return static_cast<kth_error_code_t>((kth_chain_block_const_cpp(self).check()).value());
 }
 
-void kth_chain_block_generate_merkle_root_out(kth_block_t block, kth_hash_t* out_merkle) {
-    auto hash_cpp = kth_chain_block_const_cpp(block).generate_merkle_root();
-    kth::copy_c_hash(hash_cpp, out_merkle);
+kth_error_code_t kth_chain_block_connect(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return static_cast<kth_error_code_t>((kth_chain_block_const_cpp(self).connect()).value());
 }
 
-kth_size_t kth_chain_block_signature_operations(kth_block_t block) {
-    return kth_chain_block_const_cpp(block).signature_operations();
+kth_hash_list_mut_t kth_chain_block_to_hashes(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new std::vector<std::array<unsigned char, 32>>(kth_chain_block_const_cpp(self).to_hashes());
 }
 
-kth_size_t kth_chain_block_signature_operations_bip16_active(kth_block_t block, kth_bool_t bip16_active) {
-#if defined(KTH_CURRENCY_BCH)
-    kth_bool_t bip141_active = 0;
-#else
-    kth_bool_t bip141_active = 1;
-#endif
-
-    return kth_chain_block_const_cpp(block).signature_operations(kth::int_to_bool(bip16_active), kth::int_to_bool(bip141_active));
+kth_header_const_t kth_chain_block_header(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth_chain_block_const_cpp(self).header());
 }
 
-kth_size_t kth_chain_block_total_inputs(kth_block_t block, kth_bool_t with_coinbase=1) {
-    return kth_chain_block_const_cpp(block).total_inputs(kth::int_to_bool(with_coinbase));
+kth_transaction_list_const_t kth_chain_block_transactions(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth_chain_block_const_cpp(self).transactions());
 }
 
-kth_bool_t kth_chain_block_is_extra_coinbases(kth_block_t block) {
-    return kth::bool_to_int(kth_chain_block_const_cpp(block).is_extra_coinbases());
+kth_hash_t kth_chain_block_hash(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto value_cpp = kth_chain_block_const_cpp(self).hash();
+    return kth::to_hash_t(value_cpp);
 }
 
-kth_bool_t kth_chain_block_is_final(kth_block_t block, kth_size_t height, uint32_t kth_block_time) {
-    return kth::bool_to_int(kth_chain_block_const_cpp(block).is_final(height, kth_block_time));
+uint64_t kth_chain_block_fees(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_block_const_cpp(self).fees();
 }
 
-kth_bool_t kth_chain_block_is_distinct_transaction_set(kth_block_t block) {
-    return kth::bool_to_int(kth_chain_block_const_cpp(block).is_distinct_transaction_set());
+uint64_t kth_chain_block_claim(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_block_const_cpp(self).claim();
 }
 
-kth_bool_t kth_chain_block_is_valid_coinbase_claim(kth_block_t block, kth_size_t height) {
-    return kth::bool_to_int(kth_chain_block_const_cpp(block).is_valid_coinbase_claim(height));
+kth_hash_t kth_chain_block_generate_merkle_root(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto value_cpp = kth_chain_block_const_cpp(self).generate_merkle_root();
+    return kth::to_hash_t(value_cpp);
 }
 
-kth_bool_t kth_chain_block_is_valid_coinbase_script(kth_block_t block, kth_size_t height) {
-    return kth::bool_to_int(kth_chain_block_const_cpp(block).is_valid_coinbase_script(height));
+kth_error_code_t kth_chain_block_check_transactions(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return static_cast<kth_error_code_t>((kth_chain_block_const_cpp(self).check_transactions()).value());
 }
 
-kth_bool_t kth_chain_block_is_internal_double_spend(kth_block_t block) {
-    return kth::bool_to_int(kth_chain_block_const_cpp(block).is_internal_double_spend());
+kth_size_t kth_chain_block_non_coinbase_input_count(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_block_const_cpp(self).non_coinbase_input_count();
 }
 
-kth_bool_t kth_chain_block_is_valid_merkle_root(kth_block_t block) {
-    return kth::bool_to_int(kth_chain_block_const_cpp(block).is_valid_merkle_root());
+
+// Setters
+
+void kth_chain_block_set_transactions(kth_block_mut_t self, kth_transaction_list_const_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const& value_cpp = kth_chain_transaction_list_const_cpp(value);
+    kth_chain_block_mut_cpp(self).set_transactions(value_cpp);
 }
 
-uint8_t const* kth_chain_block_to_data(kth_block_t block, kth_bool_t wire, kth_size_t* out_size) {
-    auto block_data = kth_chain_block_const_cpp(block).to_data(kth::int_to_bool(wire));
-    return kth::create_c_array(block_data, *out_size);
+void kth_chain_block_set_header(kth_block_mut_t self, kth_header_const_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const& value_cpp = kth_chain_header_const_cpp(value);
+    kth_chain_block_mut_cpp(self).set_header(value_cpp);
+}
+
+
+// Predicates
+
+kth_bool_t kth_chain_block_is_valid(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_valid());
+}
+
+kth_bool_t kth_chain_block_is_extra_coinbases(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_extra_coinbases());
+}
+
+kth_bool_t kth_chain_block_is_final(kth_block_const_t self, kth_size_t height, uint32_t block_time) {
+    KTH_PRECONDITION(self != nullptr);
+    auto height_cpp = static_cast<size_t>(height);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_final(height_cpp, block_time));
+}
+
+kth_bool_t kth_chain_block_is_distinct_transaction_set(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_distinct_transaction_set());
+}
+
+kth_bool_t kth_chain_block_is_valid_coinbase_claim(kth_block_const_t self, kth_size_t height) {
+    KTH_PRECONDITION(self != nullptr);
+    auto height_cpp = static_cast<size_t>(height);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_valid_coinbase_claim(height_cpp));
+}
+
+kth_bool_t kth_chain_block_is_valid_coinbase_script(kth_block_const_t self, kth_size_t height) {
+    KTH_PRECONDITION(self != nullptr);
+    auto height_cpp = static_cast<size_t>(height);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_valid_coinbase_script(height_cpp));
+}
+
+kth_bool_t kth_chain_block_is_forward_reference(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_forward_reference());
+}
+
+kth_bool_t kth_chain_block_is_canonical_ordered(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_canonical_ordered());
+}
+
+kth_bool_t kth_chain_block_is_internal_double_spend(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_internal_double_spend());
+}
+
+kth_bool_t kth_chain_block_is_valid_merkle_root(kth_block_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_block_const_cpp(self).is_valid_merkle_root());
+}
+
+
+// Operations
+
+kth_size_t kth_chain_block_total_inputs(kth_block_const_t self, kth_bool_t with_coinbase) {
+    KTH_PRECONDITION(self != nullptr);
+    auto with_coinbase_cpp = kth::int_to_bool(with_coinbase);
+    return kth_chain_block_const_cpp(self).total_inputs(with_coinbase_cpp);
+}
+
+kth_error_code_t kth_chain_block_accept(kth_block_const_t self, kth_script_flags_t flags, kth_size_t height, uint32_t median_time_past, kth_size_t max_block_size_dynamic, kth_size_t max_sigops, kth_bool_t is_under_checkpoint, kth_bool_t transactions) {
+    KTH_PRECONDITION(self != nullptr);
+    auto height_cpp = static_cast<size_t>(height);
+    auto max_block_size_dynamic_cpp = static_cast<size_t>(max_block_size_dynamic);
+    auto max_sigops_cpp = static_cast<size_t>(max_sigops);
+    auto is_under_checkpoint_cpp = kth::int_to_bool(is_under_checkpoint);
+    auto transactions_cpp = kth::int_to_bool(transactions);
+    return static_cast<kth_error_code_t>((kth_chain_block_const_cpp(self).accept(flags, height_cpp, median_time_past, max_block_size_dynamic_cpp, max_sigops_cpp, is_under_checkpoint_cpp, transactions_cpp)).value());
+}
+
+uint64_t kth_chain_block_reward(kth_block_const_t self, kth_size_t height) {
+    KTH_PRECONDITION(self != nullptr);
+    auto height_cpp = static_cast<size_t>(height);
+    return kth_chain_block_const_cpp(self).reward(height_cpp);
+}
+
+kth_size_t kth_chain_block_signature_operations(kth_block_const_t self, kth_bool_t bip16, kth_bool_t bip141) {
+    KTH_PRECONDITION(self != nullptr);
+    auto bip16_cpp = kth::int_to_bool(bip16);
+    auto bip141_cpp = kth::int_to_bool(bip141);
+    return kth_chain_block_const_cpp(self).signature_operations(bip16_cpp, bip141_cpp);
+}
+
+kth_error_code_t kth_chain_block_accept_transactions(kth_block_const_t self, kth_script_flags_t flags, kth_size_t height, uint32_t median_time_past, kth_size_t max_sigops, kth_bool_t is_under_checkpoint) {
+    KTH_PRECONDITION(self != nullptr);
+    auto height_cpp = static_cast<size_t>(height);
+    auto max_sigops_cpp = static_cast<size_t>(max_sigops);
+    auto is_under_checkpoint_cpp = kth::int_to_bool(is_under_checkpoint);
+    return static_cast<kth_error_code_t>((kth_chain_block_const_cpp(self).accept_transactions(flags, height_cpp, median_time_past, max_sigops_cpp, is_under_checkpoint_cpp)).value());
+}
+
+kth_error_code_t kth_chain_block_connect_transactions(kth_block_const_t self, kth_chain_state_const_t state) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(state != nullptr);
+    auto const& state_cpp = kth_chain_chain_state_const_cpp(state);
+    return static_cast<kth_error_code_t>((kth_chain_block_const_cpp(self).connect_transactions(state_cpp)).value());
+}
+
+void kth_chain_block_reset(kth_block_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_block_mut_cpp(self).reset();
+}
+
+
+// Static utilities
+
+kth_size_t kth_chain_block_locator_size(kth_size_t top) {
+    auto top_cpp = static_cast<size_t>(top);
+    return kth::domain::chain::block::locator_size(top_cpp);
+}
+
+kth_block_indexes_mut_t kth_chain_block_locator_heights(kth_size_t top) {
+    auto top_cpp = static_cast<size_t>(top);
+    return new std::vector<size_t>(kth::domain::chain::block::locator_heights(top_cpp));
+}
+
+uint64_t kth_chain_block_subsidy(kth_size_t height, kth_bool_t retarget) {
+    auto height_cpp = static_cast<size_t>(height);
+    auto retarget_cpp = kth::int_to_bool(retarget);
+    return kth::domain::chain::block::subsidy(height_cpp, retarget_cpp);
 }
 
 } // extern "C"

--- a/src/c-api/src/chain/block_list.cpp
+++ b/src/c-api/src/chain/block_list.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,13 +6,51 @@
 
 #include <kth/capi/chain/block.h>
 #include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
 
-
-KTH_LIST_DEFINE_CONVERTERS(chain, kth_block_list_t, kth::domain::chain::block, block_list)
-KTH_LIST_DEFINE_CONSTRUCT_FROM_CPP(chain, kth_block_list_t, kth::domain::chain::block, block_list)
-
+// ---------------------------------------------------------------------------
 extern "C" {
 
-KTH_LIST_DEFINE(chain, kth_block_list_t, kth_block_t, block_list, kth::domain::chain::block, kth_chain_block_const_cpp)
+kth_block_list_mut_t kth_chain_block_list_construct_default(void) {
+    return new std::vector<kth::domain::chain::block>();
+}
+
+void kth_chain_block_list_push_back(kth_block_list_mut_t list, kth_block_const_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    static_cast<std::vector<kth::domain::chain::block>*>(list)->push_back(kth_chain_block_const_cpp(elem));
+}
+
+void kth_chain_block_list_destruct(kth_block_list_mut_t list) {
+    if (list == nullptr) return;
+    delete static_cast<std::vector<kth::domain::chain::block>*>(list);
+}
+
+kth_size_t kth_chain_block_list_count(kth_block_list_const_t list) {
+    KTH_PRECONDITION(list != nullptr);
+    return static_cast<std::vector<kth::domain::chain::block> const*>(list)->size();
+}
+
+kth_block_const_t kth_chain_block_list_nth(kth_block_list_const_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto const& vec = *static_cast<std::vector<kth::domain::chain::block> const*>(list);
+    KTH_PRECONDITION(index < vec.size());
+    return &vec[index];
+}
+
+void kth_chain_block_list_assign_at(kth_block_list_mut_t list, kth_size_t index, kth_block_const_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    auto& vec = *static_cast<std::vector<kth::domain::chain::block>*>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec[index] = kth_chain_block_const_cpp(elem);
+}
+
+void kth_chain_block_list_erase(kth_block_list_mut_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto& vec = *static_cast<std::vector<kth::domain::chain::block>*>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec.erase(vec.begin() + index);
+}
 
 } // extern "C"


### PR DESCRIPTION
## Summary
- Migrate `chain/block` C-API from legacy `void*` (`kth_block_t`) to const/mut typed handles (`kth_block_const_t` / `kth_block_mut_t`)
- Generated via `generate_capi_v2.py` — adds copy, equals, from_data with out-parameter error handling, static genesis factories, and full preconditions
- Add missing typedefs to `primitives.h` (block, block_list, block_indexes, transaction_list const/mut pairs)
- Add const/mut conversion shims to `conversions.hpp` for block and transaction_list

## Test plan
- [x] Build passes (BCH mode)
- [ ] CodeRabbit review
- [ ] Add unit tests (block.cpp) in follow-up or this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public C-API signatures for `chain/block` and `block_list` change to new const/mut handle types and add many new entry points, which can break downstream bindings and introduce ownership/lifetime pitfalls if misused. Core logic remains delegated to existing domain types, so functional risk is mostly around ABI/API compatibility and memory management.
> 
> **Overview**
> Modernizes the `chain/block` C-API by replacing legacy `kth_block_t` usage with explicit `kth_block_const_t`/`kth_block_mut_t` handles, adding ownership annotations, stricter `KTH_PRECONDITION` checks, and switching block deserialization to an error-returning `construct_from_data` out-parameter API.
> 
> Expands the surface area with new block utilities (genesis factories, copy/equality, additional serialization variants, accept/connect/check helpers, locator/subsidy helpers, and various getters/predicates), and replaces the macro-generated `block_list` API with explicit list functions that return borrowed element views.
> 
> Updates `primitives.h` typedefs and `conversions.hpp` shims to support the new const/mut handles (including `transaction_list`) while keeping other legacy converters intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faecd0f643ec4b7940c4f3a52441249ed9e901c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Expanded block creation/copy/genesis factories; getters/setters for header and transactions and explicit lifecycle control.
  - More serialization options: size queries and simple/explicit serialization paths.
  - Block-list operations: construct, append, access, assign, erase.
  - Additional validation and transaction-level accept/connect entry points.
  - New inspection/analytics: hash export, fees/claim counts, non-coinbase input counts, merkle checks, locator utilities, subsidy with retarget option.

* **Refactor**
  - API modernized to distinguish immutable vs mutable handles for safer, clearer usage; improved conversion helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->