### PR TITLE
ci: cancel redundant workflow runs on PR updates

### DIFF
--- a/.github/workflows/build-deps-with-container.yml
+++ b/.github/workflows/build-deps-with-container.yml
@@ -49,7 +49,7 @@ jobs:
           submodules: true
 
       # - if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@v4
+      #   uses: actions/setup-python@v5
       #   with:
       #     python-version: '3.11'
       - name: 🔧 Setup Conan

--- a/.github/workflows/build-deps-without-container.yml
+++ b/.github/workflows/build-deps-without-container.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: 🐍 Setup Python
         if: ${{ inputs.reference != 'null' && inputs.compiler != 'GCC' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 env:
   CONAN_REMOTE: kth

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -12,6 +12,9 @@ on:
       - master
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 env:
   CONAN_REMOTE: kth
   CONAN_REMOTE_URL: https://packages.kth.cash/api/

--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -97,7 +97,7 @@ jobs:
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@v4
+      #   uses: actions/setup-python@v5
       #   with:
       #     python-version: '3.11'
 

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -93,7 +93,7 @@ jobs:
 
       # - if: ${{ inputs.compiler != 'GCC' }}
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/calc-deps-with-container.yml
+++ b/.github/workflows/calc-deps-with-container.yml
@@ -48,7 +48,7 @@ jobs:
 
 
       # - if: ${{ inputs.compiler != 'GCC' }}
-      #   uses: actions/setup-python@v4
+      #   uses: actions/setup-python@v5
       #   with:
       #     python-version: '3.11'
 

--- a/.github/workflows/calc-deps-without-container.yml
+++ b/.github/workflows/calc-deps-without-container.yml
@@ -44,7 +44,7 @@ jobs:
 
       # - if: ${{ inputs.compiler != 'GCC' }}
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/check-conan-updates.yml
+++ b/.github/workflows/check-conan-updates.yml
@@ -11,6 +11,9 @@ on:
       - 'scripts/check_conan_updates.py'
       - '.github/workflows/check-conan-updates.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   check-updates:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-conan-updates.yml
+++ b/.github/workflows/check-conan-updates.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/check-conan-updates.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   check-updates:

--- a/.github/workflows/cosmetic-changes.yml
+++ b/.github/workflows/cosmetic-changes.yml
@@ -12,6 +12,9 @@ on:
       - 'doc/**'
       - '.github/workflows/cosmetic-changes.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   cosmetic-check:
     # Solo ejecutar para branches con prefijos cosméticos

--- a/.github/workflows/cosmetic-changes.yml
+++ b/.github/workflows/cosmetic-changes.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/cosmetic-changes.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   cosmetic-check:
@@ -26,7 +26,7 @@ jobs:
     
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,9 @@ on:
     branches: [master]
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ on:
       - master
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 env:
   NAME: kth-mono
   CONAN_REMOTE: kth

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 env:
   NAME: kth-mono
@@ -75,7 +75,7 @@ jobs:
       - name: 🔐 Check permissions
         id: check
         continue-on-error: true
-        uses: prince-chrismc/check-actor-permissions-action@v2
+        uses: prince-chrismc/check-actor-permissions-action@v3
         with:
           permission: write
 
@@ -93,7 +93,7 @@ jobs:
       build-version: ${{ steps.version.outputs.build-version }}
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
@@ -158,7 +158,7 @@ jobs:
   #     # name: docker.pkg.github.com/${{ github.repository }}/alpine-image
   #     name: docker.pkg.github.com/k-nuth/kth/alpine-image
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #       with:
   #         submodules: true
   #     - id: version
@@ -198,7 +198,7 @@ jobs:
           echo "Head ref: ${{ github.head_ref }}"
           echo "Base ref: ${{ github.base_ref }}"
       - name: 📥 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: 🧮 Generate Job Matrix


### PR DESCRIPTION
When a new commit is pushed to the same PR branch, in-progress GitHub Actions runs for that branch are now cancelled automatically. Saves GHA minutes and speeds up feedback on rapid iteration.

Only active for pull_request events — pushes to master and tag-based releases always run to completion.

Applied to: main, coverage, cosmetic-changes, build-wasm, check-conan-updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that add PR-scoped concurrency cancellation and bump GitHub Action versions; main impact is potentially canceling older in-progress PR runs on rapid updates.
> 
> **Overview**
> Adds **PR-scoped concurrency** to several GitHub Actions workflows (e.g., `main.yml`, `coverage.yml`, `build-wasm.yml`, `check-conan-updates.yml`, `cosmetic-changes.yml`) so that when new commits are pushed to the same PR branch, older in-progress runs are automatically canceled.
> 
> Updates workflow dependencies by bumping `actions/setup-python` to `v5` where used (including commented snippets), upgrading `actions/checkout` to `v4` in remaining workflows, and updating `prince-chrismc/check-actor-permissions-action` to `v3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb80326ceb9be483a45be7f7f61f1dba743e492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to enhance concurrent run management across build, testing, and coverage pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->