### PR TITLE
refactor(c-api): harden constructors and modernize wallet/ec_public

### DIFF
--- a/src/c-api/include/kth/capi/binary.h
+++ b/src/c-api/include/kth/capi/binary.h
@@ -20,15 +20,15 @@ extern "C" {
 KTH_EXPORT KTH_OWNED
 kth_binary_mut_t kth_core_binary_construct_default(void);
 
-/** @return Owned `kth_binary_mut_t`. Caller must release with `kth_core_binary_destruct`. */
+/** @return Owned `kth_binary_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_core_binary_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_binary_mut_t kth_core_binary_construct_from_bit_string(char const* bit_string);
 
-/** @return Owned `kth_binary_mut_t`. Caller must release with `kth_core_binary_destruct`. */
+/** @return Owned `kth_binary_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_core_binary_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_binary_mut_t kth_core_binary_construct_from_size_number(kth_size_t size, uint32_t number);
 
-/** @return Owned `kth_binary_mut_t`. Caller must release with `kth_core_binary_destruct`. */
+/** @return Owned `kth_binary_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_core_binary_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_binary_mut_t kth_core_binary_construct_from_size_blocks(kth_size_t size, uint8_t const* blocks, kth_size_t n);
 
@@ -102,7 +102,7 @@ void kth_core_binary_shift_left(kth_binary_mut_t self, kth_size_t distance);
 KTH_EXPORT
 void kth_core_binary_shift_right(kth_binary_mut_t self, kth_size_t distance);
 
-/** @return Owned `kth_binary_mut_t`. Caller must release with `kth_core_binary_destruct`. */
+/** @return Owned `kth_binary_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_core_binary_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_binary_mut_t kth_core_binary_substring(kth_binary_const_t self, kth_size_t start, kth_size_t length);
 

--- a/src/c-api/include/kth/capi/chain/block.h
+++ b/src/c-api/include/kth/capi/chain/block.h
@@ -26,7 +26,7 @@ KTH_EXPORT
 kth_error_code_t kth_chain_block_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_block_mut_t* out);
 
 /**
- * @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`.
+ * @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`.
  * @param header Borrowed input. Copied by value into the resulting object; ownership of `header` stays with the caller.
  * @param transactions Borrowed input. Copied by value into the resulting object; ownership of `transactions` stays with the caller.
  */
@@ -36,27 +36,27 @@ kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transac
 
 // Static factories
 
-/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_mainnet(void);
 
-/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_testnet(void);
 
-/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_regtest(void);
 
-/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_testnet4(void);
 
-/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_scalenet(void);
 
-/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_chipnet(void);
 

--- a/src/c-api/include/kth/capi/chain/compact_block.h
+++ b/src/c-api/include/kth/capi/chain/compact_block.h
@@ -25,7 +25,7 @@ KTH_EXPORT
 kth_error_code_t kth_chain_compact_block_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_compact_block_mut_t* out);
 
 /**
- * @return Owned `kth_compact_block_mut_t`. Caller must release with `kth_chain_compact_block_destruct`.
+ * @return Owned `kth_compact_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_compact_block_destruct`.
  * @param header Borrowed input. Copied by value into the resulting object; ownership of `header` stays with the caller.
  * @param short_ids Borrowed input. Copied by value into the resulting object; ownership of `short_ids` stays with the caller.
  * @param transactions Borrowed input. Copied by value into the resulting object; ownership of `transactions` stays with the caller.

--- a/src/c-api/include/kth/capi/chain/double_spend_proof.h
+++ b/src/c-api/include/kth/capi/chain/double_spend_proof.h
@@ -16,7 +16,7 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_double_spend_proof_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_double_spend_proof_destruct`. */
+/** @return Owned `kth_double_spend_proof_mut_t`. Caller must release with `kth_chain_double_spend_proof_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_double_spend_proof_mut_t kth_chain_double_spend_proof_construct_default(void);
 

--- a/src/c-api/include/kth/capi/chain/get_blocks.h
+++ b/src/c-api/include/kth/capi/chain/get_blocks.h
@@ -25,14 +25,14 @@ KTH_EXPORT
 kth_error_code_t kth_chain_get_blocks_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_get_blocks_mut_t* out);
 
 /**
- * @return Owned `kth_get_blocks_mut_t`. Caller must release with `kth_chain_get_blocks_destruct`.
+ * @return Owned `kth_get_blocks_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_get_blocks_destruct`.
  * @param start Borrowed input. Copied by value into the resulting object; ownership of `start` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
 kth_get_blocks_mut_t kth_chain_get_blocks_construct(kth_hash_list_const_t start, kth_hash_t stop);
 
 /**
- * @return Owned `kth_get_blocks_mut_t`. Caller must release with `kth_chain_get_blocks_destruct`.
+ * @return Owned `kth_get_blocks_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_get_blocks_destruct`.
  * @param start Borrowed input. Copied by value into the resulting object; ownership of `start` stays with the caller.
  * @warning `stop` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */

--- a/src/c-api/include/kth/capi/chain/get_headers.h
+++ b/src/c-api/include/kth/capi/chain/get_headers.h
@@ -25,14 +25,14 @@ KTH_EXPORT
 kth_error_code_t kth_chain_get_headers_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_get_headers_mut_t* out);
 
 /**
- * @return Owned `kth_get_headers_mut_t`. Caller must release with `kth_chain_get_headers_destruct`.
+ * @return Owned `kth_get_headers_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_get_headers_destruct`.
  * @param start Borrowed input. Copied by value into the resulting object; ownership of `start` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
 kth_get_headers_mut_t kth_chain_get_headers_construct(kth_hash_list_const_t start, kth_hash_t stop);
 
 /**
- * @return Owned `kth_get_headers_mut_t`. Caller must release with `kth_chain_get_headers_destruct`.
+ * @return Owned `kth_get_headers_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_get_headers_destruct`.
  * @param start Borrowed input. Copied by value into the resulting object; ownership of `start` stays with the caller.
  * @warning `stop` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */

--- a/src/c-api/include/kth/capi/chain/header.h
+++ b/src/c-api/include/kth/capi/chain/header.h
@@ -24,12 +24,12 @@ kth_header_mut_t kth_chain_header_construct_default(void);
 KTH_EXPORT
 kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_header_mut_t* out);
 
-/** @return Owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`. */
+/** @return Owned `kth_header_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_header_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_header_mut_t kth_chain_header_construct(uint32_t version, kth_hash_t previous_block_hash, kth_hash_t merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce);
 
 /**
- * @return Owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`.
+ * @return Owned `kth_header_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_header_destruct`.
  * @warning `previous_block_hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  * @warning `merkle` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */

--- a/src/c-api/include/kth/capi/chain/input.h
+++ b/src/c-api/include/kth/capi/chain/input.h
@@ -25,7 +25,7 @@ KTH_EXPORT
 kth_error_code_t kth_chain_input_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_input_mut_t* out);
 
 /**
- * @return Owned `kth_input_mut_t`. Caller must release with `kth_chain_input_destruct`.
+ * @return Owned `kth_input_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_input_destruct`.
  * @param previous_output Borrowed input. Copied by value into the resulting object; ownership of `previous_output` stays with the caller.
  * @param script Borrowed input. Copied by value into the resulting object; ownership of `script` stays with the caller.
  */
@@ -65,7 +65,7 @@ kth_size_t kth_chain_input_serialized_size(kth_input_const_t self, kth_bool_t wi
 
 // Getters
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_chain_input_address(kth_input_const_t self);
 

--- a/src/c-api/include/kth/capi/chain/merkle_block.h
+++ b/src/c-api/include/kth/capi/chain/merkle_block.h
@@ -25,7 +25,7 @@ KTH_EXPORT
 kth_error_code_t kth_chain_merkle_block_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_merkle_block_mut_t* out);
 
 /**
- * @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`.
+ * @return Owned `kth_merkle_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_merkle_block_destruct`.
  * @param header Borrowed input. Copied by value into the resulting object; ownership of `header` stays with the caller.
  * @param hashes Borrowed input. Copied by value into the resulting object; ownership of `hashes` stays with the caller.
  */
@@ -33,7 +33,7 @@ KTH_EXPORT KTH_OWNED
 kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_header_total_transactions_hashes_flags(kth_header_const_t header, kth_size_t total_transactions, kth_hash_list_const_t hashes, uint8_t const* flags, kth_size_t n);
 
 /**
- * @return Owned `kth_merkle_block_mut_t`. Caller must release with `kth_chain_merkle_block_destruct`.
+ * @return Owned `kth_merkle_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_merkle_block_destruct`.
  * @param block Borrowed input. Copied by value into the resulting object; ownership of `block` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED

--- a/src/c-api/include/kth/capi/chain/operation.h
+++ b/src/c-api/include/kth/capi/chain/operation.h
@@ -26,11 +26,11 @@ kth_operation_mut_t kth_chain_operation_construct_default(void);
 KTH_EXPORT
 kth_error_code_t kth_chain_operation_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_operation_mut_t* out);
 
-/** @return Owned `kth_operation_mut_t`. Caller must release with `kth_chain_operation_destruct`. */
+/** @return Owned `kth_operation_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_operation_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_operation_mut_t kth_chain_operation_construct_from_uncoded_minimal(uint8_t const* uncoded, kth_size_t n, kth_bool_t minimal);
 
-/** @return Owned `kth_operation_mut_t`. Caller must release with `kth_chain_operation_destruct`. */
+/** @return Owned `kth_operation_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_operation_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_operation_mut_t kth_chain_operation_construct_from_code(kth_opcode_t code);
 

--- a/src/c-api/include/kth/capi/chain/output.h
+++ b/src/c-api/include/kth/capi/chain/output.h
@@ -25,7 +25,7 @@ KTH_EXPORT
 kth_error_code_t kth_chain_output_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_output_mut_t* out);
 
 /**
- * @return Owned `kth_output_mut_t`. Caller must release with `kth_chain_output_destruct`.
+ * @return Owned `kth_output_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_output_destruct`.
  * @param script Borrowed input. Copied by value into the resulting object; ownership of `script` stays with the caller.
  * @param token_data Borrowed input. Copied by value into the resulting object; ownership of `token_data` stays with the caller.
  */
@@ -102,11 +102,11 @@ kth_bool_t kth_chain_output_is_dust(kth_output_const_t self, uint64_t minimum_ou
 
 // Operations
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_chain_output_address_simple(kth_output_const_t self, kth_bool_t testnet);
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_chain_output_address(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version);
 

--- a/src/c-api/include/kth/capi/chain/output_point.h
+++ b/src/c-api/include/kth/capi/chain/output_point.h
@@ -24,19 +24,19 @@ kth_output_point_mut_t kth_chain_output_point_construct_default(void);
 KTH_EXPORT
 kth_error_code_t kth_chain_output_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_output_point_mut_t* out);
 
-/** @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`. */
+/** @return Owned `kth_output_point_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_output_point_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(kth_hash_t hash, uint32_t index);
 
 /**
- * @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`.
+ * @return Owned `kth_output_point_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_output_point_destruct`.
  * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
 kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index_unsafe(uint8_t const* hash, uint32_t index);
 
 /**
- * @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`.
+ * @return Owned `kth_output_point_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_output_point_destruct`.
  * @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED

--- a/src/c-api/include/kth/capi/chain/point.h
+++ b/src/c-api/include/kth/capi/chain/point.h
@@ -24,12 +24,12 @@ kth_point_mut_t kth_chain_point_construct_default(void);
 KTH_EXPORT
 kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_point_mut_t* out);
 
-/** @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`. */
+/** @return Owned `kth_point_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_point_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_point_mut_t kth_chain_point_construct(kth_hash_t hash, uint32_t index);
 
 /**
- * @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`.
+ * @return Owned `kth_point_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_point_destruct`.
  * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED

--- a/src/c-api/include/kth/capi/chain/prefilled_transaction.h
+++ b/src/c-api/include/kth/capi/chain/prefilled_transaction.h
@@ -25,7 +25,7 @@ KTH_EXPORT
 kth_error_code_t kth_chain_prefilled_transaction_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_prefilled_transaction_mut_t* out);
 
 /**
- * @return Owned `kth_prefilled_transaction_mut_t`. Caller must release with `kth_chain_prefilled_transaction_destruct`.
+ * @return Owned `kth_prefilled_transaction_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_prefilled_transaction_destruct`.
  * @param tx Borrowed input. Copied by value into the resulting object; ownership of `tx` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED

--- a/src/c-api/include/kth/capi/chain/script.h
+++ b/src/c-api/include/kth/capi/chain/script.h
@@ -11,6 +11,7 @@
 #include <kth/capi/visibility.h>
 #include <kth/capi/chain/script_flags.h>
 #include <kth/capi/chain/script_pattern.h>
+#include <kth/capi/wallet/primitives.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,13 +28,13 @@ KTH_EXPORT
 kth_error_code_t kth_chain_script_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_script_mut_t* out);
 
 /**
- * @return Owned `kth_script_mut_t`. Caller must release with `kth_chain_script_destruct`.
+ * @return Owned `kth_script_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_script_destruct`.
  * @param ops Borrowed input. Copied by value into the resulting object; ownership of `ops` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
 kth_script_mut_t kth_chain_script_construct_from_operations(kth_operation_list_const_t ops);
 
-/** @return Owned `kth_script_mut_t`. Caller must release with `kth_chain_script_destruct`. */
+/** @return Owned `kth_script_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_script_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_script_mut_t kth_chain_script_construct_from_encoded_prefix(uint8_t const* encoded, kth_size_t n, kth_bool_t prefix);
 
@@ -88,7 +89,7 @@ kth_operation_const_t kth_chain_script_back(kth_script_const_t self);
 KTH_EXPORT
 kth_operation_list_const_t kth_chain_script_operations(kth_script_const_t self);
 
-/** @return Owned `kth_operation_mut_t`. Caller must release with `kth_chain_operation_destruct`. */
+/** @return Owned `kth_operation_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_operation_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_operation_mut_t kth_chain_script_first_operation(kth_script_const_t self);
 
@@ -236,6 +237,10 @@ kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unsafe(
 
 /** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
 KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocking(uint8_t const* end, kth_size_t n, kth_ec_public_const_t pubkey);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocking_placeholder(kth_size_t endorsement_size, kth_size_t pubkey_size);
 
 /** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
@@ -273,7 +278,7 @@ KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_multisig_pattern_data_stack(uint8_t signatures, kth_data_stack_const_t points);
 
 KTH_EXPORT
-kth_error_code_t kth_chain_script_verify(kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t flags, kth_script_const_t input_script, kth_script_const_t prevout_script, uint64_t arg5);
+kth_error_code_t kth_chain_script_verify(kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t flags, kth_script_const_t input_script, kth_script_const_t prevout_script, uint64_t value);
 
 KTH_EXPORT
 kth_error_code_t kth_chain_script_verify_simple(kth_transaction_const_t tx, uint32_t input, kth_script_flags_t flags);

--- a/src/c-api/include/kth/capi/chain/transaction.h
+++ b/src/c-api/include/kth/capi/chain/transaction.h
@@ -26,7 +26,7 @@ KTH_EXPORT
 kth_error_code_t kth_chain_transaction_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_transaction_mut_t* out);
 
 /**
- * @return Owned `kth_transaction_mut_t`. Caller must release with `kth_chain_transaction_destruct`.
+ * @return Owned `kth_transaction_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_transaction_destruct`.
  * @param inputs Borrowed input. Copied by value into the resulting object; ownership of `inputs` stays with the caller.
  * @param outputs Borrowed input. Copied by value into the resulting object; ownership of `outputs` stays with the caller.
  */
@@ -34,14 +34,14 @@ KTH_EXPORT KTH_OWNED
 kth_transaction_mut_t kth_chain_transaction_construct_from_version_locktime_inputs_outputs(uint32_t version, uint32_t locktime, kth_input_list_const_t inputs, kth_output_list_const_t outputs);
 
 /**
- * @return Owned `kth_transaction_mut_t`. Caller must release with `kth_chain_transaction_destruct`.
+ * @return Owned `kth_transaction_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_transaction_destruct`.
  * @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
 kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash(kth_transaction_const_t x, kth_hash_t hash);
 
 /**
- * @return Owned `kth_transaction_mut_t`. Caller must release with `kth_chain_transaction_destruct`.
+ * @return Owned `kth_transaction_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_transaction_destruct`.
  * @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller.
  * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */

--- a/src/c-api/include/kth/capi/wallet/ec_private.h
+++ b/src/c-api/include/kth/capi/wallet/ec_private.h
@@ -21,38 +21,38 @@ extern "C" {
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_default(void);
 
-/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+/** @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_version(char const* wif, uint8_t version);
 
-/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+/** @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version(kth_wif_compressed_t wif_compressed, uint8_t version);
 
 /**
- * @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`.
+ * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
  * @warning `wif_compressed` MUST point to a buffer of at least 38 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version_unsafe(uint8_t const* wif_compressed, uint8_t version);
 
-/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+/** @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version(kth_wif_uncompressed_t wif_uncompressed, uint8_t version);
 
 /**
- * @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`.
+ * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
  * @warning `wif_uncompressed` MUST point to a buffer of at least 37 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version_unsafe(uint8_t const* wif_uncompressed, uint8_t version);
 
-/** @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`. */
+/** @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(kth_hash_t secret, uint16_t version, kth_bool_t compress);
 
 /**
- * @return Owned `kth_ec_private_mut_t`. Caller must release with `kth_wallet_ec_private_destruct`.
+ * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
  * @warning `secret` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
@@ -81,6 +81,10 @@ kth_bool_t kth_wallet_ec_private_equals(kth_ec_private_const_t self, kth_ec_priv
 
 // Getters
 
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
+KTH_EXPORT
+kth_bool_t kth_wallet_ec_private_valid(kth_ec_private_const_t self);
+
 /** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
 KTH_EXPORT KTH_OWNED
 char* kth_wallet_ec_private_encoded(kth_ec_private_const_t self);
@@ -100,11 +104,11 @@ uint8_t kth_wallet_ec_private_wif_version(kth_ec_private_const_t self);
 KTH_EXPORT
 kth_bool_t kth_wallet_ec_private_compressed(kth_ec_private_const_t self);
 
-/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+/** @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_private_to_public(kth_ec_private_const_t self);
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_ec_private_to_payment_address(kth_ec_private_const_t self);
 

--- a/src/c-api/include/kth/capi/wallet/ec_public.h
+++ b/src/c-api/include/kth/capi/wallet/ec_public.h
@@ -22,37 +22,37 @@ KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_default(void);
 
 /**
- * @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`.
+ * @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`.
  * @param secret Borrowed input. Copied by value into the resulting object; ownership of `secret` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_ec_private(kth_ec_private_const_t secret);
 
-/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+/** @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_decoded(uint8_t const* decoded, kth_size_t n);
 
-/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+/** @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_base16(char const* base16);
 
-/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+/** @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress(kth_ec_compressed_t compressed_point, kth_bool_t compress);
 
 /**
- * @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`.
+ * @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`.
  * @warning `compressed_point` MUST point to a buffer of at least 33 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress_unsafe(uint8_t const* compressed_point, kth_bool_t compress);
 
-/** @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`. */
+/** @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress(kth_ec_uncompressed_t uncompressed_point, kth_bool_t compress);
 
 /**
- * @return Owned `kth_ec_public_mut_t`. Caller must release with `kth_wallet_ec_public_destruct`.
+ * @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`.
  * @warning `uncompressed_point` MUST point to a buffer of at least 65 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
@@ -81,12 +81,15 @@ kth_bool_t kth_wallet_ec_public_equals(kth_ec_public_const_t self, kth_ec_public
 
 // Serialization
 
-/** @return Owned byte buffer (33 bytes compressed, 65 uncompressed). Caller must release with `kth_core_destruct_array`. */
-KTH_EXPORT KTH_OWNED
-uint8_t* kth_wallet_ec_public_to_data(kth_ec_public_const_t self, kth_size_t* out_size);
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_public_to_data(kth_ec_public_const_t self, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size);
 
 
 // Getters
+
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
+KTH_EXPORT
+kth_bool_t kth_wallet_ec_public_valid(kth_ec_public_const_t self);
 
 /** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
 KTH_EXPORT KTH_OWNED
@@ -96,16 +99,11 @@ KTH_EXPORT
 kth_ec_compressed_t kth_wallet_ec_public_point(kth_ec_public_const_t self);
 
 KTH_EXPORT
-uint16_t kth_wallet_ec_public_version(kth_ec_public_const_t self);
-
-KTH_EXPORT
-uint8_t kth_wallet_ec_public_payment_version(kth_ec_public_const_t self);
-
-KTH_EXPORT
-uint8_t kth_wallet_ec_public_wif_version(kth_ec_public_const_t self);
-
-KTH_EXPORT
 kth_bool_t kth_wallet_ec_public_compressed(kth_ec_public_const_t self);
+
+/** @warning `out` MUST point to a buffer of at least 65 bytes; `n` MUST be `>= 65`. Passing a shorter buffer aborts via the precondition check. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_ec_public_to_uncompressed(kth_ec_public_const_t self, uint8_t* out, kth_size_t n);
 
 
 // Operations
@@ -113,10 +111,7 @@ kth_bool_t kth_wallet_ec_public_compressed(kth_ec_public_const_t self);
 KTH_EXPORT
 kth_bool_t kth_wallet_ec_public_less(kth_ec_public_const_t self, kth_ec_public_const_t x);
 
-KTH_EXPORT
-kth_bool_t kth_wallet_ec_public_to_uncompressed(kth_ec_public_const_t self, uint8_t* out);
-
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_ec_public_to_payment_address(kth_ec_public_const_t self, uint8_t version);
 

--- a/src/c-api/include/kth/capi/wallet/hd_private.h
+++ b/src/c-api/include/kth/capi/wallet/hd_private.h
@@ -11,7 +11,6 @@
 #include <kth/capi/visibility.h>
 #include <kth/capi/wallet/primitives.h>
 #include <kth/capi/wallet/hd_lineage.h>
-#include <kth/capi/wallet/hd_public.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,7 +18,7 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`. */
+/** @return Owned `kth_hd_private_mut_t`. Caller must release with `kth_wallet_hd_private_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_hd_private_mut_t kth_wallet_hd_private_construct_default(void);
 
@@ -82,7 +81,7 @@ void kth_wallet_hd_private_destruct(kth_hd_private_mut_t self);
 
 // Copy
 
-/** @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`. */
+/** @return Owned `kth_hd_private_mut_t`. Caller must release with `kth_wallet_hd_private_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_hd_private_mut_t kth_wallet_hd_private_copy(kth_hd_private_const_t self);
 
@@ -109,6 +108,7 @@ kth_hd_key_t kth_wallet_hd_private_to_hd_key(kth_hd_private_const_t self);
 KTH_EXPORT KTH_OWNED
 kth_hd_public_mut_t kth_wallet_hd_private_to_public(kth_hd_private_const_t self);
 
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
 KTH_EXPORT
 kth_bool_t kth_wallet_hd_private_valid(kth_hd_private_const_t self);
 

--- a/src/c-api/include/kth/capi/wallet/hd_public.h
+++ b/src/c-api/include/kth/capi/wallet/hd_public.h
@@ -18,7 +18,7 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_hd_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_public_destruct`. */
+/** @return Owned `kth_hd_public_mut_t`. Caller must release with `kth_wallet_hd_public_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_hd_public_mut_t kth_wallet_hd_public_construct_default(void);
 
@@ -62,7 +62,7 @@ void kth_wallet_hd_public_destruct(kth_hd_public_mut_t self);
 
 // Copy
 
-/** @return Owned `kth_hd_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_public_destruct`. */
+/** @return Owned `kth_hd_public_mut_t`. Caller must release with `kth_wallet_hd_public_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_hd_public_mut_t kth_wallet_hd_public_copy(kth_hd_public_const_t self);
 
@@ -75,6 +75,7 @@ kth_bool_t kth_wallet_hd_public_equals(kth_hd_public_const_t self, kth_hd_public
 
 // Getters
 
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
 KTH_EXPORT
 kth_bool_t kth_wallet_hd_public_valid(kth_hd_public_const_t self);
 

--- a/src/c-api/include/kth/capi/wallet/payment_address.h
+++ b/src/c-api/include/kth/capi/wallet/payment_address.h
@@ -21,63 +21,63 @@ extern "C" {
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_default(void);
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded(kth_payment_t decoded);
 
 /**
- * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
  * @warning `decoded` MUST point to a buffer of at least 25 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded_unsafe(uint8_t const* decoded);
 
 /**
- * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
  * @param secret Borrowed input. Copied by value into the resulting object; ownership of `secret` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_private(kth_ec_private_const_t secret);
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address(char const* address);
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address_net(char const* address, kth_network_t net);
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t short_hash, uint8_t version);
 
 /**
- * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
  * @warning `short_hash` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version_unsafe(uint8_t const* short_hash, uint8_t version);
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version(kth_hash_t hash, uint8_t version);
 
 /**
- * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
  * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version_unsafe(uint8_t const* hash, uint8_t version);
 
 /**
- * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
  * @param point Borrowed input. Copied by value into the resulting object; ownership of `point` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_public_version(kth_ec_public_const_t point, uint8_t version);
 
 /**
- * @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`.
+ * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
  * @param script Borrowed input. Copied by value into the resulting object; ownership of `script` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
@@ -86,7 +86,7 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_from_script_versi
 
 // Static factories
 
-/** @return Owned `kth_payment_address_mut_t`. Caller must release with `kth_wallet_payment_address_destruct`. */
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version);
 
@@ -113,6 +113,7 @@ kth_bool_t kth_wallet_payment_address_equals(kth_payment_address_const_t self, k
 
 // Getters
 
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
 KTH_EXPORT
 kth_bool_t kth_wallet_payment_address_valid(kth_payment_address_const_t self);
 

--- a/src/c-api/src/binary.cpp
+++ b/src/c-api/src/binary.cpp
@@ -30,19 +30,25 @@ kth_binary_mut_t kth_core_binary_construct_default(void) {
 kth_binary_mut_t kth_core_binary_construct_from_bit_string(char const* bit_string) {
     KTH_PRECONDITION(bit_string != nullptr);
     auto const bit_string_cpp = std::string_view(bit_string);
-    return new kth::binary(bit_string_cpp);
+    auto* obj = new kth::binary(bit_string_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_binary_mut_t kth_core_binary_construct_from_size_number(kth_size_t size, uint32_t number) {
     auto const size_cpp = static_cast<size_t>(size);
-    return new kth::binary(size_cpp, number);
+    auto* obj = new kth::binary(size_cpp, number);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_binary_mut_t kth_core_binary_construct_from_size_blocks(kth_size_t size, uint8_t const* blocks, kth_size_t n) {
     KTH_PRECONDITION(blocks != nullptr || n == 0);
     auto const size_cpp = static_cast<size_t>(size);
     auto const blocks_cpp = kth::byte_span(blocks, static_cast<size_t>(n));
-    return new kth::binary(size_cpp, blocks_cpp);
+    auto* obj = new kth::binary(size_cpp, blocks_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
@@ -165,7 +171,9 @@ kth_binary_mut_t kth_core_binary_substring(kth_binary_const_t self, kth_size_t s
     KTH_PRECONDITION(self != nullptr);
     auto const start_cpp = static_cast<size_t>(start);
     auto const length_cpp = static_cast<size_t>(length);
-    return new kth::binary(kth_core_binary_const_cpp(self).substring(start_cpp, length_cpp));
+    auto* obj = new kth::binary(kth_core_binary_const_cpp(self).substring(start_cpp, length_cpp));
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_bool_t kth_core_binary_less(kth_binary_const_t self, kth_binary_const_t x) {

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/block.h>
 
 #include <kth/capi/conversions.hpp>
@@ -43,34 +45,48 @@ kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transac
     KTH_PRECONDITION(transactions != nullptr);
     auto const& header_cpp = kth_chain_header_const_cpp(header);
     auto const& transactions_cpp = kth_chain_transaction_list_const_cpp(transactions);
-    return new kth::domain::chain::block(header_cpp, transactions_cpp);
+    auto* obj = new kth::domain::chain::block(header_cpp, transactions_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
 // Static factories
 
 kth_block_mut_t kth_chain_block_genesis_mainnet(void) {
-    return new kth::domain::chain::block(kth::domain::chain::block::genesis_mainnet());
+    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_mainnet());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_block_mut_t kth_chain_block_genesis_testnet(void) {
-    return new kth::domain::chain::block(kth::domain::chain::block::genesis_testnet());
+    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_testnet());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_block_mut_t kth_chain_block_genesis_regtest(void) {
-    return new kth::domain::chain::block(kth::domain::chain::block::genesis_regtest());
+    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_regtest());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_block_mut_t kth_chain_block_genesis_testnet4(void) {
-    return new kth::domain::chain::block(kth::domain::chain::block::genesis_testnet4());
+    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_testnet4());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_block_mut_t kth_chain_block_genesis_scalenet(void) {
-    return new kth::domain::chain::block(kth::domain::chain::block::genesis_scalenet());
+    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_scalenet());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_block_mut_t kth_chain_block_genesis_chipnet(void) {
-    return new kth::domain::chain::block(kth::domain::chain::block::genesis_chipnet());
+    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_chipnet());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/compact_block.cpp
+++ b/src/c-api/src/chain/compact_block.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/compact_block.h>
 
 #include <kth/capi/conversions.hpp>
@@ -44,7 +46,9 @@ kth_compact_block_mut_t kth_chain_compact_block_construct(kth_header_const_t hea
     auto const& header_cpp = kth_chain_header_const_cpp(header);
     auto const& short_ids_cpp = kth_core_u64_list_const_cpp(short_ids);
     auto const& transactions_cpp = kth_chain_prefilled_transaction_list_const_cpp(transactions);
-    return new kth::domain::message::compact_block(header_cpp, nonce, short_ids_cpp, transactions_cpp);
+    auto* obj = new kth::domain::message::compact_block(header_cpp, nonce, short_ids_cpp, transactions_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/double_spend_proof.cpp
+++ b/src/c-api/src/chain/double_spend_proof.cpp
@@ -83,7 +83,7 @@ uint8_t* kth_chain_double_spend_proof_to_data(kth_double_spend_proof_const_t sel
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const version_cpp = static_cast<size_t>(version);
-    auto const& data = kth_chain_double_spend_proof_const_cpp(self).to_data(version_cpp);
+    auto const data = kth_chain_double_spend_proof_const_cpp(self).to_data(version_cpp);
     return kth::create_c_array(data, *out_size);
 }
 

--- a/src/c-api/src/chain/get_blocks.cpp
+++ b/src/c-api/src/chain/get_blocks.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/get_blocks.h>
 
 #include <kth/capi/conversions.hpp>
@@ -41,7 +43,9 @@ kth_get_blocks_mut_t kth_chain_get_blocks_construct(kth_hash_list_const_t start,
     KTH_PRECONDITION(start != nullptr);
     auto const& start_cpp = kth_core_hash_list_const_cpp(start);
     auto const stop_cpp = kth::hash_to_cpp(stop.hash);
-    return new kth::domain::message::get_blocks(start_cpp, stop_cpp);
+    auto* obj = new kth::domain::message::get_blocks(start_cpp, stop_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_get_blocks_mut_t kth_chain_get_blocks_construct_unsafe(kth_hash_list_const_t start, uint8_t const* stop) {
@@ -49,7 +53,9 @@ kth_get_blocks_mut_t kth_chain_get_blocks_construct_unsafe(kth_hash_list_const_t
     KTH_PRECONDITION(stop != nullptr);
     auto const& start_cpp = kth_core_hash_list_const_cpp(start);
     auto const stop_cpp = kth::hash_to_cpp(stop);
-    return new kth::domain::message::get_blocks(start_cpp, stop_cpp);
+    auto* obj = new kth::domain::message::get_blocks(start_cpp, stop_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/get_headers.cpp
+++ b/src/c-api/src/chain/get_headers.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/get_headers.h>
 
 #include <kth/capi/conversions.hpp>
@@ -41,7 +43,9 @@ kth_get_headers_mut_t kth_chain_get_headers_construct(kth_hash_list_const_t star
     KTH_PRECONDITION(start != nullptr);
     auto const& start_cpp = kth_core_hash_list_const_cpp(start);
     auto const stop_cpp = kth::hash_to_cpp(stop.hash);
-    return new kth::domain::message::get_headers(start_cpp, stop_cpp);
+    auto* obj = new kth::domain::message::get_headers(start_cpp, stop_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_get_headers_mut_t kth_chain_get_headers_construct_unsafe(kth_hash_list_const_t start, uint8_t const* stop) {
@@ -49,7 +53,9 @@ kth_get_headers_mut_t kth_chain_get_headers_construct_unsafe(kth_hash_list_const
     KTH_PRECONDITION(stop != nullptr);
     auto const& start_cpp = kth_core_hash_list_const_cpp(start);
     auto const stop_cpp = kth::hash_to_cpp(stop);
-    return new kth::domain::message::get_headers(start_cpp, stop_cpp);
+    auto* obj = new kth::domain::message::get_headers(start_cpp, stop_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/header.h>
 
 #include <kth/capi/conversions.hpp>
@@ -41,7 +43,9 @@ kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_s
 kth_header_mut_t kth_chain_header_construct(uint32_t version, kth_hash_t previous_block_hash, kth_hash_t merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce) {
     auto const previous_block_hash_cpp = kth::hash_to_cpp(previous_block_hash.hash);
     auto const merkle_cpp = kth::hash_to_cpp(merkle.hash);
-    return new kth::domain::chain::header(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce);
+    auto* obj = new kth::domain::chain::header(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_header_mut_t kth_chain_header_construct_unsafe(uint32_t version, uint8_t const* previous_block_hash, uint8_t const* merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce) {
@@ -49,7 +53,9 @@ kth_header_mut_t kth_chain_header_construct_unsafe(uint32_t version, uint8_t con
     KTH_PRECONDITION(merkle != nullptr);
     auto const previous_block_hash_cpp = kth::hash_to_cpp(previous_block_hash);
     auto const merkle_cpp = kth::hash_to_cpp(merkle);
-    return new kth::domain::chain::header(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce);
+    auto* obj = new kth::domain::chain::header(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/input.cpp
+++ b/src/c-api/src/chain/input.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/input.h>
 
 #include <kth/capi/conversions.hpp>
@@ -43,7 +45,9 @@ kth_input_mut_t kth_chain_input_construct(kth_output_point_const_t previous_outp
     KTH_PRECONDITION(script != nullptr);
     auto const& previous_output_cpp = kth_chain_output_point_const_cpp(previous_output);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
-    return new kth::domain::chain::input(previous_output_cpp, script_cpp, sequence);
+    auto* obj = new kth::domain::chain::input(previous_output_cpp, script_cpp, sequence);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
@@ -93,7 +97,9 @@ kth_size_t kth_chain_input_serialized_size(kth_input_const_t self, kth_bool_t wi
 
 kth_payment_address_mut_t kth_chain_input_address(kth_input_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    return new kth::domain::wallet::payment_address(kth_chain_input_const_cpp(self).address());
+    auto* obj = new kth::domain::wallet::payment_address(kth_chain_input_const_cpp(self).address());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_list_mut_t kth_chain_input_addresses(kth_input_const_t self) {

--- a/src/c-api/src/chain/merkle_block.cpp
+++ b/src/c-api/src/chain/merkle_block.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/merkle_block.h>
 
 #include <kth/capi/conversions.hpp>
@@ -45,13 +47,17 @@ kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_header_total_transa
     auto const total_transactions_cpp = static_cast<size_t>(total_transactions);
     auto const& hashes_cpp = kth_core_hash_list_const_cpp(hashes);
     auto const flags_cpp = n != 0 ? kth::data_chunk(flags, flags + n) : kth::data_chunk{};
-    return new kth::domain::message::merkle_block(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp);
+    auto* obj = new kth::domain::message::merkle_block(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_block(kth_block_const_t block) {
     KTH_PRECONDITION(block != nullptr);
     auto const& block_cpp = kth_chain_block_const_cpp(block);
-    return new kth::domain::message::merkle_block(block_cpp);
+    auto* obj = new kth::domain::message::merkle_block(block_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/operation.cpp
+++ b/src/c-api/src/chain/operation.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/operation.h>
 
 #include <kth/capi/conversions.hpp>
@@ -41,12 +43,16 @@ kth_operation_mut_t kth_chain_operation_construct_from_uncoded_minimal(uint8_t c
     KTH_PRECONDITION(uncoded != nullptr || n == 0);
     auto const uncoded_cpp = n != 0 ? kth::data_chunk(uncoded, uncoded + n) : kth::data_chunk{};
     auto const minimal_cpp = kth::int_to_bool(minimal);
-    return new kth::domain::machine::operation(uncoded_cpp, minimal_cpp);
+    auto* obj = new kth::domain::machine::operation(uncoded_cpp, minimal_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_operation_mut_t kth_chain_operation_construct_from_code(kth_opcode_t code) {
     auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
-    return new kth::domain::machine::operation(code_cpp);
+    auto* obj = new kth::domain::machine::operation(code_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/output.cpp
+++ b/src/c-api/src/chain/output.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/output.h>
 
 #include <kth/capi/conversions.hpp>
@@ -42,7 +44,9 @@ kth_output_mut_t kth_chain_output_construct(uint64_t value, kth_script_const_t s
     KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
     auto const token_data_cpp = (token_data == nullptr ? std::nullopt : std::optional<kth::domain::chain::token_data_t>(kth_chain_token_data_const_cpp(token_data)));
-    return new kth::domain::chain::output(value, script_cpp, token_data_cpp);
+    auto* obj = new kth::domain::chain::output(value, script_cpp, token_data_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
@@ -146,12 +150,16 @@ kth_bool_t kth_chain_output_is_dust(kth_output_const_t self, uint64_t minimum_ou
 kth_payment_address_mut_t kth_chain_output_address_simple(kth_output_const_t self, kth_bool_t testnet) {
     KTH_PRECONDITION(self != nullptr);
     auto const testnet_cpp = kth::int_to_bool(testnet);
-    return new kth::domain::wallet::payment_address(kth_chain_output_const_cpp(self).address(testnet_cpp));
+    auto* obj = new kth::domain::wallet::payment_address(kth_chain_output_const_cpp(self).address(testnet_cpp));
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_chain_output_address(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version) {
     KTH_PRECONDITION(self != nullptr);
-    return new kth::domain::wallet::payment_address(kth_chain_output_const_cpp(self).address(p2kh_version, p2sh_version));
+    auto* obj = new kth::domain::wallet::payment_address(kth_chain_output_const_cpp(self).address(p2kh_version, p2sh_version));
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_list_mut_t kth_chain_output_addresses(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version) {

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/output_point.h>
 
 #include <kth/capi/conversions.hpp>
@@ -40,19 +42,25 @@ kth_error_code_t kth_chain_output_point_construct_from_data(uint8_t const* data,
 
 kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(kth_hash_t hash, uint32_t index) {
     auto const hash_cpp = kth::hash_to_cpp(hash.hash);
-    return new kth::domain::chain::output_point(hash_cpp, index);
+    auto* obj = new kth::domain::chain::output_point(hash_cpp, index);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index_unsafe(uint8_t const* hash, uint32_t index) {
     KTH_PRECONDITION(hash != nullptr);
     auto const hash_cpp = kth::hash_to_cpp(hash);
-    return new kth::domain::chain::output_point(hash_cpp, index);
+    auto* obj = new kth::domain::chain::output_point(hash_cpp, index);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_output_point_mut_t kth_chain_output_point_construct_from_point(kth_point_const_t x) {
     KTH_PRECONDITION(x != nullptr);
     auto const& x_cpp = kth_chain_point_const_cpp(x);
-    return new kth::domain::chain::output_point(x_cpp);
+    auto* obj = new kth::domain::chain::output_point(x_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/point.cpp
+++ b/src/c-api/src/chain/point.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/point.h>
 
 #include <kth/capi/conversions.hpp>
@@ -40,20 +42,25 @@ kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_si
 
 kth_point_mut_t kth_chain_point_construct(kth_hash_t hash, uint32_t index) {
     auto const hash_cpp = kth::hash_to_cpp(hash.hash);
-    return new kth::domain::chain::point(hash_cpp, index);
+    auto* obj = new kth::domain::chain::point(hash_cpp, index);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_point_mut_t kth_chain_point_construct_unsafe(uint8_t const* hash, uint32_t index) {
     KTH_PRECONDITION(hash != nullptr);
     auto const hash_cpp = kth::hash_to_cpp(hash);
-    return new kth::domain::chain::point(hash_cpp, index);
+    auto* obj = new kth::domain::chain::point(hash_cpp, index);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
 // Static factories
 
 kth_point_mut_t kth_chain_point_null(void) {
-    return new kth::domain::chain::point(kth::domain::chain::point::null());
+    auto* obj = new kth::domain::chain::point(kth::domain::chain::point::null());
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/prefilled_transaction.cpp
+++ b/src/c-api/src/chain/prefilled_transaction.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/prefilled_transaction.h>
 
 #include <kth/capi/conversions.hpp>
@@ -40,7 +42,9 @@ kth_error_code_t kth_chain_prefilled_transaction_construct_from_data(uint8_t con
 kth_prefilled_transaction_mut_t kth_chain_prefilled_transaction_construct(uint64_t index, kth_transaction_const_t tx) {
     KTH_PRECONDITION(tx != nullptr);
     auto const& tx_cpp = kth_chain_transaction_const_cpp(tx);
-    return new kth::domain::message::prefilled_transaction(index, tx_cpp);
+    auto* obj = new kth::domain::message::prefilled_transaction(index, tx_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/chain/script.cpp
+++ b/src/c-api/src/chain/script.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/script.h>
 
 #include <kth/capi/conversions.hpp>
@@ -41,14 +43,18 @@ kth_error_code_t kth_chain_script_construct_from_data(uint8_t const* data, kth_s
 kth_script_mut_t kth_chain_script_construct_from_operations(kth_operation_list_const_t ops) {
     KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
-    return new kth::domain::chain::script(ops_cpp);
+    auto* obj = new kth::domain::chain::script(ops_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_script_mut_t kth_chain_script_construct_from_encoded_prefix(uint8_t const* encoded, kth_size_t n, kth_bool_t prefix) {
     KTH_PRECONDITION(encoded != nullptr || n == 0);
     auto const encoded_cpp = n != 0 ? kth::data_chunk(encoded, encoded + n) : kth::data_chunk{};
     auto const prefix_cpp = kth::int_to_bool(prefix);
-    return new kth::domain::chain::script(encoded_cpp, prefix_cpp);
+    auto* obj = new kth::domain::chain::script(encoded_cpp, prefix_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
@@ -125,7 +131,9 @@ kth_operation_list_const_t kth_chain_script_operations(kth_script_const_t self) 
 
 kth_operation_mut_t kth_chain_script_first_operation(kth_script_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    return new kth::domain::machine::operation(kth_chain_script_const_cpp(self).first_operation());
+    auto* obj = new kth::domain::machine::operation(kth_chain_script_const_cpp(self).first_operation());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_script_pattern_t kth_chain_script_pattern(kth_script_const_t self) {
@@ -418,6 +426,14 @@ kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unsafe(
     return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_public_key_hash_pattern(hash_cpp));
 }
 
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocking(uint8_t const* end, kth_size_t n, kth_ec_public_const_t pubkey) {
+    KTH_PRECONDITION(end != nullptr || n == 0);
+    KTH_PRECONDITION(pubkey != nullptr);
+    auto const end_cpp = n != 0 ? kth::data_chunk(end, end + n) : kth::data_chunk{};
+    auto const& pubkey_cpp = kth_wallet_ec_public_const_cpp(pubkey);
+    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_public_key_hash_pattern_unlocking(end_cpp, pubkey_cpp));
+}
+
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocking_placeholder(kth_size_t endorsement_size, kth_size_t pubkey_size) {
     auto const endorsement_size_cpp = static_cast<size_t>(endorsement_size);
     auto const pubkey_size_cpp = static_cast<size_t>(pubkey_size);
@@ -464,14 +480,14 @@ kth_operation_list_mut_t kth_chain_script_to_pay_multisig_pattern_data_stack(uin
     return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_multisig_pattern(signatures, points_cpp));
 }
 
-kth_error_code_t kth_chain_script_verify(kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t flags, kth_script_const_t input_script, kth_script_const_t prevout_script, uint64_t arg5) {
+kth_error_code_t kth_chain_script_verify(kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t flags, kth_script_const_t input_script, kth_script_const_t prevout_script, uint64_t value) {
     KTH_PRECONDITION(tx != nullptr);
     KTH_PRECONDITION(input_script != nullptr);
     KTH_PRECONDITION(prevout_script != nullptr);
     auto const& tx_cpp = kth_chain_transaction_const_cpp(tx);
     auto const& input_script_cpp = kth_chain_script_const_cpp(input_script);
     auto const& prevout_script_cpp = kth_chain_script_const_cpp(prevout_script);
-    return static_cast<kth_error_code_t>((kth::domain::chain::script::verify(tx_cpp, input_index, flags, input_script_cpp, prevout_script_cpp, arg5)).value());
+    return static_cast<kth_error_code_t>((kth::domain::chain::script::verify(tx_cpp, input_index, flags, input_script_cpp, prevout_script_cpp, value)).value());
 }
 
 kth_error_code_t kth_chain_script_verify_simple(kth_transaction_const_t tx, uint32_t input, kth_script_flags_t flags) {

--- a/src/c-api/src/chain/transaction.cpp
+++ b/src/c-api/src/chain/transaction.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/chain/transaction.h>
 
 #include <kth/capi/conversions.hpp>
@@ -43,14 +45,18 @@ kth_transaction_mut_t kth_chain_transaction_construct_from_version_locktime_inpu
     KTH_PRECONDITION(outputs != nullptr);
     auto const& inputs_cpp = kth_chain_input_list_const_cpp(inputs);
     auto const& outputs_cpp = kth_chain_output_list_const_cpp(outputs);
-    return new kth::domain::chain::transaction(version, locktime, inputs_cpp, outputs_cpp);
+    auto* obj = new kth::domain::chain::transaction(version, locktime, inputs_cpp, outputs_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash(kth_transaction_const_t x, kth_hash_t hash) {
     KTH_PRECONDITION(x != nullptr);
     auto const& x_cpp = kth_chain_transaction_const_cpp(x);
     auto const hash_cpp = kth::hash_to_cpp(hash.hash);
-    return new kth::domain::chain::transaction(x_cpp, hash_cpp);
+    auto* obj = new kth::domain::chain::transaction(x_cpp, hash_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash_unsafe(kth_transaction_const_t x, uint8_t const* hash) {
@@ -58,7 +64,9 @@ kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash_unsa
     KTH_PRECONDITION(hash != nullptr);
     auto const& x_cpp = kth_chain_transaction_const_cpp(x);
     auto const hash_cpp = kth::hash_to_cpp(hash);
-    return new kth::domain::chain::transaction(x_cpp, hash_cpp);
+    auto* obj = new kth::domain::chain::transaction(x_cpp, hash_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/wallet/ec_private.cpp
+++ b/src/c-api/src/wallet/ec_private.cpp
@@ -28,42 +28,56 @@ kth_ec_private_mut_t kth_wallet_ec_private_construct_default(void) {
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_version(char const* wif, uint8_t version) {
     KTH_PRECONDITION(wif != nullptr);
     auto const wif_cpp = std::string(wif);
-    return new kth::domain::wallet::ec_private(wif_cpp, version);
+    auto* obj = new kth::domain::wallet::ec_private(wif_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version(kth_wif_compressed_t wif_compressed, uint8_t version) {
     auto const wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed.data);
-    return new kth::domain::wallet::ec_private(wif_compressed_cpp, version);
+    auto* obj = new kth::domain::wallet::ec_private(wif_compressed_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version_unsafe(uint8_t const* wif_compressed, uint8_t version) {
     KTH_PRECONDITION(wif_compressed != nullptr);
     auto const wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed);
-    return new kth::domain::wallet::ec_private(wif_compressed_cpp, version);
+    auto* obj = new kth::domain::wallet::ec_private(wif_compressed_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version(kth_wif_uncompressed_t wif_uncompressed, uint8_t version) {
     auto const wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed.data);
-    return new kth::domain::wallet::ec_private(wif_uncompressed_cpp, version);
+    auto* obj = new kth::domain::wallet::ec_private(wif_uncompressed_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version_unsafe(uint8_t const* wif_uncompressed, uint8_t version) {
     KTH_PRECONDITION(wif_uncompressed != nullptr);
     auto const wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed);
-    return new kth::domain::wallet::ec_private(wif_uncompressed_cpp, version);
+    auto* obj = new kth::domain::wallet::ec_private(wif_uncompressed_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(kth_hash_t secret, uint16_t version, kth_bool_t compress) {
     auto const secret_cpp = kth::hash_to_cpp(secret.hash);
     auto const compress_cpp = kth::int_to_bool(compress);
-    return new kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp);
+    auto* obj = new kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress_unsafe(uint8_t const* secret, uint16_t version, kth_bool_t compress) {
     KTH_PRECONDITION(secret != nullptr);
     auto const secret_cpp = kth::hash_to_cpp(secret);
     auto const compress_cpp = kth::int_to_bool(compress);
-    return new kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp);
+    auto* obj = new kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
@@ -93,6 +107,11 @@ kth_bool_t kth_wallet_ec_private_equals(kth_ec_private_const_t self, kth_ec_priv
 
 
 // Getters
+
+kth_bool_t kth_wallet_ec_private_valid(kth_ec_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_wallet_ec_private_const_cpp(self).operator bool());
+}
 
 char* kth_wallet_ec_private_encoded(kth_ec_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
@@ -128,12 +147,16 @@ kth_bool_t kth_wallet_ec_private_compressed(kth_ec_private_const_t self) {
 
 kth_ec_public_mut_t kth_wallet_ec_private_to_public(kth_ec_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    return new kth::domain::wallet::ec_public(kth_wallet_ec_private_const_cpp(self).to_public());
+    auto* obj = new kth::domain::wallet::ec_public(kth_wallet_ec_private_const_cpp(self).to_public());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_ec_private_to_payment_address(kth_ec_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    return new kth::domain::wallet::payment_address(kth_wallet_ec_private_const_cpp(self).to_payment_address());
+    auto* obj = new kth::domain::wallet::payment_address(kth_wallet_ec_private_const_cpp(self).to_payment_address());
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 

--- a/src/c-api/src/wallet/ec_public.cpp
+++ b/src/c-api/src/wallet/ec_public.cpp
@@ -30,45 +30,59 @@ kth_ec_public_mut_t kth_wallet_ec_public_construct_default(void) {
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_ec_private(kth_ec_private_const_t secret) {
     KTH_PRECONDITION(secret != nullptr);
     auto const& secret_cpp = kth_wallet_ec_private_const_cpp(secret);
-    return new kth::domain::wallet::ec_public(secret_cpp);
+    auto* obj = new kth::domain::wallet::ec_public(secret_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_decoded(uint8_t const* decoded, kth_size_t n) {
     KTH_PRECONDITION(decoded != nullptr || n == 0);
     auto const decoded_cpp = n != 0 ? kth::data_chunk(decoded, decoded + n) : kth::data_chunk{};
-    return new kth::domain::wallet::ec_public(decoded_cpp);
+    auto* obj = new kth::domain::wallet::ec_public(decoded_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_base16(char const* base16) {
     KTH_PRECONDITION(base16 != nullptr);
     auto const base16_cpp = std::string(base16);
-    return new kth::domain::wallet::ec_public(base16_cpp);
+    auto* obj = new kth::domain::wallet::ec_public(base16_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress(kth_ec_compressed_t compressed_point, kth_bool_t compress) {
     auto const compressed_point_cpp = kth::ec_compressed_to_cpp(compressed_point.data);
     auto const compress_cpp = kth::int_to_bool(compress);
-    return new kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp);
+    auto* obj = new kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress_unsafe(uint8_t const* compressed_point, kth_bool_t compress) {
     KTH_PRECONDITION(compressed_point != nullptr);
     auto const compressed_point_cpp = kth::ec_compressed_to_cpp(compressed_point);
     auto const compress_cpp = kth::int_to_bool(compress);
-    return new kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp);
+    auto* obj = new kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress(kth_ec_uncompressed_t uncompressed_point, kth_bool_t compress) {
     auto const uncompressed_point_cpp = kth::ec_uncompressed_to_cpp(uncompressed_point.data);
     auto const compress_cpp = kth::int_to_bool(compress);
-    return new kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp);
+    auto* obj = new kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress_unsafe(uint8_t const* uncompressed_point, kth_bool_t compress) {
     KTH_PRECONDITION(uncompressed_point != nullptr);
     auto const uncompressed_point_cpp = kth::ec_uncompressed_to_cpp(uncompressed_point);
     auto const compress_cpp = kth::int_to_bool(compress);
-    return new kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp);
+    auto* obj = new kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
@@ -99,19 +113,24 @@ kth_bool_t kth_wallet_ec_public_equals(kth_ec_public_const_t self, kth_ec_public
 
 // Serialization
 
-uint8_t* kth_wallet_ec_public_to_data(kth_ec_public_const_t self, kth_size_t* out_size) {
+kth_error_code_t kth_wallet_ec_public_to_data(kth_ec_public_const_t self, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    kth::data_chunk data;
-    if ( ! kth_wallet_ec_public_const_cpp(self).to_data(data)) {
-        *out_size = 0;
-        return nullptr;
-    }
-    return kth::create_c_array(data, *out_size);
+    auto const result = kth_wallet_ec_public_const_cpp(self).to_data();
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = kth::create_c_array(*result, *out_size);
+    return kth_ec_success;
 }
 
 
 // Getters
+
+kth_bool_t kth_wallet_ec_public_valid(kth_ec_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth_wallet_ec_public_const_cpp(self).operator bool());
+}
 
 char* kth_wallet_ec_public_encoded(kth_ec_public_const_t self) {
     KTH_PRECONDITION(self != nullptr);
@@ -125,24 +144,19 @@ kth_ec_compressed_t kth_wallet_ec_public_point(kth_ec_public_const_t self) {
     return kth::to_ec_compressed_t(value_cpp);
 }
 
-uint16_t kth_wallet_ec_public_version(kth_ec_public_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth_wallet_ec_public_const_cpp(self).version();
-}
-
-uint8_t kth_wallet_ec_public_payment_version(kth_ec_public_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth_wallet_ec_public_const_cpp(self).payment_version();
-}
-
-uint8_t kth_wallet_ec_public_wif_version(kth_ec_public_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth_wallet_ec_public_const_cpp(self).wif_version();
-}
-
 kth_bool_t kth_wallet_ec_public_compressed(kth_ec_public_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::bool_to_int(kth_wallet_ec_public_const_cpp(self).compressed());
+}
+
+kth_error_code_t kth_wallet_ec_public_to_uncompressed(kth_ec_public_const_t self, uint8_t* out, kth_size_t n) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(n >= 65);
+    auto const result = kth_wallet_ec_public_const_cpp(self).to_uncompressed();
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    std::memcpy(out, result->data(), result->size());
+    return kth_ec_success;
 }
 
 
@@ -155,20 +169,11 @@ kth_bool_t kth_wallet_ec_public_less(kth_ec_public_const_t self, kth_ec_public_c
     return kth::bool_to_int(kth_wallet_ec_public_const_cpp(self).operator<(x_cpp));
 }
 
-kth_bool_t kth_wallet_ec_public_to_uncompressed(kth_ec_public_const_t self, uint8_t* out) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(out != nullptr);
-    std::array<uint8_t, 65> out_cpp;
-    auto const cpp_result = kth_wallet_ec_public_const_cpp(self).to_uncompressed(out_cpp);
-    if (cpp_result) {
-        std::memcpy(out, out_cpp.data(), out_cpp.size());
-    }
-    return kth::bool_to_int(cpp_result);
-}
-
 kth_payment_address_mut_t kth_wallet_ec_public_to_payment_address(kth_ec_public_const_t self, uint8_t version) {
     KTH_PRECONDITION(self != nullptr);
-    return new kth::domain::wallet::payment_address(kth_wallet_ec_public_const_cpp(self).to_payment_address(version));
+    auto* obj = new kth::domain::wallet::payment_address(kth_wallet_ec_public_const_cpp(self).to_payment_address(version));
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/payment_address.cpp
+++ b/src/c-api/src/wallet/payment_address.cpp
@@ -27,66 +27,88 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_default(void) {
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded(kth_payment_t decoded) {
     auto const decoded_cpp = kth::payment_to_cpp(decoded.hash);
-    return new kth::domain::wallet::payment_address(decoded_cpp);
+    auto* obj = new kth::domain::wallet::payment_address(decoded_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded_unsafe(uint8_t const* decoded) {
     KTH_PRECONDITION(decoded != nullptr);
     auto const decoded_cpp = kth::payment_to_cpp(decoded);
-    return new kth::domain::wallet::payment_address(decoded_cpp);
+    auto* obj = new kth::domain::wallet::payment_address(decoded_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_private(kth_ec_private_const_t secret) {
     KTH_PRECONDITION(secret != nullptr);
     auto const& secret_cpp = kth_wallet_ec_private_const_cpp(secret);
-    return new kth::domain::wallet::payment_address(secret_cpp);
+    auto* obj = new kth::domain::wallet::payment_address(secret_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address(char const* address) {
     KTH_PRECONDITION(address != nullptr);
     auto const address_cpp = std::string(address);
-    return new kth::domain::wallet::payment_address(address_cpp);
+    auto* obj = new kth::domain::wallet::payment_address(address_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address_net(char const* address, kth_network_t net) {
     KTH_PRECONDITION(address != nullptr);
     auto const address_cpp = std::string(address);
     auto const net_cpp = static_cast<kth::domain::config::network>(net);
-    return new kth::domain::wallet::payment_address(address_cpp, net_cpp);
+    auto* obj = new kth::domain::wallet::payment_address(address_cpp, net_cpp);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t short_hash, uint8_t version) {
     auto const short_hash_cpp = kth::short_hash_to_cpp(short_hash.hash);
-    return new kth::domain::wallet::payment_address(short_hash_cpp, version);
+    auto* obj = new kth::domain::wallet::payment_address(short_hash_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version_unsafe(uint8_t const* short_hash, uint8_t version) {
     KTH_PRECONDITION(short_hash != nullptr);
     auto const short_hash_cpp = kth::short_hash_to_cpp(short_hash);
-    return new kth::domain::wallet::payment_address(short_hash_cpp, version);
+    auto* obj = new kth::domain::wallet::payment_address(short_hash_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version(kth_hash_t hash, uint8_t version) {
     auto const hash_cpp = kth::hash_to_cpp(hash.hash);
-    return new kth::domain::wallet::payment_address(hash_cpp, version);
+    auto* obj = new kth::domain::wallet::payment_address(hash_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version_unsafe(uint8_t const* hash, uint8_t version) {
     KTH_PRECONDITION(hash != nullptr);
     auto const hash_cpp = kth::hash_to_cpp(hash);
-    return new kth::domain::wallet::payment_address(hash_cpp, version);
+    auto* obj = new kth::domain::wallet::payment_address(hash_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_public_version(kth_ec_public_const_t point, uint8_t version) {
     KTH_PRECONDITION(point != nullptr);
     auto const& point_cpp = kth_wallet_ec_public_const_cpp(point);
-    return new kth::domain::wallet::payment_address(point_cpp, version);
+    auto* obj = new kth::domain::wallet::payment_address(point_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_script_version(kth_script_const_t script, uint8_t version) {
     KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
-    return new kth::domain::wallet::payment_address(script_cpp, version);
+    auto* obj = new kth::domain::wallet::payment_address(script_cpp, version);
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
@@ -95,7 +117,9 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_from_script_versi
 kth_payment_address_mut_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version) {
     KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
-    return new kth::domain::wallet::payment_address(kth::domain::wallet::payment_address::from_pay_public_key_hash_script(script_cpp, version));
+    auto* obj = new kth::domain::wallet::payment_address(kth::domain::wallet::payment_address::from_pay_public_key_hash_script(script_cpp, version));
+    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
+    return obj;
 }
 
 
@@ -128,7 +152,7 @@ kth_bool_t kth_wallet_payment_address_equals(kth_payment_address_const_t self, k
 
 kth_bool_t kth_wallet_payment_address_valid(kth_payment_address_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth_wallet_payment_address_const_cpp(self).valid());
+    return kth::bool_to_int(kth_wallet_payment_address_const_cpp(self).operator bool());
 }
 
 char* kth_wallet_payment_address_encoded_legacy(kth_payment_address_const_t self) {

--- a/src/c-api/test/wallet/hd_private.cpp
+++ b/src/c-api/test/wallet/hd_private.cpp
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include <kth/capi/wallet/hd_private.h>
+#include <kth/capi/wallet/hd_public.h>
 #include <kth/capi/primitives.h>
 
 #include "../test_helpers.hpp"

--- a/src/domain/include/kth/domain/wallet/ec_public.hpp
+++ b/src/domain/include/kth/domain/wallet/ec_public.hpp
@@ -6,8 +6,10 @@
 #define KTH_DOMAIN_WALLET_EC_PUBLIC_HPP
 
 #include <cstdint>
+#include <expected>
 #include <iostream>
 #include <string>
+#include <system_error>
 
 #include <kth/domain/define.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
@@ -76,20 +78,13 @@ struct KD_API ec_public {
     ec_compressed const& point() const;
 
     [[nodiscard]]
-    uint16_t version() const;
-
-    [[nodiscard]]
-    uint8_t payment_version() const;
-
-    [[nodiscard]]
-    uint8_t wif_version() const;
-
-    [[nodiscard]]
     bool compressed() const;
 
     /// Methods.
-    bool to_data(data_chunk& out) const;
-    bool to_uncompressed(ec_uncompressed& out) const;
+    [[nodiscard]]
+    std::expected<data_chunk, std::error_code> to_data() const;
+    [[nodiscard]]
+    std::expected<ec_uncompressed, std::error_code> to_uncompressed() const;
 
     [[nodiscard]]
     payment_address to_payment_address(uint8_t version = mainnet_p2kh) const;
@@ -116,7 +111,6 @@ private:
     /// These should be const, apart from the need to implement assignment.
     bool valid_{false};
     bool compress_{true};
-    uint8_t version_;
     ec_compressed point_ = null_compressed_point;
 };
 

--- a/src/domain/src/chain/script_basis.cpp
+++ b/src/domain/src/chain/script_basis.cpp
@@ -555,15 +555,14 @@ operation::list script_basis::to_pay_public_key_hash_pattern(short_hash const& h
 }
 
 operation::list script_basis::to_pay_public_key_hash_pattern_unlocking(endorsement const& end, wallet::ec_public const& pubkey) {
-    // data_chunk endorsement(endorsement_size, 0);
-    data_chunk pubkey_data;
-    if ( ! pubkey.to_data(pubkey_data)) {
+    auto pubkey_data = pubkey.to_data();
+    if ( ! pubkey_data) {
         return operation::list {};
     }
     return operation::list {
         operation(opcode::push_size_0),
         operation(end),
-        operation(pubkey_data)
+        operation(std::move(*pubkey_data))
     };
 }
 

--- a/src/domain/src/wallet/ec_public.cpp
+++ b/src/domain/src/wallet/ec_public.cpp
@@ -11,6 +11,7 @@
 
 #include <kth/domain/wallet/ec_private.hpp>
 #include <kth/domain/wallet/payment_address.hpp>
+#include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/math/hash.hpp>
@@ -116,10 +117,10 @@ std::string ec_public::encoded() const {
     }
 
     // If the point is valid it should always decompress, but if not, is null.
-    ec_uncompressed uncompressed(null_uncompressed_point);
-    to_uncompressed(uncompressed);
-    return encode_base16(uncompressed);
+    auto const uncompressed = to_uncompressed();
+    return encode_base16(uncompressed ? *uncompressed : null_uncompressed_point);
 }
+
 
 // Accessors.
 // ----------------------------------------------------------------------------
@@ -135,33 +136,32 @@ bool ec_public::compressed() const {
 // Methods.
 // ----------------------------------------------------------------------------
 
-bool ec_public::to_data(data_chunk& out) const {
+std::expected<data_chunk, std::error_code> ec_public::to_data() const {
     if ( ! valid_) {
-        return false;
+        return std::unexpected(error::pubkey_type);
     }
 
     if (compressed()) {
-        out.resize(ec_compressed_size);
-        std::copy_n(point_.begin(), ec_compressed_size, out.begin());
-        return true;
+        return data_chunk(point_.begin(), point_.begin() + ec_compressed_size);
     }
 
-    ec_uncompressed uncompressed;
-    if (to_uncompressed(uncompressed)) {
-        out.resize(ec_uncompressed_size);
-        std::copy_n(uncompressed.begin(), ec_uncompressed_size, out.begin());
-        return true;
+    auto const uncompressed = to_uncompressed();
+    if ( ! uncompressed) {
+        return std::unexpected(uncompressed.error());
     }
-
-    return false;
+    return data_chunk(uncompressed->begin(), uncompressed->end());
 }
 
-bool ec_public::to_uncompressed(ec_uncompressed& out) const {
+std::expected<ec_uncompressed, std::error_code> ec_public::to_uncompressed() const {
     if ( ! valid_) {
-        return false;
+        return std::unexpected(error::pubkey_type);
     }
 
-    return kth::decompress(out, to_array<ec_compressed_size>(point_));
+    ec_uncompressed out;
+    if ( ! kth::decompress(out, to_array<ec_compressed_size>(point_))) {
+        return std::unexpected(error::pubkey_type);
+    }
+    return out;
 }
 
 payment_address ec_public::to_payment_address(uint8_t version) const {
@@ -173,7 +173,7 @@ payment_address ec_public::to_payment_address(uint8_t version) const {
 
 bool ec_public::operator==(ec_public const& x) const {
     return valid_ == x.valid_ && compress_ == x.compress_ &&
-           version_ == x.version_ && point_ == x.point_;
+           point_ == x.point_;
 }
 
 bool ec_public::operator!=(ec_public const& x) const {

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -280,12 +280,12 @@ payment_address payment_address::from_public(ec_public const& point, uint8_t ver
         return payment_address{};
     }
 
-    data_chunk data;
-    if ( ! point.to_data(data)) {
+    auto const data = point.to_data();
+    if ( ! data) {
         return payment_address{};
     }
 
-    return payment_address{bitcoin_short_hash(data), version};
+    return payment_address{bitcoin_short_hash(*data), version};
 }
 
 payment_address payment_address::from_script(chain::script const& script, uint8_t version) {


### PR DESCRIPTION
## Summary
- All chain and wallet constructors now return `NULL` when the underlying C++ object reports invalid state, matching the contract already documented in their doc blocks. Before this change they could hand back objects in an invalid state, forcing every caller to re-check via `_valid()`.
- **Modernize `wallet/ec_public` C++ API** so its C bindings are homogeneous with the rest of the surface:
  - `to_data` now returns `std::expected<data_chunk, std::error_code>` instead of the old `bool to_data(data_chunk& out)`. The C binding follows the `expected<byte_buffer>` template: `kth_error_code_t + uint8_t** out + kth_size_t* out_size` — same shape as every `from_data` factory.
  - `to_uncompressed` now returns `std::expected<ec_uncompressed, std::error_code>` (failure reports `error::pubkey_type`) instead of `bool to_uncompressed(ec_uncompressed& out)`. The C binding is `kth_error_code_t to_uncompressed(self, uint8_t* out, kth_size_t n)` with a size precondition — no more silent UB on short buffers.
  - Drop `version`, `payment_version`, `wif_version` — they were declared but never implemented on the domain side (undefined symbols at link time for consumers referencing them).
  - Add the missing `_valid` predicate.
- `chain/script`:
  - Expose `to_pay_public_key_hash_pattern_unlocking` (domain method that was not yet bound).
  - Include `wallet/primitives.h` so consumers pulling `script.h` in isolation compile cleanly.
- Unify ownership / lifetime docstrings so the "or NULL" clause only appears for entry points that actually gate on \`kth::check_valid\`. List factories and default / copy constructors no longer advertise a nullable contract they can't deliver.

## Test plan
- [x] C-API test suite compiles and passes.
- [x] Downstream language backends (py-native) rebuild against the updated surface.
- [x] Verify no references remain to the removed \`ec_public\` version accessors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes C-API contracts and signatures (notably `kth_wallet_ec_public_to_data` and new error-returning APIs), which can break downstream bindings and require callers to handle NULL/error codes correctly.
> 
> **Overview**
> Hardens many C-API constructors (core `binary`, chain message/struct types, and wallet keys/addresses) to **return `NULL` when the underlying C++ object is invalid**, aligning runtime behavior with the documented nullable contract and adding consistent `kth::check_valid` gating.
> 
> Modernizes `wallet/ec_public` by switching domain-level `to_data`/`to_uncompressed` to `std::expected<..., std::error_code>` and updating the C bindings to return `kth_error_code_t` with out-parameters; it also **adds `*_valid()` predicates** and removes unused/undefined `ec_public` version accessors.
> 
> Extends `chain/script` with a new binding for `kth_chain_script_to_pay_public_key_hash_pattern_unlocking`, fixes header include dependencies, and makes a few small API/doc cleanups (e.g., rename `arg5` to `value`, minor serialization copy tweak).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8943e328842942d5caf04c358e209aef6d9b9b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validity checking functions for wallet cryptographic key types.

* **Bug Fixes**
  * Improved error handling across C API construction functions—they now properly return `NULL` on construction failures instead of potentially returning invalid objects.
  * Enhanced serialization APIs with proper error reporting via error codes.

* **Documentation**
  * Updated API contracts to document `NULL` return values on construction/parsing failures.
  * Clarified destructor requirements to apply only to non-`NULL` results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->