### PR TITLE
release: 0.79.0

### DIFF
--- a/src/c-api/README.md
+++ b/src/c-api/README.md
@@ -20,7 +20,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=c-api/0.78.0 --update
+$ conan install --requires=c-api/0.79.0 --update
 ```
 
 ### "Hello, Knuth!":

--- a/src/consensus/README.md
+++ b/src/consensus/README.md
@@ -19,7 +19,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=consensus/0.78.0 --update
+$ conan install --requires=consensus/0.79.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -16,7 +16,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=database/0.78.0 --update
+$ conan install --requires=database/0.79.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/domain/README.md
+++ b/src/domain/README.md
@@ -16,7 +16,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=domain/0.78.0 --update
+$ conan install --requires=domain/0.79.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/domain/include/kth/domain/version.hpp
+++ b/src/domain/include/kth/domain/version.hpp
@@ -15,7 +15,7 @@
 namespace kth {
 
 // Version string from build system (conan -> cmake -> C++)
-inline constexpr std::string_view version = "0.80.0";
+inline constexpr std::string_view version = "0.79.0";
 
 // Currency identifier
 #if defined(KTH_CURRENCY_BCH)

--- a/src/infrastructure/README.md
+++ b/src/infrastructure/README.md
@@ -16,7 +16,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=infrastructure/0.78.0 --update
+$ conan install --requires=infrastructure/0.79.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -16,7 +16,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=network/0.78.0 --update
+$ conan install --requires=network/0.79.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).

--- a/src/node-exe/README.md
+++ b/src/node-exe/README.md
@@ -47,7 +47,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate node executable:
 
 ```
-$ conan install --requires=kth/0.78.0 --update --deploy=direct_deploy
+$ conan install --requires=kth/0.79.0 --update --deploy=direct_deploy
 
 ```
 

--- a/src/node/README.md
+++ b/src/node/README.md
@@ -18,7 +18,7 @@ $ conan config install https://github.com/k-nuth/ci-utils/raw/master/conan/confi
 2. Install the appropriate library:
 
 ```
-$ conan install --requires=node/0.78.0 --update
+$ conan install --requires=node/0.79.0 --update
 ```
 
 For more more detailed instructions, please refer to our [documentation](https://kth.cash/docs/).


### PR DESCRIPTION
release: 0.79.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/version-constant updates only, with no functional logic changes. Main risk is consumers relying on the previously published `0.80.0` version string.
> 
> **Overview**
> Updates module READMEs (`c-api`, `consensus`, `database`, `domain`, `infrastructure`, `network`, `node`, and `node-exe`) to reference Conan package version `0.79.0` instead of `0.78.0`.
> 
> Aligns the generated `src/domain/include/kth/domain/version.hpp` `kth::version` string to `0.79.0` (from `0.80.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cfd85617c132c110a4cf6e043f19f345ee2bcce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->