### PR TITLE
refactor(c-api): unify and harden wallet/payment_address bindings

### DIFF
--- a/src/c-api/console/main.cpp
+++ b/src/c-api/console/main.cpp
@@ -85,12 +85,15 @@ int main(int /*argc*/, char* /*argv*/[]) {
     // std::signal(SIGTERM, handle_stop);
 
 
-    auto pa = kth_wallet_payment_address_construct_from_string("1KcSdYdo4LJj2n5iHt5Hn3WEJQ6wWyPU3n");
-    auto valid = kth_wallet_payment_address_is_valid(pa);
-    auto address_str = kth_wallet_payment_address_encoded(pa);
+    auto pa = kth_wallet_payment_address_construct_from_address("1KcSdYdo4LJj2n5iHt5Hn3WEJQ6wWyPU3n");
+    auto valid = kth_wallet_payment_address_valid(pa);
+    auto address_str = kth_wallet_payment_address_encoded_legacy(pa);
     auto cash_address_str = kth_wallet_payment_address_encoded_cashaddr(pa, false);
     std::println("{}", address_str);
     std::println("{}", cash_address_str);
+    kth_core_destruct_string(address_str);
+    kth_core_destruct_string(cash_address_str);
+    kth_wallet_payment_address_destruct(pa);
 
 
 

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -27,7 +27,9 @@
 #include <kth/domain/message/get_headers.hpp>
 #include <kth/domain/message/merkle_block.hpp>
 #include <kth/domain/message/prefilled_transaction.hpp>
-// #include <kth/domain/wallet/ec_public.hpp>
+#include <kth/domain/wallet/ec_private.hpp>
+#include <kth/domain/wallet/ec_public.hpp>
+#include <kth/domain/wallet/payment_address.hpp>
 #include <kth/domain/wallet/wallet_manager.hpp>
 
 // #ifndef __EMSCRIPTEN__
@@ -251,13 +253,48 @@ KTH_LIST_DECLARE_CONVERTERS(chain, kth_operation_list_t, kth::domain::machine::o
 
 // Wallet.
 // ------------------------------------------------------------------------------------
-KTH_CONV_DECLARE(wallet, kth_payment_address_t, kth::domain::wallet::payment_address, payment_address)
+
+// ec_private — partial registration (not fully migrated yet). The legacy
+// KTH_CONV_DECLARE produces the void*-based overloads; the inline
+// converters here add the const_t/mut_t overloads so generated code that
+// takes kth_ec_private_const_t can resolve correctly.
 KTH_CONV_DECLARE(wallet, kth_ec_private_t, kth::domain::wallet::ec_private, ec_private)
+inline kth::domain::wallet::ec_private const&
+kth_wallet_ec_private_const_cpp(kth_ec_private_const_t o) {
+    return *static_cast<kth::domain::wallet::ec_private const*>(o);
+}
+inline kth::domain::wallet::ec_private&
+kth_wallet_ec_private_mut_cpp(kth_ec_private_mut_t o) {
+    return *static_cast<kth::domain::wallet::ec_private*>(o);
+}
+
+// ec_public — same partial registration pattern.
 KTH_CONV_DECLARE(wallet, kth_ec_public_t, kth::domain::wallet::ec_public, ec_public)
+inline kth::domain::wallet::ec_public const&
+kth_wallet_ec_public_const_cpp(kth_ec_public_const_t o) {
+    return *static_cast<kth::domain::wallet::ec_public const*>(o);
+}
+inline kth::domain::wallet::ec_public&
+kth_wallet_ec_public_mut_cpp(kth_ec_public_mut_t o) {
+    return *static_cast<kth::domain::wallet::ec_public*>(o);
+}
+
+// payment_address conversion functions. Defined in src/wallet/payment_address.cpp.
+kth::domain::wallet::payment_address const& kth_wallet_payment_address_const_cpp(kth_payment_address_const_t o);
+kth::domain::wallet::payment_address&       kth_wallet_payment_address_mut_cpp(kth_payment_address_mut_t o);
+
 KTH_CONV_DECLARE(wallet, kth_wallet_data_t, kth::domain::wallet::wallet_data, wallet_data)
 
-KTH_LIST_DECLARE_CONSTRUCT_FROM_CPP_BOTH(wallet, kth_payment_address_list_t, kth::domain::wallet::payment_address, payment_address_list)
-KTH_LIST_DECLARE_CONVERTERS(wallet, kth_payment_address_list_t, kth::domain::wallet::payment_address, payment_address_list)
+// payment_address_list — inline converters for the generated list binding.
+inline std::vector<kth::domain::wallet::payment_address> const&
+kth_wallet_payment_address_list_const_cpp(kth_payment_address_list_const_t l) {
+    return *static_cast<std::vector<kth::domain::wallet::payment_address> const*>(l);
+}
+inline std::vector<kth::domain::wallet::payment_address>&
+kth_wallet_payment_address_list_mut_cpp(kth_payment_address_list_mut_t l) {
+    return *static_cast<std::vector<kth::domain::wallet::payment_address>*>(l);
+}
+
 
 // Core.
 // ------------------------------------------------------------------------------------

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -11,6 +11,7 @@
 #include <type_traits>
 #include <utility>
 
+#include <kth/capi/wallet/primitives.h>
 #include <kth/domain/config/network.hpp>
 #include <kth/domain/machine/opcode.hpp>
 #include <kth/domain/wallet/wallet_manager.hpp>
@@ -191,6 +192,20 @@ kth::long_hash long_hash_to_cpp(uint8_t const* x) {
     return ret;
 }
 
+inline
+kth_payment_t to_payment_t(kth::domain::wallet::payment const& x) {
+    kth_payment_t ret;
+    std::copy_n(x.begin(), x.size(), ret.hash);
+    return ret;
+}
+
+inline
+kth::domain::wallet::payment payment_to_cpp(uint8_t const* x) {
+    kth::domain::wallet::payment ret;
+    std::copy_n(x, ret.size(), std::begin(ret));
+    return ret;
+}
+
 template <typename T>
 inline
 T* mnew(std::size_t n = 1) {
@@ -229,8 +244,10 @@ CharT* allocate_and_copy_c_str(CharT const* str) {
 template <typename StrT>
 inline
 auto* create_c_str(StrT const& str) {
-    auto* c_str = mnew<typename StrT::value_type>(str.size() + 1);
-    std::copy_n(str.c_str(), str.size() + 1, c_str);
+    using CharT = typename StrT::value_type;
+    auto* c_str = mnew<CharT>(str.size() + 1);
+    std::copy_n(str.data(), str.size(), c_str);
+    c_str[str.size()] = CharT{};  // null-terminate (works for string_view too)
     return c_str;
 }
 

--- a/src/c-api/include/kth/capi/wallet/payment_address.h
+++ b/src/c-api/include/kth/capi/wallet/payment_address.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,68 +9,168 @@
 
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
-
 #include <kth/capi/wallet/primitives.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// Constructors
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_default(void);
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded(kth_payment_t decoded);
+
+/**
+ * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @warning `decoded` MUST point to a buffer of at least 25 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded_unsafe(uint8_t const* decoded);
+
+/**
+ * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @param secret Borrowed input. Copied by value into the resulting object; ownership of `secret` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_private(kth_ec_private_const_t secret);
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address(char const* address);
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address_net(char const* address, kth_network_t net);
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t short_hash, uint8_t version);
+
+/**
+ * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @warning `short_hash` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version_unsafe(uint8_t const* short_hash, uint8_t version);
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version(kth_hash_t hash, uint8_t version);
+
+/**
+ * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version_unsafe(uint8_t const* hash, uint8_t version);
+
+/**
+ * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @param point Borrowed input. Copied by value into the resulting object; ownership of `point` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_public_version(kth_ec_public_const_t point, uint8_t version);
+
+/**
+ * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @param script Borrowed input. Copied by value into the resulting object; ownership of `script` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_script_version(kth_script_const_t script, uint8_t version);
+
+
+// Static factories
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
 KTH_EXPORT
-kth_payment_address_t kth_wallet_payment_address_construct_from_string(char const* address);
+void kth_wallet_payment_address_destruct(kth_payment_address_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_payment_address_copy(kth_payment_address_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-kth_payment_address_t kth_wallet_payment_address_construct_from_short_hash(kth_shorthash_t const* hash, uint8_t version);
+kth_bool_t kth_wallet_payment_address_equals(kth_payment_address_const_t self, kth_payment_address_const_t other);
+
+
+// Getters
 
 KTH_EXPORT
-kth_payment_address_t kth_wallet_payment_address_construct_from_hash(kth_hash_t const* hash, uint8_t version);
+kth_bool_t kth_wallet_payment_address_valid(kth_payment_address_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_payment_address_encoded_legacy(kth_payment_address_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_payment_address_encoded_token(kth_payment_address_const_t self);
 
 KTH_EXPORT
-kth_payment_address_t kth_wallet_payment_address_construct_from_public(kth_ec_public_t point, uint8_t version);
+uint8_t kth_wallet_payment_address_version(kth_payment_address_const_t self);
+
+/** @return Borrowed pointer into `self`. Do not free. Length is written to `out_size`. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+uint8_t const* kth_wallet_payment_address_hash_span(kth_payment_address_const_t self, kth_size_t* out_size);
 
 KTH_EXPORT
-kth_payment_address_t kth_wallet_payment_address_construct_from_script(kth_script_const_t script, uint8_t version);
+kth_shorthash_t kth_wallet_payment_address_hash20(kth_payment_address_const_t self);
 
 KTH_EXPORT
-kth_payment_address_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version);
+kth_hash_t kth_wallet_payment_address_hash32(kth_payment_address_const_t self);
 
 KTH_EXPORT
-void kth_wallet_payment_address_destruct(kth_payment_address_t payment_address);
+kth_payment_t kth_wallet_payment_address_to_payment(kth_payment_address_const_t self);
+
+
+// Operations
 
 KTH_EXPORT
-char* kth_wallet_payment_address_encoded_legacy(kth_payment_address_t payment_address);
+kth_bool_t kth_wallet_payment_address_less(kth_payment_address_const_t self, kth_payment_address_const_t x);
 
-#if defined(KTH_CURRENCY_BCH)
-KTH_EXPORT
-char* kth_wallet_payment_address_encoded_cashaddr(kth_payment_address_t payment_address, kth_bool_t token_aware);
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_payment_address_encoded_cashaddr(kth_payment_address_const_t self, kth_bool_t token_aware);
 
-KTH_EXPORT
-char* kth_wallet_payment_address_encoded_token(kth_payment_address_t payment_address);
-#endif //KTH_CURRENCY_BCH
 
-KTH_EXPORT
-kth_shorthash_t kth_wallet_payment_address_hash20(kth_payment_address_t payment_address);
+// Static utilities
 
-KTH_EXPORT
-kth_hash_t kth_wallet_payment_address_hash32(kth_payment_address_t payment_address);
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_payment_address_cashaddr_prefix_for(kth_network_t net);
 
-KTH_EXPORT
-uint8_t kth_wallet_payment_address_version(kth_payment_address_t payment_address);
+/** @return Owned `kth_payment_address_list_mut_t`. Caller must release with `kth_wallet_payment_address_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_list_mut_t kth_wallet_payment_address_extract(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version);
 
-KTH_EXPORT
-kth_bool_t kth_wallet_payment_address_is_valid(kth_payment_address_t payment_address);
+/** @return Owned `kth_payment_address_list_mut_t`. Caller must release with `kth_wallet_payment_address_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_list_mut_t kth_wallet_payment_address_extract_input(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version);
 
-KTH_EXPORT
-kth_payment_address_list_const_t kth_wallet_payment_address_extract(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version);
-
-KTH_EXPORT
-kth_payment_address_list_const_t kth_wallet_payment_address_extract_input(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version);
-
-KTH_EXPORT
-kth_payment_address_list_const_t kth_wallet_payment_address_extract_output(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version);
+/** @return Owned `kth_payment_address_list_mut_t`. Caller must release with `kth_wallet_payment_address_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_list_mut_t kth_wallet_payment_address_extract_output(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_WALLET_PAYMENT_ADDRESS_H_ */
+#endif // KTH_CAPI_WALLET_PAYMENT_ADDRESS_H_

--- a/src/c-api/include/kth/capi/wallet/payment_address_list.h
+++ b/src/c-api/include/kth/capi/wallet/payment_address_list.h
@@ -1,11 +1,12 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef KTH_CAPI_WALLET_PAYMENT_ADDRESS_LIST_H_
 #define KTH_CAPI_WALLET_PAYMENT_ADDRESS_LIST_H_
 
-#include <kth/capi/list_creator.h>
+#include <stdint.h>
+
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
 
@@ -13,7 +14,29 @@
 extern "C" {
 #endif
 
-KTH_LIST_DECLARE(wallet, kth_payment_address_list_t, kth_payment_address_t, payment_address_list)
+/** @return Owned `kth_payment_address_list_mut_t`. Caller must release with `kth_wallet_payment_address_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_list_mut_t kth_wallet_payment_address_list_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_payment_address_list_push_back(kth_payment_address_list_mut_t list, kth_payment_address_const_t elem);
+
+/** No-op if `list` is null. */
+KTH_EXPORT
+void kth_wallet_payment_address_list_destruct(kth_payment_address_list_mut_t list);
+
+KTH_EXPORT
+kth_size_t kth_wallet_payment_address_list_count(kth_payment_address_list_const_t list);
+
+/** @return Borrowed `kth_payment_address_const_t` view into the list. Do not destruct; the list retains ownership. Invalidated by any mutation of the list. */
+KTH_EXPORT
+kth_payment_address_const_t kth_wallet_payment_address_list_nth(kth_payment_address_list_const_t list, kth_size_t index);
+
+KTH_EXPORT
+void kth_wallet_payment_address_list_assign_at(kth_payment_address_list_mut_t list, kth_size_t index, kth_payment_address_const_t elem);
+
+KTH_EXPORT
+void kth_wallet_payment_address_list_erase(kth_payment_address_list_mut_t list, kth_size_t index);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/wallet/primitives.h
+++ b/src/c-api/include/kth/capi/wallet/primitives.h
@@ -57,9 +57,18 @@ typedef struct {
     uint8_t data[KTH_EC_SIGNATURE_SIZE];
 } kth_ec_signature_t;
 
+#define KTH_BITCOIN_PAYMENT_SIZE 25
+typedef struct kth_payment_t {
+    uint8_t hash[KTH_BITCOIN_PAYMENT_SIZE];
+} kth_payment_t;
+
 
 typedef void* kth_ec_private_t;
+typedef void* kth_ec_private_mut_t;
+typedef void const* kth_ec_private_const_t;
 typedef void* kth_ec_public_t;
+typedef void* kth_ec_public_mut_t;
+typedef void const* kth_ec_public_const_t;
 typedef void* kth_hd_private_t;
 typedef void* kth_hd_public_t;
 

--- a/src/c-api/src/wallet/payment_address.cpp
+++ b/src/c-api/src/wallet/payment_address.cpp
@@ -1,120 +1,221 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <kth/capi/wallet/payment_address.h>
 
+#include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
-#include <kth/capi/type_conversions.h>
-
 #include <kth/domain/wallet/payment_address.hpp>
 
-#include <kth/capi/conversions.hpp>
-
-KTH_CONV_DEFINE(wallet, kth_payment_address_t, kth::domain::wallet::payment_address, payment_address)
+// Conversion functions
+kth::domain::wallet::payment_address& kth_wallet_payment_address_mut_cpp(kth_payment_address_mut_t o) {
+    return *static_cast<kth::domain::wallet::payment_address*>(o);
+}
+kth::domain::wallet::payment_address const& kth_wallet_payment_address_const_cpp(kth_payment_address_const_t o) {
+    return *static_cast<kth::domain::wallet::payment_address const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_payment_address_t kth_wallet_payment_address_construct_from_string(char const* address) {
-    return new kth::domain::wallet::payment_address(std::string(address));
+// Constructors
+
+kth_payment_address_mut_t kth_wallet_payment_address_construct_default(void) {
+    return new kth::domain::wallet::payment_address();
 }
 
-kth_payment_address_t kth_wallet_payment_address_construct_from_short_hash(kth_shorthash_t const* hash, uint8_t version) {
-    auto const hash_cpp = kth::short_hash_to_cpp(hash->hash);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded(kth_payment_t decoded) {
+    auto const decoded_cpp = kth::payment_to_cpp(decoded.hash);
+    return new kth::domain::wallet::payment_address(decoded_cpp);
+}
+
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded_unsafe(uint8_t const* decoded) {
+    KTH_PRECONDITION(decoded != nullptr);
+    auto const decoded_cpp = kth::payment_to_cpp(decoded);
+    return new kth::domain::wallet::payment_address(decoded_cpp);
+}
+
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_private(kth_ec_private_const_t secret) {
+    KTH_PRECONDITION(secret != nullptr);
+    auto const& secret_cpp = kth_wallet_ec_private_const_cpp(secret);
+    return new kth::domain::wallet::payment_address(secret_cpp);
+}
+
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address(char const* address) {
+    KTH_PRECONDITION(address != nullptr);
+    auto const address_cpp = std::string(address);
+    return new kth::domain::wallet::payment_address(address_cpp);
+}
+
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address_net(char const* address, kth_network_t net) {
+    KTH_PRECONDITION(address != nullptr);
+    auto const address_cpp = std::string(address);
+    auto const net_cpp = static_cast<kth::domain::config::network>(net);
+    return new kth::domain::wallet::payment_address(address_cpp, net_cpp);
+}
+
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t short_hash, uint8_t version) {
+    auto const short_hash_cpp = kth::short_hash_to_cpp(short_hash.hash);
+    return new kth::domain::wallet::payment_address(short_hash_cpp, version);
+}
+
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version_unsafe(uint8_t const* short_hash, uint8_t version) {
+    KTH_PRECONDITION(short_hash != nullptr);
+    auto const short_hash_cpp = kth::short_hash_to_cpp(short_hash);
+    return new kth::domain::wallet::payment_address(short_hash_cpp, version);
+}
+
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version(kth_hash_t hash, uint8_t version) {
+    auto const hash_cpp = kth::hash_to_cpp(hash.hash);
     return new kth::domain::wallet::payment_address(hash_cpp, version);
 }
 
-kth_payment_address_t kth_wallet_payment_address_construct_from_hash(kth_hash_t const* hash, uint8_t version) {
-    auto const hash_cpp = kth::hash_to_cpp(hash->hash);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version_unsafe(uint8_t const* hash, uint8_t version) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto const hash_cpp = kth::hash_to_cpp(hash);
     return new kth::domain::wallet::payment_address(hash_cpp, version);
 }
 
-kth_payment_address_t kth_wallet_payment_address_construct_from_point(kth_ec_public_t point, uint8_t version) {
-    auto const point_cpp = kth_wallet_ec_public_const_cpp(point);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_public_version(kth_ec_public_const_t point, uint8_t version) {
+    KTH_PRECONDITION(point != nullptr);
+    auto const& point_cpp = kth_wallet_ec_public_const_cpp(point);
     return new kth::domain::wallet::payment_address(point_cpp, version);
 }
 
-kth_payment_address_t kth_wallet_payment_address_construct_from_script(kth_script_const_t script, uint8_t version) {
-    auto script_cpp = kth_chain_script_const_cpp(script);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_script_version(kth_script_const_t script, uint8_t version) {
+    KTH_PRECONDITION(script != nullptr);
+    auto const& script_cpp = kth_chain_script_const_cpp(script);
     return new kth::domain::wallet::payment_address(script_cpp, version);
 }
 
-kth_payment_address_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version) {
-    auto script_cpp = kth_chain_script_const_cpp(script);
-    auto pa = kth::domain::wallet::payment_address::from_pay_public_key_hash_script(script_cpp, version);
-    return kth::move_or_copy_and_leak(std::move(pa));
-}
 
+// Static factories
 
-void kth_wallet_payment_address_destruct(kth_payment_address_t payment_address) {
-    delete &kth_wallet_payment_address_cpp(payment_address);
-}
-
-//User is responsible for releasing return value memory
-char* kth_wallet_payment_address_encoded_legacy(kth_payment_address_t payment_address) {
-    std::string str = kth_wallet_payment_address_const_cpp(payment_address).encoded_legacy();
-    return kth::create_c_str(str);
-}
-
-#if defined(KTH_CURRENCY_BCH)
-//User is responsible for releasing return value memory
-char* kth_wallet_payment_address_encoded_cashaddr(kth_payment_address_t payment_address, kth_bool_t token_aware) {
-    std::string str = kth_wallet_payment_address_const_cpp(payment_address).encoded_cashaddr(token_aware);
-    return kth::create_c_str(str);
-}
-
-//User is responsible for releasing return value memory
-char* kth_wallet_payment_address_encoded_token(kth_payment_address_t payment_address) {
-    std::string str = kth_wallet_payment_address_const_cpp(payment_address).encoded_token();
-    return kth::create_c_str(str);
-}
-#endif //KTH_CURRENCY_BCH
-
-kth_shorthash_t kth_wallet_payment_address_hash20(kth_payment_address_t payment_address) {
-    auto hash_cpp = kth_wallet_payment_address_const_cpp(payment_address).hash20();
-    // printf("kth_wallet_payment_address_hash20()\n");
-    // for (auto i = 0; i < 20; i++) {
-    //     printf("%d ", int(hash_cpp[i]));
-    // }
-    // printf("\n");
-    return kth::to_shorthash_t(hash_cpp);
-}
-
-kth_hash_t kth_wallet_payment_address_hash32(kth_payment_address_t payment_address) {
-    auto hash_cpp = kth_wallet_payment_address_const_cpp(payment_address).hash32();
-    // printf("kth_wallet_payment_address_hash32()\n");
-    // for (auto i = 0; i < 32; i++) {
-    //     printf("%d ", int(hash_cpp[i]));
-    // }
-    // printf("\n");
-    return kth::to_hash_t(hash_cpp);
-}
-
-uint8_t kth_wallet_payment_address_version(kth_payment_address_t payment_address) {
-    return kth_wallet_payment_address_const_cpp(payment_address).version();
-}
-
-kth_bool_t kth_wallet_payment_address_is_valid(kth_payment_address_t payment_address) {
-    return kth::bool_to_int(bool(kth_wallet_payment_address_const_cpp(payment_address)));
-}
-
-kth_payment_address_list_const_t kth_wallet_payment_address_extract(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version) {
+kth_payment_address_mut_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version) {
+    KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
-    auto addrs = kth::domain::wallet::payment_address::extract(script_cpp, p2kh_version, p2sh_version);
-    return kth::move_or_copy_and_leak(std::move(addrs));
+    return new kth::domain::wallet::payment_address(kth::domain::wallet::payment_address::from_pay_public_key_hash_script(script_cpp, version));
 }
 
-kth_payment_address_list_const_t kth_wallet_payment_address_extract_input(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version) {
-    auto const& script_cpp = kth_chain_script_const_cpp(script);
-    auto addrs = kth::domain::wallet::payment_address::extract_input(script_cpp, p2kh_version, p2sh_version);
-    return kth::move_or_copy_and_leak(std::move(addrs));
+
+// Destructor
+
+void kth_wallet_payment_address_destruct(kth_payment_address_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_wallet_payment_address_mut_cpp(self);
 }
 
-kth_payment_address_list_const_t kth_wallet_payment_address_extract_output(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version) {
+
+// Copy
+
+kth_payment_address_mut_t kth_wallet_payment_address_copy(kth_payment_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::wallet::payment_address(kth_wallet_payment_address_const_cpp(self));
+}
+
+
+// Equality
+
+kth_bool_t kth_wallet_payment_address_equals(kth_payment_address_const_t self, kth_payment_address_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_wallet_payment_address_const_cpp(self) == kth_wallet_payment_address_const_cpp(other));
+}
+
+
+// Getters
+
+kth_bool_t kth_wallet_payment_address_valid(kth_payment_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_wallet_payment_address_const_cpp(self).valid());
+}
+
+char* kth_wallet_payment_address_encoded_legacy(kth_payment_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth_wallet_payment_address_const_cpp(self).encoded_legacy();
+    return kth::create_c_str(s);
+}
+
+char* kth_wallet_payment_address_encoded_token(kth_payment_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth_wallet_payment_address_const_cpp(self).encoded_token();
+    return kth::create_c_str(s);
+}
+
+uint8_t kth_wallet_payment_address_version(kth_payment_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_wallet_payment_address_const_cpp(self).version();
+}
+
+uint8_t const* kth_wallet_payment_address_hash_span(kth_payment_address_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const span = kth_wallet_payment_address_const_cpp(self).hash_span();
+    *out_size = span.size();
+    return span.data();
+}
+
+kth_shorthash_t kth_wallet_payment_address_hash20(kth_payment_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_wallet_payment_address_const_cpp(self).hash20();
+    return kth::to_shorthash_t(value_cpp);
+}
+
+kth_hash_t kth_wallet_payment_address_hash32(kth_payment_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_wallet_payment_address_const_cpp(self).hash32();
+    return kth::to_hash_t(value_cpp);
+}
+
+kth_payment_t kth_wallet_payment_address_to_payment(kth_payment_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_wallet_payment_address_const_cpp(self).to_payment();
+    return kth::to_payment_t(value_cpp);
+}
+
+
+// Operations
+
+kth_bool_t kth_wallet_payment_address_less(kth_payment_address_const_t self, kth_payment_address_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth_wallet_payment_address_const_cpp(x);
+    return kth::bool_to_int(kth_wallet_payment_address_const_cpp(self).operator<(x_cpp));
+}
+
+char* kth_wallet_payment_address_encoded_cashaddr(kth_payment_address_const_t self, kth_bool_t token_aware) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const token_aware_cpp = kth::int_to_bool(token_aware);
+    auto const s = kth_wallet_payment_address_const_cpp(self).encoded_cashaddr(token_aware_cpp);
+    return kth::create_c_str(s);
+}
+
+
+// Static utilities
+
+char* kth_wallet_payment_address_cashaddr_prefix_for(kth_network_t net) {
+    auto const net_cpp = static_cast<kth::domain::config::network>(net);
+    auto const s = kth::domain::wallet::payment_address::cashaddr_prefix_for(net_cpp);
+    return kth::create_c_str(s);
+}
+
+kth_payment_address_list_mut_t kth_wallet_payment_address_extract(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version) {
+    KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
-    auto addrs = kth::domain::wallet::payment_address::extract_output(script_cpp, p2kh_version, p2sh_version);
-    return kth::move_or_copy_and_leak(std::move(addrs));
+    return new std::vector<kth::domain::wallet::payment_address>(kth::domain::wallet::payment_address::extract(script_cpp, p2kh_version, p2sh_version));
+}
+
+kth_payment_address_list_mut_t kth_wallet_payment_address_extract_input(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version) {
+    KTH_PRECONDITION(script != nullptr);
+    auto const& script_cpp = kth_chain_script_const_cpp(script);
+    return new std::vector<kth::domain::wallet::payment_address>(kth::domain::wallet::payment_address::extract_input(script_cpp, p2kh_version, p2sh_version));
+}
+
+kth_payment_address_list_mut_t kth_wallet_payment_address_extract_output(kth_script_const_t script, uint8_t p2kh_version, uint8_t p2sh_version) {
+    KTH_PRECONDITION(script != nullptr);
+    auto const& script_cpp = kth_chain_script_const_cpp(script);
+    return new std::vector<kth::domain::wallet::payment_address>(kth::domain::wallet::payment_address::extract_output(script_cpp, p2kh_version, p2sh_version));
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/payment_address_list.cpp
+++ b/src/c-api/src/wallet/payment_address_list.cpp
@@ -1,19 +1,56 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <kth/capi/wallet/payment_address_list.h>
 
-#include <vector>
-
+#include <kth/capi/wallet/payment_address.h>
 #include <kth/capi/conversions.hpp>
-#include <kth/capi/list_creator.h>
+#include <kth/capi/helpers.hpp>
 
-#include <kth/domain/wallet/payment_address.hpp>
-
-KTH_LIST_DEFINE_CONVERTERS(wallet, kth_payment_address_list_t, kth::domain::wallet::payment_address, payment_address_list)
-KTH_LIST_DEFINE_CONSTRUCT_FROM_CPP_BOTH(wallet, kth_payment_address_list_t, kth::domain::wallet::payment_address, payment_address_list)
-
+// ---------------------------------------------------------------------------
 extern "C" {
-KTH_LIST_DEFINE(wallet, kth_payment_address_list_t, kth_payment_address_t, payment_address_list, kth::domain::wallet::payment_address, kth_wallet_payment_address_const_cpp)
+
+kth_payment_address_list_mut_t kth_wallet_payment_address_list_construct_default(void) {
+    return new std::vector<kth::domain::wallet::payment_address>();
+}
+
+void kth_wallet_payment_address_list_push_back(kth_payment_address_list_mut_t list, kth_payment_address_const_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    static_cast<std::vector<kth::domain::wallet::payment_address>*>(list)->push_back(kth_wallet_payment_address_const_cpp(elem));
+}
+
+void kth_wallet_payment_address_list_destruct(kth_payment_address_list_mut_t list) {
+    if (list == nullptr) return;
+    delete static_cast<std::vector<kth::domain::wallet::payment_address>*>(list);
+}
+
+kth_size_t kth_wallet_payment_address_list_count(kth_payment_address_list_const_t list) {
+    KTH_PRECONDITION(list != nullptr);
+    return static_cast<std::vector<kth::domain::wallet::payment_address> const*>(list)->size();
+}
+
+kth_payment_address_const_t kth_wallet_payment_address_list_nth(kth_payment_address_list_const_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto const& vec = *static_cast<std::vector<kth::domain::wallet::payment_address> const*>(list);
+    KTH_PRECONDITION(index < vec.size());
+    return &vec[index];
+}
+
+void kth_wallet_payment_address_list_assign_at(kth_payment_address_list_mut_t list, kth_size_t index, kth_payment_address_const_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    auto& vec = *static_cast<std::vector<kth::domain::wallet::payment_address>*>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec[index] = kth_wallet_payment_address_const_cpp(elem);
+}
+
+void kth_wallet_payment_address_list_erase(kth_payment_address_list_mut_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto& vec = *static_cast<std::vector<kth::domain::wallet::payment_address>*>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec.erase(vec.begin() + index);
+}
+
 } // extern "C"

--- a/src/domain/include/kth/domain/wallet/payment_address.hpp
+++ b/src/domain/include/kth/domain/wallet/payment_address.hpp
@@ -79,7 +79,7 @@ struct KD_API payment_address {
     payment_address(std::string const& address, config::network net);
 
     explicit
-    payment_address(short_hash const& hash, uint8_t version = mainnet_p2kh);
+    payment_address(short_hash const& short_hash, uint8_t version = mainnet_p2kh);
 
     explicit
     payment_address(hash_digest const& hash, uint8_t version = mainnet_p2kh);

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -55,12 +55,12 @@ payment_address::payment_address(chain::script const& script, uint8_t version)
     : payment_address(payment_address{from_script(script, version)})
 {}
 
-payment_address::payment_address(short_hash const& hash, uint8_t version)
+payment_address::payment_address(short_hash const& short_hash, uint8_t version)
     : valid_(true)
     , version_(version)
-    , hash_size_(hash.size())
+    , hash_size_(short_hash.size())
 {
-    std::copy_n(hash.begin(), hash.size(), hash_data_.begin());
+    std::copy_n(short_hash.begin(), short_hash.size(), hash_data_.begin());
 }
 
 payment_address::payment_address(hash_digest const& hash, uint8_t version)


### PR DESCRIPTION
## Summary

Migrate `kth::domain::wallet::payment_address` to the const/mut typed-handle pattern. Zero skipped methods — every public method of the C++ class is now exposed, including previously unexposed functions like `hash_span`, `to_payment`, and the new network-aware string constructor from PR #240.

## New types

- `kth_payment_t` — 25-byte value struct for the encoded payment address (1 version + 20 hash + 4 checksum).
- `kth_ec_private_mut_t` / `_const_t` — partial registration (class not fully migrated, but usable as a parameter).
- `kth_ec_public_mut_t` / `_const_t` — same partial registration.

## New / expanded API surface

**Constructors**: `construct_default`, `construct_from_decoded` (+ unsafe), `construct_from_ec_private`, `construct_from_address`, `construct_from_address_net` (network-aware), `construct_from_short_hash_version` (+ unsafe), `construct_from_hash_version` (+ unsafe), `construct_from_ec_public_version`, `construct_from_script_version`.

**Getters**: `valid`, `version`, `hash20` (kth_shorthash_t), `hash32` (kth_hash_t), `hash_span` (borrowed byte view — new!), `to_payment` (kth_payment_t — new!), `encoded_legacy`, `encoded_cashaddr`, `encoded_token`.

**Static**: `from_pay_public_key_hash_script`, `cashaddr_prefix_for` (new!), `extract` / `extract_input` / `extract_output` → `kth_payment_address_list_mut_t` (correctly owned, was incorrectly `_const_t` before).

**Operators**: `copy`, `equals`, `less`.

**List**: `payment_address_list` regenerated from macro-based to explicit code.

## Removed

- `kth_wallet_payment_address_set_cashaddr_prefix` (dead code).
- Legacy `KTH_CONV_DECLARE` / `KTH_LIST_DECLARE_CONVERTERS` macros for payment_address — replaced by inline converters.

## C++ domain change

- Renamed the `short_hash` constructor parameter from `hash` to `short_hash` so the C function names don't collide (`construct_from_short_hash_version` vs `construct_from_hash_version`).

## Test plan

- [x] `kth_capi_test` green on the maintainer's local build.
- [x] Zero skipped methods in the generator output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it reshapes the public C API for `payment_address` (new function names, ownership semantics, and handle types), which can break downstream bindings and introduces new lifetime/borrowed-pointer behaviors (`hash_span`).
> 
> **Overview**
> Refactors the C bindings for `wallet/payment_address` to use const/mut typed handles with explicit ownership annotations, expanding coverage to essentially all `payment_address` operations (new constructors including network-aware parsing, copy/equals/less, `hash_span`, `to_payment`, and `cashaddr_prefix_for`).
> 
> Replaces macro-generated `payment_address_list` bindings with explicit vector-backed list functions and fixes extraction helpers to return **owned** `kth_payment_address_list_mut_t` lists instead of `_const_t`. Also adds new wallet primitives (`kth_payment_t`, const/mut aliases for `ec_private`/`ec_public`), updates conversion/helper utilities, and adjusts the console example to use the new API and properly free returned strings/addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa7fb7818bbe0153eb1ca4fbbf97e7eb43dbe37e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple new payment-address constructors (address, decoded, EC key, hash/short-hash, script) and copy/compare helpers
  * Owned/borrowed payment-address handles and explicit list construction, push/erase/assign/nth/count APIs
  * New fixed-size payment primitive and conversion helpers; encoded address outputs return owned C strings

* **Refactor**
  * Wallet payment-address API reshaped for clearer ownership, const-correctness, and safer list handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->