### PR TITLE
refactor(c-api): nullable contract for empty-as-failure list factories

### DIFF
--- a/src/c-api/include/kth/capi/chain/script.h
+++ b/src/c-api/include/kth/capi/chain/script.h
@@ -216,11 +216,11 @@ kth_error_code_t kth_chain_script_create_endorsement(kth_hash_t secret, kth_scri
 KTH_EXPORT
 kth_error_code_t kth_chain_script_create_endorsement_unsafe(uint8_t const* secret, kth_script_const_t prevout_script, kth_transaction_const_t tx, uint32_t input_index, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_endorsement_type_t type, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size);
 
-/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+/** @return Owned `kth_operation_list_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_operation_list_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_null_data_pattern(uint8_t const* data, kth_size_t n);
 
-/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+/** @return Owned `kth_operation_list_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_operation_list_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_pattern(uint8_t const* point, kth_size_t n);
 
@@ -235,7 +235,7 @@ kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern(kth_sho
 KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unsafe(uint8_t const* hash);
 
-/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+/** @return Owned `kth_operation_list_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_operation_list_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocking(uint8_t const* end, kth_size_t n, kth_ec_public_const_t pubkey);
 

--- a/src/c-api/src/chain/script.cpp
+++ b/src/c-api/src/chain/script.cpp
@@ -400,13 +400,17 @@ kth_error_code_t kth_chain_script_create_endorsement_unsafe(uint8_t const* secre
 kth_operation_list_mut_t kth_chain_script_to_null_data_pattern(uint8_t const* data, kth_size_t n) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     auto const data_cpp = kth::byte_span(data, static_cast<size_t>(n));
-    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_null_data_pattern(data_cpp));
+    auto cpp_result = kth::domain::chain::script::to_null_data_pattern(data_cpp);
+    if (cpp_result.empty()) return nullptr;
+    return new std::vector<kth::domain::machine::operation>(std::move(cpp_result));
 }
 
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_pattern(uint8_t const* point, kth_size_t n) {
     KTH_PRECONDITION(point != nullptr || n == 0);
     auto const point_cpp = kth::byte_span(point, static_cast<size_t>(n));
-    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_public_key_pattern(point_cpp));
+    auto cpp_result = kth::domain::chain::script::to_pay_public_key_pattern(point_cpp);
+    if (cpp_result.empty()) return nullptr;
+    return new std::vector<kth::domain::machine::operation>(std::move(cpp_result));
 }
 
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern(kth_shorthash_t hash) {
@@ -425,7 +429,9 @@ kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocki
     KTH_PRECONDITION(pubkey != nullptr);
     auto const end_cpp = n != 0 ? kth::data_chunk(end, end + n) : kth::data_chunk{};
     auto const& pubkey_cpp = kth_wallet_ec_public_const_cpp(pubkey);
-    return new std::vector<kth::domain::machine::operation>(kth::domain::chain::script::to_pay_public_key_hash_pattern_unlocking(end_cpp, pubkey_cpp));
+    auto cpp_result = kth::domain::chain::script::to_pay_public_key_hash_pattern_unlocking(end_cpp, pubkey_cpp);
+    if (cpp_result.empty()) return nullptr;
+    return new std::vector<kth::domain::machine::operation>(std::move(cpp_result));
 }
 
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocking_placeholder(kth_size_t endorsement_size, kth_size_t pubkey_size) {

--- a/src/c-api/test/chain/script.cpp
+++ b/src/c-api/test/chain/script.cpp
@@ -19,6 +19,7 @@
 #include <kth/capi/chain/transaction.h>
 #include <kth/capi/hash.h>
 #include <kth/capi/primitives.h>
+#include <kth/capi/wallet/ec_public.h>
 
 #include "../test_helpers.hpp"
 
@@ -193,6 +194,125 @@ TEST_CASE("C-API Script - to_pay_script_hash_32_pattern returns operation list",
     REQUIRE(kth_chain_script_is_valid(script) != 0);
     REQUIRE(kth_chain_script_empty(script) == 0);
     kth_chain_script_destruct(script);
+    kth_chain_operation_list_destruct(ops);
+}
+
+// ---------------------------------------------------------------------------
+// Empty-as-failure list factories: return NULL when the C++ layer
+// signals an invalid input via an empty result vector.
+// ---------------------------------------------------------------------------
+
+// A valid 33-byte compressed secp256k1 public key (BIP32 test vector 1
+// master public key), usable to exercise the success path of the
+// pay_public_key factories.
+static uint8_t const kValidCompressedPoint[33] = {
+    0x03, 0x39, 0xa3, 0x60, 0x13, 0x30, 0x15, 0x97,
+    0xda, 0xef, 0x41, 0xfb, 0xe5, 0x93, 0xa0, 0x2c,
+    0xc5, 0x13, 0xd0, 0xb5, 0x55, 0x27, 0xec, 0x2d,
+    0xf1, 0x05, 0x0e, 0x2e, 0x8f, 0xf4, 0x9c, 0x85,
+    0xc2
+};
+
+TEST_CASE("C-API Script - to_null_data_pattern valid data returns list",
+          "[C-API Script]") {
+    uint8_t const data[4] = { 0x01, 0x02, 0x03, 0x04 };
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_null_data_pattern(data, sizeof(data));
+    REQUIRE(ops != NULL);
+    kth_chain_operation_list_destruct(ops);
+}
+
+TEST_CASE("C-API Script - to_null_data_pattern oversized data returns NULL",
+          "[C-API Script]") {
+    // The max_null_data_size limit is 80 bytes; one byte over triggers
+    // the empty-list failure signal in the C++ layer.
+    uint8_t data[81];
+    memset(data, 0x42, sizeof(data));
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_null_data_pattern(data, sizeof(data));
+    REQUIRE(ops == NULL);
+}
+
+TEST_CASE("C-API Script - to_pay_public_key_pattern valid point returns list",
+          "[C-API Script]") {
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_pay_public_key_pattern(
+            kValidCompressedPoint, sizeof(kValidCompressedPoint));
+    REQUIRE(ops != NULL);
+    kth_chain_operation_list_destruct(ops);
+}
+
+TEST_CASE("C-API Script - to_pay_public_key_pattern malformed point returns NULL",
+          "[C-API Script]") {
+    // A 33-byte blob with an invalid prefix (0x00) fails the
+    // is_public_key check, so the C++ factory yields an empty list.
+    uint8_t malformed[33];
+    memset(malformed, 0x00, sizeof(malformed));
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_pay_public_key_pattern(malformed, sizeof(malformed));
+    REQUIRE(ops == NULL);
+}
+
+TEST_CASE("C-API Script - to_pay_public_key_pattern wrong-size point returns NULL",
+          "[C-API Script]") {
+    // Neither 33 (compressed) nor 65 (uncompressed) bytes — fails the
+    // size check inside is_public_key.
+    uint8_t too_short[10];
+    memset(too_short, 0x03, sizeof(too_short));
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_pay_public_key_pattern(too_short, sizeof(too_short));
+    REQUIRE(ops == NULL);
+}
+
+TEST_CASE("C-API Script - to_pay_public_key_hash_pattern_unlocking valid pubkey returns list",
+          "[C-API Script]") {
+    kth_ec_public_mut_t pub =
+        kth_wallet_ec_public_construct_from_decoded(
+            kValidCompressedPoint, sizeof(kValidCompressedPoint));
+    REQUIRE(pub != NULL);
+
+    // A 71-byte DER-like endorsement blob; content is not validated at
+    // this layer, we just need something non-empty to push.
+    uint8_t endorsement[71];
+    memset(endorsement, 0x30, sizeof(endorsement));
+
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_pay_public_key_hash_pattern_unlocking(
+            endorsement, sizeof(endorsement), pub);
+    REQUIRE(ops != NULL);
+
+    kth_chain_operation_list_destruct(ops);
+    kth_wallet_ec_public_destruct(pub);
+}
+
+TEST_CASE("C-API Script - to_pay_public_key_hash_pattern_unlocking invalid pubkey returns NULL",
+          "[C-API Script]") {
+    // Default-constructed ec_public has valid_ == false, so its
+    // to_data() returns an error and the C++ factory yields an empty
+    // unlocking list that we turn into NULL.
+    kth_ec_public_mut_t pub = kth_wallet_ec_public_construct_default();
+    REQUIRE(pub != NULL);
+    REQUIRE(kth_wallet_ec_public_valid(pub) == 0);
+
+    uint8_t endorsement[71];
+    memset(endorsement, 0x30, sizeof(endorsement));
+
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_pay_public_key_hash_pattern_unlocking(
+            endorsement, sizeof(endorsement), pub);
+    REQUIRE(ops == NULL);
+
+    kth_wallet_ec_public_destruct(pub);
+}
+
+TEST_CASE("C-API Script - to_pay_public_key_hash_pattern always returns a list",
+          "[C-API Script]") {
+    // Control case: sibling pattern that is NOT opt-in to the
+    // empty-as-failure convention. Any 20-byte hash produces a valid
+    // 5-op list, so the factory never returns NULL.
+    kth_operation_list_mut_t ops =
+        kth_chain_script_to_pay_public_key_hash_pattern(kShortHash);
+    REQUIRE(ops != NULL);
     kth_chain_operation_list_destruct(ops);
 }
 


### PR DESCRIPTION
## Summary
Closes #257.

Three script pattern factories used \`{}\` from the C++ side as a failure
signal but the C-API wrapper always handed back a non-null heap vector,
leaving callers without a way to distinguish "couldn't construct" from
"valid but empty list":

- \`kth_chain_script_to_null_data_pattern\` — data exceeds max push size.
- \`kth_chain_script_to_pay_public_key_pattern\` — point fails public-key validation.
- \`kth_chain_script_to_pay_public_key_hash_pattern_unlocking\` — pubkey serialization fails.

Each now captures the C++ result, returns \`nullptr\` when empty, and
documents the nullable contract via the standard \`@return Owned ..., or NULL ...\`
docstring. Sibling list factories whose empty result is semantically
valid (no addresses extracted, empty block, fixed-size patterns that
always succeed) are unaffected.

Stacked on top of #258.

## Test plan
- [x] C-API test suite compiles and passes.
- [ ] \`to_null_data_pattern\` with oversized data returns NULL.
- [ ] \`to_pay_public_key_pattern\` with malformed point returns NULL.
- [ ] \`to_pay_public_key_hash_pattern_unlocking\` with invalid pubkey returns NULL.
- [ ] \`to_pay_public_key_hash_pattern\` (non-opted-in) still returns a non-null 5-op list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the C-API contract for three script pattern factories to return `NULL` on invalid inputs, which can break existing callers that assumed a non-null list and don’t check for null before use.
> 
> **Overview**
> Aligns three C-API script pattern factories with the C++ “empty vector means failure” convention by returning `NULL` (instead of an allocated empty operation list) when construction fails: `kth_chain_script_to_null_data_pattern`, `kth_chain_script_to_pay_public_key_pattern`, and `kth_chain_script_to_pay_public_key_hash_pattern_unlocking`.
> 
> Updates the header docs to explicitly document the nullable return contract, and extends the C-API test suite with positive/negative cases (including invalid pubkey scenarios) to assert the new behavior while confirming sibling factories remain non-null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f19c26d0dab930f709a40a2792285a17f290575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for script pattern operations to properly signal failures by returning null values instead of empty results.

* **Documentation**
  * Clarified return value documentation for script pattern functions to specify null results on construction failures and required cleanup procedures.

* **Tests**
  * Added comprehensive test coverage for script pattern functions, including edge cases and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->