### PR TITLE
refactor(c-api): unify and harden ec_public, ec_private, and operation bindings

### DIFF
--- a/src/c-api/include/kth/capi/chain/operation.h
+++ b/src/c-api/include/kth/capi/chain/operation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,90 +9,149 @@
 
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
-
 #include <kth/capi/chain/opcode.h>
+#include <kth/capi/chain/script_flags.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-KTH_EXPORT
-kth_operation_t kth_chain_operation_construct_default();
+// Constructors
 
-KTH_EXPORT
-kth_operation_t kth_chain_operation_construct_from_bytes(uint8_t* uncoded, kth_size_t n, kth_bool_t minimal);
+/** @return Owned `kth_operation_mut_t`. Caller must release with `kth_chain_operation_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_mut_t kth_chain_operation_construct_default(void);
 
+/** @param[out] out Must point to a null `kth_operation_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_operation_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_operation_t kth_chain_operation_construct_from_opcode(kth_opcode_t opcode);
+kth_error_code_t kth_chain_operation_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_operation_mut_t* out);
 
+/** @return Owned `kth_operation_mut_t`. Caller must release with `kth_chain_operation_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_mut_t kth_chain_operation_construct_from_uncoded_minimal(uint8_t const* uncoded, kth_size_t n, kth_bool_t minimal);
+
+/** @return Owned `kth_operation_mut_t`. Caller must release with `kth_chain_operation_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_mut_t kth_chain_operation_construct_from_code(kth_opcode_t code);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
 KTH_EXPORT
-kth_operation_t kth_chain_operation_construct_from_string(char const* value);
+void kth_chain_operation_destruct(kth_operation_mut_t self);
 
-KTH_EXPORT
-void kth_chain_operation_destruct(kth_operation_t operation);
 
-KTH_EXPORT
-char const* kth_chain_operation_to_string(kth_operation_t operation, uint64_t active_flags);
+// Copy
 
-KTH_EXPORT
-uint8_t const* kth_chain_operation_to_data(kth_operation_t operation, kth_size_t* out_size);
+/** @return Owned `kth_operation_mut_t`. Caller must release with `kth_chain_operation_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_mut_t kth_chain_operation_copy(kth_operation_const_t self);
 
-KTH_EXPORT
-kth_bool_t kth_chain_operation_from_data_mutable(kth_operation_t operation, uint8_t const* data, kth_size_t n);
 
-KTH_EXPORT
-kth_bool_t kth_chain_operation_from_string_mutable(kth_operation_t operation, char const* value);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_is_valid(kth_operation_t operation);
-
-KTH_EXPORT
-kth_size_t kth_chain_operation_serialized_size(kth_operation_t operation);
-
-KTH_EXPORT
-kth_opcode_t kth_chain_operation_code(kth_operation_t operation);
-
-KTH_EXPORT
-uint8_t const* kth_chain_operation_data(kth_operation_t operation, kth_size_t* out_size);
-
-// ******************************************
-// Categories of operations
-// ******************************************
+// Equality
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_push(kth_operation_t operation);
+kth_bool_t kth_chain_operation_equals(kth_operation_const_t self, kth_operation_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_operation_to_data(kth_operation_const_t self, kth_size_t* out_size);
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_counted(kth_operation_t operation);
+kth_size_t kth_chain_operation_serialized_size(kth_operation_const_t self);
+
+
+// Getters
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_version(kth_operation_t operation);
+kth_opcode_t kth_chain_operation_code(kth_operation_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_operation_data(kth_operation_const_t self, kth_size_t* out_size);
+
+
+// Predicates
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_positive(kth_operation_t operation);
+kth_bool_t kth_chain_operation_is_valid(kth_operation_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_disabled(kth_operation_t operation, uint64_t active_flags);
+kth_bool_t kth_chain_operation_is_push(kth_opcode_t code);
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_conditional(kth_operation_t operation);
+kth_bool_t kth_chain_operation_is_payload(kth_opcode_t code);
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_relaxed_push(kth_operation_t operation);
+kth_bool_t kth_chain_operation_is_counted(kth_opcode_t code);
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_oversized(kth_operation_t operation, kth_size_t max_size);
+kth_bool_t kth_chain_operation_is_version(kth_opcode_t code);
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_minimal_push(kth_operation_t operation);
+kth_bool_t kth_chain_operation_is_numeric(kth_opcode_t code);
 
 KTH_EXPORT
-kth_bool_t kth_chain_operation_is_nominal_push(kth_operation_t operation);
+kth_bool_t kth_chain_operation_is_positive(kth_opcode_t code);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_reserved(kth_opcode_t code);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_disabled(kth_opcode_t code, kth_script_flags_t active_flags);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_conditional(kth_opcode_t code);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_relaxed_push(kth_opcode_t code);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_push_simple(kth_operation_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_counted_simple(kth_operation_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_version_simple(kth_operation_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_positive_simple(kth_operation_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_disabled_simple(kth_operation_const_t self, kth_script_flags_t active_flags);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_conditional_simple(kth_operation_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_relaxed_push_simple(kth_operation_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_oversized(kth_operation_const_t self, kth_size_t max_size);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_minimal_push(kth_operation_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_is_nominal_push(kth_operation_const_t self);
 
 
-// ******************************************
-// static functions
-// ******************************************
+// Operations
+
+KTH_EXPORT
+kth_bool_t kth_chain_operation_from_string(kth_operation_mut_t self, char const* mnemonic);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_chain_operation_to_string(kth_operation_const_t self, kth_script_flags_t active_flags);
+
+
+// Static utilities
 
 KTH_EXPORT
 kth_opcode_t kth_chain_operation_opcode_from_size(kth_size_t size);
@@ -109,38 +168,8 @@ kth_opcode_t kth_chain_operation_opcode_from_positive(uint8_t value);
 KTH_EXPORT
 uint8_t kth_chain_operation_opcode_to_positive(kth_opcode_t code);
 
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_push(kth_opcode_t code);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_payload(kth_opcode_t code);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_counted(kth_opcode_t code);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_version(kth_opcode_t code);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_numeric(kth_opcode_t code);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_positive(kth_opcode_t code);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_reserved(kth_opcode_t code);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_disabled(kth_opcode_t code, uint64_t active_flags);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_conditional(kth_opcode_t code);
-
-KTH_EXPORT
-kth_bool_t kth_chain_operation_opcode_is_relaxed_push(kth_opcode_t code);
-
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_OPERATION_H_ */
+#endif // KTH_CAPI_CHAIN_OPERATION_H_

--- a/src/c-api/include/kth/capi/chain/operation_list.h
+++ b/src/c-api/include/kth/capi/chain/operation_list.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,7 +7,6 @@
 
 #include <stdint.h>
 
-#include <kth/capi/list_creator.h>
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
 
@@ -15,7 +14,29 @@
 extern "C" {
 #endif
 
-KTH_LIST_DECLARE(chain, kth_operation_list_t, kth_operation_t, operation_list)
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_operation_list_construct_default(void);
+
+KTH_EXPORT
+void kth_chain_operation_list_push_back(kth_operation_list_mut_t list, kth_operation_const_t elem);
+
+/** No-op if `list` is null. */
+KTH_EXPORT
+void kth_chain_operation_list_destruct(kth_operation_list_mut_t list);
+
+KTH_EXPORT
+kth_size_t kth_chain_operation_list_count(kth_operation_list_const_t list);
+
+/** @return Borrowed `kth_operation_const_t` view into the list. Do not destruct; the list retains ownership. Invalidated by any mutation of the list. */
+KTH_EXPORT
+kth_operation_const_t kth_chain_operation_list_nth(kth_operation_list_const_t list, kth_size_t index);
+
+KTH_EXPORT
+void kth_chain_operation_list_assign_at(kth_operation_list_mut_t list, kth_size_t index, kth_operation_const_t elem);
+
+KTH_EXPORT
+void kth_chain_operation_list_erase(kth_operation_list_mut_t list, kth_size_t index);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -90,21 +90,6 @@ inline kth::domain::chain::chain_state& kth_chain_chain_state_mut_cpp(kth_chain_
     return *static_cast<kth::domain::chain::chain_state*>(o);
 }
 
-// The following types are not migrated to const/mut yet (their existing
-// converters via KTH_CONV_DECLARE / KTH_LIST_DECLARE_CONVERTERS take the
-// legacy `_t = void*` form). The migrated C-API uses the matching
-// `_const_t` / `_mut_t` aliases for read-only and mutable handles, so we
-// add inline overloads here that bridge the two until each type migrates.
-
-inline std::vector<kth::domain::machine::operation> const&
-kth_chain_operation_list_const_cpp(kth_operation_list_const_t l) {
-    return *static_cast<std::vector<kth::domain::machine::operation> const*>(l);
-}
-inline std::vector<kth::domain::machine::operation>&
-kth_chain_operation_list_mut_cpp(kth_operation_list_mut_t l) {
-    return *static_cast<std::vector<kth::domain::machine::operation>*>(l);
-}
-
 // transaction conversion functions take const/mut handle types directly.
 // Defined in src/chain/transaction.cpp.
 kth::domain::chain::transaction const& kth_chain_transaction_const_cpp(kth_transaction_const_t o);
@@ -217,7 +202,6 @@ KTH_CONV_DECLARE(chain, kth_history_compact_t, kth::domain::chain::history_compa
 // #endif
 
 KTH_CONV_DECLARE(chain, kth_stealth_compact_t, kth::domain::chain::stealth_compact, stealth_compact)
-KTH_CONV_DECLARE(chain, kth_operation_t, kth::domain::machine::operation, operation)
 
 KTH_LIST_DECLARE_CONSTRUCT_FROM_CPP(chain, kth_utxo_list_t, kth::domain::chain::utxo, utxo_list)
 // hash_list — inline converters and construct_from_cpp.
@@ -245,39 +229,32 @@ inline std::vector<uint64_t>&
 kth_core_u64_list_mut_cpp(kth_u64_list_mut_t l) {
     return *static_cast<std::vector<uint64_t>*>(l);
 }
-KTH_LIST_DECLARE_CONSTRUCT_FROM_CPP_CONST(chain, kth_operation_list_t, kth::domain::machine::operation, operation_list)
-
 KTH_LIST_DECLARE_CONVERTERS(chain, kth_utxo_list_t, kth::domain::chain::utxo, utxo_list)
 
-KTH_LIST_DECLARE_CONVERTERS(chain, kth_operation_list_t, kth::domain::machine::operation, operation_list)
+// operation conversion functions. Defined in src/chain/operation.cpp.
+kth::domain::machine::operation const& kth_chain_operation_const_cpp(kth_operation_const_t o);
+kth::domain::machine::operation&       kth_chain_operation_mut_cpp(kth_operation_mut_t o);
+
+// operation_list — inline converters (replaces macro-based KTH_LIST_DECLARE_CONVERTERS).
+inline std::vector<kth::domain::machine::operation> const&
+kth_chain_operation_list_const_cpp(kth_operation_list_const_t l) {
+    return *static_cast<std::vector<kth::domain::machine::operation> const*>(l);
+}
+inline std::vector<kth::domain::machine::operation>&
+kth_chain_operation_list_mut_cpp(kth_operation_list_mut_t l) {
+    return *static_cast<std::vector<kth::domain::machine::operation>*>(l);
+}
 
 // Wallet.
 // ------------------------------------------------------------------------------------
 
-// ec_private — partial registration (not fully migrated yet). The legacy
-// KTH_CONV_DECLARE produces the void*-based overloads; the inline
-// converters here add the const_t/mut_t overloads so generated code that
-// takes kth_ec_private_const_t can resolve correctly.
-KTH_CONV_DECLARE(wallet, kth_ec_private_t, kth::domain::wallet::ec_private, ec_private)
-inline kth::domain::wallet::ec_private const&
-kth_wallet_ec_private_const_cpp(kth_ec_private_const_t o) {
-    return *static_cast<kth::domain::wallet::ec_private const*>(o);
-}
-inline kth::domain::wallet::ec_private&
-kth_wallet_ec_private_mut_cpp(kth_ec_private_mut_t o) {
-    return *static_cast<kth::domain::wallet::ec_private*>(o);
-}
+// ec_private conversion functions. Defined in src/wallet/ec_private.cpp.
+kth::domain::wallet::ec_private const& kth_wallet_ec_private_const_cpp(kth_ec_private_const_t o);
+kth::domain::wallet::ec_private&       kth_wallet_ec_private_mut_cpp(kth_ec_private_mut_t o);
 
-// ec_public — same partial registration pattern.
-KTH_CONV_DECLARE(wallet, kth_ec_public_t, kth::domain::wallet::ec_public, ec_public)
-inline kth::domain::wallet::ec_public const&
-kth_wallet_ec_public_const_cpp(kth_ec_public_const_t o) {
-    return *static_cast<kth::domain::wallet::ec_public const*>(o);
-}
-inline kth::domain::wallet::ec_public&
-kth_wallet_ec_public_mut_cpp(kth_ec_public_mut_t o) {
-    return *static_cast<kth::domain::wallet::ec_public*>(o);
-}
+// ec_public conversion functions. Defined in src/wallet/ec_public.cpp.
+kth::domain::wallet::ec_public const& kth_wallet_ec_public_const_cpp(kth_ec_public_const_t o);
+kth::domain::wallet::ec_public&       kth_wallet_ec_public_mut_cpp(kth_ec_public_mut_t o);
 
 // payment_address conversion functions. Defined in src/wallet/payment_address.cpp.
 kth::domain::wallet::payment_address const& kth_wallet_payment_address_const_cpp(kth_payment_address_const_t o);

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -206,6 +206,57 @@ kth::domain::wallet::payment payment_to_cpp(uint8_t const* x) {
     return ret;
 }
 
+// Generic helpers for value_struct ↔ C++ array conversions.
+// Covers ec_compressed (33), ec_uncompressed (65), wif_compressed (38),
+// wif_uncompressed (37), and any future fixed-size byte arrays.
+template<size_t N>
+inline
+std::array<uint8_t, N> to_array_cpp(uint8_t const* x) {
+    std::array<uint8_t, N> ret;
+    std::copy_n(x, N, ret.begin());
+    return ret;
+}
+
+// ec_compressed (33 bytes)
+inline kth_ec_compressed_t to_ec_compressed_t(kth::ec_compressed const& x) {
+    kth_ec_compressed_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::ec_compressed ec_compressed_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::ec_compressed_size>(x);
+}
+
+// ec_uncompressed (65 bytes)
+inline kth_ec_uncompressed_t to_ec_uncompressed_t(kth::ec_uncompressed const& x) {
+    kth_ec_uncompressed_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::ec_uncompressed ec_uncompressed_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::ec_uncompressed_size>(x);
+}
+
+// wif_compressed (38 bytes)
+inline kth_wif_compressed_t to_wif_compressed_t(kth::domain::wallet::wif_compressed const& x) {
+    kth_wif_compressed_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::domain::wallet::wif_compressed wif_compressed_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::domain::wallet::wif_compressed_size>(x);
+}
+
+// wif_uncompressed (37 bytes)
+inline kth_wif_uncompressed_t to_wif_uncompressed_t(kth::domain::wallet::wif_uncompressed const& x) {
+    kth_wif_uncompressed_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::domain::wallet::wif_uncompressed wif_uncompressed_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::domain::wallet::wif_uncompressed_size>(x);
+}
+
 template <typename T>
 inline
 T* mnew(std::size_t n = 1) {

--- a/src/c-api/include/kth/capi/wallet/ec_private.h
+++ b/src/c-api/include/kth/capi/wallet/ec_private.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,53 +15,119 @@
 extern "C" {
 #endif
 
+// Constructors
+
+/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_private_mut_t kth_wallet_ec_private_construct_default(void);
+
+/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_version(char const* wif, uint8_t version);
+
+/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version(kth_wif_compressed_t wif_compressed, uint8_t version);
+
+/**
+ * @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`.
+ * @warning `wif_compressed` MUST point to a buffer of at least 38 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version_unsafe(uint8_t const* wif_compressed, uint8_t version);
+
+/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version(kth_wif_uncompressed_t wif_uncompressed, uint8_t version);
+
+/**
+ * @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`.
+ * @warning `wif_uncompressed` MUST point to a buffer of at least 37 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version_unsafe(uint8_t const* wif_uncompressed, uint8_t version);
+
+/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(kth_hash_t secret, uint16_t version, kth_bool_t compress);
+
+/**
+ * @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`.
+ * @warning `secret` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress_unsafe(uint8_t const* secret, uint16_t version, kth_bool_t compress);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
 KTH_EXPORT
-kth_ec_private_t kth_wallet_ec_private_construct_default(void);
+void kth_wallet_ec_private_destruct(kth_ec_private_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_private_mut_t kth_wallet_ec_private_copy(kth_ec_private_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-kth_ec_private_t kth_wallet_ec_private_construct_string(char const* wif, uint8_t version);
+kth_bool_t kth_wallet_ec_private_equals(kth_ec_private_const_t self, kth_ec_private_const_t other);
+
+
+// Getters
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_ec_private_encoded(kth_ec_private_const_t self);
 
 KTH_EXPORT
-kth_ec_private_t kth_wallet_ec_private_construct_compressed(kth_wif_compressed_t const* wif, uint8_t version);
+kth_hash_t kth_wallet_ec_private_secret(kth_ec_private_const_t self);
 
 KTH_EXPORT
-kth_ec_private_t kth_wallet_ec_private_construct_uncompressed(kth_wif_uncompressed_t const* wif, uint8_t version);
+uint16_t kth_wallet_ec_private_version(kth_ec_private_const_t self);
 
 KTH_EXPORT
-kth_ec_private_t kth_wallet_ec_private_construct_secret(kth_ec_secret_t const* secret, uint16_t version, kth_bool_t compress);
+uint8_t kth_wallet_ec_private_payment_version(kth_ec_private_const_t self);
 
 KTH_EXPORT
-void kth_wallet_ec_private_destruct(kth_ec_private_t obj);
+uint8_t kth_wallet_ec_private_wif_version(kth_ec_private_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_wallet_ec_private_is_valid(kth_ec_private_t obj);
+kth_bool_t kth_wallet_ec_private_compressed(kth_ec_private_const_t self);
+
+/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_private_to_public(kth_ec_private_const_t self);
+
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_ec_private_to_payment_address(kth_ec_private_const_t self);
+
+
+// Operations
 
 KTH_EXPORT
-char* kth_wallet_ec_private_encoded(kth_ec_private_t obj);
+kth_bool_t kth_wallet_ec_private_less(kth_ec_private_const_t self, kth_ec_private_const_t x);
+
+
+// Static utilities
 
 KTH_EXPORT
-kth_ec_secret_t kth_wallet_ec_private_secret(kth_ec_private_t obj);
+uint8_t kth_wallet_ec_private_to_address_prefix(uint16_t version);
 
 KTH_EXPORT
-uint16_t kth_wallet_ec_private_version(kth_ec_private_t obj);
+uint8_t kth_wallet_ec_private_to_wif_prefix(uint16_t version);
 
 KTH_EXPORT
-uint8_t kth_wallet_ec_private_payment_version(kth_ec_private_t obj);
-
-KTH_EXPORT
-uint8_t kth_wallet_ec_private_wif_version(kth_ec_private_t obj);
-
-KTH_EXPORT
-kth_bool_t kth_wallet_ec_private_compressed(kth_ec_private_t obj);
-
-KTH_EXPORT
-kth_ec_public_t kth_wallet_ec_private_to_public(kth_ec_private_t obj);
-
-KTH_EXPORT
-kth_payment_address_t kth_wallet_ec_private_to_payment_address(kth_ec_private_t obj);
+uint16_t kth_wallet_ec_private_to_version(uint8_t address, uint8_t wif);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_WALLET_EC_PRIVATE_H_ */
+#endif // KTH_CAPI_WALLET_EC_PRIVATE_H_

--- a/src/c-api/include/kth/capi/wallet/ec_public.h
+++ b/src/c-api/include/kth/capi/wallet/ec_public.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,56 +15,113 @@
 extern "C" {
 #endif
 
+// Constructors
+
+/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_public_construct_default(void);
+
+/**
+ * @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`.
+ * @param secret Borrowed input. Copied by value into the resulting object; ownership of `secret` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_ec_private(kth_ec_private_const_t secret);
+
+/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_decoded(uint8_t const* decoded, kth_size_t n);
+
+/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_base16(char const* base16);
+
+/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress(kth_ec_compressed_t compressed_point, kth_bool_t compress);
+
+/**
+ * @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`.
+ * @warning `compressed_point` MUST point to a buffer of at least 33 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress_unsafe(uint8_t const* compressed_point, kth_bool_t compress);
+
+/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress(kth_ec_uncompressed_t uncompressed_point, kth_bool_t compress);
+
+/**
+ * @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`.
+ * @warning `uncompressed_point` MUST point to a buffer of at least 65 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress_unsafe(uint8_t const* uncompressed_point, kth_bool_t compress);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
 KTH_EXPORT
-kth_ec_public_t kth_wallet_ec_public_construct_default(void);
+void kth_wallet_ec_public_destruct(kth_ec_public_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ec_public_mut_t kth_wallet_ec_public_copy(kth_ec_public_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-kth_ec_public_t kth_wallet_ec_public_construct(kth_ec_private_t secret);
+kth_bool_t kth_wallet_ec_public_equals(kth_ec_public_const_t self, kth_ec_public_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer (33 bytes compressed, 65 uncompressed). Caller must release with `kth_core_destruct_array`. */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_wallet_ec_public_to_data(kth_ec_public_const_t self, kth_size_t* out_size);
+
+
+// Getters
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_ec_public_encoded(kth_ec_public_const_t self);
 
 KTH_EXPORT
-kth_ec_public_t kth_wallet_ec_public_construct_from_decoded(uint8_t const* decoded, kth_size_t size);
+kth_ec_compressed_t kth_wallet_ec_public_point(kth_ec_public_const_t self);
 
 KTH_EXPORT
-kth_ec_public_t kth_wallet_ec_public_construct_from_base16(char const* base16);
+uint16_t kth_wallet_ec_public_version(kth_ec_public_const_t self);
 
 KTH_EXPORT
-kth_ec_public_t kth_wallet_ec_public_construct_from_point(kth_ec_compressed_t const* point, kth_bool_t compress);
+uint8_t kth_wallet_ec_public_payment_version(kth_ec_public_const_t self);
 
 KTH_EXPORT
-void kth_wallet_ec_public_destruct(kth_ec_public_t obj);
+uint8_t kth_wallet_ec_public_wif_version(kth_ec_public_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_wallet_ec_public_is_valid(kth_ec_public_t obj);
+kth_bool_t kth_wallet_ec_public_compressed(kth_ec_public_const_t self);
+
+
+// Operations
 
 KTH_EXPORT
-char* kth_wallet_ec_public_encoded(kth_ec_public_t obj);
+kth_bool_t kth_wallet_ec_public_less(kth_ec_public_const_t self, kth_ec_public_const_t x);
 
 KTH_EXPORT
-kth_ec_compressed_t kth_wallet_ec_public_point(kth_ec_public_t obj);
+kth_bool_t kth_wallet_ec_public_to_uncompressed(kth_ec_public_const_t self, uint8_t* out);
 
-// KTH_EXPORT
-// uint16_t kth_wallet_ec_public_version(kth_ec_public_t obj);
-
-// KTH_EXPORT
-// uint8_t kth_wallet_ec_public_payment_version(kth_ec_public_t obj);
-
-// KTH_EXPORT
-// uint8_t kth_wallet_ec_public_wif_version(kth_ec_public_t obj);
-
-KTH_EXPORT
-kth_bool_t kth_wallet_ec_public_compressed(kth_ec_public_t obj);
-
-KTH_EXPORT
-uint8_t const* kth_wallet_ec_public_to_data(kth_ec_public_t obj, kth_size_t* out_size);
-
-KTH_EXPORT
-kth_bool_t kth_wallet_ec_public_to_uncompressed(kth_ec_public_t obj, kth_ec_uncompressed_t* out_data);
-
-KTH_EXPORT
-kth_payment_address_t kth_wallet_ec_public_to_payment_address(kth_ec_public_t obj, uint8_t version);
+/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_ec_public_to_payment_address(kth_ec_public_const_t self, uint8_t version);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_WALLET_EC_PUBLIC_H_ */
+#endif // KTH_CAPI_WALLET_EC_PUBLIC_H_

--- a/src/c-api/src/chain/operation.cpp
+++ b/src/c-api/src/chain/operation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,198 +7,255 @@
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/domain/machine/operation.hpp>
 
-KTH_CONV_DEFINE(chain, kth_operation_t, kth::domain::machine::operation, operation)
+// Conversion functions
+kth::domain::machine::operation& kth_chain_operation_mut_cpp(kth_operation_mut_t o) {
+    return *static_cast<kth::domain::machine::operation*>(o);
+}
+kth::domain::machine::operation const& kth_chain_operation_const_cpp(kth_operation_const_t o) {
+    return *static_cast<kth::domain::machine::operation const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_operation_t kth_chain_operation_construct_default() {
+// Constructors
+
+kth_operation_mut_t kth_chain_operation_construct_default(void) {
     return new kth::domain::machine::operation();
 }
 
-kth_operation_t kth_chain_operation_construct_from_bytes(uint8_t* uncoded, kth_size_t n, kth_bool_t minimal) {
-    kth::data_chunk uncoded_cpp(uncoded, std::next(uncoded, n));
-    return new kth::domain::machine::operation(uncoded_cpp, kth::int_to_bool(minimal));
+kth_error_code_t kth_chain_operation_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_operation_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
+    auto result = kth::domain::machine::operation::from_data(data_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::machine::operation(std::move(*result));
+    return kth_ec_success;
 }
 
-kth_operation_t kth_chain_operation_construct_from_opcode(kth_opcode_t opcode) {
-    return new kth::domain::machine::operation(kth::opcode_to_cpp(opcode));
+kth_operation_mut_t kth_chain_operation_construct_from_uncoded_minimal(uint8_t const* uncoded, kth_size_t n, kth_bool_t minimal) {
+    KTH_PRECONDITION(uncoded != nullptr || n == 0);
+    auto const uncoded_cpp = n != 0 ? kth::data_chunk(uncoded, uncoded + n) : kth::data_chunk{};
+    auto const minimal_cpp = kth::int_to_bool(minimal);
+    return new kth::domain::machine::operation(uncoded_cpp, minimal_cpp);
 }
 
-kth_operation_t kth_chain_operation_construct_from_string(char const* value) {
-    auto op = new kth::domain::machine::operation();
-    op->from_string(std::string(value));
-    return op;
+kth_operation_mut_t kth_chain_operation_construct_from_code(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return new kth::domain::machine::operation(code_cpp);
 }
 
-void kth_chain_operation_destruct(kth_operation_t operation) {
-    delete &kth_chain_operation_cpp(operation);
+
+// Destructor
+
+void kth_chain_operation_destruct(kth_operation_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_operation_mut_cpp(self);
 }
 
-char const* kth_chain_operation_to_string(kth_operation_t operation, uint64_t active_flags) {
-    return kth::create_c_str(kth_chain_operation_cpp(operation).to_string(active_flags));
+
+// Copy
+
+kth_operation_mut_t kth_chain_operation_copy(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::machine::operation(kth_chain_operation_const_cpp(self));
 }
 
-uint8_t const* kth_chain_operation_to_data(kth_operation_t operation, kth_size_t* out_size) {
-    auto operation_data = kth_chain_operation_cpp(operation).to_data();
-    return kth::create_c_array(operation_data, *out_size);
+
+// Equality
+
+kth_bool_t kth_chain_operation_equals(kth_operation_const_t self, kth_operation_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self) == kth_chain_operation_const_cpp(other));
 }
 
-kth_bool_t kth_chain_operation_from_data_mutable(kth_operation_t operation, uint8_t const* data, kth_size_t n) {
-    kth::data_chunk data_cpp(data, std::next(data, n));
-    kth::byte_reader reader(data_cpp);
-    
-    auto res = kth::domain::machine::operation::from_data(reader);
-    if (res) {
-        auto& op_cpp = kth_chain_operation_cpp(operation);
-        op_cpp = std::move(*res);
-    }
-    return kth::bool_to_int(bool(res));
-}
 
-kth_bool_t kth_chain_operation_from_string_mutable(kth_operation_t operation, char const* value) {
-    auto& op_cpp = kth_chain_operation_cpp(operation);
-    auto const res = op_cpp.from_string(std::string(value));
-    return kth::bool_to_int(res);
-}
+// Serialization
 
-kth_bool_t kth_chain_operation_is_valid(kth_operation_t operation) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_valid());
-}
-
-kth_size_t kth_chain_operation_serialized_size(kth_operation_t operation) {
-    return kth_chain_operation_cpp(operation).serialized_size();
-}
-
-kth_opcode_t kth_chain_operation_code(kth_operation_t operation) {
-    return kth::opcode_to_c(kth_chain_operation_cpp(operation).code());
-}
-
-uint8_t const* kth_chain_operation_data(kth_operation_t operation, kth_size_t* out_size) {
-    auto data = kth_chain_operation_cpp(operation).data();
+uint8_t* kth_chain_operation_to_data(kth_operation_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth_chain_operation_const_cpp(self).to_data();
     return kth::create_c_array(data, *out_size);
 }
 
-// ******************************************
-// Categories of operations
-// ******************************************
-
-kth_bool_t kth_chain_operation_is_push(kth_operation_t operation) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_push());
+kth_size_t kth_chain_operation_serialized_size(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_operation_const_cpp(self).serialized_size();
 }
 
-kth_bool_t kth_chain_operation_is_counted(kth_operation_t operation) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_counted());
+
+// Getters
+
+kth_opcode_t kth_chain_operation_code(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return static_cast<kth_opcode_t>(kth_chain_operation_const_cpp(self).code());
 }
 
-kth_bool_t kth_chain_operation_is_version(kth_operation_t operation) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_version());
+uint8_t* kth_chain_operation_data(kth_operation_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth_chain_operation_const_cpp(self).data();
+    return kth::create_c_array(data, *out_size);
 }
 
-kth_bool_t kth_chain_operation_is_positive(kth_operation_t operation) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_positive());
+
+// Predicates
+
+kth_bool_t kth_chain_operation_is_valid(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_valid());
 }
 
-kth_bool_t kth_chain_operation_is_disabled(kth_operation_t operation, uint64_t active_flags) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_disabled(active_flags));
+kth_bool_t kth_chain_operation_is_push(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_push(code_cpp));
 }
 
-kth_bool_t kth_chain_operation_is_conditional(kth_operation_t operation) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_conditional());
+kth_bool_t kth_chain_operation_is_payload(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_payload(code_cpp));
 }
 
-kth_bool_t kth_chain_operation_is_relaxed_push(kth_operation_t operation) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_relaxed_push());
+kth_bool_t kth_chain_operation_is_counted(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_counted(code_cpp));
 }
 
-kth_bool_t kth_chain_operation_is_oversized(kth_operation_t operation, kth_size_t max_size) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_oversized(max_size));
+kth_bool_t kth_chain_operation_is_version(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_version(code_cpp));
 }
 
-kth_bool_t kth_chain_operation_is_minimal_push(kth_operation_t operation) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_minimal_push());
+kth_bool_t kth_chain_operation_is_numeric(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_numeric(code_cpp));
 }
 
-kth_bool_t kth_chain_operation_is_nominal_push(kth_operation_t operation) {
-    return kth::bool_to_int(kth_chain_operation_cpp(operation).is_nominal_push());
+kth_bool_t kth_chain_operation_is_positive(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_positive(code_cpp));
 }
 
-// ******************************************
-// static functions
-// ******************************************
+kth_bool_t kth_chain_operation_is_reserved(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_reserved(code_cpp));
+}
+
+kth_bool_t kth_chain_operation_is_disabled(kth_opcode_t code, kth_script_flags_t active_flags) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_disabled(code_cpp, active_flags));
+}
+
+kth_bool_t kth_chain_operation_is_conditional(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_conditional(code_cpp));
+}
+
+kth_bool_t kth_chain_operation_is_relaxed_push(kth_opcode_t code) {
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::bool_to_int(kth::domain::machine::operation::is_relaxed_push(code_cpp));
+}
+
+kth_bool_t kth_chain_operation_is_push_simple(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_push());
+}
+
+kth_bool_t kth_chain_operation_is_counted_simple(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_counted());
+}
+
+kth_bool_t kth_chain_operation_is_version_simple(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_version());
+}
+
+kth_bool_t kth_chain_operation_is_positive_simple(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_positive());
+}
+
+kth_bool_t kth_chain_operation_is_disabled_simple(kth_operation_const_t self, kth_script_flags_t active_flags) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_disabled(active_flags));
+}
+
+kth_bool_t kth_chain_operation_is_conditional_simple(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_conditional());
+}
+
+kth_bool_t kth_chain_operation_is_relaxed_push_simple(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_relaxed_push());
+}
+
+kth_bool_t kth_chain_operation_is_oversized(kth_operation_const_t self, kth_size_t max_size) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const max_size_cpp = static_cast<size_t>(max_size);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_oversized(max_size_cpp));
+}
+
+kth_bool_t kth_chain_operation_is_minimal_push(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_minimal_push());
+}
+
+kth_bool_t kth_chain_operation_is_nominal_push(kth_operation_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_operation_const_cpp(self).is_nominal_push());
+}
+
+
+// Operations
+
+kth_bool_t kth_chain_operation_from_string(kth_operation_mut_t self, char const* mnemonic) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(mnemonic != nullptr);
+    auto const mnemonic_cpp = std::string(mnemonic);
+    return kth::bool_to_int(kth_chain_operation_mut_cpp(self).from_string(mnemonic_cpp));
+}
+
+char* kth_chain_operation_to_string(kth_operation_const_t self, kth_script_flags_t active_flags) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth_chain_operation_const_cpp(self).to_string(active_flags);
+    return kth::create_c_str(s);
+}
+
+
+// Static utilities
 
 kth_opcode_t kth_chain_operation_opcode_from_size(kth_size_t size) {
-    return kth::opcode_to_c(kth::domain::machine::operation::opcode_from_size(size));
+    auto const size_cpp = static_cast<size_t>(size);
+    return static_cast<kth_opcode_t>(kth::domain::machine::operation::opcode_from_size(size_cpp));
 }
 
 kth_opcode_t kth_chain_operation_minimal_opcode_from_data(uint8_t const* data, kth_size_t n) {
-    kth::data_chunk data_cpp(data, std::next(data, n));
-    return kth::opcode_to_c(kth::domain::machine::operation::minimal_opcode_from_data(data_cpp));
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    auto const data_cpp = n != 0 ? kth::data_chunk(data, data + n) : kth::data_chunk{};
+    return static_cast<kth_opcode_t>(kth::domain::machine::operation::minimal_opcode_from_data(data_cpp));
 }
 
 kth_opcode_t kth_chain_operation_nominal_opcode_from_data(uint8_t const* data, kth_size_t n) {
-    kth::data_chunk data_cpp(data, std::next(data, n));
-    return kth::opcode_to_c(kth::domain::machine::operation::nominal_opcode_from_data(data_cpp));
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    auto const data_cpp = n != 0 ? kth::data_chunk(data, data + n) : kth::data_chunk{};
+    return static_cast<kth_opcode_t>(kth::domain::machine::operation::nominal_opcode_from_data(data_cpp));
 }
 
 kth_opcode_t kth_chain_operation_opcode_from_positive(uint8_t value) {
-    return kth::opcode_to_c(kth::domain::machine::operation::opcode_from_positive(value));
+    return static_cast<kth_opcode_t>(kth::domain::machine::operation::opcode_from_positive(value));
 }
 
 uint8_t kth_chain_operation_opcode_to_positive(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::domain::machine::operation::opcode_to_positive(code_c);
-}
-
-kth_bool_t kth_chain_operation_opcode_is_push(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_push(code_c));
-}
-
-kth_bool_t kth_chain_operation_opcode_is_payload(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_payload(code_c));
-}
-
-kth_bool_t kth_chain_operation_opcode_is_counted(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_counted(code_c));
-}
-
-kth_bool_t kth_chain_operation_opcode_is_version(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_version(code_c));
-}
-
-kth_bool_t kth_chain_operation_opcode_is_numeric(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_numeric(code_c));
-}
-
-kth_bool_t kth_chain_operation_opcode_is_positive(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_positive(code_c));
-}
-
-kth_bool_t kth_chain_operation_opcode_is_reserved(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_reserved(code_c));
-}
-
-kth_bool_t kth_chain_operation_opcode_is_disabled(kth_opcode_t code, uint64_t active_flags) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_disabled(code_c, active_flags));
-}
-
-kth_bool_t kth_chain_operation_opcode_is_conditional(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_conditional(code_c));
-}
-
-kth_bool_t kth_chain_operation_opcode_is_relaxed_push(kth_opcode_t code) {
-    auto code_c = kth::opcode_to_cpp(code);
-    return kth::bool_to_int(kth::domain::machine::operation::is_relaxed_push(code_c));
+    auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
+    return kth::domain::machine::operation::opcode_to_positive(code_cpp);
 }
 
 } // extern "C"

--- a/src/c-api/src/chain/operation_list.cpp
+++ b/src/c-api/src/chain/operation_list.cpp
@@ -1,17 +1,56 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <kth/capi/chain/operation_list.h>
 
-#include <kth/capi/chain/output.h>
+#include <kth/capi/chain/operation.h>
 #include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
 
-KTH_LIST_DEFINE_CONVERTERS(chain, kth_operation_list_t, kth::domain::machine::operation, operation_list)
-KTH_LIST_DEFINE_CONSTRUCT_FROM_CPP_CONST(chain, kth_operation_list_t, kth::domain::machine::operation, operation_list)
-
+// ---------------------------------------------------------------------------
 extern "C" {
 
-KTH_LIST_DEFINE(chain, kth_operation_list_t, kth_operation_t, operation_list, kth::domain::machine::operation, kth_chain_operation_const_cpp)
+kth_operation_list_mut_t kth_chain_operation_list_construct_default(void) {
+    return new std::vector<kth::domain::machine::operation>();
+}
+
+void kth_chain_operation_list_push_back(kth_operation_list_mut_t list, kth_operation_const_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    static_cast<std::vector<kth::domain::machine::operation>*>(list)->push_back(kth_chain_operation_const_cpp(elem));
+}
+
+void kth_chain_operation_list_destruct(kth_operation_list_mut_t list) {
+    if (list == nullptr) return;
+    delete static_cast<std::vector<kth::domain::machine::operation>*>(list);
+}
+
+kth_size_t kth_chain_operation_list_count(kth_operation_list_const_t list) {
+    KTH_PRECONDITION(list != nullptr);
+    return static_cast<std::vector<kth::domain::machine::operation> const*>(list)->size();
+}
+
+kth_operation_const_t kth_chain_operation_list_nth(kth_operation_list_const_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto const& vec = *static_cast<std::vector<kth::domain::machine::operation> const*>(list);
+    KTH_PRECONDITION(index < vec.size());
+    return &vec[index];
+}
+
+void kth_chain_operation_list_assign_at(kth_operation_list_mut_t list, kth_size_t index, kth_operation_const_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    auto& vec = *static_cast<std::vector<kth::domain::machine::operation>*>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec[index] = kth_chain_operation_const_cpp(elem);
+}
+
+void kth_chain_operation_list_erase(kth_operation_list_mut_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto& vec = *static_cast<std::vector<kth::domain::machine::operation>*>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec.erase(vec.begin() + index);
+}
 
 } // extern "C"

--- a/src/c-api/src/vm/interpreter.cpp
+++ b/src/c-api/src/vm/interpreter.cpp
@@ -37,7 +37,7 @@ kth_error_code_t kth_vm_interpreter_run(kth_program_t program) {
 
 kth_error_code_t kth_vm_interpreter_run_operation(kth_operation_t operation, kth_program_t program) {
     auto const result = kth::domain::machine::interpreter::run(
-        kth_chain_operation_cpp(operation),
+        kth_chain_operation_const_cpp(operation),
         kth_vm_program_cpp(program)
     );
     return kth::to_c_err(result);

--- a/src/c-api/src/wallet/ec_private.cpp
+++ b/src/c-api/src/wallet/ec_private.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,79 +6,159 @@
 
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
-#include <kth/capi/type_conversions.h>
+#include <kth/domain/wallet/ec_private.hpp>
 
-#include <kth/capi/wallet/conversions.hpp>
+// Conversion functions
+kth::domain::wallet::ec_private& kth_wallet_ec_private_mut_cpp(kth_ec_private_mut_t o) {
+    return *static_cast<kth::domain::wallet::ec_private*>(o);
+}
+kth::domain::wallet::ec_private const& kth_wallet_ec_private_const_cpp(kth_ec_private_const_t o) {
+    return *static_cast<kth::domain::wallet::ec_private const*>(o);
+}
 
-KTH_CONV_DEFINE(wallet, kth_ec_private_t, kth::domain::wallet::ec_private, ec_private)
-
+// ---------------------------------------------------------------------------
 extern "C" {
 
-kth_ec_private_t kth_wallet_ec_private_construct_default() {
+// Constructors
+
+kth_ec_private_mut_t kth_wallet_ec_private_construct_default(void) {
     return new kth::domain::wallet::ec_private();
 }
 
-kth_ec_private_t kth_wallet_ec_private_construct_string(char const* wif, uint8_t version) {
-    return new kth::domain::wallet::ec_private(std::string(wif), version);
-}
-
-kth_ec_private_t kth_wallet_ec_private_construct_compressed(kth_wif_compressed_t const* wif, uint8_t version) {
-    auto wif_cpp = detail::from_wif_compressed_t(*wif);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_version(char const* wif, uint8_t version) {
+    KTH_PRECONDITION(wif != nullptr);
+    auto const wif_cpp = std::string(wif);
     return new kth::domain::wallet::ec_private(wif_cpp, version);
 }
 
-kth_ec_private_t kth_wallet_ec_private_construct_uncompressed(kth_wif_uncompressed_t const* wif, uint8_t version) {
-    auto wif_cpp = detail::from_wif_uncompressed_t(*wif);
-    return new kth::domain::wallet::ec_private(wif_cpp, version);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version(kth_wif_compressed_t wif_compressed, uint8_t version) {
+    auto const wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed.data);
+    return new kth::domain::wallet::ec_private(wif_compressed_cpp, version);
 }
 
-kth_ec_private_t kth_wallet_ec_private_construct_secret(kth_ec_secret_t const* secret, uint16_t version, kth_bool_t compress) {
-    auto secret_cpp = detail::from_ec_secret_t(*secret);
-    return new kth::domain::wallet::ec_private(secret_cpp, version, kth::int_to_bool(compress));
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version_unsafe(uint8_t const* wif_compressed, uint8_t version) {
+    KTH_PRECONDITION(wif_compressed != nullptr);
+    auto const wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed);
+    return new kth::domain::wallet::ec_private(wif_compressed_cpp, version);
 }
 
-void kth_wallet_ec_private_destruct(kth_ec_private_t obj) {
-    delete &kth_wallet_ec_private_cpp(obj);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version(kth_wif_uncompressed_t wif_uncompressed, uint8_t version) {
+    auto const wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed.data);
+    return new kth::domain::wallet::ec_private(wif_uncompressed_cpp, version);
 }
 
-kth_bool_t kth_wallet_ec_private_is_valid(kth_ec_private_t obj) {
-    return kth::bool_to_int(kth_wallet_ec_private_const_cpp(obj).operator bool());
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version_unsafe(uint8_t const* wif_uncompressed, uint8_t version) {
+    KTH_PRECONDITION(wif_uncompressed != nullptr);
+    auto const wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed);
+    return new kth::domain::wallet::ec_private(wif_uncompressed_cpp, version);
 }
 
-char* kth_wallet_ec_private_encoded(kth_ec_private_t obj) {
-    std::string encoded = kth_wallet_ec_private_const_cpp(obj).encoded();
-    return kth::create_c_str(encoded);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(kth_hash_t secret, uint16_t version, kth_bool_t compress) {
+    auto const secret_cpp = kth::hash_to_cpp(secret.hash);
+    auto const compress_cpp = kth::int_to_bool(compress);
+    return new kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp);
 }
 
-kth_ec_secret_t kth_wallet_ec_private_secret(kth_ec_private_t obj) {
-    auto& secret_cpp = kth_wallet_ec_private_const_cpp(obj).secret();
-    return detail::to_ec_secret_t(secret_cpp);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress_unsafe(uint8_t const* secret, uint16_t version, kth_bool_t compress) {
+    KTH_PRECONDITION(secret != nullptr);
+    auto const secret_cpp = kth::hash_to_cpp(secret);
+    auto const compress_cpp = kth::int_to_bool(compress);
+    return new kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp);
 }
 
-uint16_t kth_wallet_ec_private_version(kth_ec_private_t obj) {
-    return kth_wallet_ec_private_const_cpp(obj).version();
+
+// Destructor
+
+void kth_wallet_ec_private_destruct(kth_ec_private_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_wallet_ec_private_mut_cpp(self);
 }
 
-uint8_t kth_wallet_ec_private_payment_version(kth_ec_private_t obj) {
-    return kth_wallet_ec_private_const_cpp(obj).payment_version();
+
+// Copy
+
+kth_ec_private_mut_t kth_wallet_ec_private_copy(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::wallet::ec_private(kth_wallet_ec_private_const_cpp(self));
 }
 
-uint8_t kth_wallet_ec_private_wif_version(kth_ec_private_t obj) {
-    return kth_wallet_ec_private_const_cpp(obj).wif_version();
+
+// Equality
+
+kth_bool_t kth_wallet_ec_private_equals(kth_ec_private_const_t self, kth_ec_private_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_wallet_ec_private_const_cpp(self) == kth_wallet_ec_private_const_cpp(other));
 }
 
-kth_bool_t kth_wallet_ec_private_compressed(kth_ec_private_t obj) {
-    return kth::bool_to_int(kth_wallet_ec_private_const_cpp(obj).compressed());
+
+// Getters
+
+char* kth_wallet_ec_private_encoded(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth_wallet_ec_private_const_cpp(self).encoded();
+    return kth::create_c_str(s);
 }
 
-kth_ec_public_t kth_wallet_ec_private_to_public(kth_ec_private_t obj) {
-    auto public_key = kth_wallet_ec_private_const_cpp(obj).to_public();
-    return kth::move_or_copy_and_leak(std::move(public_key));
+kth_hash_t kth_wallet_ec_private_secret(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_wallet_ec_private_const_cpp(self).secret();
+    return kth::to_hash_t(value_cpp);
 }
 
-kth_payment_address_t kth_wallet_ec_private_to_payment_address(kth_ec_private_t obj) {
-    auto payment_address = kth_wallet_ec_private_const_cpp(obj).to_payment_address();
-    return kth::move_or_copy_and_leak(std::move(payment_address));
+uint16_t kth_wallet_ec_private_version(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_wallet_ec_private_const_cpp(self).version();
+}
+
+uint8_t kth_wallet_ec_private_payment_version(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_wallet_ec_private_const_cpp(self).payment_version();
+}
+
+uint8_t kth_wallet_ec_private_wif_version(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_wallet_ec_private_const_cpp(self).wif_version();
+}
+
+kth_bool_t kth_wallet_ec_private_compressed(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_wallet_ec_private_const_cpp(self).compressed());
+}
+
+kth_ec_public_mut_t kth_wallet_ec_private_to_public(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::wallet::ec_public(kth_wallet_ec_private_const_cpp(self).to_public());
+}
+
+kth_payment_address_mut_t kth_wallet_ec_private_to_payment_address(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::wallet::payment_address(kth_wallet_ec_private_const_cpp(self).to_payment_address());
+}
+
+
+// Operations
+
+kth_bool_t kth_wallet_ec_private_less(kth_ec_private_const_t self, kth_ec_private_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth_wallet_ec_private_const_cpp(x);
+    return kth::bool_to_int(kth_wallet_ec_private_const_cpp(self).operator<(x_cpp));
+}
+
+
+// Static utilities
+
+uint8_t kth_wallet_ec_private_to_address_prefix(uint16_t version) {
+    return kth::domain::wallet::ec_private::to_address_prefix(version);
+}
+
+uint8_t kth_wallet_ec_private_to_wif_prefix(uint16_t version) {
+    return kth::domain::wallet::ec_private::to_wif_prefix(version);
+}
+
+uint16_t kth_wallet_ec_private_to_version(uint8_t address, uint8_t wif) {
+    return kth::domain::wallet::ec_private::to_version(address, wif);
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/ec_public.cpp
+++ b/src/c-api/src/wallet/ec_public.cpp
@@ -1,118 +1,174 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <cstring>
 
 #include <kth/capi/wallet/ec_public.h>
 
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
-#include <kth/capi/type_conversions.h>
+#include <kth/domain/wallet/ec_public.hpp>
 
-#include <kth/capi/wallet/conversions.hpp>
+// Conversion functions
+kth::domain::wallet::ec_public& kth_wallet_ec_public_mut_cpp(kth_ec_public_mut_t o) {
+    return *static_cast<kth::domain::wallet::ec_public*>(o);
+}
+kth::domain::wallet::ec_public const& kth_wallet_ec_public_const_cpp(kth_ec_public_const_t o) {
+    return *static_cast<kth::domain::wallet::ec_public const*>(o);
+}
 
-KTH_CONV_DEFINE(wallet, kth_ec_public_t, kth::domain::wallet::ec_public, ec_public)
-
+// ---------------------------------------------------------------------------
 extern "C" {
 
-kth_ec_public_t kth_wallet_ec_public_construct_default() {
+// Constructors
+
+kth_ec_public_mut_t kth_wallet_ec_public_construct_default(void) {
     return new kth::domain::wallet::ec_public();
 }
 
-kth_ec_public_t kth_wallet_ec_public_construct(kth_ec_private_t secret) {
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_ec_private(kth_ec_private_const_t secret) {
+    KTH_PRECONDITION(secret != nullptr);
     auto const& secret_cpp = kth_wallet_ec_private_const_cpp(secret);
     return new kth::domain::wallet::ec_public(secret_cpp);
 }
 
-kth_ec_public_t kth_wallet_ec_public_construct_from_decoded(uint8_t const* decoded, kth_size_t size) {
-    return new kth::domain::wallet::ec_public(std::vector<uint8_t>(decoded, decoded + size));
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_decoded(uint8_t const* decoded, kth_size_t n) {
+    KTH_PRECONDITION(decoded != nullptr || n == 0);
+    auto const decoded_cpp = n != 0 ? kth::data_chunk(decoded, decoded + n) : kth::data_chunk{};
+    return new kth::domain::wallet::ec_public(decoded_cpp);
 }
 
-kth_ec_public_t kth_wallet_ec_public_construct_from_base16(char const* base16) {
-    return new kth::domain::wallet::ec_public(std::string(base16));
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_base16(char const* base16) {
+    KTH_PRECONDITION(base16 != nullptr);
+    auto const base16_cpp = std::string(base16);
+    return new kth::domain::wallet::ec_public(base16_cpp);
 }
 
-kth_ec_public_t kth_wallet_ec_public_construct_from_point(kth_ec_compressed_t const* point, kth_bool_t compress) {
-    auto const& point_cpp = detail::from_ec_compressed_t(*point);
-    return new kth::domain::wallet::ec_public(point_cpp, kth::int_to_bool(compress));
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress(kth_ec_compressed_t compressed_point, kth_bool_t compress) {
+    auto const compressed_point_cpp = kth::ec_compressed_to_cpp(compressed_point.data);
+    auto const compress_cpp = kth::int_to_bool(compress);
+    return new kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp);
 }
 
-void kth_wallet_ec_public_destruct(kth_ec_public_t obj) {
-    delete &kth_wallet_ec_public_cpp(obj);
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress_unsafe(uint8_t const* compressed_point, kth_bool_t compress) {
+    KTH_PRECONDITION(compressed_point != nullptr);
+    auto const compressed_point_cpp = kth::ec_compressed_to_cpp(compressed_point);
+    auto const compress_cpp = kth::int_to_bool(compress);
+    return new kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp);
 }
 
-kth_bool_t kth_wallet_ec_public_is_valid(kth_ec_public_t obj) {
-    return kth::bool_to_int(kth_wallet_ec_public_const_cpp(obj).operator bool());
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress(kth_ec_uncompressed_t uncompressed_point, kth_bool_t compress) {
+    auto const uncompressed_point_cpp = kth::ec_uncompressed_to_cpp(uncompressed_point.data);
+    auto const compress_cpp = kth::int_to_bool(compress);
+    return new kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp);
 }
 
-char* kth_wallet_ec_public_encoded(kth_ec_public_t obj) {
-    std::string encoded = kth_wallet_ec_public_const_cpp(obj).encoded();
-    return kth::create_c_str(encoded);
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress_unsafe(uint8_t const* uncompressed_point, kth_bool_t compress) {
+    KTH_PRECONDITION(uncompressed_point != nullptr);
+    auto const uncompressed_point_cpp = kth::ec_uncompressed_to_cpp(uncompressed_point);
+    auto const compress_cpp = kth::int_to_bool(compress);
+    return new kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp);
 }
 
-kth_ec_compressed_t kth_wallet_ec_public_point(kth_ec_public_t obj) {
-    auto const& point_cpp = kth_wallet_ec_public_const_cpp(obj).point();
-    return detail::to_ec_compressed_t(point_cpp);
+
+// Destructor
+
+void kth_wallet_ec_public_destruct(kth_ec_public_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_wallet_ec_public_mut_cpp(self);
 }
 
-// uint16_t kth_wallet_ec_public_version(kth_ec_public_t obj) {
-//     return kth_wallet_ec_public_const_cpp(obj).version();
-// }
 
-// uint8_t kth_wallet_ec_public_payment_version(kth_ec_public_t obj) {
-//     return kth_wallet_ec_public_const_cpp(obj).payment_version();
-// }
+// Copy
 
-// uint8_t kth_wallet_ec_public_wif_version(kth_ec_public_t obj) {
-//     return kth_wallet_ec_public_const_cpp(obj).wif_version();
-// }
-
-kth_bool_t kth_wallet_ec_public_compressed(kth_ec_public_t obj) {
-    return kth::bool_to_int(kth_wallet_ec_public_const_cpp(obj).compressed());
+kth_ec_public_mut_t kth_wallet_ec_public_copy(kth_ec_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::wallet::ec_public(kth_wallet_ec_public_const_cpp(self));
 }
 
-//Note: It is the responsability of the user to release/destruct the array
-uint8_t const* kth_wallet_ec_public_to_data(kth_ec_public_t obj, kth_size_t* out_size) {
+
+// Equality
+
+kth_bool_t kth_wallet_ec_public_equals(kth_ec_public_const_t self, kth_ec_public_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_wallet_ec_public_const_cpp(self) == kth_wallet_ec_public_const_cpp(other));
+}
+
+
+// Serialization
+
+uint8_t* kth_wallet_ec_public_to_data(kth_ec_public_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
     kth::data_chunk data;
-    bool const success = kth_wallet_ec_public_const_cpp(obj).to_data(data);
-    if ( ! success) {
+    if ( ! kth_wallet_ec_public_const_cpp(self).to_data(data)) {
         *out_size = 0;
         return nullptr;
     }
     return kth::create_c_array(data, *out_size);
 }
 
-kth_bool_t kth_wallet_ec_public_to_uncompressed(kth_ec_public_t obj, kth_ec_uncompressed_t* out_data) {
-    kth::ec_uncompressed uncompressed;
-    bool const success = kth_wallet_ec_public_const_cpp(obj).to_uncompressed(uncompressed);
-    if ( ! success) {
-        out_data = nullptr;
-        return false;
-    }
-    std::memcpy(out_data, uncompressed.data(), uncompressed.size());
-    return kth::bool_to_int(success);
+
+// Getters
+
+char* kth_wallet_ec_public_encoded(kth_ec_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth_wallet_ec_public_const_cpp(self).encoded();
+    return kth::create_c_str(s);
 }
 
-kth_payment_address_t kth_wallet_ec_public_to_payment_address(kth_ec_public_t obj, uint8_t version) {
-    auto const& payment_address_cpp = kth_wallet_ec_public_const_cpp(obj).to_payment_address(version);
-    return kth::move_or_copy_and_leak(std::move(payment_address_cpp));
+kth_ec_compressed_t kth_wallet_ec_public_point(kth_ec_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_wallet_ec_public_const_cpp(self).point();
+    return kth::to_ec_compressed_t(value_cpp);
+}
+
+uint16_t kth_wallet_ec_public_version(kth_ec_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_wallet_ec_public_const_cpp(self).version();
+}
+
+uint8_t kth_wallet_ec_public_payment_version(kth_ec_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_wallet_ec_public_const_cpp(self).payment_version();
+}
+
+uint8_t kth_wallet_ec_public_wif_version(kth_ec_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_wallet_ec_public_const_cpp(self).wif_version();
+}
+
+kth_bool_t kth_wallet_ec_public_compressed(kth_ec_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_wallet_ec_public_const_cpp(self).compressed());
+}
+
+
+// Operations
+
+kth_bool_t kth_wallet_ec_public_less(kth_ec_public_const_t self, kth_ec_public_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth_wallet_ec_public_const_cpp(x);
+    return kth::bool_to_int(kth_wallet_ec_public_const_cpp(self).operator<(x_cpp));
+}
+
+kth_bool_t kth_wallet_ec_public_to_uncompressed(kth_ec_public_const_t self, uint8_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    std::array<uint8_t, 65> out_cpp;
+    auto const cpp_result = kth_wallet_ec_public_const_cpp(self).to_uncompressed(out_cpp);
+    if (cpp_result) {
+        std::memcpy(out, out_cpp.data(), out_cpp.size());
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+kth_payment_address_mut_t kth_wallet_ec_public_to_payment_address(kth_ec_public_const_t self, uint8_t version) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::wallet::payment_address(kth_wallet_ec_public_const_cpp(self).to_payment_address(version));
 }
 
 } // extern "C"
-
-
-// // kth_payment_address_t kth_wallet_ec_public_destiny(kth_ec_public_t obj) {
-// //     return &kth_wallet_ec_public_cpp(obj).first;
-// // }
-
-// uint16_t kth_wallet_ec_public_version(kth_ec_public_t obj) {
-//     return kth_wallet_ec_public_const_cpp(obj).version();
-// }
-
-// uint8_t kth_wallet_ec_public_payment_version(kth_ec_public_t obj) {
-//     return kth_wallet_ec_public_const_cpp(obj).payment_version();
-// }
-
-// uint8_t kth_wallet_ec_public_wif_version(kth_ec_public_t obj) {
-//     return kth_wallet_ec_public_const_cpp(obj).wif_version();
-// }
-

--- a/src/domain/include/kth/domain/wallet/ec_private.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_private.hpp
@@ -79,12 +79,12 @@ struct KD_API ec_private {
     
     explicit
     ec_private(std::string const& wif, uint8_t version = mainnet_p2kh);
-    
+
     explicit
-    ec_private(wif_compressed const& wif, uint8_t version = mainnet_p2kh);
-    
+    ec_private(wif_compressed const& wif_compressed, uint8_t version = mainnet_p2kh);
+
     explicit
-    ec_private(wif_uncompressed const& wif, uint8_t version = mainnet_p2kh);
+    ec_private(wif_uncompressed const& wif_uncompressed, uint8_t version = mainnet_p2kh);
 
     /// The version is 16 bits. The most significant byte is the WIF prefix and
     /// the least significant byte is the address perfix. 0x8000 by default.

--- a/src/domain/include/kth/domain/wallet/ec_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_public.hpp
@@ -47,10 +47,10 @@ struct KD_API ec_public {
     ec_public(std::string const& base16);
 
     explicit
-    ec_public(ec_compressed const& point, bool compress = true);
+    ec_public(ec_compressed const& compressed_point, bool compress = true);
 
     explicit
-    ec_public(ec_uncompressed const& point, bool compress = false);
+    ec_public(ec_uncompressed const& uncompressed_point, bool compress = false);
 
     ec_public(ec_public const& x) = default;
     ec_public& operator=(ec_public const& x) = default;

--- a/src/domain/src/wallet/ec_private.cpp
+++ b/src/domain/src/wallet/ec_private.cpp
@@ -39,12 +39,12 @@ ec_private::ec_private(std::string const& wif, uint8_t version)
     : ec_private(from_string(wif, version))
 {}
 
-ec_private::ec_private(wif_compressed const& wif, uint8_t version)
-    : ec_private(from_compressed(wif, version))
+ec_private::ec_private(wif_compressed const& wif_compressed, uint8_t version)
+    : ec_private(from_compressed(wif_compressed, version))
 {}
 
-ec_private::ec_private(wif_uncompressed const& wif, uint8_t version)
-    : ec_private(from_uncompressed(wif, version))
+ec_private::ec_private(wif_uncompressed const& wif_uncompressed, uint8_t version)
+    : ec_private(from_uncompressed(wif_uncompressed, version))
 {}
 
 ec_private::ec_private(ec_secret const& secret, uint16_t version, bool compress)

--- a/src/domain/src/wallet/ec_public.cpp
+++ b/src/domain/src/wallet/ec_public.cpp
@@ -39,12 +39,12 @@ ec_public::ec_public(std::string const& base16)
     : ec_public(from_string(base16)) {
 }
 
-ec_public::ec_public(ec_uncompressed const& point, bool compress)
-    : ec_public(from_point(point, compress)) {
+ec_public::ec_public(ec_uncompressed const& uncompressed_point, bool compress)
+    : ec_public(from_point(uncompressed_point, compress)) {
 }
 
-ec_public::ec_public(ec_compressed const& point, bool compress)
-    : valid_(true), compress_(compress), point_(point) {
+ec_public::ec_public(ec_compressed const& compressed_point, bool compress)
+    : valid_(true), compress_(compress), point_(compressed_point) {
 }
 
 // Validators.


### PR DESCRIPTION
## Summary

Migrate the three remaining generable classes to the const/mut typed-handle pattern:
- `ec_public` and `ec_private` from the wallet layer (previously partially registered, now fully migrated)
- `operation` from the machine layer, including `operation_list` (last macro-based list)

## What's new

**Value structs**: `ec_compressed` (33B), `ec_uncompressed` (65B), `wif_compressed` (38B), `wif_uncompressed` (37B) — all registered with conversion helpers. The generator now supports per-struct field names (`.hash` vs `.data`) via the `vstruct_field` attribute.

**Enum**: `kth::domain::machine::opcode` → `kth_opcode_t` registered in the enum registry.

**ec_public**: full API — constructors (default, from_ec_private, from_string, from_data_chunk, from_ec_compressed, from_ec_uncompressed), copy/equals/less, encoded, point, version, payment_version, wif_version, compressed, to_data (out-param), to_uncompressed (out-param), to_payment_address.

**ec_private**: full API — constructors (default, from_string, from_wif_compressed, from_wif_uncompressed, from_ec_secret), copy/equals/less, encoded, secret, version, payment_version, wif_version, compressed, to_public, to_payment_address. Static helpers: to_address_prefix, to_wif_prefix, to_version.

**operation (+list)**: constructors, copy/equals, from_data, to_data, to_string, serialized_size, code, data, is_valid, 15+ static utility functions. `operation_list` replaces the last macro-based list. 2 methods skipped: stream-based `to_data` (expected) and `disabled_error` (unmapped return type).

## Cleanup

- Legacy `KTH_CONV_DECLARE(operation)` / `KTH_LIST_DECLARE_CONVERTERS(operation_list)` / `KTH_LIST_DECLARE_CONSTRUCT_FROM_CPP_CONST(operation_list)` removed from `conversions.hpp` — replaced by forward declarations + inline converters.
- ec_private / ec_public partial registrations (inline converters + `KTH_CONV_DECLARE` macros) upgraded to full out-of-line conversions defined in the generated `.cpp`.
- Generic `to_array_cpp<N>` template added to `helpers.hpp` for future value_struct sizes.

## Test plan

- [x] `kth_capi_test` green on the maintainer's local build.
- [x] Zero skipped for ec_public and ec_private. 2 expected skips for operation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes exported C-API signatures and ownership semantics for `operation`, `operation_list`, `ec_public`, and `ec_private`, which can break downstream callers and introduce lifetime/memory-management bugs if mismatched.
> 
> **Overview**
> Standardizes the C bindings for `chain/operation`, `chain/operation_list`, and wallet `ec_private`/`ec_public` to the const/mut typed-handle model with explicit ownership annotations, null-safe destructors, and new copy/equals/less helpers.
> 
> Replaces macro-generated `operation_list` and legacy converter macros with hand-written list APIs and out-of-line conversion functions, updates serialization/string APIs to return **owned** buffers/strings, and adds safer constructors (including `_unsafe` raw-pointer variants) plus stricter precondition checks. Also updates VM interpreter wiring to use the new `operation` const converter and includes minor domain-level parameter renames for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8b454c40b33cbce6b4a9dad68d4899f259c459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized C API with explicit ownership and null-safe destructors for operations, operation lists, and wallet keys.
  * Standardized read-only vs mutable handles and made serialization/string outputs return caller-owned buffers/strings.
* **New Features**
  * Added explicit list manipulation APIs (construct, push, erase, index) with safe borrowed element access.
  * Added richer EC/WIF conversion helpers and new predicates for operation validation and sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->