### PR TITLE
refactor(c-api): unify and harden chain/double_spend_proof bindings

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -512,6 +512,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/output_point_list.cpp
         test/chain/stealth_compact.cpp
         test/chain/history_compact.cpp
+        test/chain/double_spend_proof.cpp
         test/wallet/hd_public.cpp
         test/wallet/hd_private.cpp
     )

--- a/src/c-api/include/kth/capi/chain/double_spend_proof.h
+++ b/src/c-api/include/kth/capi/chain/double_spend_proof.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,35 +14,102 @@
 extern "C" {
 #endif
 
+// Constructors
+
+/** @return Owned `kth_double_spend_proof_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_double_spend_proof_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_double_spend_proof_mut_t kth_chain_double_spend_proof_construct_default(void);
+
+/** @param[out] out Must point to a null `kth_double_spend_proof_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_double_spend_proof_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_output_point_const_t kth_chain_double_spend_proof_out_point(kth_double_spend_proof_t dsp);
+kth_error_code_t kth_chain_double_spend_proof_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_double_spend_proof_mut_t* out);
+
+/**
+ * @return Owned `kth_double_spend_proof_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_double_spend_proof_destruct`.
+ * @param out_point Borrowed input. Copied by value into the resulting object; ownership of `out_point` stays with the caller.
+ * @param spender1 Borrowed input. Copied by value into the resulting object; ownership of `spender1` stays with the caller.
+ * @param spender2 Borrowed input. Copied by value into the resulting object; ownership of `spender2` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_double_spend_proof_mut_t kth_chain_double_spend_proof_construct(kth_output_point_const_t out_point, kth_double_spend_proof_spender_const_t spender1, kth_double_spend_proof_spender_const_t spender2);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_chain_double_spend_proof_destruct(kth_double_spend_proof_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_double_spend_proof_mut_t`. Caller must release with `kth_chain_double_spend_proof_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_double_spend_proof_mut_t kth_chain_double_spend_proof_copy(kth_double_spend_proof_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender1(kth_double_spend_proof_t dsp);
+kth_bool_t kth_chain_double_spend_proof_equals(kth_double_spend_proof_const_t self, kth_double_spend_proof_const_t other);
+
+
+// Serialization
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_double_spend_proof_to_data(kth_double_spend_proof_const_t self, kth_size_t version, kth_size_t* out_size);
 
 KTH_EXPORT
-kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender2(kth_double_spend_proof_t dsp);
+kth_size_t kth_chain_double_spend_proof_serialized_size(kth_double_spend_proof_const_t self, kth_size_t version);
+
+
+// Getters
+
+/** @return Borrowed `kth_output_point_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_output_point_const_t kth_chain_double_spend_proof_out_point(kth_double_spend_proof_const_t self);
+
+/** @return Borrowed `kth_double_spend_proof_spender_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender1(kth_double_spend_proof_const_t self);
+
+/** @return Borrowed `kth_double_spend_proof_spender_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender2(kth_double_spend_proof_const_t self);
 
 KTH_EXPORT
-kth_hash_t kth_chain_double_spend_proof_hash(kth_double_spend_proof_t dsp);
+kth_hash_t kth_chain_double_spend_proof_hash(kth_double_spend_proof_const_t self);
+
+
+// Setters
+
+/** @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller. */
+KTH_EXPORT
+void kth_chain_double_spend_proof_set_out_point(kth_double_spend_proof_mut_t self, kth_output_point_const_t x);
+
+/** @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller. */
+KTH_EXPORT
+void kth_chain_double_spend_proof_set_spender1(kth_double_spend_proof_mut_t self, kth_double_spend_proof_spender_const_t x);
+
+/** @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller. */
+KTH_EXPORT
+void kth_chain_double_spend_proof_set_spender2(kth_double_spend_proof_mut_t self, kth_double_spend_proof_spender_const_t x);
+
+
+// Predicates
 
 KTH_EXPORT
-void kth_chain_double_spend_proof_hash_out(kth_double_spend_proof_t dsp, kth_hash_t* out_hash);
+kth_bool_t kth_chain_double_spend_proof_is_valid(kth_double_spend_proof_const_t self);
+
+
+// Operations
 
 KTH_EXPORT
-kth_bool_t kth_chain_double_spend_proof_is_valid(kth_double_spend_proof_t dsp);
-
-KTH_EXPORT
-kth_size_t kth_chain_double_spend_proof_serialized_size(kth_double_spend_proof_t dsp, uint32_t version);
-
-KTH_EXPORT
-void kth_chain_double_spend_proof_destruct(kth_double_spend_proof_t dsp);
-
-KTH_EXPORT
-void kth_chain_double_spend_proof_reset(kth_double_spend_proof_t dsp);
+void kth_chain_double_spend_proof_reset(kth_double_spend_proof_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_DOUBLE_SPEND_PROOF_H_ */
+#endif // KTH_CAPI_CHAIN_DOUBLE_SPEND_PROOF_H_

--- a/src/c-api/include/kth/capi/chain/double_spend_proof_spender.h
+++ b/src/c-api/include/kth/capi/chain/double_spend_proof_spender.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,44 +14,113 @@
 extern "C" {
 #endif
 
+// Constructors
+
+/** @param[out] out Must point to a null `kth_double_spend_proof_spender_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_double_spend_proof_spender_destruct`. Untouched on error. */
 KTH_EXPORT
-uint32_t kth_chain_double_spend_proof_spender_version(kth_double_spend_proof_spender_const_t spender);
+kth_error_code_t kth_chain_double_spend_proof_spender_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_double_spend_proof_spender_mut_t* out);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_chain_double_spend_proof_spender_destruct(kth_double_spend_proof_spender_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_double_spend_proof_spender_mut_t`. Caller must release with `kth_chain_double_spend_proof_spender_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_double_spend_proof_spender_mut_t kth_chain_double_spend_proof_spender_copy(kth_double_spend_proof_spender_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-uint32_t kth_chain_double_spend_proof_spender_out_sequence(kth_double_spend_proof_spender_const_t spender);
+kth_bool_t kth_chain_double_spend_proof_spender_equals(kth_double_spend_proof_spender_const_t self, kth_double_spend_proof_spender_const_t other);
+
+
+// Serialization
 
 KTH_EXPORT
-uint32_t kth_chain_double_spend_proof_spender_locktime(kth_double_spend_proof_spender_const_t spender);
+kth_size_t kth_chain_double_spend_proof_spender_serialized_size(kth_double_spend_proof_spender_const_t self);
+
+
+// Getters
 
 KTH_EXPORT
-kth_hash_t kth_chain_double_spend_proof_spender_prev_outs_hash(kth_double_spend_proof_spender_const_t spender);
+uint32_t kth_chain_double_spend_proof_spender_version(kth_double_spend_proof_spender_const_t self);
 
 KTH_EXPORT
-void kth_chain_double_spend_proof_spender_prev_outs_hash_out(kth_double_spend_proof_spender_const_t dsp, kth_hash_t* out_hash);
+uint32_t kth_chain_double_spend_proof_spender_out_sequence(kth_double_spend_proof_spender_const_t self);
 
 KTH_EXPORT
-kth_hash_t kth_chain_double_spend_proof_spender_sequence_hash(kth_double_spend_proof_spender_const_t spender);
+uint32_t kth_chain_double_spend_proof_spender_locktime(kth_double_spend_proof_spender_const_t self);
 
 KTH_EXPORT
-void kth_chain_double_spend_proof_spender_sequence_hash_out(kth_double_spend_proof_spender_const_t dsp, kth_hash_t* out_hash);
+kth_hash_t kth_chain_double_spend_proof_spender_prev_outs_hash(kth_double_spend_proof_spender_const_t self);
 
 KTH_EXPORT
-kth_hash_t kth_chain_double_spend_proof_spender_outputs_hash(kth_double_spend_proof_spender_const_t spender);
+kth_hash_t kth_chain_double_spend_proof_spender_sequence_hash(kth_double_spend_proof_spender_const_t self);
 
 KTH_EXPORT
-void kth_chain_double_spend_proof_spender_outputs_hash_out(kth_double_spend_proof_spender_const_t dsp, kth_hash_t* out_hash);
+kth_hash_t kth_chain_double_spend_proof_spender_outputs_hash(kth_double_spend_proof_spender_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_double_spend_proof_spender_push_data(kth_double_spend_proof_spender_const_t self, kth_size_t* out_size);
+
+
+// Setters
 
 KTH_EXPORT
-uint8_t const* kth_chain_double_spend_proof_spender_push_data(kth_double_spend_proof_spender_const_t spender, kth_size_t* out_size);
+void kth_chain_double_spend_proof_spender_set_version(kth_double_spend_proof_spender_mut_t self, uint32_t value);
 
 KTH_EXPORT
-kth_bool_t kth_chain_double_spend_proof_spender_is_valid(kth_double_spend_proof_spender_const_t spender);
+void kth_chain_double_spend_proof_spender_set_out_sequence(kth_double_spend_proof_spender_mut_t self, uint32_t value);
 
 KTH_EXPORT
-kth_size_t kth_chain_double_spend_proof_spender_serialized_size(kth_double_spend_proof_spender_const_t spender);
+void kth_chain_double_spend_proof_spender_set_locktime(kth_double_spend_proof_spender_mut_t self, uint32_t value);
+
+KTH_EXPORT
+void kth_chain_double_spend_proof_spender_set_prev_outs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value);
+
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+KTH_EXPORT
+void kth_chain_double_spend_proof_spender_set_prev_outs_hash_unsafe(kth_double_spend_proof_spender_mut_t self, uint8_t const* value);
+
+KTH_EXPORT
+void kth_chain_double_spend_proof_spender_set_sequence_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value);
+
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+KTH_EXPORT
+void kth_chain_double_spend_proof_spender_set_sequence_hash_unsafe(kth_double_spend_proof_spender_mut_t self, uint8_t const* value);
+
+KTH_EXPORT
+void kth_chain_double_spend_proof_spender_set_outputs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value);
+
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+KTH_EXPORT
+void kth_chain_double_spend_proof_spender_set_outputs_hash_unsafe(kth_double_spend_proof_spender_mut_t self, uint8_t const* value);
+
+KTH_EXPORT
+void kth_chain_double_spend_proof_spender_set_push_data(kth_double_spend_proof_spender_mut_t self, uint8_t const* value, kth_size_t n);
+
+
+// Predicates
+
+KTH_EXPORT
+kth_bool_t kth_chain_double_spend_proof_spender_is_valid(kth_double_spend_proof_spender_const_t self);
+
+
+// Operations
+
+KTH_EXPORT
+void kth_chain_double_spend_proof_spender_reset(kth_double_spend_proof_spender_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_DOUBLE_SPEND_PROOF_SPENDER_H_ */
+#endif // KTH_CAPI_CHAIN_DOUBLE_SPEND_PROOF_SPENDER_H_

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -25,6 +25,7 @@
 #include <kth/domain/message/compact_block.hpp>
 #include <kth/domain/message/get_blocks.hpp>
 #include <kth/domain/message/get_headers.hpp>
+#include <kth/domain/message/double_spend_proof.hpp>
 #include <kth/domain/message/merkle_block.hpp>
 #include <kth/domain/message/prefilled_transaction.hpp>
 #include <kth/domain/wallet/ec_private.hpp>
@@ -205,6 +206,14 @@ kth::domain::chain::history_compact&       kth_chain_history_compact_mut_cpp(kth
 // stealth_compact conversion functions. Defined in src/chain/stealth_compact.cpp.
 kth::domain::chain::stealth_compact const& kth_chain_stealth_compact_const_cpp(kth_stealth_compact_const_t o);
 kth::domain::chain::stealth_compact&       kth_chain_stealth_compact_mut_cpp(kth_stealth_compact_mut_t o);
+
+// double_spend_proof conversion functions. Defined in src/chain/double_spend_proof.cpp.
+kth::domain::message::double_spend_proof const& kth_chain_double_spend_proof_const_cpp(kth_double_spend_proof_const_t o);
+kth::domain::message::double_spend_proof&       kth_chain_double_spend_proof_mut_cpp(kth_double_spend_proof_mut_t o);
+
+// double_spend_proof::spender conversion functions. Defined in src/chain/double_spend_proof_spender.cpp.
+kth::domain::message::double_spend_proof::spender const& kth_chain_double_spend_proof_spender_const_cpp(kth_double_spend_proof_spender_const_t o);
+kth::domain::message::double_spend_proof::spender&       kth_chain_double_spend_proof_spender_mut_cpp(kth_double_spend_proof_spender_mut_t o);
 
 KTH_LIST_DECLARE_CONSTRUCT_FROM_CPP(chain, kth_utxo_list_t, kth::domain::chain::utxo, utxo_list)
 // hash_list — inline converters and construct_from_cpp.

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -98,8 +98,9 @@ typedef void* kth_block_list_mut_t;
 typedef void const* kth_block_list_const_t;
 typedef void* kth_compact_block_mut_t;
 typedef void const* kth_compact_block_const_t;
-typedef void* kth_double_spend_proof_t;
-typedef void* kth_double_spend_proof_spender_t;
+typedef void* kth_double_spend_proof_mut_t;
+typedef void const* kth_double_spend_proof_const_t;
+typedef void* kth_double_spend_proof_spender_mut_t;
 typedef void const* kth_double_spend_proof_spender_const_t;
 typedef void* kth_header_mut_t;
 typedef void const* kth_header_const_t;
@@ -286,7 +287,7 @@ typedef void (*kth_result_handler_t)(kth_chain_t, void*, kth_error_code_t);
 typedef void (*kth_transactions_by_address_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_hash_list_mut_t);
 typedef kth_bool_t (*kth_subscribe_blockchain_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_size_t, kth_block_list_mut_t, kth_block_list_mut_t);
 typedef kth_bool_t (*kth_subscribe_transaction_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_transaction_mut_t);
-typedef kth_bool_t (*kth_subscribe_ds_proof_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_double_spend_proof_t);
+typedef kth_bool_t (*kth_subscribe_ds_proof_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_double_spend_proof_mut_t);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/src/chain/double_spend_proof.cpp
+++ b/src/c-api/src/chain/double_spend_proof.cpp
@@ -1,55 +1,160 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <kth/domain/message/double_spend_proof.hpp>
+#include <utility>
 
 #include <kth/capi/chain/double_spend_proof.h>
+
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
-#include <kth/capi/type_conversions.h>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/domain/message/double_spend_proof.hpp>
 
-KTH_CONV_DEFINE(chain, kth_double_spend_proof_t, kth::domain::message::double_spend_proof, double_spend_proof)
+// Conversion functions
+kth::domain::message::double_spend_proof& kth_chain_double_spend_proof_mut_cpp(kth_double_spend_proof_mut_t o) {
+    return *static_cast<kth::domain::message::double_spend_proof*>(o);
+}
+kth::domain::message::double_spend_proof const& kth_chain_double_spend_proof_const_cpp(kth_double_spend_proof_const_t o) {
+    return *static_cast<kth::domain::message::double_spend_proof const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_output_point_const_t kth_chain_double_spend_proof_out_point(kth_double_spend_proof_t dsp) {
-    return &kth_chain_double_spend_proof_cpp(dsp).out_point();
+// Constructors
+
+kth_double_spend_proof_mut_t kth_chain_double_spend_proof_construct_default(void) {
+    return new kth::domain::message::double_spend_proof();
 }
 
-kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender1(kth_double_spend_proof_t dsp) {
-    return &kth_chain_double_spend_proof_cpp(dsp).spender1();
+kth_error_code_t kth_chain_double_spend_proof_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_double_spend_proof_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
+    auto result = kth::domain::message::double_spend_proof::from_data(data_cpp, version);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::message::double_spend_proof(std::move(*result));
+    return kth_ec_success;
 }
 
-kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender2(kth_double_spend_proof_t dsp) {
-    return &kth_chain_double_spend_proof_cpp(dsp).spender2();
+kth_double_spend_proof_mut_t kth_chain_double_spend_proof_construct(kth_output_point_const_t out_point, kth_double_spend_proof_spender_const_t spender1, kth_double_spend_proof_spender_const_t spender2) {
+    KTH_PRECONDITION(out_point != nullptr);
+    KTH_PRECONDITION(spender1 != nullptr);
+    KTH_PRECONDITION(spender2 != nullptr);
+    auto const& out_point_cpp = kth_chain_output_point_const_cpp(out_point);
+    auto const& spender1_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender1);
+    auto const& spender2_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender2);
+    auto* obj = new kth::domain::message::double_spend_proof(out_point_cpp, spender1_cpp, spender2_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
-kth_hash_t kth_chain_double_spend_proof_hash(kth_double_spend_proof_t dsp) {
-    auto const& hash_cpp = kth_chain_double_spend_proof_const_cpp(dsp).hash();
-    return kth::to_hash_t(hash_cpp);
+
+// Destructor
+
+void kth_chain_double_spend_proof_destruct(kth_double_spend_proof_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_double_spend_proof_mut_cpp(self);
 }
 
-void kth_chain_double_spend_proof_hash_out(kth_double_spend_proof_t dsp, kth_hash_t* out_hash) {
-    auto const& hash_cpp = kth_chain_double_spend_proof_const_cpp(dsp).hash();
-    kth::copy_c_hash(hash_cpp, out_hash);
+
+// Copy
+
+kth_double_spend_proof_mut_t kth_chain_double_spend_proof_copy(kth_double_spend_proof_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::message::double_spend_proof(kth_chain_double_spend_proof_const_cpp(self));
 }
 
-kth_bool_t kth_chain_double_spend_proof_is_valid(kth_double_spend_proof_t dsp) {
-    return kth::bool_to_int(kth_chain_double_spend_proof_const_cpp(dsp).is_valid());
+
+// Equality
+
+kth_bool_t kth_chain_double_spend_proof_equals(kth_double_spend_proof_const_t self, kth_double_spend_proof_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_double_spend_proof_const_cpp(self) == kth_chain_double_spend_proof_const_cpp(other));
 }
 
-kth_size_t kth_chain_double_spend_proof_serialized_size(kth_double_spend_proof_t dsp, uint32_t version) {
-    return kth_chain_double_spend_proof_const_cpp(dsp).serialized_size(version);
+
+// Serialization
+
+uint8_t* kth_chain_double_spend_proof_to_data(kth_double_spend_proof_const_t self, kth_size_t version, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const version_cpp = static_cast<size_t>(version);
+    auto const& data = kth_chain_double_spend_proof_const_cpp(self).to_data(version_cpp);
+    return kth::create_c_array(data, *out_size);
 }
 
-void kth_chain_double_spend_proof_destruct(kth_double_spend_proof_t dsp) {
-    delete &kth_chain_double_spend_proof_cpp(dsp);
+kth_size_t kth_chain_double_spend_proof_serialized_size(kth_double_spend_proof_const_t self, kth_size_t version) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const version_cpp = static_cast<size_t>(version);
+    return kth_chain_double_spend_proof_const_cpp(self).serialized_size(version_cpp);
 }
 
-void kth_chain_double_spend_proof_reset(kth_double_spend_proof_t dsp) {
-    kth_chain_double_spend_proof_cpp(dsp).reset();
+
+// Getters
+
+kth_output_point_const_t kth_chain_double_spend_proof_out_point(kth_double_spend_proof_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth_chain_double_spend_proof_const_cpp(self).out_point());
+}
+
+kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender1(kth_double_spend_proof_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth_chain_double_spend_proof_const_cpp(self).spender1());
+}
+
+kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender2(kth_double_spend_proof_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth_chain_double_spend_proof_const_cpp(self).spender2());
+}
+
+kth_hash_t kth_chain_double_spend_proof_hash(kth_double_spend_proof_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_chain_double_spend_proof_const_cpp(self).hash();
+    return kth::to_hash_t(value_cpp);
+}
+
+
+// Setters
+
+void kth_chain_double_spend_proof_set_out_point(kth_double_spend_proof_mut_t self, kth_output_point_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth_chain_output_point_const_cpp(x);
+    kth_chain_double_spend_proof_mut_cpp(self).set_out_point(x_cpp);
+}
+
+void kth_chain_double_spend_proof_set_spender1(kth_double_spend_proof_mut_t self, kth_double_spend_proof_spender_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth_chain_double_spend_proof_spender_const_cpp(x);
+    kth_chain_double_spend_proof_mut_cpp(self).set_spender1(x_cpp);
+}
+
+void kth_chain_double_spend_proof_set_spender2(kth_double_spend_proof_mut_t self, kth_double_spend_proof_spender_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth_chain_double_spend_proof_spender_const_cpp(x);
+    kth_chain_double_spend_proof_mut_cpp(self).set_spender2(x_cpp);
+}
+
+
+// Predicates
+
+kth_bool_t kth_chain_double_spend_proof_is_valid(kth_double_spend_proof_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_double_spend_proof_const_cpp(self).is_valid());
+}
+
+
+// Operations
+
+void kth_chain_double_spend_proof_reset(kth_double_spend_proof_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_double_spend_proof_mut_cpp(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/src/chain/double_spend_proof_spender.cpp
+++ b/src/c-api/src/chain/double_spend_proof_spender.cpp
@@ -1,74 +1,194 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <kth/domain/message/double_spend_proof.hpp>
+#include <utility>
 
 #include <kth/capi/chain/double_spend_proof_spender.h>
+
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
-#include <kth/capi/type_conversions.h>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/domain/message/double_spend_proof.hpp>
 
-KTH_CONV_DEFINE_JUST_CONST(chain, kth_double_spend_proof_spender_const_t, kth::domain::message::double_spend_proof::spender, double_spend_proof_spender)
+// Conversion functions
+kth::domain::message::double_spend_proof::spender& kth_chain_double_spend_proof_spender_mut_cpp(kth_double_spend_proof_spender_mut_t o) {
+    return *static_cast<kth::domain::message::double_spend_proof::spender*>(o);
+}
+kth::domain::message::double_spend_proof::spender const& kth_chain_double_spend_proof_spender_const_cpp(kth_double_spend_proof_spender_const_t o) {
+    return *static_cast<kth::domain::message::double_spend_proof::spender const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-uint32_t kth_chain_double_spend_proof_spender_version(kth_double_spend_proof_spender_const_t spender) {
-    return kth_chain_double_spend_proof_spender_const_cpp(spender).version;
-}
+// Constructors
 
-uint32_t kth_chain_double_spend_proof_spender_out_sequence(kth_double_spend_proof_spender_const_t spender) {
-    return kth_chain_double_spend_proof_spender_const_cpp(spender).out_sequence;
-}
-
-uint32_t kth_chain_double_spend_proof_spender_locktime(kth_double_spend_proof_spender_const_t spender) {
-    return kth_chain_double_spend_proof_spender_const_cpp(spender).locktime;
-}
-
-kth_hash_t kth_chain_double_spend_proof_spender_prev_outs_hash(kth_double_spend_proof_spender_const_t spender) {
-    auto const& hash_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender).prev_outs_hash;
-    return kth::to_hash_t(hash_cpp);
-}
-
-void kth_chain_double_spend_proof_spender_prev_outs_hash_out(kth_double_spend_proof_spender_const_t spender, kth_hash_t* out_hash) {
-    auto const& hash_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender).prev_outs_hash;
-    kth::copy_c_hash(hash_cpp, out_hash);
-}
-
-kth_hash_t kth_chain_double_spend_proof_spender_sequence_hash(kth_double_spend_proof_spender_const_t spender) {
-    auto const& hash_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender).sequence_hash;
-    return kth::to_hash_t(hash_cpp);
-}
-
-void kth_chain_double_spend_proof_spender_sequence_hash_out(kth_double_spend_proof_spender_const_t spender, kth_hash_t* out_hash) {
-    auto const& hash_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender).sequence_hash;
-    kth::copy_c_hash(hash_cpp, out_hash);
+kth_error_code_t kth_chain_double_spend_proof_spender_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_double_spend_proof_spender_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
+    auto result = kth::domain::message::double_spend_proof::spender::from_data(data_cpp, version);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = new kth::domain::message::double_spend_proof::spender(std::move(*result));
+    return kth_ec_success;
 }
 
 
-kth_hash_t kth_chain_double_spend_proof_spender_outputs_hash(kth_double_spend_proof_spender_const_t spender) {
-    auto const& hash_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender).outputs_hash;
-    return kth::to_hash_t(hash_cpp);
-}
+// Destructor
 
-void kth_chain_double_spend_proof_spender_outputs_hash_out(kth_double_spend_proof_spender_const_t spender, kth_hash_t* out_hash) {
-    auto const& hash_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender).outputs_hash;
-    kth::copy_c_hash(hash_cpp, out_hash);
+void kth_chain_double_spend_proof_spender_destruct(kth_double_spend_proof_spender_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_double_spend_proof_spender_mut_cpp(self);
 }
 
 
-uint8_t const* kth_chain_double_spend_proof_spender_push_data(kth_double_spend_proof_spender_const_t spender, kth_size_t* out_size) {
-    auto const& data = kth_chain_double_spend_proof_spender_const_cpp(spender).push_data;
+// Copy
+
+kth_double_spend_proof_spender_mut_t kth_chain_double_spend_proof_spender_copy(kth_double_spend_proof_spender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::message::double_spend_proof::spender(kth_chain_double_spend_proof_spender_const_cpp(self));
+}
+
+
+// Equality
+
+kth_bool_t kth_chain_double_spend_proof_spender_equals(kth_double_spend_proof_spender_const_t self, kth_double_spend_proof_spender_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_double_spend_proof_spender_const_cpp(self) == kth_chain_double_spend_proof_spender_const_cpp(other));
+}
+
+
+// Serialization
+
+kth_size_t kth_chain_double_spend_proof_spender_serialized_size(kth_double_spend_proof_spender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_double_spend_proof_spender_const_cpp(self).serialized_size();
+}
+
+
+// Getters
+
+uint32_t kth_chain_double_spend_proof_spender_version(kth_double_spend_proof_spender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_double_spend_proof_spender_const_cpp(self).version;
+}
+
+uint32_t kth_chain_double_spend_proof_spender_out_sequence(kth_double_spend_proof_spender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_double_spend_proof_spender_const_cpp(self).out_sequence;
+}
+
+uint32_t kth_chain_double_spend_proof_spender_locktime(kth_double_spend_proof_spender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth_chain_double_spend_proof_spender_const_cpp(self).locktime;
+}
+
+kth_hash_t kth_chain_double_spend_proof_spender_prev_outs_hash(kth_double_spend_proof_spender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_chain_double_spend_proof_spender_const_cpp(self).prev_outs_hash;
+    return kth::to_hash_t(value_cpp);
+}
+
+kth_hash_t kth_chain_double_spend_proof_spender_sequence_hash(kth_double_spend_proof_spender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_chain_double_spend_proof_spender_const_cpp(self).sequence_hash;
+    return kth::to_hash_t(value_cpp);
+}
+
+kth_hash_t kth_chain_double_spend_proof_spender_outputs_hash(kth_double_spend_proof_spender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_chain_double_spend_proof_spender_const_cpp(self).outputs_hash;
+    return kth::to_hash_t(value_cpp);
+}
+
+uint8_t* kth_chain_double_spend_proof_spender_push_data(kth_double_spend_proof_spender_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const& data = kth_chain_double_spend_proof_spender_const_cpp(self).push_data;
     return kth::create_c_array(data, *out_size);
 }
 
-kth_bool_t kth_chain_double_spend_proof_spender_is_valid(kth_double_spend_proof_spender_const_t spender) {
-    return kth::bool_to_int(kth_chain_double_spend_proof_spender_const_cpp(spender).is_valid());
+
+// Setters
+
+void kth_chain_double_spend_proof_spender_set_version(kth_double_spend_proof_spender_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).version = value;
 }
 
-kth_size_t kth_chain_double_spend_proof_spender_serialized_size(kth_double_spend_proof_spender_const_t spender) {
-    return kth_chain_double_spend_proof_spender_const_cpp(spender).serialized_size();
+void kth_chain_double_spend_proof_spender_set_out_sequence(kth_double_spend_proof_spender_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).out_sequence = value;
+}
+
+void kth_chain_double_spend_proof_spender_set_locktime(kth_double_spend_proof_spender_mut_t self, uint32_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).locktime = value;
+}
+
+void kth_chain_double_spend_proof_spender_set_prev_outs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).prev_outs_hash = value_cpp;
+}
+
+void kth_chain_double_spend_proof_spender_set_prev_outs_hash_unsafe(kth_double_spend_proof_spender_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).prev_outs_hash = value_cpp;
+}
+
+void kth_chain_double_spend_proof_spender_set_sequence_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).sequence_hash = value_cpp;
+}
+
+void kth_chain_double_spend_proof_spender_set_sequence_hash_unsafe(kth_double_spend_proof_spender_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).sequence_hash = value_cpp;
+}
+
+void kth_chain_double_spend_proof_spender_set_outputs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).outputs_hash = value_cpp;
+}
+
+void kth_chain_double_spend_proof_spender_set_outputs_hash_unsafe(kth_double_spend_proof_spender_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).outputs_hash = value_cpp;
+}
+
+void kth_chain_double_spend_proof_spender_set_push_data(kth_double_spend_proof_spender_mut_t self, uint8_t const* value, kth_size_t n) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr || n == 0);
+    auto const value_cpp = n != 0 ? kth::data_chunk(value, value + n) : kth::data_chunk{};
+    kth_chain_double_spend_proof_spender_mut_cpp(self).push_data = value_cpp;
+}
+
+
+// Predicates
+
+kth_bool_t kth_chain_double_spend_proof_spender_is_valid(kth_double_spend_proof_spender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_chain_double_spend_proof_spender_const_cpp(self).is_valid());
+}
+
+
+// Operations
+
+void kth_chain_double_spend_proof_spender_reset(kth_double_spend_proof_spender_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth_chain_double_spend_proof_spender_mut_cpp(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/double_spend_proof.cpp
+++ b/src/c-api/test/chain/double_spend_proof.cpp
@@ -1,0 +1,573 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/chain/double_spend_proof.h>
+#include <kth/capi/chain/double_spend_proof_spender.h>
+#include <kth/capi/chain/output_point.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+static kth_hash_t const kHashA = {{
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+    0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+    0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00
+}};
+
+static kth_hash_t const kHashB = {{
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef
+}};
+
+static kth_hash_t const kHashC = {{
+    0xca, 0xfe, 0xba, 0xbe, 0xca, 0xfe, 0xba, 0xbe,
+    0xca, 0xfe, 0xba, 0xbe, 0xca, 0xfe, 0xba, 0xbe,
+    0xca, 0xfe, 0xba, 0xbe, 0xca, 0xfe, 0xba, 0xbe,
+    0xca, 0xfe, 0xba, 0xbe, 0xca, 0xfe, 0xba, 0xbe
+}};
+
+// A minimal spender wire payload: 4+4+4 little-endian fields followed by
+// three 32-byte hashes, with empty trailing push_data. Total = 108 bytes.
+// Values: version=1, out_sequence=2, locktime=3, prev_outs_hash=kHashA,
+// sequence_hash=kHashB, outputs_hash=kHashC, push_data=(empty).
+static uint8_t const kSpenderWire[108] = {
+    // version = 1
+    0x01, 0x00, 0x00, 0x00,
+    // out_sequence = 2
+    0x02, 0x00, 0x00, 0x00,
+    // locktime = 3
+    0x03, 0x00, 0x00, 0x00,
+    // prev_outs_hash (kHashA)
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+    0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+    0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+    // sequence_hash (kHashB)
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+    // outputs_hash (kHashC)
+    0xca, 0xfe, 0xba, 0xbe, 0xca, 0xfe, 0xba, 0xbe,
+    0xca, 0xfe, 0xba, 0xbe, 0xca, 0xfe, 0xba, 0xbe,
+    0xca, 0xfe, 0xba, 0xbe, 0xca, 0xfe, 0xba, 0xbe,
+    0xca, 0xfe, 0xba, 0xbe, 0xca, 0xfe, 0xba, 0xbe
+};
+
+// ===========================================================================
+// DoubleSpendProofSpender
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DspSpender - destruct null is safe",
+          "[C-API DspSpender]") {
+    kth_chain_double_spend_proof_spender_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// from_data / construct
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DspSpender - from_data wire layout populates all fields",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(sp != NULL);
+
+    REQUIRE(kth_chain_double_spend_proof_spender_is_valid(sp) != 0);
+    REQUIRE(kth_chain_double_spend_proof_spender_version(sp) == 1u);
+    REQUIRE(kth_chain_double_spend_proof_spender_out_sequence(sp) == 2u);
+    REQUIRE(kth_chain_double_spend_proof_spender_locktime(sp) == 3u);
+    REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_prev_outs_hash(sp), kHashA) != 0);
+    REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_sequence_hash(sp), kHashB) != 0);
+    REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_outputs_hash(sp), kHashC) != 0);
+
+    kth_size_t push_size = 0;
+    uint8_t* push = kth_chain_double_spend_proof_spender_push_data(sp, &push_size);
+    REQUIRE(push_size == 0u);
+    kth_core_destruct_array(push);
+
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+TEST_CASE("C-API DspSpender - from_data insufficient bytes fails",
+          "[C-API DspSpender]") {
+    uint8_t data[10];
+    memset(data, 0, sizeof(data));
+    kth_double_spend_proof_spender_mut_t out = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        data, sizeof(data), 0u, &out);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(out == NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DspSpender - serialized_size is 108 for empty push_data",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(kth_chain_double_spend_proof_spender_serialized_size(sp) == 108u);
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+TEST_CASE("C-API DspSpender - serialized_size grows with push_data",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+
+    uint8_t const push[5] = {1, 2, 3, 4, 5};
+    kth_chain_double_spend_proof_spender_set_push_data(sp, push, sizeof(push));
+    REQUIRE(kth_chain_double_spend_proof_spender_serialized_size(sp) == 113u);
+
+    kth_size_t out_size = 0;
+    uint8_t* got = kth_chain_double_spend_proof_spender_push_data(sp, &out_size);
+    REQUIRE(out_size == sizeof(push));
+    REQUIRE(memcmp(got, push, sizeof(push)) == 0);
+    kth_core_destruct_array(got);
+
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+// ---------------------------------------------------------------------------
+// Setters / getters round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DspSpender - scalar setters round-trip",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+
+    kth_chain_double_spend_proof_spender_set_version(sp, 0xdeadbeefu);
+    kth_chain_double_spend_proof_spender_set_out_sequence(sp, 0xcafebabu);
+    kth_chain_double_spend_proof_spender_set_locktime(sp, 0x12345678u);
+
+    REQUIRE(kth_chain_double_spend_proof_spender_version(sp) == 0xdeadbeefu);
+    REQUIRE(kth_chain_double_spend_proof_spender_out_sequence(sp) == 0xcafebabu);
+    REQUIRE(kth_chain_double_spend_proof_spender_locktime(sp) == 0x12345678u);
+
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+TEST_CASE("C-API DspSpender - hash setters round-trip",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+
+    kth_chain_double_spend_proof_spender_set_prev_outs_hash(sp, kHashB);
+    kth_chain_double_spend_proof_spender_set_sequence_hash(sp, kHashC);
+    kth_chain_double_spend_proof_spender_set_outputs_hash(sp, kHashA);
+
+    REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_prev_outs_hash(sp), kHashB) != 0);
+    REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_sequence_hash(sp), kHashC) != 0);
+    REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_outputs_hash(sp), kHashA) != 0);
+
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+TEST_CASE("C-API DspSpender - unsafe hash setters round-trip",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+
+    kth_chain_double_spend_proof_spender_set_prev_outs_hash_unsafe(sp, kHashC.hash);
+    kth_chain_double_spend_proof_spender_set_sequence_hash_unsafe(sp, kHashA.hash);
+    kth_chain_double_spend_proof_spender_set_outputs_hash_unsafe(sp, kHashB.hash);
+
+    REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_prev_outs_hash(sp), kHashC) != 0);
+    REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_sequence_hash(sp), kHashA) != 0);
+    REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_outputs_hash(sp), kHashB) != 0);
+
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+TEST_CASE("C-API DspSpender - set_push_data with NULL and zero n clears it",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+
+    uint8_t const seed[3] = {9, 9, 9};
+    kth_chain_double_spend_proof_spender_set_push_data(sp, seed, sizeof(seed));
+
+    kth_chain_double_spend_proof_spender_set_push_data(sp, NULL, 0);
+    kth_size_t out_size = 99u;
+    uint8_t* got = kth_chain_double_spend_proof_spender_push_data(sp, &out_size);
+    REQUIRE(out_size == 0u);
+    kth_core_destruct_array(got);
+
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equals
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DspSpender - copy preserves equality",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t original = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &original);
+    REQUIRE(ec == kth_ec_success);
+
+    kth_double_spend_proof_spender_mut_t copy = kth_chain_double_spend_proof_spender_copy(original);
+    REQUIRE(copy != NULL);
+    REQUIRE(kth_chain_double_spend_proof_spender_equals(original, copy) != 0);
+
+    kth_chain_double_spend_proof_spender_set_version(copy, 99u);
+    REQUIRE(kth_chain_double_spend_proof_spender_equals(original, copy) == 0);
+
+    kth_chain_double_spend_proof_spender_destruct(copy);
+    kth_chain_double_spend_proof_spender_destruct(original);
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DspSpender - reset zeroes all fields",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(kth_chain_double_spend_proof_spender_is_valid(sp) != 0);
+
+    kth_chain_double_spend_proof_spender_reset(sp);
+
+    REQUIRE(kth_chain_double_spend_proof_spender_is_valid(sp) == 0);
+    REQUIRE(kth_chain_double_spend_proof_spender_version(sp) == 0u);
+    REQUIRE(kth_chain_double_spend_proof_spender_out_sequence(sp) == 0u);
+    REQUIRE(kth_chain_double_spend_proof_spender_locktime(sp) == 0u);
+    REQUIRE(kth_hash_is_null(kth_chain_double_spend_proof_spender_prev_outs_hash(sp)) != 0);
+    REQUIRE(kth_hash_is_null(kth_chain_double_spend_proof_spender_sequence_hash(sp)) != 0);
+    REQUIRE(kth_hash_is_null(kth_chain_double_spend_proof_spender_outputs_hash(sp)) != 0);
+
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DspSpender - from_data null out aborts",
+          "[C-API DspSpender][precondition]") {
+    KTH_EXPECT_ABORT(
+        kth_chain_double_spend_proof_spender_construct_from_data(kSpenderWire, sizeof(kSpenderWire), 0u, NULL));
+}
+
+TEST_CASE("C-API DspSpender - copy null self aborts",
+          "[C-API DspSpender][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_spender_copy(NULL));
+}
+
+TEST_CASE("C-API DspSpender - getter null aborts",
+          "[C-API DspSpender][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_spender_version(NULL));
+}
+
+TEST_CASE("C-API DspSpender - set_prev_outs_hash_unsafe null aborts",
+          "[C-API DspSpender][precondition]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_spender_set_prev_outs_hash_unsafe(sp, NULL));
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+// ===========================================================================
+// DoubleSpendProof
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Dsp - default construct produces invalid proof",
+          "[C-API Dsp]") {
+    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct_default();
+    REQUIRE(dsp != NULL);
+    // A default-constructed DSP has a default out_point and zero-filled
+    // spenders — therefore is_valid() == false.
+    REQUIRE(kth_chain_double_spend_proof_is_valid(dsp) == 0);
+    kth_chain_double_spend_proof_destruct(dsp);
+}
+
+TEST_CASE("C-API Dsp - destruct null is safe", "[C-API Dsp]") {
+    kth_chain_double_spend_proof_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Construction from components
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Dsp - construct with valid components is valid",
+          "[C-API Dsp]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 7u);
+    kth_double_spend_proof_spender_mut_t s1 = NULL;
+    kth_double_spend_proof_spender_mut_t s2 = NULL;
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s1) == kth_ec_success);
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s2) == kth_ec_success);
+
+    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct(op, s1, s2);
+    REQUIRE(dsp != NULL);
+    REQUIRE(kth_chain_double_spend_proof_is_valid(dsp) != 0);
+
+    // out_point was copied by value; fields round-trip.
+    kth_output_point_const_t op_view = kth_chain_double_spend_proof_out_point(dsp);
+    REQUIRE(kth_chain_output_point_index(op_view) == 7u);
+    REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op_view), kHashA) != 0);
+
+    // spender1 / spender2 round-trip.
+    kth_double_spend_proof_spender_const_t sp1_view = kth_chain_double_spend_proof_spender1(dsp);
+    kth_double_spend_proof_spender_const_t sp2_view = kth_chain_double_spend_proof_spender2(dsp);
+    REQUIRE(kth_chain_double_spend_proof_spender_equals(sp1_view, s1) != 0);
+    REQUIRE(kth_chain_double_spend_proof_spender_equals(sp2_view, s2) != 0);
+
+    kth_chain_double_spend_proof_destruct(dsp);
+    kth_chain_double_spend_proof_spender_destruct(s2);
+    kth_chain_double_spend_proof_spender_destruct(s1);
+    kth_chain_output_point_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Dsp - serialized_size matches to_data length",
+          "[C-API Dsp]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 0u);
+    kth_double_spend_proof_spender_mut_t s1 = NULL;
+    kth_double_spend_proof_spender_mut_t s2 = NULL;
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s1) == kth_ec_success);
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s2) == kth_ec_success);
+
+    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct(op, s1, s2);
+    REQUIRE(dsp != NULL);
+
+    kth_size_t const expected_size = kth_chain_double_spend_proof_serialized_size(dsp, 0u);
+    // outpoint (36) + spender1 (108) + spender2 (108) = 252
+    REQUIRE(expected_size == 252u);
+
+    kth_size_t got_size = 0;
+    uint8_t* raw = kth_chain_double_spend_proof_to_data(dsp, 0u, &got_size);
+    REQUIRE(raw != NULL);
+    REQUIRE(got_size == expected_size);
+
+    kth_core_destruct_array(raw);
+    kth_chain_double_spend_proof_destruct(dsp);
+    kth_chain_double_spend_proof_spender_destruct(s2);
+    kth_chain_double_spend_proof_spender_destruct(s1);
+    kth_chain_output_point_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Dsp - setters replace fields",
+          "[C-API Dsp]") {
+    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct_default();
+    REQUIRE(dsp != NULL);
+
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashB, 42u);
+    kth_chain_double_spend_proof_set_out_point(dsp, op);
+    kth_output_point_const_t op_view = kth_chain_double_spend_proof_out_point(dsp);
+    REQUIRE(kth_chain_output_point_index(op_view) == 42u);
+    REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op_view), kHashB) != 0);
+
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &sp) == kth_ec_success);
+
+    kth_chain_double_spend_proof_set_spender1(dsp, sp);
+    kth_chain_double_spend_proof_set_spender2(dsp, sp);
+    REQUIRE(kth_chain_double_spend_proof_spender_equals(kth_chain_double_spend_proof_spender1(dsp), sp) != 0);
+    REQUIRE(kth_chain_double_spend_proof_spender_equals(kth_chain_double_spend_proof_spender2(dsp), sp) != 0);
+    REQUIRE(kth_chain_double_spend_proof_is_valid(dsp) != 0);
+
+    kth_chain_double_spend_proof_spender_destruct(sp);
+    kth_chain_output_point_destruct(op);
+    kth_chain_double_spend_proof_destruct(dsp);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equals
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Dsp - copy preserves equality and diverges after mutation",
+          "[C-API Dsp]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 7u);
+    kth_double_spend_proof_spender_mut_t s1 = NULL;
+    kth_double_spend_proof_spender_mut_t s2 = NULL;
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s1) == kth_ec_success);
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s2) == kth_ec_success);
+
+    kth_double_spend_proof_mut_t original = kth_chain_double_spend_proof_construct(op, s1, s2);
+    REQUIRE(original != NULL);
+    kth_double_spend_proof_mut_t copy = kth_chain_double_spend_proof_copy(original);
+    REQUIRE(copy != NULL);
+    REQUIRE(kth_chain_double_spend_proof_equals(original, copy) != 0);
+
+    // Mutate the copy — the two must diverge.
+    kth_output_point_mut_t other_op = kth_chain_output_point_construct_from_hash_index(kHashB, 99u);
+    kth_chain_double_spend_proof_set_out_point(copy, other_op);
+    REQUIRE(kth_chain_double_spend_proof_equals(original, copy) == 0);
+
+    kth_chain_output_point_destruct(other_op);
+    kth_chain_double_spend_proof_destruct(copy);
+    kth_chain_double_spend_proof_destruct(original);
+    kth_chain_double_spend_proof_spender_destruct(s2);
+    kth_chain_double_spend_proof_spender_destruct(s1);
+    kth_chain_output_point_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Hash
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Dsp - hash is deterministic and mutation changes it",
+          "[C-API Dsp]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 0u);
+    kth_double_spend_proof_spender_mut_t s1 = NULL;
+    kth_double_spend_proof_spender_mut_t s2 = NULL;
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s1) == kth_ec_success);
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s2) == kth_ec_success);
+
+    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct(op, s1, s2);
+    REQUIRE(dsp != NULL);
+
+    kth_hash_t h1 = kth_chain_double_spend_proof_hash(dsp);
+    kth_hash_t h2 = kth_chain_double_spend_proof_hash(dsp);
+    REQUIRE(kth_hash_equal(h1, h2) != 0);
+    REQUIRE(kth_hash_is_null(h1) == 0);
+
+    // Mutate and verify the hash changes.
+    kth_double_spend_proof_spender_mut_t s_alt = kth_chain_double_spend_proof_spender_copy(s1);
+    kth_chain_double_spend_proof_spender_set_version(s_alt, 99u);
+    kth_chain_double_spend_proof_set_spender1(dsp, s_alt);
+    kth_hash_t h3 = kth_chain_double_spend_proof_hash(dsp);
+    REQUIRE(kth_hash_equal(h1, h3) == 0);
+
+    kth_chain_double_spend_proof_spender_destruct(s_alt);
+    kth_chain_double_spend_proof_destruct(dsp);
+    kth_chain_double_spend_proof_spender_destruct(s2);
+    kth_chain_double_spend_proof_spender_destruct(s1);
+    kth_chain_output_point_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Dsp - reset drops to invalid state",
+          "[C-API Dsp]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 7u);
+    kth_double_spend_proof_spender_mut_t s1 = NULL;
+    kth_double_spend_proof_spender_mut_t s2 = NULL;
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s1) == kth_ec_success);
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &s2) == kth_ec_success);
+
+    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct(op, s1, s2);
+    REQUIRE(dsp != NULL);
+    REQUIRE(kth_chain_double_spend_proof_is_valid(dsp) != 0);
+
+    kth_chain_double_spend_proof_reset(dsp);
+    REQUIRE(kth_chain_double_spend_proof_is_valid(dsp) == 0);
+
+    kth_chain_double_spend_proof_destruct(dsp);
+    kth_chain_double_spend_proof_spender_destruct(s2);
+    kth_chain_double_spend_proof_spender_destruct(s1);
+    kth_chain_output_point_destruct(op);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Dsp - copy null self aborts",
+          "[C-API Dsp][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_copy(NULL));
+}
+
+TEST_CASE("C-API Dsp - equals null self aborts",
+          "[C-API Dsp][precondition]") {
+    kth_double_spend_proof_mut_t other = kth_chain_double_spend_proof_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_equals(NULL, other));
+    kth_chain_double_spend_proof_destruct(other);
+}
+
+TEST_CASE("C-API Dsp - out_point null aborts",
+          "[C-API Dsp][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_out_point(NULL));
+}
+
+TEST_CASE("C-API Dsp - construct null out_point aborts",
+          "[C-API Dsp][precondition]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &sp) == kth_ec_success);
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_construct(NULL, sp, sp));
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+TEST_CASE("C-API Dsp - construct_from_data null out aborts",
+          "[C-API Dsp][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_construct_from_data(NULL, 0, 0u, NULL));
+}
+
+TEST_CASE("C-API Dsp - to_data null out_size aborts",
+          "[C-API Dsp][precondition]") {
+    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_to_data(dsp, 0u, NULL));
+    kth_chain_double_spend_proof_destruct(dsp);
+}

--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -580,6 +580,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/message/block.cpp
         test/message/block_transactions.cpp
         test/message/compact_block.cpp
+        test/message/double_spend_proof.cpp
         test/message/fee_filter.cpp
         test/message/filter_add.cpp
         test/message/filter_clear.cpp

--- a/src/domain/test/message/double_spend_proof.cpp
+++ b/src/domain/test/message/double_spend_proof.cpp
@@ -1,0 +1,334 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+using namespace kth;
+using namespace kd;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Test hashes — stable bit patterns used across the suite.
+static auto const k_hash_a = "1122334455667788" "99aabbccddeeff00"
+                             "1122334455667788" "99aabbccddeeff00"_hash;
+static auto const k_hash_b = "deadbeefdeadbeef" "deadbeefdeadbeef"
+                             "deadbeefdeadbeef" "deadbeefdeadbeef"_hash;
+static auto const k_hash_c = "cafebabecafebabe" "cafebabecafebabe"
+                             "cafebabecafebabe" "cafebabecafebabe"_hash;
+
+// Builds a spender with populated fields and no push_data, so its
+// serialized size is exactly 108 bytes (4+4+4+32+32+32). This makes
+// from_data round-trips deterministic (push_data is read via
+// read_remaining_bytes() and will be empty when we feed exactly 108 bytes).
+static message::double_spend_proof::spender make_spender(uint32_t version = 1) {
+    message::double_spend_proof::spender s;
+    s.version = version;
+    s.out_sequence = 2;
+    s.locktime = 3;
+    s.prev_outs_hash = k_hash_a;
+    s.sequence_hash = k_hash_b;
+    s.outputs_hash = k_hash_c;
+    return s;
+}
+
+// Builds an output_point with a non-null hash and an arbitrary index.
+static chain::output_point make_out_point() {
+    return chain::output_point(k_hash_a, 7u);
+}
+
+// ===========================================================================
+// spender
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Lifecycle / predicates
+// ---------------------------------------------------------------------------
+
+TEST_CASE("double_spend_proof::spender  default construct  is invalid", "[double_spend_proof::spender]") {
+    message::double_spend_proof::spender s;
+    REQUIRE( ! s.is_valid());
+    REQUIRE(s.version == 0u);
+    REQUIRE(s.out_sequence == 0u);
+    REQUIRE(s.locktime == 0u);
+    REQUIRE(s.prev_outs_hash == null_hash);
+    REQUIRE(s.sequence_hash == null_hash);
+    REQUIRE(s.outputs_hash == null_hash);
+    REQUIRE(s.push_data.empty());
+}
+
+TEST_CASE("double_spend_proof::spender  any nonzero field  is valid", "[double_spend_proof::spender]") {
+    {
+        message::double_spend_proof::spender s;
+        s.version = 1;
+        REQUIRE(s.is_valid());
+    }
+    {
+        message::double_spend_proof::spender s;
+        s.out_sequence = 1;
+        REQUIRE(s.is_valid());
+    }
+    {
+        message::double_spend_proof::spender s;
+        s.locktime = 1;
+        REQUIRE(s.is_valid());
+    }
+    {
+        message::double_spend_proof::spender s;
+        s.prev_outs_hash = k_hash_a;
+        REQUIRE(s.is_valid());
+    }
+    {
+        message::double_spend_proof::spender s;
+        s.sequence_hash = k_hash_a;
+        REQUIRE(s.is_valid());
+    }
+    {
+        message::double_spend_proof::spender s;
+        s.outputs_hash = k_hash_a;
+        REQUIRE(s.is_valid());
+    }
+}
+
+TEST_CASE("double_spend_proof::spender  reset  zeroes all fields", "[double_spend_proof::spender]") {
+    auto s = make_spender();
+    s.push_data = data_chunk{1, 2, 3};
+    REQUIRE(s.is_valid());
+
+    s.reset();
+
+    REQUIRE( ! s.is_valid());
+    REQUIRE(s.version == 0u);
+    REQUIRE(s.out_sequence == 0u);
+    REQUIRE(s.locktime == 0u);
+    REQUIRE(s.prev_outs_hash == null_hash);
+    REQUIRE(s.sequence_hash == null_hash);
+    REQUIRE(s.outputs_hash == null_hash);
+    REQUIRE(s.push_data.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Equality
+// ---------------------------------------------------------------------------
+
+TEST_CASE("double_spend_proof::spender  equality  reflexive and diverges under mutation", "[double_spend_proof::spender]") {
+    auto a = make_spender();
+    auto b = make_spender();
+    REQUIRE(a == b);
+    REQUIRE( ! (a != b));
+
+    b.version = 99;
+    REQUIRE(a != b);
+    REQUIRE( ! (a == b));
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+TEST_CASE("double_spend_proof::spender  serialized_size  is 108 with empty push_data", "[double_spend_proof::spender]") {
+    auto const s = make_spender();
+    REQUIRE(s.serialized_size() == 108u);
+}
+
+TEST_CASE("double_spend_proof::spender  serialized_size  grows with push_data", "[double_spend_proof::spender]") {
+    auto s = make_spender();
+    s.push_data = data_chunk{1, 2, 3, 4, 5};
+    REQUIRE(s.serialized_size() == 113u);
+}
+
+TEST_CASE("double_spend_proof::spender  from_data insufficient bytes  failure", "[double_spend_proof::spender]") {
+    data_chunk raw{0x00, 0x01, 0x02};
+    byte_reader reader(raw);
+    auto result = message::double_spend_proof::spender::from_data(reader, 0u);
+    REQUIRE( ! result);
+}
+
+TEST_CASE("double_spend_proof::spender  round-trip with empty push_data  preserves fields", "[double_spend_proof::spender]") {
+    auto const expected = make_spender();
+
+    // Spender does not expose a public stand-alone to_data(), only the
+    // templated writer variant. We feed it through the DSP serialization,
+    // which calls spender::to_data internally; but to isolate the spender
+    // round-trip we build the wire bytes manually with the same ordering.
+    data_chunk raw;
+    raw.reserve(expected.serialized_size());
+    // version LE
+    raw.push_back(static_cast<uint8_t>(expected.version & 0xffu));
+    raw.push_back(static_cast<uint8_t>((expected.version >> 8) & 0xffu));
+    raw.push_back(static_cast<uint8_t>((expected.version >> 16) & 0xffu));
+    raw.push_back(static_cast<uint8_t>((expected.version >> 24) & 0xffu));
+    // out_sequence LE
+    raw.push_back(static_cast<uint8_t>(expected.out_sequence & 0xffu));
+    raw.push_back(static_cast<uint8_t>((expected.out_sequence >> 8) & 0xffu));
+    raw.push_back(static_cast<uint8_t>((expected.out_sequence >> 16) & 0xffu));
+    raw.push_back(static_cast<uint8_t>((expected.out_sequence >> 24) & 0xffu));
+    // locktime LE
+    raw.push_back(static_cast<uint8_t>(expected.locktime & 0xffu));
+    raw.push_back(static_cast<uint8_t>((expected.locktime >> 8) & 0xffu));
+    raw.push_back(static_cast<uint8_t>((expected.locktime >> 16) & 0xffu));
+    raw.push_back(static_cast<uint8_t>((expected.locktime >> 24) & 0xffu));
+    // three hashes in declaration order
+    raw.insert(raw.end(), expected.prev_outs_hash.begin(), expected.prev_outs_hash.end());
+    raw.insert(raw.end(), expected.sequence_hash.begin(), expected.sequence_hash.end());
+    raw.insert(raw.end(), expected.outputs_hash.begin(), expected.outputs_hash.end());
+
+    REQUIRE(raw.size() == 108u);
+
+    byte_reader reader(raw);
+    auto result = message::double_spend_proof::spender::from_data(reader, 0u);
+    REQUIRE(result);
+    REQUIRE(*result == expected);
+}
+
+// ===========================================================================
+// double_spend_proof
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Constructors / predicates
+// ---------------------------------------------------------------------------
+
+TEST_CASE("double_spend_proof  default construct  is invalid", "[double_spend_proof]") {
+    message::double_spend_proof dsp;
+    REQUIRE( ! dsp.is_valid());
+}
+
+TEST_CASE("double_spend_proof  three-arg construct  preserves fields", "[double_spend_proof]") {
+    auto const out_point = make_out_point();
+    auto const s1 = make_spender(1);
+    auto const s2 = make_spender(2);
+
+    message::double_spend_proof dsp(out_point, s1, s2);
+    REQUIRE(dsp.is_valid());
+    REQUIRE(dsp.out_point() == out_point);
+    REQUIRE(dsp.spender1() == s1);
+    REQUIRE(dsp.spender2() == s2);
+}
+
+TEST_CASE("double_spend_proof  is_valid  requires all three components", "[double_spend_proof]") {
+    auto const op = make_out_point();
+    auto const s = make_spender();
+
+    // Valid out_point + two valid spenders → valid.
+    REQUIRE(message::double_spend_proof(op, s, s).is_valid());
+
+    // Default-constructed out_point makes the whole proof invalid.
+    REQUIRE( ! message::double_spend_proof(chain::output_point{}, s, s).is_valid());
+
+    // A default (all-zero) spender makes the proof invalid.
+    REQUIRE( ! message::double_spend_proof(op, message::double_spend_proof::spender{}, s).is_valid());
+    REQUIRE( ! message::double_spend_proof(op, s, message::double_spend_proof::spender{}).is_valid());
+}
+
+TEST_CASE("double_spend_proof  reset  drops to invalid", "[double_spend_proof]") {
+    message::double_spend_proof dsp(make_out_point(), make_spender(), make_spender());
+    REQUIRE(dsp.is_valid());
+
+    dsp.reset();
+    REQUIRE( ! dsp.is_valid());
+    REQUIRE(dsp.out_point() == chain::output_point{});
+    REQUIRE( ! dsp.spender1().is_valid());
+    REQUIRE( ! dsp.spender2().is_valid());
+}
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+TEST_CASE("double_spend_proof  setters  replace fields", "[double_spend_proof]") {
+    message::double_spend_proof dsp;
+
+    auto const op = make_out_point();
+    dsp.set_out_point(op);
+    REQUIRE(dsp.out_point() == op);
+
+    auto const s1 = make_spender(1);
+    dsp.set_spender1(s1);
+    REQUIRE(dsp.spender1() == s1);
+
+    auto const s2 = make_spender(2);
+    dsp.set_spender2(s2);
+    REQUIRE(dsp.spender2() == s2);
+
+    REQUIRE(dsp.is_valid());
+}
+
+// ---------------------------------------------------------------------------
+// Equality
+// ---------------------------------------------------------------------------
+
+TEST_CASE("double_spend_proof  equality  reflexive and diverges under mutation", "[double_spend_proof]") {
+    message::double_spend_proof a(make_out_point(), make_spender(1), make_spender(2));
+    message::double_spend_proof b(make_out_point(), make_spender(1), make_spender(2));
+
+    REQUIRE(a == b);
+    REQUIRE( ! (a != b));
+
+    b.set_spender1(make_spender(99));
+    REQUIRE(a != b);
+    REQUIRE( ! (a == b));
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+TEST_CASE("double_spend_proof  serialized_size  matches to_data length", "[double_spend_proof]") {
+    message::double_spend_proof dsp(make_out_point(), make_spender(1), make_spender(2));
+
+    auto const size = dsp.serialized_size(0);
+    // outpoint (36) + spender1 (108) + spender2 (108) = 252
+    REQUIRE(size == 252u);
+
+    auto const raw = dsp.to_data(0);
+    REQUIRE(raw.size() == size);
+}
+
+TEST_CASE("double_spend_proof  from_data insufficient bytes  failure", "[double_spend_proof]") {
+    data_chunk const raw{0xab, 0xcd, 0xef};
+    byte_reader reader(raw);
+    auto result = message::double_spend_proof::from_data(reader, 0u);
+    REQUIRE( ! result);
+}
+
+// ---------------------------------------------------------------------------
+// Hash
+// ---------------------------------------------------------------------------
+
+TEST_CASE("double_spend_proof  hash  is deterministic", "[double_spend_proof]") {
+    message::double_spend_proof dsp(make_out_point(), make_spender(1), make_spender(2));
+
+    auto const h1 = dsp.hash();
+    auto const h2 = dsp.hash();
+    REQUIRE(h1 == h2);
+    REQUIRE(h1 != null_hash);
+
+    // The free-function overload must agree with the member.
+    REQUIRE(message::hash(dsp) == h1);
+}
+
+TEST_CASE("double_spend_proof  hash  changes under mutation", "[double_spend_proof]") {
+    message::double_spend_proof dsp(make_out_point(), make_spender(1), make_spender(2));
+    auto const h1 = dsp.hash();
+
+    dsp.set_spender1(make_spender(99));
+    auto const h2 = dsp.hash();
+    REQUIRE(h1 != h2);
+}
+
+TEST_CASE("double_spend_proof  hash  differs between distinct proofs", "[double_spend_proof]") {
+    message::double_spend_proof a(make_out_point(), make_spender(1), make_spender(2));
+    message::double_spend_proof b(chain::output_point(k_hash_b, 7u), make_spender(1), make_spender(2));
+    REQUIRE(a.hash() != b.hash());
+}
+
+// ---------------------------------------------------------------------------
+// Static metadata
+// ---------------------------------------------------------------------------
+
+TEST_CASE("double_spend_proof  command  is dsproof-beta", "[double_spend_proof]") {
+    REQUIRE(message::double_spend_proof::command == "dsproof-beta");
+}


### PR DESCRIPTION
## Summary
- Migrate `double_spend_proof` and its nested `spender` type to the const/mut typed handle pattern (`kth_double_spend_proof_{const,mut}_t` and `kth_double_spend_proof_spender_{const,mut}_t`).
- Expose field-level accessors on `spender` for every public data member (version / out_sequence / locktime / prev_outs_hash / sequence_hash / outputs_hash / push_data), including `_unsafe` pointer variants for the hash setters.
- Add behavioral test coverage at both layers: `src/c-api/test/chain/double_spend_proof.cpp` and `src/domain/test/message/double_spend_proof.cpp` — the domain had no dedicated DSP coverage before this PR (only two passing references to the command string).

## Test plan
- [ ] C-API test suite (`kth_capi_test`) compiles and passes, including the new `[C-API Dsp]` and `[C-API DspSpender]` cases.
- [ ] Domain test suite compiles and passes, including the new `[double_spend_proof]` and `[double_spend_proof::spender]` cases.
- [ ] No regressions in other C-API bindings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public C-API surface and ownership semantics (new handle types, new constructors/serialization buffers), which can break downstream consumers if mismatched, but changes are localized and heavily covered by new tests.
> 
> **Overview**
> Refactors the C-API bindings for **double-spend proof** to use the const/mut typed-handle pattern (`kth_double_spend_proof_{const,mut}_t` and `kth_double_spend_proof_spender_{const,mut}_t`), updating function signatures (including the DS-proof subscription callback) and adding explicit conversion shims in `conversions.hpp`.
> 
> Expands the exposed C surface for `double_spend_proof` and `spender` with safer lifecycle/utility APIs (default + from-bytes constructors, copy, equality, serialization to owned buffers, full field getters/setters including `_unsafe` hash setters, and reset/validity checks) backed by new Catch2 tests in both `c-api` and `domain` test suites, and wires those tests into CMake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae801459bcba2b9e90936b581281f959ff68629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->