### PR TITLE
refactor(c-api): collapse factory pattern via make_leaked helpers

### DIFF
--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -379,8 +379,29 @@ void copy_c_hash(HashCpp const& in, HashC* out) {
     std::copy_n(in.begin(), in.size(), static_cast<uint8_t*>(out->hash));
 }
 
+// Promote a value to the heap and surrender ownership to the caller —
+// i.e. "leak" it, which from the C-API perspective is exactly the
+// transfer the consumer is expected to release later via the matching
+// `kth_*_destruct` function. Forwards into `new T(...)`, so an rvalue
+// is moved and an lvalue is copied. The `_leak` suffix is intentional:
+// it documents the ownership transfer at every call site (instead of
+// hiding it behind a generic factory name), making leaks greppable.
 template <typename T>
-std::decay_t<T>* move_or_copy_and_leak(T&& x) {
+std::decay_t<T>* make_leaked(T&& x) {
+    return new std::decay_t<T>(std::forward<T>(x));
+}
+
+// Same as `make_leaked`, but gates the leak on `check_valid(&x)`.
+// The validity of the heap copy mirrors the source's validity (the
+// constructor doesn't change `operator bool`), so we test `x` BEFORE
+// allocating — invalid input returns `nullptr` without ever touching
+// the heap. Matches the documented "or NULL on failure" contract that
+// generated factories advertise. Sentinel factories whose return is
+// intentionally `operator bool == false` (e.g. `point::null()`)
+// should opt out and use `make_leaked` instead.
+template <typename T>
+std::decay_t<T>* make_leaked_if_valid(T&& x) {
+    if ( ! check_valid(&x)) return nullptr;
     return new std::decay_t<T>(std::forward<T>(x));
 }
 

--- a/src/c-api/src/binary.cpp
+++ b/src/c-api/src/binary.cpp
@@ -30,25 +30,19 @@ kth_binary_mut_t kth_core_binary_construct_default(void) {
 kth_binary_mut_t kth_core_binary_construct_from_bit_string(char const* bit_string) {
     KTH_PRECONDITION(bit_string != nullptr);
     auto const bit_string_cpp = std::string_view(bit_string);
-    auto* obj = new kth::binary(bit_string_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::binary(bit_string_cpp));
 }
 
 kth_binary_mut_t kth_core_binary_construct_from_size_number(kth_size_t size, uint32_t number) {
     auto const size_cpp = static_cast<size_t>(size);
-    auto* obj = new kth::binary(size_cpp, number);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::binary(size_cpp, number));
 }
 
 kth_binary_mut_t kth_core_binary_construct_from_size_blocks(kth_size_t size, uint8_t const* blocks, kth_size_t n) {
     KTH_PRECONDITION(blocks != nullptr || n == 0);
     auto const size_cpp = static_cast<size_t>(size);
     auto const blocks_cpp = kth::byte_span(blocks, static_cast<size_t>(n));
-    auto* obj = new kth::binary(size_cpp, blocks_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::binary(size_cpp, blocks_cpp));
 }
 
 
@@ -171,9 +165,7 @@ kth_binary_mut_t kth_core_binary_substring(kth_binary_const_t self, kth_size_t s
     KTH_PRECONDITION(self != nullptr);
     auto const start_cpp = static_cast<size_t>(start);
     auto const length_cpp = static_cast<size_t>(length);
-    auto* obj = new kth::binary(kth_core_binary_const_cpp(self).substring(start_cpp, length_cpp));
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_core_binary_const_cpp(self).substring(start_cpp, length_cpp));
 }
 
 kth_bool_t kth_core_binary_less(kth_binary_const_t self, kth_binary_const_t x) {

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -36,7 +36,7 @@ kth_error_code_t kth_chain_block_construct_from_data(uint8_t const* data, kth_si
     auto const wire_cpp = kth::int_to_bool(wire);
     auto result = kth::domain::chain::block::from_data(data_cpp, wire_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::block(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -45,48 +45,34 @@ kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transac
     KTH_PRECONDITION(transactions != nullptr);
     auto const& header_cpp = kth_chain_header_const_cpp(header);
     auto const& transactions_cpp = kth_chain_transaction_list_const_cpp(transactions);
-    auto* obj = new kth::domain::chain::block(header_cpp, transactions_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::block(header_cpp, transactions_cpp));
 }
 
 
 // Static factories
 
 kth_block_mut_t kth_chain_block_genesis_mainnet(void) {
-    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_mainnet());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::block::genesis_mainnet());
 }
 
 kth_block_mut_t kth_chain_block_genesis_testnet(void) {
-    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_testnet());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::block::genesis_testnet());
 }
 
 kth_block_mut_t kth_chain_block_genesis_regtest(void) {
-    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_regtest());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::block::genesis_regtest());
 }
 
 kth_block_mut_t kth_chain_block_genesis_testnet4(void) {
-    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_testnet4());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::block::genesis_testnet4());
 }
 
 kth_block_mut_t kth_chain_block_genesis_scalenet(void) {
-    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_scalenet());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::block::genesis_scalenet());
 }
 
 kth_block_mut_t kth_chain_block_genesis_chipnet(void) {
-    auto* obj = new kth::domain::chain::block(kth::domain::chain::block::genesis_chipnet());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::block::genesis_chipnet());
 }
 
 

--- a/src/c-api/src/chain/chain_sync.cpp
+++ b/src/c-api/src/chain/chain_sync.cpp
@@ -386,7 +386,7 @@ kth_mempool_transaction_list_t kth_chain_sync_mempool_transactions(kth_chain_t c
 kth_transaction_list_mut_t kth_chain_sync_mempool_transactions_from_wallets(kth_chain_t chain, kth_payment_address_list_t addresses, kth_bool_t use_testnet_rules) {
     auto const& addresses_cpp = *static_cast<std::vector<kth::domain::wallet::payment_address> const*>(addresses);
     auto txs = safe_chain(chain).get_mempool_transactions_from_wallets(addresses_cpp, kth::int_to_bool(use_testnet_rules));
-    return kth::move_or_copy_and_leak(std::move(txs));
+    return kth::make_leaked(std::move(txs));
 }
 
 // Organizers.

--- a/src/c-api/src/chain/compact_block.cpp
+++ b/src/c-api/src/chain/compact_block.cpp
@@ -35,7 +35,7 @@ kth_error_code_t kth_chain_compact_block_construct_from_data(uint8_t const* data
     auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
     auto result = kth::domain::message::compact_block::from_data(data_cpp, version);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::message::compact_block(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -46,9 +46,7 @@ kth_compact_block_mut_t kth_chain_compact_block_construct(kth_header_const_t hea
     auto const& header_cpp = kth_chain_header_const_cpp(header);
     auto const& short_ids_cpp = kth_core_u64_list_const_cpp(short_ids);
     auto const& transactions_cpp = kth_chain_prefilled_transaction_list_const_cpp(transactions);
-    auto* obj = new kth::domain::message::compact_block(header_cpp, nonce, short_ids_cpp, transactions_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::message::compact_block(header_cpp, nonce, short_ids_cpp, transactions_cpp));
 }
 
 

--- a/src/c-api/src/chain/double_spend_proof.cpp
+++ b/src/c-api/src/chain/double_spend_proof.cpp
@@ -35,7 +35,7 @@ kth_error_code_t kth_chain_double_spend_proof_construct_from_data(uint8_t const*
     auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
     auto result = kth::domain::message::double_spend_proof::from_data(data_cpp, version);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::message::double_spend_proof(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -46,9 +46,7 @@ kth_double_spend_proof_mut_t kth_chain_double_spend_proof_construct(kth_output_p
     auto const& out_point_cpp = kth_chain_output_point_const_cpp(out_point);
     auto const& spender1_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender1);
     auto const& spender2_cpp = kth_chain_double_spend_proof_spender_const_cpp(spender2);
-    auto* obj = new kth::domain::message::double_spend_proof(out_point_cpp, spender1_cpp, spender2_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::message::double_spend_proof(out_point_cpp, spender1_cpp, spender2_cpp));
 }
 
 

--- a/src/c-api/src/chain/double_spend_proof_spender.cpp
+++ b/src/c-api/src/chain/double_spend_proof_spender.cpp
@@ -31,7 +31,7 @@ kth_error_code_t kth_chain_double_spend_proof_spender_construct_from_data(uint8_
     auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
     auto result = kth::domain::message::double_spend_proof::spender::from_data(data_cpp, version);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::message::double_spend_proof::spender(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 

--- a/src/c-api/src/chain/get_blocks.cpp
+++ b/src/c-api/src/chain/get_blocks.cpp
@@ -35,7 +35,7 @@ kth_error_code_t kth_chain_get_blocks_construct_from_data(uint8_t const* data, k
     auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
     auto result = kth::domain::message::get_blocks::from_data(data_cpp, version);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::message::get_blocks(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -43,9 +43,7 @@ kth_get_blocks_mut_t kth_chain_get_blocks_construct(kth_hash_list_const_t start,
     KTH_PRECONDITION(start != nullptr);
     auto const& start_cpp = kth_core_hash_list_const_cpp(start);
     auto const stop_cpp = kth::hash_to_cpp(stop.hash);
-    auto* obj = new kth::domain::message::get_blocks(start_cpp, stop_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::message::get_blocks(start_cpp, stop_cpp));
 }
 
 kth_get_blocks_mut_t kth_chain_get_blocks_construct_unsafe(kth_hash_list_const_t start, uint8_t const* stop) {
@@ -53,9 +51,7 @@ kth_get_blocks_mut_t kth_chain_get_blocks_construct_unsafe(kth_hash_list_const_t
     KTH_PRECONDITION(stop != nullptr);
     auto const& start_cpp = kth_core_hash_list_const_cpp(start);
     auto const stop_cpp = kth::hash_to_cpp(stop);
-    auto* obj = new kth::domain::message::get_blocks(start_cpp, stop_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::message::get_blocks(start_cpp, stop_cpp));
 }
 
 

--- a/src/c-api/src/chain/get_headers.cpp
+++ b/src/c-api/src/chain/get_headers.cpp
@@ -35,7 +35,7 @@ kth_error_code_t kth_chain_get_headers_construct_from_data(uint8_t const* data, 
     auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
     auto result = kth::domain::message::get_headers::from_data(data_cpp, version);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::message::get_headers(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -43,9 +43,7 @@ kth_get_headers_mut_t kth_chain_get_headers_construct(kth_hash_list_const_t star
     KTH_PRECONDITION(start != nullptr);
     auto const& start_cpp = kth_core_hash_list_const_cpp(start);
     auto const stop_cpp = kth::hash_to_cpp(stop.hash);
-    auto* obj = new kth::domain::message::get_headers(start_cpp, stop_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::message::get_headers(start_cpp, stop_cpp));
 }
 
 kth_get_headers_mut_t kth_chain_get_headers_construct_unsafe(kth_hash_list_const_t start, uint8_t const* stop) {
@@ -53,9 +51,7 @@ kth_get_headers_mut_t kth_chain_get_headers_construct_unsafe(kth_hash_list_const
     KTH_PRECONDITION(stop != nullptr);
     auto const& start_cpp = kth_core_hash_list_const_cpp(start);
     auto const stop_cpp = kth::hash_to_cpp(stop);
-    auto* obj = new kth::domain::message::get_headers(start_cpp, stop_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::message::get_headers(start_cpp, stop_cpp));
 }
 
 

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -36,16 +36,14 @@ kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_s
     auto const wire_cpp = kth::int_to_bool(wire);
     auto result = kth::domain::chain::header::from_data(data_cpp, wire_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::header(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
 kth_header_mut_t kth_chain_header_construct(uint32_t version, kth_hash_t previous_block_hash, kth_hash_t merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce) {
     auto const previous_block_hash_cpp = kth::hash_to_cpp(previous_block_hash.hash);
     auto const merkle_cpp = kth::hash_to_cpp(merkle.hash);
-    auto* obj = new kth::domain::chain::header(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::header(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce));
 }
 
 kth_header_mut_t kth_chain_header_construct_unsafe(uint32_t version, uint8_t const* previous_block_hash, uint8_t const* merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce) {
@@ -53,9 +51,7 @@ kth_header_mut_t kth_chain_header_construct_unsafe(uint32_t version, uint8_t con
     KTH_PRECONDITION(merkle != nullptr);
     auto const previous_block_hash_cpp = kth::hash_to_cpp(previous_block_hash);
     auto const merkle_cpp = kth::hash_to_cpp(merkle);
-    auto* obj = new kth::domain::chain::header(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::header(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce));
 }
 
 

--- a/src/c-api/src/chain/input.cpp
+++ b/src/c-api/src/chain/input.cpp
@@ -36,7 +36,7 @@ kth_error_code_t kth_chain_input_construct_from_data(uint8_t const* data, kth_si
     auto const wire_cpp = kth::int_to_bool(wire);
     auto result = kth::domain::chain::input::from_data(data_cpp, wire_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::input(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -45,9 +45,7 @@ kth_input_mut_t kth_chain_input_construct(kth_output_point_const_t previous_outp
     KTH_PRECONDITION(script != nullptr);
     auto const& previous_output_cpp = kth_chain_output_point_const_cpp(previous_output);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
-    auto* obj = new kth::domain::chain::input(previous_output_cpp, script_cpp, sequence);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::input(previous_output_cpp, script_cpp, sequence));
 }
 
 
@@ -97,9 +95,7 @@ kth_size_t kth_chain_input_serialized_size(kth_input_const_t self, kth_bool_t wi
 
 kth_payment_address_mut_t kth_chain_input_address(kth_input_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::wallet::payment_address(kth_chain_input_const_cpp(self).address());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_chain_input_const_cpp(self).address());
 }
 
 kth_payment_address_list_mut_t kth_chain_input_addresses(kth_input_const_t self) {
@@ -128,7 +124,7 @@ kth_error_code_t kth_chain_input_extract_embedded_script(kth_input_const_t self,
     KTH_PRECONDITION(*out == nullptr);
     auto result = kth_chain_input_const_cpp(self).extract_embedded_script();
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::script(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 

--- a/src/c-api/src/chain/merkle_block.cpp
+++ b/src/c-api/src/chain/merkle_block.cpp
@@ -35,7 +35,7 @@ kth_error_code_t kth_chain_merkle_block_construct_from_data(uint8_t const* data,
     auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
     auto result = kth::domain::message::merkle_block::from_data(data_cpp, version);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::message::merkle_block(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -47,17 +47,13 @@ kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_header_total_transa
     auto const total_transactions_cpp = static_cast<size_t>(total_transactions);
     auto const& hashes_cpp = kth_core_hash_list_const_cpp(hashes);
     auto const flags_cpp = n != 0 ? kth::data_chunk(flags, flags + n) : kth::data_chunk{};
-    auto* obj = new kth::domain::message::merkle_block(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::message::merkle_block(header_cpp, total_transactions_cpp, hashes_cpp, flags_cpp));
 }
 
 kth_merkle_block_mut_t kth_chain_merkle_block_construct_from_block(kth_block_const_t block) {
     KTH_PRECONDITION(block != nullptr);
     auto const& block_cpp = kth_chain_block_const_cpp(block);
-    auto* obj = new kth::domain::message::merkle_block(block_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::message::merkle_block(block_cpp));
 }
 
 

--- a/src/c-api/src/chain/operation.cpp
+++ b/src/c-api/src/chain/operation.cpp
@@ -35,7 +35,7 @@ kth_error_code_t kth_chain_operation_construct_from_data(uint8_t const* data, kt
     auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
     auto result = kth::domain::machine::operation::from_data(data_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::machine::operation(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -43,16 +43,12 @@ kth_operation_mut_t kth_chain_operation_construct_from_uncoded_minimal(uint8_t c
     KTH_PRECONDITION(uncoded != nullptr || n == 0);
     auto const uncoded_cpp = n != 0 ? kth::data_chunk(uncoded, uncoded + n) : kth::data_chunk{};
     auto const minimal_cpp = kth::int_to_bool(minimal);
-    auto* obj = new kth::domain::machine::operation(uncoded_cpp, minimal_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::machine::operation(uncoded_cpp, minimal_cpp));
 }
 
 kth_operation_mut_t kth_chain_operation_construct_from_code(kth_opcode_t code) {
     auto const code_cpp = static_cast<kth::domain::machine::opcode>(code);
-    auto* obj = new kth::domain::machine::operation(code_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::machine::operation(code_cpp));
 }
 
 

--- a/src/c-api/src/chain/output.cpp
+++ b/src/c-api/src/chain/output.cpp
@@ -36,7 +36,7 @@ kth_error_code_t kth_chain_output_construct_from_data(uint8_t const* data, kth_s
     auto const wire_cpp = kth::int_to_bool(wire);
     auto result = kth::domain::chain::output::from_data(data_cpp, wire_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::output(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -44,9 +44,7 @@ kth_output_mut_t kth_chain_output_construct(uint64_t value, kth_script_const_t s
     KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
     auto const token_data_cpp = (token_data == nullptr ? std::nullopt : std::optional<kth::domain::chain::token_data_t>(kth_chain_token_data_const_cpp(token_data)));
-    auto* obj = new kth::domain::chain::output(value, script_cpp, token_data_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::output(value, script_cpp, token_data_cpp));
 }
 
 
@@ -150,16 +148,12 @@ kth_bool_t kth_chain_output_is_dust(kth_output_const_t self, uint64_t minimum_ou
 kth_payment_address_mut_t kth_chain_output_address_simple(kth_output_const_t self, kth_bool_t testnet) {
     KTH_PRECONDITION(self != nullptr);
     auto const testnet_cpp = kth::int_to_bool(testnet);
-    auto* obj = new kth::domain::wallet::payment_address(kth_chain_output_const_cpp(self).address(testnet_cpp));
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_chain_output_const_cpp(self).address(testnet_cpp));
 }
 
 kth_payment_address_mut_t kth_chain_output_address(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::wallet::payment_address(kth_chain_output_const_cpp(self).address(p2kh_version, p2sh_version));
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_chain_output_const_cpp(self).address(p2kh_version, p2sh_version));
 }
 
 kth_payment_address_list_mut_t kth_chain_output_addresses(kth_output_const_t self, uint8_t p2kh_version, uint8_t p2sh_version) {

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -36,31 +36,25 @@ kth_error_code_t kth_chain_output_point_construct_from_data(uint8_t const* data,
     auto const wire_cpp = kth::int_to_bool(wire);
     auto result = kth::domain::chain::output_point::from_data(data_cpp, wire_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::output_point(std::move(*result));
+    *out = kth::make_leaked<kth::domain::chain::output_point>(std::move(*result));
     return kth_ec_success;
 }
 
 kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(kth_hash_t hash, uint32_t index) {
     auto const hash_cpp = kth::hash_to_cpp(hash.hash);
-    auto* obj = new kth::domain::chain::output_point(hash_cpp, index);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::output_point(hash_cpp, index));
 }
 
 kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index_unsafe(uint8_t const* hash, uint32_t index) {
     KTH_PRECONDITION(hash != nullptr);
     auto const hash_cpp = kth::hash_to_cpp(hash);
-    auto* obj = new kth::domain::chain::output_point(hash_cpp, index);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::output_point(hash_cpp, index));
 }
 
 kth_output_point_mut_t kth_chain_output_point_construct_from_point(kth_point_const_t x) {
     KTH_PRECONDITION(x != nullptr);
     auto const& x_cpp = kth_chain_point_const_cpp(x);
-    auto* obj = new kth::domain::chain::output_point(x_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::output_point(x_cpp));
 }
 
 

--- a/src/c-api/src/chain/point.cpp
+++ b/src/c-api/src/chain/point.cpp
@@ -36,31 +36,26 @@ kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_si
     auto const wire_cpp = kth::int_to_bool(wire);
     auto result = kth::domain::chain::point::from_data(data_cpp, wire_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::point(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
 kth_point_mut_t kth_chain_point_construct(kth_hash_t hash, uint32_t index) {
     auto const hash_cpp = kth::hash_to_cpp(hash.hash);
-    auto* obj = new kth::domain::chain::point(hash_cpp, index);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::point(hash_cpp, index));
 }
 
 kth_point_mut_t kth_chain_point_construct_unsafe(uint8_t const* hash, uint32_t index) {
     KTH_PRECONDITION(hash != nullptr);
     auto const hash_cpp = kth::hash_to_cpp(hash);
-    auto* obj = new kth::domain::chain::point(hash_cpp, index);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::point(hash_cpp, index));
 }
 
 
 // Static factories
 
 kth_point_mut_t kth_chain_point_null(void) {
-    auto* obj = new kth::domain::chain::point(kth::domain::chain::point::null());
-    return obj;
+    return kth::make_leaked(kth::domain::chain::point::null());
 }
 
 

--- a/src/c-api/src/chain/prefilled_transaction.cpp
+++ b/src/c-api/src/chain/prefilled_transaction.cpp
@@ -35,16 +35,14 @@ kth_error_code_t kth_chain_prefilled_transaction_construct_from_data(uint8_t con
     auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
     auto result = kth::domain::message::prefilled_transaction::from_data(data_cpp, version);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::message::prefilled_transaction(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
 kth_prefilled_transaction_mut_t kth_chain_prefilled_transaction_construct(uint64_t index, kth_transaction_const_t tx) {
     KTH_PRECONDITION(tx != nullptr);
     auto const& tx_cpp = kth_chain_transaction_const_cpp(tx);
-    auto* obj = new kth::domain::message::prefilled_transaction(index, tx_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::message::prefilled_transaction(index, tx_cpp));
 }
 
 

--- a/src/c-api/src/chain/script.cpp
+++ b/src/c-api/src/chain/script.cpp
@@ -36,25 +36,21 @@ kth_error_code_t kth_chain_script_construct_from_data(uint8_t const* data, kth_s
     auto const wire_cpp = kth::int_to_bool(wire);
     auto result = kth::domain::chain::script::from_data(data_cpp, wire_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::script(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
 kth_script_mut_t kth_chain_script_construct_from_operations(kth_operation_list_const_t ops) {
     KTH_PRECONDITION(ops != nullptr);
     auto const& ops_cpp = kth_chain_operation_list_const_cpp(ops);
-    auto* obj = new kth::domain::chain::script(ops_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::script(ops_cpp));
 }
 
 kth_script_mut_t kth_chain_script_construct_from_encoded_prefix(uint8_t const* encoded, kth_size_t n, kth_bool_t prefix) {
     KTH_PRECONDITION(encoded != nullptr || n == 0);
     auto const encoded_cpp = n != 0 ? kth::data_chunk(encoded, encoded + n) : kth::data_chunk{};
     auto const prefix_cpp = kth::int_to_bool(prefix);
-    auto* obj = new kth::domain::chain::script(encoded_cpp, prefix_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::script(encoded_cpp, prefix_cpp));
 }
 
 
@@ -131,9 +127,7 @@ kth_operation_list_const_t kth_chain_script_operations(kth_script_const_t self) 
 
 kth_operation_mut_t kth_chain_script_first_operation(kth_script_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::machine::operation(kth_chain_script_const_cpp(self).first_operation());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_chain_script_const_cpp(self).first_operation());
 }
 
 kth_script_pattern_t kth_chain_script_pattern(kth_script_const_t self) {
@@ -326,7 +320,7 @@ kth_error_code_t kth_chain_script_from_data_with_size(uint8_t const* data, kth_s
     auto const size_cpp = static_cast<size_t>(size);
     auto result = kth::domain::chain::script::from_data_with_size(data_cpp, size_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::script(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 

--- a/src/c-api/src/chain/transaction.cpp
+++ b/src/c-api/src/chain/transaction.cpp
@@ -36,7 +36,7 @@ kth_error_code_t kth_chain_transaction_construct_from_data(uint8_t const* data, 
     auto const wire_cpp = kth::int_to_bool(wire);
     auto result = kth::domain::chain::transaction::from_data(data_cpp, wire_cpp);
     if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
-    *out = new kth::domain::chain::transaction(std::move(*result));
+    *out = kth::make_leaked(std::move(*result));
     return kth_ec_success;
 }
 
@@ -45,18 +45,14 @@ kth_transaction_mut_t kth_chain_transaction_construct_from_version_locktime_inpu
     KTH_PRECONDITION(outputs != nullptr);
     auto const& inputs_cpp = kth_chain_input_list_const_cpp(inputs);
     auto const& outputs_cpp = kth_chain_output_list_const_cpp(outputs);
-    auto* obj = new kth::domain::chain::transaction(version, locktime, inputs_cpp, outputs_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::transaction(version, locktime, inputs_cpp, outputs_cpp));
 }
 
 kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash(kth_transaction_const_t x, kth_hash_t hash) {
     KTH_PRECONDITION(x != nullptr);
     auto const& x_cpp = kth_chain_transaction_const_cpp(x);
     auto const hash_cpp = kth::hash_to_cpp(hash.hash);
-    auto* obj = new kth::domain::chain::transaction(x_cpp, hash_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::transaction(x_cpp, hash_cpp));
 }
 
 kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash_unsafe(kth_transaction_const_t x, uint8_t const* hash) {
@@ -64,9 +60,7 @@ kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash_unsa
     KTH_PRECONDITION(hash != nullptr);
     auto const& x_cpp = kth_chain_transaction_const_cpp(x);
     auto const hash_cpp = kth::hash_to_cpp(hash);
-    auto* obj = new kth::domain::chain::transaction(x_cpp, hash_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::chain::transaction(x_cpp, hash_cpp));
 }
 
 

--- a/src/c-api/src/vm/interpreter.cpp
+++ b/src/c-api/src/vm/interpreter.cpp
@@ -71,7 +71,7 @@ kth_bool_t kth_vm_interpreter_debug_steps_available(kth_program_const_t program,
 kth_error_code_t kth_vm_interpreter_debug_step(kth_program_const_t program, kth_size_t step, kth_size_t* out_step, kth_program_t* out_program) {
     auto const [err, new_step, new_program_cpp] = kth::domain::machine::interpreter::debug_step(kth_vm_program_const_cpp(program), step);
     *out_step = new_step;
-    *out_program = kth::move_or_copy_and_leak(std::move(new_program_cpp));
+    *out_program = kth::make_leaked(std::move(new_program_cpp));
     // printf("kth_vm_interpreter_debug_step() - out_step:     %p\n", out_step);
     // printf("kth_vm_interpreter_debug_step() - out_program:  %p\n", out_program);
     // printf("kth_vm_interpreter_debug_step() - *out_program: %p\n", *out_program);

--- a/src/c-api/src/vm/program.cpp
+++ b/src/c-api/src/vm/program.cpp
@@ -318,7 +318,7 @@ uint8_t const* kth_vm_program_top(kth_program_t program, kth_size_t* out_size) {
 kth_operation_list_t kth_vm_program_subscript(kth_program_t program) {
     // auto program_cpp = kth_vm_program_const_cpp(program);
     auto ops = kth_vm_program_const_cpp(program).subscript();
-    return kth::move_or_copy_and_leak(std::move(ops));
+    return kth::make_leaked(std::move(ops));
 }
 
 //     size_t size() const;

--- a/src/c-api/src/wallet/ec_private.cpp
+++ b/src/c-api/src/wallet/ec_private.cpp
@@ -28,56 +28,42 @@ kth_ec_private_mut_t kth_wallet_ec_private_construct_default(void) {
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_version(char const* wif, uint8_t version) {
     KTH_PRECONDITION(wif != nullptr);
     auto const wif_cpp = std::string(wif);
-    auto* obj = new kth::domain::wallet::ec_private(wif_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_private(wif_cpp, version));
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version(kth_wif_compressed_t wif_compressed, uint8_t version) {
     auto const wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed.data);
-    auto* obj = new kth::domain::wallet::ec_private(wif_compressed_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_private(wif_compressed_cpp, version));
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version_unsafe(uint8_t const* wif_compressed, uint8_t version) {
     KTH_PRECONDITION(wif_compressed != nullptr);
     auto const wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed);
-    auto* obj = new kth::domain::wallet::ec_private(wif_compressed_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_private(wif_compressed_cpp, version));
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version(kth_wif_uncompressed_t wif_uncompressed, uint8_t version) {
     auto const wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed.data);
-    auto* obj = new kth::domain::wallet::ec_private(wif_uncompressed_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_private(wif_uncompressed_cpp, version));
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version_unsafe(uint8_t const* wif_uncompressed, uint8_t version) {
     KTH_PRECONDITION(wif_uncompressed != nullptr);
     auto const wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed);
-    auto* obj = new kth::domain::wallet::ec_private(wif_uncompressed_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_private(wif_uncompressed_cpp, version));
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(kth_hash_t secret, uint16_t version, kth_bool_t compress) {
     auto const secret_cpp = kth::hash_to_cpp(secret.hash);
     auto const compress_cpp = kth::int_to_bool(compress);
-    auto* obj = new kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp));
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress_unsafe(uint8_t const* secret, uint16_t version, kth_bool_t compress) {
     KTH_PRECONDITION(secret != nullptr);
     auto const secret_cpp = kth::hash_to_cpp(secret);
     auto const compress_cpp = kth::int_to_bool(compress);
-    auto* obj = new kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_private(secret_cpp, version, compress_cpp));
 }
 
 
@@ -147,16 +133,12 @@ kth_bool_t kth_wallet_ec_private_compressed(kth_ec_private_const_t self) {
 
 kth_ec_public_mut_t kth_wallet_ec_private_to_public(kth_ec_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::wallet::ec_public(kth_wallet_ec_private_const_cpp(self).to_public());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_wallet_ec_private_const_cpp(self).to_public());
 }
 
 kth_payment_address_mut_t kth_wallet_ec_private_to_payment_address(kth_ec_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::wallet::payment_address(kth_wallet_ec_private_const_cpp(self).to_payment_address());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_wallet_ec_private_const_cpp(self).to_payment_address());
 }
 
 

--- a/src/c-api/src/wallet/ec_public.cpp
+++ b/src/c-api/src/wallet/ec_public.cpp
@@ -30,59 +30,45 @@ kth_ec_public_mut_t kth_wallet_ec_public_construct_default(void) {
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_ec_private(kth_ec_private_const_t secret) {
     KTH_PRECONDITION(secret != nullptr);
     auto const& secret_cpp = kth_wallet_ec_private_const_cpp(secret);
-    auto* obj = new kth::domain::wallet::ec_public(secret_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_public(secret_cpp));
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_decoded(uint8_t const* decoded, kth_size_t n) {
     KTH_PRECONDITION(decoded != nullptr || n == 0);
     auto const decoded_cpp = n != 0 ? kth::data_chunk(decoded, decoded + n) : kth::data_chunk{};
-    auto* obj = new kth::domain::wallet::ec_public(decoded_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_public(decoded_cpp));
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_base16(char const* base16) {
     KTH_PRECONDITION(base16 != nullptr);
     auto const base16_cpp = std::string(base16);
-    auto* obj = new kth::domain::wallet::ec_public(base16_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_public(base16_cpp));
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress(kth_ec_compressed_t compressed_point, kth_bool_t compress) {
     auto const compressed_point_cpp = kth::ec_compressed_to_cpp(compressed_point.data);
     auto const compress_cpp = kth::int_to_bool(compress);
-    auto* obj = new kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp));
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress_unsafe(uint8_t const* compressed_point, kth_bool_t compress) {
     KTH_PRECONDITION(compressed_point != nullptr);
     auto const compressed_point_cpp = kth::ec_compressed_to_cpp(compressed_point);
     auto const compress_cpp = kth::int_to_bool(compress);
-    auto* obj = new kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_public(compressed_point_cpp, compress_cpp));
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress(kth_ec_uncompressed_t uncompressed_point, kth_bool_t compress) {
     auto const uncompressed_point_cpp = kth::ec_uncompressed_to_cpp(uncompressed_point.data);
     auto const compress_cpp = kth::int_to_bool(compress);
-    auto* obj = new kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp));
 }
 
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress_unsafe(uint8_t const* uncompressed_point, kth_bool_t compress) {
     KTH_PRECONDITION(uncompressed_point != nullptr);
     auto const uncompressed_point_cpp = kth::ec_uncompressed_to_cpp(uncompressed_point);
     auto const compress_cpp = kth::int_to_bool(compress);
-    auto* obj = new kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::ec_public(uncompressed_point_cpp, compress_cpp));
 }
 
 
@@ -171,9 +157,7 @@ kth_bool_t kth_wallet_ec_public_less(kth_ec_public_const_t self, kth_ec_public_c
 
 kth_payment_address_mut_t kth_wallet_ec_public_to_payment_address(kth_ec_public_const_t self, uint8_t version) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::wallet::payment_address(kth_wallet_ec_public_const_cpp(self).to_payment_address(version));
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_wallet_ec_public_const_cpp(self).to_payment_address(version));
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/hd_private.cpp
+++ b/src/c-api/src/wallet/hd_private.cpp
@@ -28,78 +28,58 @@ kth_hd_private_mut_t kth_wallet_hd_private_construct_default(void) {
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_seed_prefixes(uint8_t const* seed, kth_size_t n, uint64_t prefixes) {
     KTH_PRECONDITION(seed != nullptr || n == 0);
     auto const seed_cpp = n != 0 ? kth::data_chunk(seed, seed + n) : kth::data_chunk{};
-    auto* obj = new kth::domain::wallet::hd_private(seed_cpp, prefixes);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(seed_cpp, prefixes));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key(kth_hd_key_t private_key) {
     auto const private_key_cpp = kth::hd_key_to_cpp(private_key.data);
-    auto* obj = new kth::domain::wallet::hd_private(private_key_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(private_key_cpp));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_unsafe(uint8_t const* private_key) {
     KTH_PRECONDITION(private_key != nullptr);
     auto const private_key_cpp = kth::hd_key_to_cpp(private_key);
-    auto* obj = new kth::domain::wallet::hd_private(private_key_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(private_key_cpp));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefixes(kth_hd_key_t private_key, uint64_t prefixes) {
     auto const private_key_cpp = kth::hd_key_to_cpp(private_key.data);
-    auto* obj = new kth::domain::wallet::hd_private(private_key_cpp, prefixes);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(private_key_cpp, prefixes));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefixes_unsafe(uint8_t const* private_key, uint64_t prefixes) {
     KTH_PRECONDITION(private_key != nullptr);
     auto const private_key_cpp = kth::hd_key_to_cpp(private_key);
-    auto* obj = new kth::domain::wallet::hd_private(private_key_cpp, prefixes);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(private_key_cpp, prefixes));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix(kth_hd_key_t private_key, uint32_t prefix) {
     auto const private_key_cpp = kth::hd_key_to_cpp(private_key.data);
-    auto* obj = new kth::domain::wallet::hd_private(private_key_cpp, prefix);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(private_key_cpp, prefix));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix_unsafe(uint8_t const* private_key, uint32_t prefix) {
     KTH_PRECONDITION(private_key != nullptr);
     auto const private_key_cpp = kth::hd_key_to_cpp(private_key);
-    auto* obj = new kth::domain::wallet::hd_private(private_key_cpp, prefix);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(private_key_cpp, prefix));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_encoded(char const* encoded) {
     KTH_PRECONDITION(encoded != nullptr);
     auto const encoded_cpp = std::string(encoded);
-    auto* obj = new kth::domain::wallet::hd_private(encoded_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(encoded_cpp));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_encoded_prefixes(char const* encoded, uint64_t prefixes) {
     KTH_PRECONDITION(encoded != nullptr);
     auto const encoded_cpp = std::string(encoded);
-    auto* obj = new kth::domain::wallet::hd_private(encoded_cpp, prefixes);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(encoded_cpp, prefixes));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_encoded_prefix(char const* encoded, uint32_t prefix) {
     KTH_PRECONDITION(encoded != nullptr);
     auto const encoded_cpp = std::string(encoded);
-    auto* obj = new kth::domain::wallet::hd_private(encoded_cpp, prefix);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_private(encoded_cpp, prefix));
 }
 
 
@@ -150,9 +130,7 @@ kth_hd_key_t kth_wallet_hd_private_to_hd_key(kth_hd_private_const_t self) {
 
 kth_hd_public_mut_t kth_wallet_hd_private_to_public(kth_hd_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::wallet::hd_public(kth_wallet_hd_private_const_cpp(self).to_public());
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_wallet_hd_private_const_cpp(self).to_public());
 }
 
 kth_bool_t kth_wallet_hd_private_valid(kth_hd_private_const_t self) {
@@ -190,16 +168,12 @@ kth_bool_t kth_wallet_hd_private_less(kth_hd_private_const_t self, kth_hd_privat
 
 kth_hd_private_mut_t kth_wallet_hd_private_derive_private(kth_hd_private_const_t self, uint32_t index) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::wallet::hd_private(kth_wallet_hd_private_const_cpp(self).derive_private(index));
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_wallet_hd_private_const_cpp(self).derive_private(index));
 }
 
 kth_hd_public_mut_t kth_wallet_hd_private_derive_public(kth_hd_private_const_t self, uint32_t index) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::wallet::hd_public(kth_wallet_hd_private_const_cpp(self).derive_public(index));
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_wallet_hd_private_const_cpp(self).derive_public(index));
 }
 
 

--- a/src/c-api/src/wallet/hd_public.cpp
+++ b/src/c-api/src/wallet/hd_public.cpp
@@ -27,48 +27,36 @@ kth_hd_public_mut_t kth_wallet_hd_public_construct_default(void) {
 
 kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key(kth_hd_key_t public_key) {
     auto const public_key_cpp = kth::hd_key_to_cpp(public_key.data);
-    auto* obj = new kth::domain::wallet::hd_public(public_key_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_public(public_key_cpp));
 }
 
 kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_unsafe(uint8_t const* public_key) {
     KTH_PRECONDITION(public_key != nullptr);
     auto const public_key_cpp = kth::hd_key_to_cpp(public_key);
-    auto* obj = new kth::domain::wallet::hd_public(public_key_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_public(public_key_cpp));
 }
 
 kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_prefix(kth_hd_key_t public_key, uint32_t prefix) {
     auto const public_key_cpp = kth::hd_key_to_cpp(public_key.data);
-    auto* obj = new kth::domain::wallet::hd_public(public_key_cpp, prefix);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_public(public_key_cpp, prefix));
 }
 
 kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_prefix_unsafe(uint8_t const* public_key, uint32_t prefix) {
     KTH_PRECONDITION(public_key != nullptr);
     auto const public_key_cpp = kth::hd_key_to_cpp(public_key);
-    auto* obj = new kth::domain::wallet::hd_public(public_key_cpp, prefix);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_public(public_key_cpp, prefix));
 }
 
 kth_hd_public_mut_t kth_wallet_hd_public_construct_from_encoded(char const* encoded) {
     KTH_PRECONDITION(encoded != nullptr);
     auto const encoded_cpp = std::string(encoded);
-    auto* obj = new kth::domain::wallet::hd_public(encoded_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_public(encoded_cpp));
 }
 
 kth_hd_public_mut_t kth_wallet_hd_public_construct_from_encoded_prefix(char const* encoded, uint32_t prefix) {
     KTH_PRECONDITION(encoded != nullptr);
     auto const encoded_cpp = std::string(encoded);
-    auto* obj = new kth::domain::wallet::hd_public(encoded_cpp, prefix);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::hd_public(encoded_cpp, prefix));
 }
 
 
@@ -146,9 +134,7 @@ kth_bool_t kth_wallet_hd_public_less(kth_hd_public_const_t self, kth_hd_public_c
 
 kth_hd_public_mut_t kth_wallet_hd_public_derive_public(kth_hd_public_const_t self, uint32_t index) {
     KTH_PRECONDITION(self != nullptr);
-    auto* obj = new kth::domain::wallet::hd_public(kth_wallet_hd_public_const_cpp(self).derive_public(index));
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth_wallet_hd_public_const_cpp(self).derive_public(index));
 }
 
 

--- a/src/c-api/src/wallet/payment_address.cpp
+++ b/src/c-api/src/wallet/payment_address.cpp
@@ -27,88 +27,66 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_default(void) {
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded(kth_payment_t decoded) {
     auto const decoded_cpp = kth::payment_to_cpp(decoded.hash);
-    auto* obj = new kth::domain::wallet::payment_address(decoded_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(decoded_cpp));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded_unsafe(uint8_t const* decoded) {
     KTH_PRECONDITION(decoded != nullptr);
     auto const decoded_cpp = kth::payment_to_cpp(decoded);
-    auto* obj = new kth::domain::wallet::payment_address(decoded_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(decoded_cpp));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_private(kth_ec_private_const_t secret) {
     KTH_PRECONDITION(secret != nullptr);
     auto const& secret_cpp = kth_wallet_ec_private_const_cpp(secret);
-    auto* obj = new kth::domain::wallet::payment_address(secret_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(secret_cpp));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address(char const* address) {
     KTH_PRECONDITION(address != nullptr);
     auto const address_cpp = std::string(address);
-    auto* obj = new kth::domain::wallet::payment_address(address_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(address_cpp));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address_net(char const* address, kth_network_t net) {
     KTH_PRECONDITION(address != nullptr);
     auto const address_cpp = std::string(address);
     auto const net_cpp = static_cast<kth::domain::config::network>(net);
-    auto* obj = new kth::domain::wallet::payment_address(address_cpp, net_cpp);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(address_cpp, net_cpp));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t short_hash, uint8_t version) {
     auto const short_hash_cpp = kth::short_hash_to_cpp(short_hash.hash);
-    auto* obj = new kth::domain::wallet::payment_address(short_hash_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(short_hash_cpp, version));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version_unsafe(uint8_t const* short_hash, uint8_t version) {
     KTH_PRECONDITION(short_hash != nullptr);
     auto const short_hash_cpp = kth::short_hash_to_cpp(short_hash);
-    auto* obj = new kth::domain::wallet::payment_address(short_hash_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(short_hash_cpp, version));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version(kth_hash_t hash, uint8_t version) {
     auto const hash_cpp = kth::hash_to_cpp(hash.hash);
-    auto* obj = new kth::domain::wallet::payment_address(hash_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(hash_cpp, version));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version_unsafe(uint8_t const* hash, uint8_t version) {
     KTH_PRECONDITION(hash != nullptr);
     auto const hash_cpp = kth::hash_to_cpp(hash);
-    auto* obj = new kth::domain::wallet::payment_address(hash_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(hash_cpp, version));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_ec_public_version(kth_ec_public_const_t point, uint8_t version) {
     KTH_PRECONDITION(point != nullptr);
     auto const& point_cpp = kth_wallet_ec_public_const_cpp(point);
-    auto* obj = new kth::domain::wallet::payment_address(point_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(point_cpp, version));
 }
 
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_script_version(kth_script_const_t script, uint8_t version) {
     KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
-    auto* obj = new kth::domain::wallet::payment_address(script_cpp, version);
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address(script_cpp, version));
 }
 
 
@@ -117,9 +95,7 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_from_script_versi
 kth_payment_address_mut_t kth_wallet_payment_address_from_pay_public_key_hash_script(kth_script_const_t script, uint8_t version) {
     KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth_chain_script_const_cpp(script);
-    auto* obj = new kth::domain::wallet::payment_address(kth::domain::wallet::payment_address::from_pay_public_key_hash_script(script_cpp, version));
-    if ( ! kth::check_valid(obj)) { delete obj; return nullptr; }
-    return obj;
+    return kth::make_leaked_if_valid(kth::domain::wallet::payment_address::from_pay_public_key_hash_script(script_cpp, version));
 }
 
 

--- a/src/c-api/src/wallet/wallet_data.cpp
+++ b/src/c-api/src/wallet/wallet_data.cpp
@@ -29,7 +29,7 @@ kth_string_list_mut_t kth_wallet_wallet_data_mnemonics(kth_wallet_data_t wallet_
 
 kth_hd_public_t kth_wallet_wallet_data_xpub(kth_wallet_data_t wallet_data) {
     auto const& xpub_cpp = kth_wallet_wallet_data_cpp(wallet_data).xpub;
-    return kth::move_or_copy_and_leak(std::move(xpub_cpp));
+    return kth::make_leaked(std::move(xpub_cpp));
 }
 
 kth_encrypted_seed_t kth_wallet_wallet_data_encrypted_seed(kth_wallet_data_t wallet_data) {

--- a/src/c-api/src/wallet/wallet_manager.cpp
+++ b/src/c-api/src/wallet/wallet_manager.cpp
@@ -26,7 +26,7 @@ kth_error_code_t kth_wallet_create_wallet(
         return kth::to_c_err(res.error());
     }
 
-    *out_wallet_data = kth::move_or_copy_and_leak(std::move(res.value()));
+    *out_wallet_data = kth::make_leaked(std::move(res.value()));
     return kth_ec_success;
 }
 


### PR DESCRIPTION
## Summary
Closes #256.

\`helpers.hpp\`:
- Rename \`move_or_copy_and_leak\` → \`make_leaked\`. The \`_leak\` suffix is
  intentional: it surfaces the ownership-transfer contract at every
  call site instead of hiding it behind a generic factory name.
- Add \`make_leaked_if_valid<T>(T&& x)\` — heap-copies \`x\` and surrenders
  ownership, returning \`nullptr\` when \`check_valid(&x)\` reports the
  source is invalid. The validity test runs against the source **before**
  any allocation, so the failure path never touches the heap.

The recurring three-line allocate / check / delete block used by
opaque-handle factories collapses to a single greppable call:

\`\`\`cpp
return kth::make_leaked_if_valid(domain::T(args...));
\`\`\`

Sentinel factories whose return is intentionally invalid by design
(e.g. \`point::null()\`) opt out of the validity gate and route through
\`make_leaked\` instead.

Pure refactor — no behavior change.

## Test plan
- [ ] C-API test suite compiles and passes.
- [ ] Spot-check a factory diff to confirm one-liner emission.
- [ ] \`kth_chain_point_null()\` still returns a valid (sentinel) handle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical refactor across many C-API constructors/factories, but it touches allocation/ownership and validity-gating behavior in a large surface area, which could affect null-return semantics or leaks if any call site relied on the old pattern.
> 
> **Overview**
> **Refactors C-API object factories/constructors to centralize heap-ownership transfer.** Adds `make_leaked` (rename of `move_or_copy_and_leak`) and new `make_leaked_if_valid`, which checks `check_valid` *before* allocating and returns `nullptr` for invalid values.
> 
> Updates a broad set of C-API entry points (binary, chain message/chain primitives, VM, wallet) to replace repeated `new`/`check_valid`/`delete` blocks with one-liners using these helpers, with explicit opt-out for sentinel factories like `kth_chain_point_null()` that intentionally return an "invalid" value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b0bc3e5782b38648e50627afc1f5555c8a042c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->