### PR TITLE
refactor(c-api): unify and harden chain/token_data bindings + cleanup

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -513,6 +513,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/stealth_compact.cpp
         test/chain/history_compact.cpp
         test/chain/double_spend_proof.cpp
+        test/chain/token_data.cpp
         test/wallet/hd_public.cpp
         test/wallet/hd_private.cpp
     )

--- a/src/c-api/include/kth/capi/chain/token_data.h
+++ b/src/c-api/include/kth/capi/chain/token_data.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,7 +9,6 @@
 
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
-
 #include <kth/capi/chain/token_capability.h>
 #include <kth/capi/chain/token_kind.h>
 
@@ -17,50 +16,133 @@
 extern "C" {
 #endif
 
+// Constructors
+
+/** @param[out] out Must point to a null `kth_token_data_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_token_data_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_token_data_t kth_chain_token_data_construct_default(void);
+kth_error_code_t kth_chain_token_data_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_token_data_mut_t* out);
+
+
+// Static factories
+
+/** @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_token_data_mut_t kth_chain_token_data_make_fungible(kth_hash_t id, uint64_t amount);
+
+/**
+ * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
+ * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_token_data_mut_t kth_chain_token_data_make_fungible_unsafe(uint8_t const* id, uint64_t amount);
+
+/** @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_token_data_mut_t kth_chain_token_data_make_non_fungible(kth_hash_t id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+
+/**
+ * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
+ * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_token_data_mut_t kth_chain_token_data_make_non_fungible_unsafe(uint8_t const* id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+
+/** @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_token_data_mut_t kth_chain_token_data_make_both(kth_hash_t id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+
+/**
+ * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
+ * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ */
+KTH_EXPORT KTH_OWNED
+kth_token_data_mut_t kth_chain_token_data_make_both_unsafe(uint8_t const* id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_chain_token_data_destruct(kth_token_data_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_token_data_mut_t`. Caller must release with `kth_chain_token_data_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_token_data_mut_t kth_chain_token_data_copy(kth_token_data_const_t self);
+
+
+// Equality
 
 KTH_EXPORT
-kth_token_data_t kth_chain_token_data_construct_fungible(kth_hash_t const* token_category, int64_t token_amount);
+kth_bool_t kth_chain_token_data_equals(kth_token_data_const_t self, kth_token_data_const_t other);
+
+
+// Serialization
 
 KTH_EXPORT
-kth_token_data_t kth_chain_token_data_construct_non_fungible(kth_hash_t const* token_category, kth_token_capability_t capability, uint8_t* commitment_data, kth_size_t commitment_n);
+kth_size_t kth_chain_token_data_serialized_size(kth_token_data_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_token_data_to_data(kth_token_data_const_t self, kth_size_t* out_size);
+
+
+// Getters
 
 KTH_EXPORT
-kth_token_data_t kth_chain_token_data_construct_both(kth_hash_t const* token_category, int64_t token_amount, kth_token_capability_t capability, uint8_t* commitment_data, kth_size_t commitment_n);
+kth_hash_t kth_chain_token_data_id(kth_token_data_const_t self);
 
 KTH_EXPORT
-void kth_chain_token_data_destruct(kth_token_data_t token_data);
+kth_token_kind_t kth_chain_token_data_get_kind(kth_token_data_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_chain_token_data_is_valid(kth_token_data_t token_data);
+uint64_t kth_chain_token_data_get_amount(kth_token_data_const_t self);
 
 KTH_EXPORT
-kth_size_t kth_chain_token_data_serialized_size(kth_token_data_t token_data);
+kth_token_capability_t kth_chain_token_data_get_nft_capability(kth_token_data_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_token_data_get_nft_commitment(kth_token_data_const_t self, kth_size_t* out_size);
 
 KTH_EXPORT
-uint8_t const* kth_chain_token_data_to_data(kth_token_data_t token_data, kth_size_t* out_size);
+uint8_t kth_chain_token_data_bitfield(kth_token_data_const_t self);
+
+
+// Setters
 
 KTH_EXPORT
-kth_token_kind_t kth_chain_token_data_kind(kth_token_data_t token_data);
+void kth_chain_token_data_set_id(kth_token_data_mut_t self, kth_hash_t value);
+
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+KTH_EXPORT
+void kth_chain_token_data_set_id_unsafe(kth_token_data_mut_t self, uint8_t const* value);
+
+
+// Predicates
 
 KTH_EXPORT
-kth_hash_t kth_chain_token_data_category(kth_token_data_t token_data);
+kth_bool_t kth_chain_token_data_is_valid(kth_token_data_const_t self);
 
 KTH_EXPORT
-void kth_chain_token_data_category_out(kth_token_data_t token_data, kth_hash_t* out_category);
+kth_bool_t kth_chain_token_data_has_nft(kth_token_data_const_t self);
 
 KTH_EXPORT
-int64_t kth_chain_token_data_fungible_amount(kth_token_data_t token_data);
+kth_bool_t kth_chain_token_data_is_fungible_only(kth_token_data_const_t self);
 
 KTH_EXPORT
-kth_token_capability_t kth_chain_token_data_non_fungible_capability(kth_token_data_t token_data);
+kth_bool_t kth_chain_token_data_is_immutable_nft(kth_token_data_const_t self);
 
 KTH_EXPORT
-uint8_t const* kth_chain_token_data_non_fungible_commitment(kth_token_data_t token_data, kth_size_t* out_size);
+kth_bool_t kth_chain_token_data_is_mutable_nft(kth_token_data_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_token_data_is_minting_nft(kth_token_data_const_t self);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_CHAIN_TOKEN_DATA_H_ */
+#endif // KTH_CAPI_CHAIN_TOKEN_DATA_H_

--- a/src/c-api/include/kth/capi/chain/token_kind.h
+++ b/src/c-api/include/kth/capi/chain/token_kind.h
@@ -14,11 +14,13 @@
 extern "C" {
 #endif
 
+// Discriminator for the three variants of the CashTokens payload.
+// Mirrors `kth::domain::chain::kind` in the C++ layer so both sides
+// share the same integral values.
 typedef enum {
-    kth_token_kind_none = 0x00,
-    kth_token_kind_fungible = 0x01,
-    kth_token_kind_non_fungible = 0x02,
-    kth_token_kind_both = 0x03,
+    kth_token_kind_fungible_only = 0,
+    kth_token_kind_non_fungible_only = 1,
+    kth_token_kind_both = 2,
 } kth_token_kind_t;
 
 #ifdef __cplusplus

--- a/src/c-api/include/kth/capi/chain/utxo.h
+++ b/src/c-api/include/kth/capi/chain/utxo.h
@@ -89,13 +89,13 @@ KTH_EXPORT
 void kth_chain_utxo_set_token_data(kth_utxo_t utxo, kth_token_data_t token_data);
 
 KTH_EXPORT
-void kth_chain_utxo_set_fungible_token_data(kth_utxo_t utxo, kth_hash_t const* token_category, int64_t token_amount);
+void kth_chain_utxo_set_fungible_token_data(kth_utxo_t utxo, kth_hash_t const* token_category, uint64_t token_amount);
 
 KTH_EXPORT
 void kth_chain_utxo_set_token_category(kth_utxo_t utxo, kth_hash_t const* token_category);
 
 KTH_EXPORT
-void kth_chain_utxo_set_token_amount(kth_utxo_t utxo, int64_t token_amount);
+void kth_chain_utxo_set_token_amount(kth_utxo_t utxo, uint64_t token_amount);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -109,18 +109,12 @@ kth_wallet_ec_compressed_list_mut_cpp(kth_ec_compressed_list_mut_t l) {
     return *static_cast<std::vector<std::array<uint8_t, 33>>*>(l);
 }
 
-// token_data is not migrated to const/mut yet. The legacy
-// KTH_CONV_DECLARE(chain, kth_token_data_t, ...) declares the converter
-// taking a non-const void*; the migrated chain/output API needs the const
-// view, so we add an inline shim here.
-inline kth::domain::chain::token_data_t const&
-kth_chain_token_data_const_cpp(kth_token_data_const_t o) {
-    return *static_cast<kth::domain::chain::token_data_t const*>(o);
-}
-inline kth::domain::chain::token_data_t&
-kth_chain_token_data_mut_cpp(kth_token_data_mut_t o) {
-    return *static_cast<kth::domain::chain::token_data_t*>(o);
-}
+// token_data: conversion functions live in src/chain/token_data.cpp.
+kth::domain::chain::token_data_t const&
+kth_chain_token_data_const_cpp(kth_token_data_const_t o);
+
+kth::domain::chain::token_data_t&
+kth_chain_token_data_mut_cpp(kth_token_data_mut_t o);
 
 // data_stack — vector of variable-length byte buffers (the script runtime
 // stack). Exposed only as an opaque handle for now; ownership and element
@@ -193,7 +187,6 @@ kth::domain::chain::script&       kth_chain_script_mut_cpp(kth_script_mut_t o);
 kth::domain::chain::point const& kth_chain_point_const_cpp(kth_point_const_t o);
 kth::domain::chain::point&       kth_chain_point_mut_cpp(kth_point_mut_t o);
 KTH_CONV_DECLARE(chain, kth_utxo_t, kth::domain::chain::utxo, utxo)
-KTH_CONV_DECLARE(chain, kth_token_data_t, kth::domain::chain::token_data_t, token_data)
 
 // #ifndef __EMSCRIPTEN__
 KTH_CONV_DECLARE(chain, kth_mempool_transaction_t, kth::blockchain::mempool_transaction_summary, mempool_transaction)

--- a/src/c-api/src/chain/token_data.cpp
+++ b/src/c-api/src/chain/token_data.cpp
@@ -1,156 +1,211 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <utility>
 
 #include <kth/capi/chain/token_data.h>
 
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/domain/chain/token_data.hpp>
 
-#include <kth/domain/chain/token_data_serialization.hpp>
-
-#include <utility>
-
-KTH_CONV_DEFINE(chain, kth_token_data_t, kth::domain::chain::token_data_t, token_data)
+// Conversion functions
+kth::domain::chain::token_data_t& kth_chain_token_data_mut_cpp(kth_token_data_mut_t o) {
+    return *static_cast<kth::domain::chain::token_data_t*>(o);
+}
+kth::domain::chain::token_data_t const& kth_chain_token_data_const_cpp(kth_token_data_const_t o) {
+    return *static_cast<kth::domain::chain::token_data_t const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_token_data_t kth_chain_token_data_construct_default() {
-    return new kth::domain::chain::token_data_t();
+// Constructors
+
+kth_error_code_t kth_chain_token_data_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_token_data_mut_t* out) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto data_cpp = kth::byte_reader(kth::byte_span(data, static_cast<size_t>(n)));
+    auto result = kth::domain::chain::token::encoding::from_data(data_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = kth::make_leaked(std::move(*result));
+    return kth_ec_success;
 }
 
-kth_token_data_t kth_chain_token_data_construct_fungible(kth_hash_t const* token_category, int64_t token_amount) {
-    using kth::domain::chain::amount_t;
 
-    auto token_category_cpp = kth::to_array(token_category->hash);
-    return new kth::domain::chain::token_data_t {
-        token_category_cpp,
-        kth::domain::chain::fungible{amount_t{token_amount}}
-    };
+// Static factories
+
+kth_token_data_mut_t kth_chain_token_data_make_fungible(kth_hash_t id, uint64_t amount) {
+    auto const id_cpp = kth::hash_to_cpp(id.hash);
+    return kth::make_leaked_if_valid(kth::domain::chain::make_fungible(id_cpp, amount));
 }
 
-kth_token_data_t kth_chain_token_data_construct_non_fungible(kth_hash_t const* token_category, kth_token_capability_t capability, uint8_t* commitment_data, kth_size_t commitment_n) {
-    auto token_category_cpp = kth::to_array(token_category->hash);
-    auto capability_cpp = kth::token_capability_to_cpp(capability);
-    kth::data_chunk commitment_cpp(commitment_data, std::next(commitment_data, commitment_n));
-
-    return new kth::domain::chain::token_data_t {
-        token_category_cpp,
-        kth::domain::chain::non_fungible{capability_cpp, std::move(commitment_cpp)}
-    };
+kth_token_data_mut_t kth_chain_token_data_make_fungible_unsafe(uint8_t const* id, uint64_t amount) {
+    KTH_PRECONDITION(id != nullptr);
+    auto const id_cpp = kth::hash_to_cpp(id);
+    return kth::make_leaked_if_valid(kth::domain::chain::make_fungible(id_cpp, amount));
 }
 
-kth_token_data_t kth_chain_token_data_construct_both(kth_hash_t const* token_category, int64_t token_amount, kth_token_capability_t capability, uint8_t* commitment_data, kth_size_t commitment_n) {
-    using kth::domain::chain::amount_t;
-
-    auto token_category_cpp = kth::to_array(token_category->hash);
-    auto capability_cpp = kth::token_capability_to_cpp(capability);
-    kth::data_chunk commitment_cpp(commitment_data, std::next(commitment_data, commitment_n));
-
-    return new kth::domain::chain::token_data_t {
-        token_category_cpp,
-        kth::domain::chain::both_kinds{
-            kth::domain::chain::fungible{
-                amount_t{token_amount}
-            },
-            kth::domain::chain::non_fungible{
-                capability_cpp,
-                std::move(commitment_cpp)
-            }
-        }
-    };
+kth_token_data_mut_t kth_chain_token_data_make_non_fungible(kth_hash_t id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+    KTH_PRECONDITION(commitment != nullptr || n == 0);
+    auto const id_cpp = kth::hash_to_cpp(id.hash);
+    auto const capability_cpp = static_cast<kth::domain::chain::capability_t>(capability);
+    auto const commitment_cpp = n != 0 ? kth::data_chunk(commitment, commitment + n) : kth::data_chunk{};
+    return kth::make_leaked_if_valid(kth::domain::chain::make_non_fungible(id_cpp, capability_cpp, commitment_cpp));
 }
 
-void kth_chain_token_data_destruct(kth_token_data_t token_data) {
-    delete &kth_chain_token_data_cpp(token_data);
+kth_token_data_mut_t kth_chain_token_data_make_non_fungible_unsafe(uint8_t const* id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+    KTH_PRECONDITION(id != nullptr);
+    KTH_PRECONDITION(commitment != nullptr || n == 0);
+    auto const id_cpp = kth::hash_to_cpp(id);
+    auto const capability_cpp = static_cast<kth::domain::chain::capability_t>(capability);
+    auto const commitment_cpp = n != 0 ? kth::data_chunk(commitment, commitment + n) : kth::data_chunk{};
+    return kth::make_leaked_if_valid(kth::domain::chain::make_non_fungible(id_cpp, capability_cpp, commitment_cpp));
 }
 
-kth_bool_t kth_chain_token_data_is_valid(kth_token_data_t token_data) {
-    return kth::bool_to_int(
-        kth::domain::chain::is_valid(
-            kth_chain_token_data_const_cpp(token_data)
-        )
-    );
+kth_token_data_mut_t kth_chain_token_data_make_both(kth_hash_t id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+    KTH_PRECONDITION(commitment != nullptr || n == 0);
+    auto const id_cpp = kth::hash_to_cpp(id.hash);
+    auto const capability_cpp = static_cast<kth::domain::chain::capability_t>(capability);
+    auto const commitment_cpp = n != 0 ? kth::data_chunk(commitment, commitment + n) : kth::data_chunk{};
+    return kth::make_leaked_if_valid(kth::domain::chain::make_both(id_cpp, amount, capability_cpp, commitment_cpp));
 }
 
-kth_size_t kth_chain_token_data_serialized_size(kth_token_data_t token_data) {
-    return kth::domain::chain::token::encoding::serialized_size(
-            kth_chain_token_data_const_cpp(token_data)
-        );
+kth_token_data_mut_t kth_chain_token_data_make_both_unsafe(uint8_t const* id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+    KTH_PRECONDITION(id != nullptr);
+    KTH_PRECONDITION(commitment != nullptr || n == 0);
+    auto const id_cpp = kth::hash_to_cpp(id);
+    auto const capability_cpp = static_cast<kth::domain::chain::capability_t>(capability);
+    auto const commitment_cpp = n != 0 ? kth::data_chunk(commitment, commitment + n) : kth::data_chunk{};
+    return kth::make_leaked_if_valid(kth::domain::chain::make_both(id_cpp, amount, capability_cpp, commitment_cpp));
 }
 
-uint8_t const* kth_chain_token_data_to_data(kth_token_data_t token_data, kth_size_t* out_size) {
-    auto token_data_data = kth::domain::chain::token::encoding::to_data(kth_chain_token_data_const_cpp(token_data));
-    return kth::create_c_array(token_data_data, *out_size);
+
+// Destructor
+
+void kth_chain_token_data_destruct(kth_token_data_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_chain_token_data_mut_cpp(self);
 }
 
-kth_token_kind_t kth_chain_token_data_kind(kth_token_data_t token_data) {
-    auto const& token_data_cpp = kth_chain_token_data_const_cpp(token_data);
-    if (std::holds_alternative<kth::domain::chain::fungible>(token_data_cpp.data)) {
-        return kth_token_kind_fungible;
-    }
-    if (std::holds_alternative<kth::domain::chain::non_fungible>(token_data_cpp.data)) {
-        return kth_token_kind_non_fungible;
-    }
-    if (std::holds_alternative<kth::domain::chain::both_kinds>(token_data_cpp.data)) {
-        return kth_token_kind_both;
-    }
-    return kth_token_kind_none;
+
+// Copy
+
+kth_token_data_mut_t kth_chain_token_data_copy(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::chain::token_data_t(kth_chain_token_data_const_cpp(self));
 }
 
-kth_hash_t kth_chain_token_data_category(kth_token_data_t token_data) {
-    auto const& category_cpp = kth_chain_token_data_const_cpp(token_data).id;
-    return kth::to_hash_t(category_cpp);
+
+// Equality
+
+kth_bool_t kth_chain_token_data_equals(kth_token_data_const_t self, kth_token_data_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::bool_to_int(kth_chain_token_data_const_cpp(self) == kth_chain_token_data_const_cpp(other));
 }
 
-void kth_chain_token_data_category_out(kth_token_data_t token_data, kth_hash_t* out_category) {
-    auto const& category_cpp = kth_chain_token_data_const_cpp(token_data).id;
-    kth::copy_c_hash(category_cpp, out_category);
+
+// Serialization
+
+kth_size_t kth_chain_token_data_serialized_size(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::domain::chain::token::encoding::serialized_size(kth_chain_token_data_const_cpp(self));
 }
 
-int64_t kth_chain_token_data_fungible_amount(kth_token_data_t token_data) {
-    auto const& token_data_cpp = kth_chain_token_data_const_cpp(token_data);
-    if (std::holds_alternative<kth::domain::chain::fungible>(token_data_cpp.data)) {
-        auto const& fungible_cpp = std::get<kth::domain::chain::fungible>(token_data_cpp.data);
-        return std::to_underlying(fungible_cpp.amount);
-    }
-    if (std::holds_alternative<kth::domain::chain::both_kinds>(token_data_cpp.data)) {
-        auto const& both_kinds_cpp = std::get<kth::domain::chain::both_kinds>(token_data_cpp.data);
-        auto const& fungible_cpp = both_kinds_cpp.first;
-        return std::to_underlying(fungible_cpp.amount);
-    }
-    return std::numeric_limits<int64_t>::max();
+uint8_t* kth_chain_token_data_to_data(kth_token_data_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth::domain::chain::token::encoding::to_data(kth_chain_token_data_const_cpp(self));
+    return kth::create_c_array(data, *out_size);
 }
 
-kth_token_capability_t kth_chain_token_data_non_fungible_capability(kth_token_data_t token_data) {
-    auto const& token_data_cpp = kth_chain_token_data_const_cpp(token_data);
-    if (std::holds_alternative<kth::domain::chain::non_fungible>(token_data_cpp.data)) {
-        auto const& non_fungible_cpp = std::get<kth::domain::chain::non_fungible>(token_data_cpp.data);
-        return kth::token_capability_to_c(non_fungible_cpp.capability);
-    }
-    if (std::holds_alternative<kth::domain::chain::both_kinds>(token_data_cpp.data)) {
-        auto const& both_kinds_cpp = std::get<kth::domain::chain::both_kinds>(token_data_cpp.data);
-        auto const& non_fungible_cpp = both_kinds_cpp.second;
-        return kth::token_capability_to_c(non_fungible_cpp.capability);
-    }
-    return kth_token_capability_none; // TODO: this is not a good way to signal an error
+
+// Getters
+
+kth_hash_t kth_chain_token_data_id(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth_chain_token_data_const_cpp(self).id;
+    return kth::to_hash_t(value_cpp);
 }
 
-uint8_t const* kth_chain_token_data_non_fungible_commitment(kth_token_data_t token_data, kth_size_t* out_size) {
-    auto const& token_data_cpp = kth_chain_token_data_const_cpp(token_data);
-    if (std::holds_alternative<kth::domain::chain::non_fungible>(token_data_cpp.data)) {
-        auto const& non_fungible_cpp = std::get<kth::domain::chain::non_fungible>(token_data_cpp.data);
-        return kth::create_c_array(non_fungible_cpp.commitment, *out_size);
-    }
-    if (std::holds_alternative<kth::domain::chain::both_kinds>(token_data_cpp.data)) {
-        auto const& both_kinds_cpp = std::get<kth::domain::chain::both_kinds>(token_data_cpp.data);
-        auto const& non_fungible_cpp = both_kinds_cpp.second;
-        return kth::create_c_array(non_fungible_cpp.commitment, *out_size);
-    }
+kth_token_kind_t kth_chain_token_data_get_kind(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return static_cast<kth_token_kind_t>(kth::domain::chain::get_kind(kth_chain_token_data_const_cpp(self)));
+}
 
-    *out_size = 0;
-    return nullptr;
+uint64_t kth_chain_token_data_get_amount(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::domain::chain::get_amount(kth_chain_token_data_const_cpp(self));
+}
+
+kth_token_capability_t kth_chain_token_data_get_nft_capability(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return static_cast<kth_token_capability_t>(kth::domain::chain::get_nft_capability(kth_chain_token_data_const_cpp(self)));
+}
+
+uint8_t* kth_chain_token_data_get_nft_commitment(kth_token_data_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth::domain::chain::get_nft_commitment(kth_chain_token_data_const_cpp(self));
+    return kth::create_c_array(data, *out_size);
+}
+
+uint8_t kth_chain_token_data_bitfield(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::domain::chain::token::encoding::bitfield(kth_chain_token_data_const_cpp(self));
+}
+
+
+// Setters
+
+void kth_chain_token_data_set_id(kth_token_data_mut_t self, kth_hash_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    kth_chain_token_data_mut_cpp(self).id = value_cpp;
+}
+
+void kth_chain_token_data_set_id_unsafe(kth_token_data_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value);
+    kth_chain_token_data_mut_cpp(self).id = value_cpp;
+}
+
+
+// Predicates
+
+kth_bool_t kth_chain_token_data_is_valid(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::domain::chain::is_valid(kth_chain_token_data_const_cpp(self)));
+}
+
+kth_bool_t kth_chain_token_data_has_nft(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::domain::chain::has_nft(kth_chain_token_data_const_cpp(self)));
+}
+
+kth_bool_t kth_chain_token_data_is_fungible_only(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::domain::chain::is_fungible_only(kth_chain_token_data_const_cpp(self)));
+}
+
+kth_bool_t kth_chain_token_data_is_immutable_nft(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::domain::chain::is_immutable_nft(kth_chain_token_data_const_cpp(self)));
+}
+
+kth_bool_t kth_chain_token_data_is_mutable_nft(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::domain::chain::is_mutable_nft(kth_chain_token_data_const_cpp(self)));
+}
+
+kth_bool_t kth_chain_token_data_is_minting_nft(kth_token_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::domain::chain::is_minting_nft(kth_chain_token_data_const_cpp(self)));
 }
 
 } // extern "C"

--- a/src/c-api/src/chain/utxo.cpp
+++ b/src/c-api/src/chain/utxo.cpp
@@ -24,13 +24,20 @@ kth_utxo_t kth_chain_utxo_construct_from_hash_index_amount(kth_hash_t const* has
 }
 
 kth_utxo_t kth_chain_utxo_construct_from_hash_index_amount_fungible(kth_hash_t const* hash, uint32_t index, uint64_t amount, kth_hash_t const* token_category, uint64_t token_amount) {
+    // CashTokens caps token amounts at INT64_MAX — accepting values
+    // above that lets callers build prefixes that later narrow
+    // incorrectly when consensus code reads them back as int64_t.
+    // This check will move into the generator when utxo migrates;
+    // until then it lives here alongside the other hand-written
+    // entry points.
+    KTH_PRECONDITION(token_amount <= (uint64_t)INT64_MAX);
     auto hash_cpp = kth::to_array(hash->hash);
     auto token_category_cpp = kth::to_array(token_category->hash);
 
     kth::domain::chain::token_data_t token_data {
         .id = token_category_cpp,
         .data = kth::domain::chain::fungible {
-            .amount = kth::domain::chain::amount_t{int64_t(token_amount)}
+            .amount = kth::domain::chain::amount_t{token_amount}
         }
     };
     auto ret = new kth::domain::chain::utxo(
@@ -59,6 +66,7 @@ kth_utxo_t kth_chain_utxo_construct_from_hash_index_amount_non_fungible(kth_hash
 }
 
 kth_utxo_t kth_chain_utxo_construct_from_hash_index_amount_both(kth_hash_t const* hash, uint32_t index, uint64_t amount, kth_hash_t const* token_category, uint64_t token_amount, kth_token_capability_t capability, uint8_t* commitment_data, kth_size_t commitment_n) {
+    KTH_PRECONDITION(token_amount <= (uint64_t)INT64_MAX);
     auto hash_cpp = kth::to_array(hash->hash);
     auto token_category_cpp = kth::to_array(token_category->hash);
     auto capability_cpp = kth::token_capability_to_cpp(capability);
@@ -69,7 +77,7 @@ kth_utxo_t kth_chain_utxo_construct_from_hash_index_amount_both(kth_hash_t const
         token_category_cpp,
         kth::domain::chain::both_kinds{
             kth::domain::chain::fungible{
-                kth::domain::chain::amount_t{int64_t(token_amount)}
+                kth::domain::chain::amount_t{token_amount}
             },
             kth::domain::chain::non_fungible{
                 capability_cpp,
@@ -158,7 +166,7 @@ uint64_t kth_chain_utxo_get_token_amount(kth_utxo_t utxo) {
         return uint64_t(std::get<kth::domain::chain::fungible>(token_data->data).amount);
     }
     if (std::holds_alternative<kth::domain::chain::both_kinds>(token_data->data)) {
-        return uint64_t(std::get<kth::domain::chain::both_kinds>(token_data->data).first.amount);
+        return uint64_t(std::get<kth::domain::chain::both_kinds>(token_data->data).fungible_part.amount);
     }
     return kth::max_uint64;
 }
@@ -175,7 +183,7 @@ kth_token_capability_t kth_chain_utxo_get_token_capability(kth_utxo_t utxo) {
     }
     if (std::holds_alternative<kth::domain::chain::both_kinds>(token_data.data)) {
         auto const& both_kinds_cpp = std::get<kth::domain::chain::both_kinds>(token_data.data);
-        auto const& non_fungible_cpp = both_kinds_cpp.second;
+        auto const& non_fungible_cpp = both_kinds_cpp.non_fungible_part;
         return kth::token_capability_to_c(non_fungible_cpp.capability);
     }
     return kth_token_capability_none; // TODO: this is not a good way to signal an error
@@ -194,7 +202,7 @@ uint8_t const* kth_chain_utxo_get_token_commitment(kth_utxo_t utxo, kth_size_t* 
     }
     if (std::holds_alternative<kth::domain::chain::both_kinds>(token_data.data)) {
         auto const& both_kinds_cpp = std::get<kth::domain::chain::both_kinds>(token_data.data);
-        auto const& non_fungible_cpp = both_kinds_cpp.second;
+        auto const& non_fungible_cpp = both_kinds_cpp.non_fungible_part;
         return kth::create_c_array(non_fungible_cpp.commitment, *out_size);
     }
 
@@ -226,13 +234,14 @@ void kth_chain_utxo_set_token_data(kth_utxo_t utxo, kth_token_data_t token_data)
     kth_chain_utxo_cpp(utxo).set_token_data(token_data_cpp);
 }
 
-void kth_chain_utxo_set_fungible_token_data(kth_utxo_t utxo, kth_hash_t const* token_category, int64_t token_amount) {
+void kth_chain_utxo_set_fungible_token_data(kth_utxo_t utxo, kth_hash_t const* token_category, uint64_t token_amount) {
+    KTH_PRECONDITION(token_amount <= (uint64_t)INT64_MAX);
     auto token_category_cpp = kth::to_array(token_category->hash);
 
     kth::domain::chain::token_data_t token_data {
         .id = token_category_cpp,
         .data = kth::domain::chain::fungible {
-            .amount = kth::domain::chain::amount_t{int64_t(token_amount)}
+            .amount = kth::domain::chain::amount_t{token_amount}
         }
     };
     kth_chain_utxo_cpp(utxo).set_token_data(token_data);
@@ -251,19 +260,20 @@ void kth_chain_utxo_set_token_category(kth_utxo_t utxo, kth_hash_t const* token_
     }
 }
 
-void kth_chain_utxo_set_token_amount(kth_utxo_t utxo, int64_t token_amount) {
+void kth_chain_utxo_set_token_amount(kth_utxo_t utxo, uint64_t token_amount) {
+    KTH_PRECONDITION(token_amount <= (uint64_t)INT64_MAX);
     auto& utxo_cpp = kth_chain_utxo_cpp(utxo);
     if (utxo_cpp.token_data()) {
         if (std::holds_alternative<kth::domain::chain::fungible>(utxo_cpp.token_data()->data)) {
-            std::get<kth::domain::chain::fungible>(utxo_cpp.token_data()->data).amount = kth::domain::chain::amount_t{int64_t(token_amount)};
+            std::get<kth::domain::chain::fungible>(utxo_cpp.token_data()->data).amount = kth::domain::chain::amount_t{token_amount};
         } else if (std::holds_alternative<kth::domain::chain::both_kinds>(utxo_cpp.token_data()->data)) {
-            std::get<kth::domain::chain::both_kinds>(utxo_cpp.token_data()->data).first.amount = kth::domain::chain::amount_t{int64_t(token_amount)};
+            std::get<kth::domain::chain::both_kinds>(utxo_cpp.token_data()->data).fungible_part.amount = kth::domain::chain::amount_t{token_amount};
         }
     } else {
         kth::domain::chain::token_data_t token_data {
             .id = kth::null_hash,
             .data = kth::domain::chain::fungible {
-                .amount = kth::domain::chain::amount_t{int64_t(token_amount)}
+                .amount = kth::domain::chain::amount_t{token_amount}
             }
         };
         utxo_cpp.set_token_data(token_data);

--- a/src/c-api/test/chain/token_data.cpp
+++ b/src/c-api/test/chain/token_data.cpp
@@ -1,0 +1,379 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/chain/token_capability.h>
+#include <kth/capi/chain/token_data.h>
+#include <kth/capi/chain/token_kind.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Token category IDs are 32-byte hash digests.
+static kth_hash_t const kCategoryA = {{
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
+}};
+
+static kth_hash_t const kCategoryB = {{
+    0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+    0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+    0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+    0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb
+}};
+
+// A 5-byte sample commitment for the NFT tests.
+static uint8_t const kCommitment[5] = {0x10, 0x20, 0x30, 0x40, 0x50};
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - destruct null is safe", "[C-API TokenData]") {
+    kth_chain_token_data_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Factories — fungible
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - make_fungible builds a valid handle",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 1234u);
+    REQUIRE(td != NULL);
+    REQUIRE(kth_chain_token_data_is_valid(td) != 0);
+    REQUIRE(kth_chain_token_data_get_kind(td) == kth_token_kind_fungible_only);
+    REQUIRE(kth_chain_token_data_is_fungible_only(td) != 0);
+    REQUIRE(kth_chain_token_data_has_nft(td) == 0);
+    REQUIRE(kth_chain_token_data_get_amount(td) == 1234u);
+    REQUIRE(kth_hash_equal(kth_chain_token_data_id(td), kCategoryA) != 0);
+
+    kth_chain_token_data_destruct(td);
+}
+
+TEST_CASE("C-API TokenData - make_fungible_unsafe builds the same handle",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t safe = kth_chain_token_data_make_fungible(kCategoryA, 7u);
+    kth_token_data_mut_t unsafe = kth_chain_token_data_make_fungible_unsafe(kCategoryA.hash, 7u);
+
+    REQUIRE(safe != NULL);
+    REQUIRE(unsafe != NULL);
+    REQUIRE(kth_chain_token_data_equals(safe, unsafe) != 0);
+
+    kth_chain_token_data_destruct(unsafe);
+    kth_chain_token_data_destruct(safe);
+}
+
+// ---------------------------------------------------------------------------
+// Factories — non_fungible
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - make_non_fungible mutable carries commitment and capability",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+        kCategoryA, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+    REQUIRE(td != NULL);
+
+    REQUIRE(kth_chain_token_data_is_valid(td) != 0);
+    REQUIRE(kth_chain_token_data_get_kind(td) == kth_token_kind_non_fungible_only);
+    REQUIRE(kth_chain_token_data_has_nft(td) != 0);
+    REQUIRE(kth_chain_token_data_is_fungible_only(td) == 0);
+    REQUIRE(kth_chain_token_data_is_mutable_nft(td) != 0);
+    REQUIRE(kth_chain_token_data_is_immutable_nft(td) == 0);
+    REQUIRE(kth_chain_token_data_is_minting_nft(td) == 0);
+
+    REQUIRE(kth_chain_token_data_get_nft_capability(td) == kth_token_capability_mut);
+
+    kth_size_t commitment_size = 0;
+    uint8_t* commitment = kth_chain_token_data_get_nft_commitment(td, &commitment_size);
+    REQUIRE(commitment_size == sizeof(kCommitment));
+    REQUIRE(memcmp(commitment, kCommitment, sizeof(kCommitment)) == 0);
+    kth_core_destruct_array(commitment);
+
+    kth_chain_token_data_destruct(td);
+}
+
+TEST_CASE("C-API TokenData - make_non_fungible immutable",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+        kCategoryA, kth_token_capability_none, kCommitment, sizeof(kCommitment));
+    REQUIRE(td != NULL);
+    REQUIRE(kth_chain_token_data_is_immutable_nft(td) != 0);
+    REQUIRE(kth_chain_token_data_is_mutable_nft(td) == 0);
+    REQUIRE(kth_chain_token_data_is_minting_nft(td) == 0);
+    kth_chain_token_data_destruct(td);
+}
+
+TEST_CASE("C-API TokenData - make_non_fungible minting",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+        kCategoryA, kth_token_capability_minting, kCommitment, sizeof(kCommitment));
+    REQUIRE(td != NULL);
+    REQUIRE(kth_chain_token_data_is_minting_nft(td) != 0);
+    kth_chain_token_data_destruct(td);
+}
+
+TEST_CASE("C-API TokenData - make_non_fungible with empty commitment",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+        kCategoryA, kth_token_capability_none, NULL, 0);
+    REQUIRE(td != NULL);
+
+    kth_size_t commitment_size = 99u;
+    uint8_t* commitment = kth_chain_token_data_get_nft_commitment(td, &commitment_size);
+    REQUIRE(commitment_size == 0u);
+    // create_c_array returns a valid (possibly zero-sized) buffer when
+    // the underlying data_chunk is empty — caller still releases it.
+    kth_core_destruct_array(commitment);
+
+    kth_chain_token_data_destruct(td);
+}
+
+// ---------------------------------------------------------------------------
+// Factories — both
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - make_both carries amount, capability, commitment",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_both(
+        kCategoryA, 9999u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+    REQUIRE(td != NULL);
+
+    REQUIRE(kth_chain_token_data_is_valid(td) != 0);
+    REQUIRE(kth_chain_token_data_get_kind(td) == kth_token_kind_both);
+    REQUIRE(kth_chain_token_data_has_nft(td) != 0);
+    REQUIRE(kth_chain_token_data_is_fungible_only(td) == 0);
+    REQUIRE(kth_chain_token_data_is_mutable_nft(td) != 0);
+
+    REQUIRE(kth_chain_token_data_get_amount(td) == 9999u);
+    REQUIRE(kth_chain_token_data_get_nft_capability(td) == kth_token_capability_mut);
+
+    kth_size_t commitment_size = 0;
+    uint8_t* commitment = kth_chain_token_data_get_nft_commitment(td, &commitment_size);
+    REQUIRE(commitment_size == sizeof(kCommitment));
+    REQUIRE(memcmp(commitment, kCommitment, sizeof(kCommitment)) == 0);
+    kth_core_destruct_array(commitment);
+
+    kth_chain_token_data_destruct(td);
+}
+
+// ---------------------------------------------------------------------------
+// Factories reject spec-invalid input by returning NULL
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - make_fungible rejects amount 0",
+          "[C-API TokenData]") {
+    // Per the CashTokens spec a valid fungible amount is strictly
+    // positive. The binding layer's `check_valid` gate sits on top of
+    // `operator bool` (which delegates to is_valid), so 0 yields NULL.
+    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 0u);
+    REQUIRE(td == NULL);
+}
+
+TEST_CASE("C-API TokenData - make_fungible rejects amounts above INT64_MAX",
+          "[C-API TokenData]") {
+    // The CHIP caps amounts at INT64_MAX. UINT64_MAX (all ones) is
+    // provably outside the spec range and must be rejected.
+    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(
+        kCategoryA, (uint64_t)0xFFFFFFFFFFFFFFFFULL);
+    REQUIRE(td == NULL);
+}
+
+TEST_CASE("C-API TokenData - make_both rejects amount 0",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_both(
+        kCategoryA, 0u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+    REQUIRE(td == NULL);
+}
+
+// ---------------------------------------------------------------------------
+// get_amount sentinel
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - get_amount returns 0 for pure NFT",
+          "[C-API TokenData]") {
+    // Per the CashTokens spec a valid fungible amount is strictly
+    // positive, so `0` unambiguously signals "no fungible payload".
+    // The consensus code in transaction_basis depends on this — see
+    // the comment on `get_amount` in token_data.hpp.
+    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+        kCategoryA, kth_token_capability_none, kCommitment, sizeof(kCommitment));
+    REQUIRE(td != NULL);
+    REQUIRE(kth_chain_token_data_get_amount(td) == 0u);
+    kth_chain_token_data_destruct(td);
+}
+
+TEST_CASE("C-API TokenData - get_nft_capability is `none` for pure fungible",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    REQUIRE(td != NULL);
+    REQUIRE(kth_chain_token_data_get_nft_capability(td) == kth_token_capability_none);
+    kth_chain_token_data_destruct(td);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equals
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - copy preserves equality", "[C-API TokenData]") {
+    kth_token_data_mut_t original = kth_chain_token_data_make_both(
+        kCategoryA, 42u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+    REQUIRE(original != NULL);
+
+    kth_token_data_mut_t copy = kth_chain_token_data_copy(original);
+    REQUIRE(copy != NULL);
+    REQUIRE(kth_chain_token_data_equals(original, copy) != 0);
+
+    kth_chain_token_data_destruct(copy);
+    kth_chain_token_data_destruct(original);
+}
+
+TEST_CASE("C-API TokenData - different categories compare unequal",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t a = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t b = kth_chain_token_data_make_fungible(kCategoryB, 1u);
+
+    REQUIRE(kth_chain_token_data_equals(a, b) == 0);
+
+    kth_chain_token_data_destruct(b);
+    kth_chain_token_data_destruct(a);
+}
+
+TEST_CASE("C-API TokenData - different amounts compare unequal",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t a = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t b = kth_chain_token_data_make_fungible(kCategoryA, 2u);
+
+    REQUIRE(kth_chain_token_data_equals(a, b) == 0);
+
+    kth_chain_token_data_destruct(b);
+    kth_chain_token_data_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// Serialization roundtrip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - to_data / from_data roundtrip (fungible)",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t original = kth_chain_token_data_make_fungible(kCategoryA, 7777u);
+    REQUIRE(original != NULL);
+
+    kth_size_t size = 0;
+    uint8_t* raw = kth_chain_token_data_to_data(original, &size);
+    REQUIRE(raw != NULL);
+    REQUIRE(size == kth_chain_token_data_serialized_size(original));
+
+    kth_token_data_mut_t parsed = NULL;
+    kth_error_code_t ec = kth_chain_token_data_construct_from_data(raw, size, &parsed);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(parsed != NULL);
+    REQUIRE(kth_chain_token_data_equals(original, parsed) != 0);
+
+    kth_chain_token_data_destruct(parsed);
+    kth_core_destruct_array(raw);
+    kth_chain_token_data_destruct(original);
+}
+
+TEST_CASE("C-API TokenData - to_data / from_data roundtrip (both)",
+          "[C-API TokenData]") {
+    kth_token_data_mut_t original = kth_chain_token_data_make_both(
+        kCategoryA, 12345u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+    REQUIRE(original != NULL);
+
+    kth_size_t size = 0;
+    uint8_t* raw = kth_chain_token_data_to_data(original, &size);
+    REQUIRE(raw != NULL);
+
+    kth_token_data_mut_t parsed = NULL;
+    kth_error_code_t ec = kth_chain_token_data_construct_from_data(raw, size, &parsed);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(parsed != NULL);
+    REQUIRE(kth_chain_token_data_equals(original, parsed) != 0);
+
+    kth_chain_token_data_destruct(parsed);
+    kth_core_destruct_array(raw);
+    kth_chain_token_data_destruct(original);
+}
+
+TEST_CASE("C-API TokenData - from_data with truncated input fails",
+          "[C-API TokenData]") {
+    uint8_t const truncated[5] = {0x00, 0x00, 0x00, 0x00, 0x00};
+    kth_token_data_mut_t parsed = NULL;
+    kth_error_code_t ec =
+        kth_chain_token_data_construct_from_data(truncated, sizeof(truncated), &parsed);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(parsed == NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - set_id replaces category", "[C-API TokenData]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    REQUIRE(td != NULL);
+
+    kth_chain_token_data_set_id(td, kCategoryB);
+    REQUIRE(kth_hash_equal(kth_chain_token_data_id(td), kCategoryB) != 0);
+
+    kth_chain_token_data_destruct(td);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API TokenData - copy null aborts",
+          "[C-API TokenData][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_token_data_copy(NULL));
+}
+
+TEST_CASE("C-API TokenData - get_kind null aborts",
+          "[C-API TokenData][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_token_data_get_kind(NULL));
+}
+
+TEST_CASE("C-API TokenData - construct_from_data null out aborts",
+          "[C-API TokenData][precondition]") {
+    KTH_EXPECT_ABORT(
+        kth_chain_token_data_construct_from_data(NULL, 0, NULL));
+}
+
+TEST_CASE("C-API TokenData - construct_from_data non-null *out aborts",
+          "[C-API TokenData][precondition]") {
+    kth_token_data_mut_t already = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    KTH_EXPECT_ABORT(
+        kth_chain_token_data_construct_from_data(NULL, 0, &already));
+    kth_chain_token_data_destruct(already);
+}
+
+TEST_CASE("C-API TokenData - to_data null out_size aborts",
+          "[C-API TokenData][precondition]") {
+    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    KTH_EXPECT_ABORT(kth_chain_token_data_to_data(td, NULL));
+    kth_chain_token_data_destruct(td);
+}
+
+TEST_CASE("C-API TokenData - make_fungible_unsafe null id aborts",
+          "[C-API TokenData][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_token_data_make_fungible_unsafe(NULL, 1u));
+}

--- a/src/domain/include/kth/domain/chain/token_data.hpp
+++ b/src/domain/include/kth/domain/chain/token_data.hpp
@@ -13,164 +13,196 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <version> // for __cpp_lib_three_way_comparison
 
 #include <kth/domain/chain/script.hpp>
+#include <kth/domain/concepts.hpp>
+#include <kth/domain/constants.hpp>
 #include <kth/domain/define.hpp>
 #include <kth/domain/deserialization.hpp>
 #include <kth/domain/machine/opcode.hpp>
 
 #include <kth/infrastructure/utility/container_sink.hpp>
+#include <kth/infrastructure/utility/data.hpp>
+#include <kth/infrastructure/utility/ostream_writer.hpp>
 #include <kth/infrastructure/utility/reader.hpp>
 #include <kth/infrastructure/utility/serializer.hpp>
 #include <kth/infrastructure/utility/thread.hpp>
 #include <kth/infrastructure/utility/writer.hpp>
 
-
-#include <kth/domain/concepts.hpp>
-
-//TODO: tengo que ver bien en qué namespace poner todo lo de tokens
-
 namespace kth::domain::chain {
 
-namespace detail {
-template<class> inline constexpr bool always_false_v = false;
-} // namespace detail
-
 namespace encoding {
-static constexpr uint8_t PREFIX_BYTE = uint8_t(::kth::domain::machine::opcode::special_token_prefix);
+inline constexpr uint8_t PREFIX_BYTE = uint8_t(::kth::domain::machine::opcode::special_token_prefix);
 } // namespace encoding
 
 using token_id_t = hash_digest;
-enum class amount_t : int64_t {};
-using commitment_t = std::vector<uint8_t>;
 
-// #if __cpp_impl_three_way_comparison >= 201907L
-// #else
-// #error "This code is not ready for C++20 yet."
-// #endif
+// CashTokens encode token amounts as VLQ integers in the range
+// [0, 2^63 − 1]. `amount_t` uses `uint64_t` to match the other kth
+// amount types (output::value, utxo::amount) and to remove the silent
+// narrowing from `read_variable_little_endian()` (which itself
+// returns `uint64_t`) into a signed enum. A valid fungible amount is
+// strictly positive (see `is_valid(fungible)` below), so callers can
+// treat `0` as the implicit "no fungible payload" sentinel — that's
+// also what `get_amount` returns in that case so the consensus code
+// can keep tallying without per-token branching.
+enum class amount_t : uint64_t {};
 
-// #if __cpp_lib_three_way_comparison >= 201907L
-// #else
-// #error "This code is not ready for C++20 yet."
-// #endif
+using commitment_t = data_chunk;
 
-//TODO(fernando): move to a helper library
-// #if __cpp_lib_three_way_comparison < 201907L
-// template <typename I1, typename I2> //, typename Cmp>
-// constexpr
-// // auto lexicographical_compare_three_way(I1 f1, I1 l1, I2 f2, I2 l2, Cmp comp) { //-> decltype(comp(*f1, *f2)) {
-// auto lexicographical_compare_three_way(I1 f1, I1 l1, I2 f2, I2 l2) { //-> decltype(comp(*f1, *f2)) {
-//     // using ret_t = decltype(comp(*f1, *f2));
-//     using ret_t = decltype(*f1 <=> *f2);
-//     static_assert(std::disjunction_v<
-//                       std::is_same<ret_t, std::strong_ordering>,
-//                       std::is_same<ret_t, std::weak_ordering>,
-//                       std::is_same<ret_t, std::partial_ordering>>,
-//                   "The return type must be a comparison category type.");
-
-//     bool exhaust1 = (f1 == l1);
-//     bool exhaust2 = (f2 == l2);
-//     for (; !exhaust1 && !exhaust2; exhaust1 = (++f1 == l1), exhaust2 = (++f2 == l2)) {
-//         // if (auto c = comp(*f1, *f2); c != 0) {
-//         if (auto c = *f1 <=> *f2; c != 0) {
-//             return c;
-//         }
-//     }
-
-//     return !exhaust1 ? std::strong_ordering::greater:
-//            !exhaust2 ? std::strong_ordering::less:
-//                        std::strong_ordering::equal;
-// }
-
-// constexpr
-// auto operator<=>(commitment_t const& x, commitment_t const& y) {
-//     return lexicographical_compare_three_way(x.begin(), x.end(), y.begin(), y.end());
-// }
-
-// constexpr
-// auto operator<=>(token_id_t const& x, token_id_t const& y) {
-//     return lexicographical_compare_three_way(x.begin(), x.end(), y.begin(), y.end());
-// }
-// #endif // __cpp_lib_three_way_comparison
-
-// The values assigned to the low-order nibble of the bitfield byte represent the "permissions" of an NFT.
-// For pure-fungible tokens, the value must be none (0x0).
-// It's important to note that only the three specified bitpatterns are valid for this nibble.
+// The values assigned to the low-order nibble of the token bitfield
+// byte represent the "permissions" of an NFT. Pure-fungible tokens
+// must use `none` (0x0). Only the three specified bitpatterns are
+// valid capabilities.
 enum class capability_t : uint8_t {
-    none    = 0x00,  // The token lacks any capability or permission and is either a pure-fungible token or an immutable non-fungible token.
-    mut     = 0x01,  // If the mutable capability is present, it means that the encoded token is a non-fungible token that can be altered.
-    minting = 0x02,  // If the minting capability is present, it indicates that the encoded token is a non-fungible token used for minting.
+    none    = 0x00,  // No capability: either fungible-only or immutable NFT.
+    mut     = 0x01,  // Mutable NFT: the payload can be altered.
+    minting = 0x02,  // Minting NFT: used to mint new tokens of the category.
 };
+
+// Returns true iff the byte matches one of the three named capability
+// literals. Used by the wire parser and by `is_valid(non_fungible)`
+// to reject hand-built values whose capability byte is out of range
+// (the type itself can hold any uint8_t by casting).
+inline constexpr
+bool is_valid_capability(uint8_t b) {
+    return b <= uint8_t(capability_t::minting);
+}
+
+inline constexpr
+bool is_valid_capability(capability_t c) {
+    return is_valid_capability(uint8_t(c));
+}
 
 struct fungible {
     amount_t amount;
 
-    // friend constexpr
-    // auto operator<=>(fungible const&, fungible const&) = default;
-
     friend constexpr
-    bool operator==(fungible const&, fungible const&) = default;
-
-    friend constexpr
-    bool operator!=(fungible const&, fungible const&) = default;
+    auto operator<=>(fungible const&, fungible const&) = default;
 };
 
 struct non_fungible {
     capability_t capability;
     commitment_t commitment;
 
-    // friend
-    // auto operator<=>(non_fungible const&, non_fungible const&) = default;
-
-    friend constexpr
-    bool operator==(non_fungible const&, non_fungible const&) = default;
-
-    friend constexpr
-    bool operator!=(non_fungible const&, non_fungible const&) = default;
+    friend
+    auto operator<=>(non_fungible const&, non_fungible const&) = default;
 };
 
-using both_kinds = std::pair<fungible, non_fungible>;
+// A token payload that carries both a fungible amount and an NFT for
+// the same category. Previously modeled as `std::pair<fungible,
+// non_fungible>` with anonymous `.first` / `.second` accessors; the
+// named struct keeps the accessor names aligned with the concepts
+// each field represents. Note: the CashTokens wire format serializes
+// the NFT portion before the fungible portion — see the encoding
+// helpers below.
+struct both_kinds {
+    fungible fungible_part;
+    non_fungible non_fungible_part;
+
+    friend
+    auto operator<=>(both_kinds const&, both_kinds const&) = default;
+};
 
 struct token_data_t {
-    token_id_t id; // id or category
+    token_id_t id;
     std::variant<fungible, non_fungible, both_kinds> data;
 
-    // friend constexpr
-    // auto operator<=>(token_data_t const&, token_data_t const&) = default;
+    // Boolean conversion keeps the C-API factories honest: the binding
+    // generator routes every factory through `kth::check_valid` which
+    // gates the heap allocation on this conversion. Without it the
+    // "returns NULL on invalid input" contract advertised in the
+    // generated docstrings would be unreachable. Definition is after
+    // the free-function `is_valid` overload below.
+    explicit operator bool() const;
 
-    friend constexpr
-    bool operator==(token_data_t const&, token_data_t const&) = default;
-
-    friend constexpr
-    bool operator!=(token_data_t const&, token_data_t const&) = default;
+    // `std::variant` gets a defaulted `<=>` in C++20 when its
+    // alternatives all have one, which is the case here. The C++
+    // language synthesises `==` from a defaulted `<=>` automatically.
+    friend
+    auto operator<=>(token_data_t const&, token_data_t const&) = default;
 };
 
 using token_data_opt = std::optional<token_data_t>;
 
+// Factories.
+// ---------------------------------------------------------------------------
+// Free-function constructors for each variant arm. The generator
+// picks them up via the extra_namespaces scan and emits matching
+// `kth_chain_token_data_make_*` entry points in the C API. Taking
+// `uint64_t` instead of `amount_t` in the C++ signature keeps the
+// generated C bindings working with plain integral types without
+// the binding layer needing to know about the strong enum.
+
+inline
+token_data_t make_fungible(token_id_t id, uint64_t amount) {
+    return token_data_t{id, fungible{amount_t{amount}}};
+}
+
+inline
+token_data_t make_non_fungible(token_id_t id, capability_t capability, commitment_t commitment) {
+    return token_data_t{id, non_fungible{capability, std::move(commitment)}};
+}
+
+inline
+token_data_t make_both(token_id_t id, uint64_t amount, capability_t capability, commitment_t commitment) {
+    return token_data_t{
+        id,
+        both_kinds{
+            fungible{amount_t{amount}},
+            non_fungible{capability, std::move(commitment)}
+        }
+    };
+}
+
+// Discriminator for the variant. Mirrors the C-API `kth_token_kind_t`
+// so both layers can share the same naming when talking about which
+// arm of the variant is active.
+enum class kind : uint8_t {
+    fungible_only = 0,
+    non_fungible_only = 1,
+    both = 2,
+};
+
+inline constexpr
+kind get_kind(token_data_t const& td) {
+    if (std::holds_alternative<fungible>(td.data)) return kind::fungible_only;
+    if (std::holds_alternative<non_fungible>(td.data)) return kind::non_fungible_only;
+    return kind::both;
+}
+
+// Validity.
+// ---------------------------------------------------------------------------
+
 inline constexpr
 bool is_valid(fungible const& x) {
-    return x.amount > amount_t{0};
+    // CashTokens CHIP: amounts are non-zero positive VLQ integers
+    // capped at 2^63 − 1. `amount_t`'s underlying is `uint64_t`, so
+    // the lower bound excludes 0 (implicit "no amount" sentinel)
+    // and the upper bound rejects anything that would narrow to a
+    // negative `int64_t` when consensus code converts it back.
+    return x.amount > amount_t{0}
+        && uint64_t(x.amount) <= uint64_t(INT64_MAX);
 }
 
 inline constexpr
 bool is_valid(non_fungible const& x) {
-    //TODO(fernando): ??
-    return true;
+    return is_valid_capability(x.capability);
 }
 
 inline constexpr
 bool is_valid(both_kinds const& x) {
-    return is_valid(x.first) && is_valid(x.second);
+    return is_valid(x.fungible_part) && is_valid(x.non_fungible_part);
 }
 
 inline constexpr
 bool is_valid(token_data_t const& x) {
-    auto const visitor = [](auto&& arg) {
-        return is_valid(arg);
-    };
-
-    //TODO(fernando): id validation
+    // Note: we deliberately do NOT reject `id == null_hash` here
+    // even though a "real" token always has a non-null category.
+    // The VM constructs transient `token_data_t` instances with a
+    // zeroed id while building intermediate state and expects
+    // `is_valid` to depend only on the variant arm being well-formed.
+    auto const visitor = [](auto&& arg) { return is_valid(arg); };
     return std::visit(visitor, x.data);
 }
 
@@ -179,13 +211,26 @@ bool is_valid(token_data_opt const& x) {
     return x.has_value() ? is_valid(x.value()) : true;
 }
 
-// Token data accessors.
+inline
+token_data_t::operator bool() const {
+    return is_valid(*this);
+}
+
+// Accessors.
 // ---------------------------------------------------------------------------
 
+// Returns the fungible amount carried by the token, or `0` when the
+// token has no fungible payload (i.e. it is a pure NFT). The
+// consensus code in `transaction_basis.cpp` calls this on every
+// token-bearing input/output and tallies the results by category, so
+// returning `0` for the "no fungible" case lets the math work
+// without per-token branching. Per the CashTokens spec a valid
+// fungible amount is strictly positive, so `0` unambiguously means
+// "no fungible payload" and never collides with a legitimate value.
 inline
-int64_t get_amount(token_data_t const& td) {
-    if (auto const* f = std::get_if<fungible>(&td.data)) return int64_t(f->amount);
-    if (auto const* b = std::get_if<both_kinds>(&td.data)) return int64_t(b->first.amount);
+uint64_t get_amount(token_data_t const& td) {
+    if (auto const* f = std::get_if<fungible>(&td.data)) return uint64_t(f->amount);
+    if (auto const* b = std::get_if<both_kinds>(&td.data)) return uint64_t(b->fungible_part.amount);
     return 0;
 }
 
@@ -198,12 +243,32 @@ bool has_nft(token_data_t const& td) {
 inline
 non_fungible const& get_nft(token_data_t const& td) {
     if (auto const* nf = std::get_if<non_fungible>(&td.data)) return *nf;
-    return std::get<both_kinds>(td.data).second;
+    return std::get<both_kinds>(td.data).non_fungible_part;
 }
 
 inline
 bool is_fungible_only(token_data_t const& td) {
     return std::holds_alternative<fungible>(td.data);
+}
+
+// Projection accessors for the NFT part of a token_data_t. They return
+// the default (`none` capability / empty commitment) when the token
+// has no NFT payload, so a consumer that forgets to check
+// `has_nft(td)` first gets a well-defined result instead of a
+// precondition abort. These exist primarily so the C-API binding
+// layer can expose the NFT fields without reaching into the variant
+// through a reference-returning helper.
+
+inline
+capability_t get_nft_capability(token_data_t const& td) {
+    if ( ! has_nft(td)) return capability_t::none;
+    return get_nft(td).capability;
+}
+
+inline
+commitment_t get_nft_commitment(token_data_t const& td) {
+    if ( ! has_nft(td)) return commitment_t{};
+    return get_nft(td).commitment;
 }
 
 inline
@@ -223,6 +288,14 @@ bool is_minting_nft(token_data_t const& td) {
 
 namespace token::encoding {
 
+// Safety bound applied when parsing commitment data from the wire.
+// The CashTokens CHIP doesn't hard-cap commitment length, but script
+// element pushes in the surrounding VM are limited to this value, so
+// accepting anything larger from an attacker-crafted token prefix
+// would just let them force unbounded allocations.
+inline constexpr
+size_t max_commitment_size = kth::max_push_data_size_legacy;
+
 inline constexpr
 size_t serialized_size(fungible const& x) {
     return kth::size_variable_integer(uint64_t(x.amount));
@@ -236,7 +309,7 @@ size_t serialized_size(non_fungible const& x) {
 
 inline constexpr
 size_t serialized_size(both_kinds const& x) {
-    return serialized_size(x.first) +  serialized_size(x.second);
+    return serialized_size(x.fungible_part) + serialized_size(x.non_fungible_part);
 }
 
 inline constexpr
@@ -246,7 +319,7 @@ size_t serialized_size(token_data_t const& x) {
     };
 
     return std::size(x.id) +
-           1 + // bitfield
+           1 + // bitfield byte
            std::visit(visitor, x.data);
 }
 
@@ -255,74 +328,15 @@ size_t serialized_size(token_data_opt const& x) {
     return x.has_value() ? serialized_size(x.value()) : 0;
 }
 
-inline constexpr
-uint8_t bitfield(fungible const& x) {
-    //TODO(fernando): this is for HAS_AMOUNT fungible data
-    return 0b0001'0000;      //0x10
-}
-
-inline constexpr
-uint8_t bitfield(non_fungible const& x) {
-    return (x.commitment.empty() ? uint8_t{0} : uint8_t{0b0100'0000}) | // 0x40 - HAS_COMMITMENT_LENGTH, the prefix encodes a commitment length and commitment.
-           uint8_t{0b0010'0000} |                                       // 0x20 - HAS_NFT, the prefix encodes a non-fungible token.
-           uint8_t(x.capability);
-}
-
-inline constexpr
-uint8_t bitfield(both_kinds const& x) {
-    return bitfield(x.first) | bitfield(x.second);
-}
-
-inline constexpr
-uint8_t bitfield(token_data_t const& x) {
-    auto const visitor = [](auto&& arg) {
-        return bitfield(arg);
-    };
-    return std::visit(visitor, x.data);
-}
-
-template <typename W>
-inline constexpr
-void to_data(W& sink, fungible const& x) {
-    sink.write_variable_little_endian(int64_t(x.amount));
-}
-
-template <typename W>
-inline constexpr
-void to_data(W& sink, non_fungible const& x) {
-    if (x.commitment.empty()) return;
-
-    sink.write_size_little_endian(x.commitment.size());
-    sink.write_bytes(x.commitment);
-}
-
-template <typename W>
-inline constexpr
-void to_data(W& sink, both_kinds const& x) {
-    to_data(sink, x.second);
-    to_data(sink, x.first);
-}
-
-template <typename W>
-inline constexpr
-void to_data(W& sink, token_data_t const& x) {
-    sink.write_hash(x.id);
-    sink.write_byte(bitfield(x));
-
-    auto const visitor = [&sink](auto&& arg) {
-        to_data(sink, arg);
-    };
-    std::visit(visitor, x.data);
-}
-
-// The high-order nibble of the bitfield byte specifies the structure of the token's data payload that follows.
-// The data that follows is described by combining the specified bitpatterns using bitwise-OR.
-// However, it's important to note that the nibble cannot be equal to 0 or have the `reserved` bit set.
+// High-order nibble of the bitfield byte: structure of the payload.
+// The nibble may combine `has_amount`, `has_nft`, `has_commitment`
+// (via bitwise-OR) but must not be zero and must not set the
+// `reserved` bit.
 enum class structure_t : uint8_t {
-    has_amount = 0x10,            // The payload encodes an amount of fungible tokens.
-    has_nft = 0x20,               // The payload encodes a non-fungible token.
-    has_commitment = 0x40,        // The payload encodes a commitment-length and a commitment (has_nft must also be set).
-    reserved = 0x80,              // Must be unset.
+    has_amount     = 0x10,
+    has_nft        = 0x20,
+    has_commitment = 0x40,
+    reserved       = 0x80,
 };
 
 inline constexpr
@@ -345,89 +359,98 @@ std::pair<uint8_t, uint8_t> nibbles(uint8_t bitfield) {
     uint8_t const higher = bitfield & 0xf0u;
     uint8_t const lower  = bitfield & 0x0fu;
     return {higher, lower};
-};
+}
 
 inline constexpr
 capability_t capability(uint8_t bitfield) {
     auto const [_, c] = nibbles(bitfield);
     return capability_t{c};
-};
+}
+
+inline constexpr
+uint8_t bitfield(fungible const& /*x*/) {
+    return uint8_t(structure_t::has_amount);
+}
+
+inline constexpr
+uint8_t bitfield(non_fungible const& x) {
+    uint8_t const commitment_bit = x.commitment.empty()
+        ? uint8_t{0}
+        : uint8_t(structure_t::has_commitment);
+    return commitment_bit
+         | uint8_t(structure_t::has_nft)
+         | uint8_t(x.capability);
+}
+
+inline constexpr
+uint8_t bitfield(both_kinds const& x) {
+    return bitfield(x.fungible_part) | bitfield(x.non_fungible_part);
+}
+
+inline constexpr
+uint8_t bitfield(token_data_t const& x) {
+    auto const visitor = [](auto&& arg) {
+        return bitfield(arg);
+    };
+    return std::visit(visitor, x.data);
+}
+
+template <typename W>
+inline constexpr
+void to_data(W& sink, fungible const& x) {
+    sink.write_variable_little_endian(uint64_t(x.amount));
+}
+
+template <typename W>
+inline constexpr
+void to_data(W& sink, non_fungible const& x) {
+    if (x.commitment.empty()) return;
+
+    sink.write_size_little_endian(x.commitment.size());
+    sink.write_bytes(x.commitment);
+}
+
+template <typename W>
+inline constexpr
+void to_data(W& sink, both_kinds const& x) {
+    // CashTokens wire format writes the NFT portion first, then the
+    // fungible amount — keep that order even with the named fields.
+    to_data(sink, x.non_fungible_part);
+    to_data(sink, x.fungible_part);
+}
+
+template <typename W>
+inline constexpr
+void to_data(W& sink, token_data_t const& x) {
+    sink.write_hash(x.id);
+    sink.write_byte(bitfield(x));
+
+    auto const visitor = [&sink](auto&& arg) {
+        to_data(sink, arg);
+    };
+    std::visit(visitor, x.data);
+}
 
 inline constexpr
 bool is_valid_bitfield(uint8_t bitfield) {
-    //TODO(fernando): comparar la logica con la que escribimos en el spec interno
-
     auto const [structure, capability] = nibbles(bitfield);
 
-    // At least 1 bit must be set in the structure nibble, but the Structure::Reserved bit must not be set.
+    // At least one structure bit must be set, and `reserved` must not.
     if (structure >= 0x80u || structure == 0x00u) return false;
 
-    // Capability nibble > 2 is invalid (that is, only valid bit-patterns for this nibble are: 0x00, 0x01, 0x02).
-    if (capability > 2u) return false;
+    // Capability nibble outside {0x00, 0x01, 0x02} is invalid.
+    if ( ! is_valid_capability(capability)) return false;
 
-    // A token prefix encoding no tokens (both has_nft and has_amount are unset) is invalid.
+    // A prefix that encodes no tokens (neither nft nor amount) is invalid.
     if ( ! has_nft(bitfield) && ! has_amount(bitfield)) return false;
 
-    // A token prefix where has_nft is unset must encode capability nibble of 0x00.
+    // A prefix without has_nft must encode a `none` capability.
     if ( ! has_nft(bitfield) && capability != 0u) return false;
 
-    // A token prefix encoding has_commitment without has_nft is invalid.
+    // has_commitment without has_nft is invalid.
     if ( ! has_nft(bitfield) && has_commitment(bitfield)) return false;
     return true;
 }
-
-// template <typename R, KTH_IS_READER(R)>
-// bool from_data_old(R& source, fungible& x, bool /*has_commitment*/) {
-//     x.amount = amount_t(source.read_variable_little_endian());
-//     return source;
-// }
-
-// template <typename R, KTH_IS_READER(R)>
-// inline constexpr
-// bool from_data_old(R& source, non_fungible& x, bool has_commitment) {
-//     if (has_commitment) {
-//         //TODO(fernando): check size is valid
-//         auto const size = source.read_size_little_endian();
-//         x.commitment = source.read_bytes(size);
-//     }
-//     return source;
-// }
-
-// template <typename R, KTH_IS_READER(R)>
-// inline constexpr
-// bool from_data_old(R& source, both_kinds& x, bool has_commitment) {
-//     from_data_old(source, x.second, has_commitment);
-//     from_data_old(source, x.first, has_commitment);
-//     return source;
-// }
-
-// template <typename R, KTH_IS_READER(R)>
-// inline constexpr
-// bool from_data_old(R& source, token_data_opt& x) {
-//     x.reset();
-//     auto const id = source.read_hash();
-//     auto const bitfield = source.read_byte();
-
-//     if ( ! is_valid_bitfield(bitfield)) {
-//         source.invalidate();
-//         return false;
-//     }
-
-//     if (has_nft(bitfield) && has_amount(bitfield)) {
-//         x.emplace(token_data_t {id, both_kinds { {}, {capability(bitfield), {}} }});
-//     } else if (has_nft(bitfield)) {
-//         x.emplace(token_data_t {id, non_fungible { .capability = capability(bitfield) }});
-//     } else if (has_amount(bitfield)) {
-//         x.emplace(token_data_t {id, fungible {}});
-//     }
-
-//     auto const visitor = [&source, bitfield](auto&& arg) {
-//         return from_data_old(source, arg, has_commitment(bitfield));
-//     };
-//     std::visit(visitor, x->data);
-
-//     return source;
-// }
 
 namespace detail {
 
@@ -447,73 +470,33 @@ expect<void> from_data(byte_reader& reader, non_fungible& x, bool has_commitment
         return {};
     }
 
-    //TODO(fernando): check size is valid
     auto const size = reader.read_size_little_endian();
     if ( ! size) {
         return std::unexpected(size.error());
+    }
+    if (*size > max_commitment_size) {
+        return std::unexpected(error::invalid_script_size);
     }
     auto commitment = reader.read_bytes(*size);
     if ( ! commitment) {
         return std::unexpected(commitment.error());
     }
-    x.commitment = std::vector<uint8_t>(std::begin(*commitment), std::end(*commitment));
+    x.commitment = commitment_t(std::begin(*commitment), std::end(*commitment));
     return {};
 }
 
 inline
 expect<void> from_data(byte_reader& reader, both_kinds& x, bool has_commitment) {
-    auto res = from_data(reader, x.second, has_commitment);
+    auto res = from_data(reader, x.non_fungible_part, has_commitment);
     if ( ! res) {
         return res;
     }
-    res = from_data(reader, x.first, has_commitment);
+    res = from_data(reader, x.fungible_part, has_commitment);
     if ( ! res) {
         return res;
     }
     return {};
 }
-
-// TODO: hacer algo así:
-// template<typename T>
-// inline constexpr expect<T> from_data(byte_reader& reader, bool has_commitment) {
-//     T result{};  // Crear una instancia vacía de T para llenarla.
-
-//     if constexpr (std::is_same_v<T, fungible>) {
-//         auto const amt = reader.read_variable_little_endian();
-//         if (!amt) {
-//             return std::unexpected(amt.error());
-//         }
-//         result.amount = amount_t(*amt);
-//     } else if constexpr (std::is_same_v<T, non_fungible>) {
-//         if (has_commitment) {
-//             auto const size = reader.read_size_little_endian();
-//             if (!size) {
-//                 return std::unexpected(size.error());
-//             }
-//             auto commitment = reader.read_bytes(size);
-//             if (!commitment) {
-//                 return std::unexpected(commitment.error());
-//             }
-//             result.commitment = std::move(*commitment);
-//         }
-//     } else if constexpr (std::is_same_v<T, both_kinds>) {
-//         // Leer el non_fungible primero
-//         auto non_fungible_result = from_data<non_fungible>(reader, has_commitment);
-//         if (!non_fungible_result) {
-//             return std::unexpected(non_fungible_result.error());
-//         }
-//         result.second = std::move(*non_fungible_result);
-
-//         // Luego leer el fungible
-//         auto fungible_result = from_data<fungible>(reader, false);  // has_commitment no aplica a fungible
-//         if (!fungible_result) {
-//             return std::unexpected(fungible_result.error());
-//         }
-//         result.first = std::move(*fungible_result);
-//     }
-
-//     return result;
-// }
 
 } // namespace detail
 
@@ -538,20 +521,15 @@ expect<token_data_t> from_data(byte_reader& reader) {
     };
     if (has_nft(*bitfield) && has_amount(*bitfield)) {
         x.data = both_kinds {
-            {},
-            {capability(*bitfield), {}}
+            fungible {},
+            non_fungible {capability(*bitfield), {}}
         };
     } else if (has_nft(*bitfield)) {
         x.data = non_fungible { .capability = capability(*bitfield) };
     }
 
     auto const visitor = [&reader, bitfield](auto&& arg) -> expect<void> {
-        using T = std::decay_t<decltype(arg)>;
-        auto const res = detail::from_data(reader, arg, has_commitment(*bitfield));
-        if ( ! res) {
-            return std::unexpected(res.error());
-        }
-        return {};
+        return detail::from_data(reader, arg, has_commitment(*bitfield));
     };
 
     auto const res = std::visit(visitor, x.data);
@@ -562,22 +540,36 @@ expect<token_data_t> from_data(byte_reader& reader) {
     return x;
 }
 
+// Non-templated entry points that adapt the templated `to_data<W>`
+// above to an owned `data_chunk`. Historically these lived in
+// `token_data_serialization.hpp`; consolidating them here means the
+// C-API binding generator — which parses a single header per class —
+// can discover the serializer without extra plumbing. The shared
+// body is factored into a helper so adding a new payload type only
+// needs a one-line forwarder.
+
+namespace detail {
+
+template <typename T>
+data_chunk to_data_impl(T const& x) {
+    data_chunk data;
+    auto const size = serialized_size(x);
+    data.reserve(size);
+    data_sink ostream(data);
+    ostream_writer sink_w(ostream);
+    to_data(sink_w, x);
+    ostream.flush();
+    KTH_ASSERT(data.size() == size);
+    return data;
+}
+
+} // namespace detail
+
+inline data_chunk to_data(fungible const& x)      { return detail::to_data_impl(x); }
+inline data_chunk to_data(non_fungible const& x)  { return detail::to_data_impl(x); }
+inline data_chunk to_data(both_kinds const& x)    { return detail::to_data_impl(x); }
+inline data_chunk to_data(token_data_t const& x)  { return detail::to_data_impl(x); }
+
 } // namespace token::encoding
 
-//TODO: create a C++ concept to model types that has serialized_size(x) and to_data(W&, x)
-//      to finish the following code we need to get rid of the W template parameter in to_data
-
-// template <typename T>
-// concept has_serialized_size = requires(T x) {
-//     { serialized_size(x) } -> std::convertible_to<size_t>;
-// };
-
-// template <typename T, typename W>
-// concept has_to_data = requires(T x, W& sink) {
-//     { to_data(sink, x) } -> std::same_as<void>;
-// };
-
-// concept serializable = has_serialized_size<T> && has_to_data<T, W>;
-
 } // namespace kth::domain::chain
-

--- a/src/domain/include/kth/domain/chain/token_data_serialization.hpp
+++ b/src/domain/include/kth/domain/chain/token_data_serialization.hpp
@@ -4,62 +4,10 @@
 
 #pragma once
 
+// The `to_data` entry points that used to live here moved into
+// `token_data.hpp` so the C-API binding generator — which parses a
+// single header per class — can pick them up. This header stays as
+// a compatibility shim; external callers can keep including it and
+// will transparently get the same overloads.
+
 #include <kth/domain/chain/token_data.hpp>
-#include <kth/infrastructure/utility/ostream_writer.hpp>
-
-namespace kth::domain::chain::token::encoding {
-
-inline
-data_chunk to_data(fungible const& x) {
-    data_chunk data;
-    auto const size = serialized_size(x);
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-    to_data(sink_w, x);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-inline
-data_chunk to_data(non_fungible const& x) {
-    data_chunk data;
-    auto const size = serialized_size(x);
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-    to_data(sink_w, x);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-inline
-data_chunk to_data(both_kinds const& x) {
-    data_chunk data;
-    auto const size = serialized_size(x);
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-    to_data(sink_w, x);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-inline
-data_chunk to_data(token_data_t const& x) {
-    data_chunk data;
-    auto const size = serialized_size(x);
-    data.reserve(size);
-    data_sink ostream(data);
-    ostream_writer sink_w(ostream);
-    to_data(sink_w, x);
-    ostream.flush();
-    KTH_ASSERT(data.size() == size);
-    return data;
-}
-
-} // namespace kth::domain::chain::encoding
-

--- a/src/domain/include/kth/domain/impl/machine/interpreter.ipp
+++ b/src/domain/include/kth/domain/impl/machine/interpreter.ipp
@@ -3018,74 +3018,32 @@ namespace detail {
 
 inline
 data_chunk get_token_category(chain::token_data_t const& token) {
+    auto const cap = chain::get_nft_capability(token);
+    bool const push_cap_byte = chain::has_nft(token)
+        && (cap == chain::capability_t::mut
+         || cap == chain::capability_t::minting);
     data_chunk vch;
-    auto const& tok_id = token.id;
-    bool push_cap_byte = false;
-    std::visit([&push_cap_byte](auto&& arg) {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, chain::non_fungible>) {
-            push_cap_byte = (arg.capability == chain::capability_t::mut ||
-                             arg.capability == chain::capability_t::minting);
-        } else if constexpr (std::is_same_v<T, chain::both_kinds>) {
-            push_cap_byte = (arg.second.capability == chain::capability_t::mut ||
-                             arg.second.capability == chain::capability_t::minting);
-        }
-    }, token.data);
-
-    vch.reserve(tok_id.size() + (push_cap_byte ? 1 : 0));
-    vch.insert(vch.end(), tok_id.begin(), tok_id.end());
+    vch.reserve(token.id.size() + (push_cap_byte ? 1 : 0));
+    vch.insert(vch.end(), token.id.begin(), token.id.end());
     if (push_cap_byte) {
-        uint8_t cap = 0;
-        std::visit([&cap](auto&& arg) {
-            using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_same_v<T, chain::non_fungible>) {
-                cap = static_cast<uint8_t>(arg.capability);
-            } else if constexpr (std::is_same_v<T, chain::both_kinds>) {
-                cap = static_cast<uint8_t>(arg.second.capability);
-            }
-        }, token.data);
-        vch.push_back(cap);
+        vch.push_back(static_cast<uint8_t>(cap));
     }
     return vch;
 }
 
 inline
 data_chunk get_token_commitment(chain::token_data_t const& token) {
-    data_chunk result;
-    std::visit([&result](auto&& arg) {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, chain::non_fungible>) {
-            result.assign(arg.commitment.begin(), arg.commitment.end());
-        } else if constexpr (std::is_same_v<T, chain::both_kinds>) {
-            result.assign(arg.second.commitment.begin(), arg.second.commitment.end());
-        }
-        // fungible: no commitment, result stays empty
-    }, token.data);
-    return result;
+    return chain::get_nft_commitment(token);
 }
 
 inline
 bool has_nft(chain::token_data_t const& token) {
-    return std::visit([](auto&& arg) {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, chain::non_fungible> || std::is_same_v<T, chain::both_kinds>) {
-            return true;
-        }
-        return false;
-    }, token.data);
+    return chain::has_nft(token);
 }
 
 inline
 int64_t get_token_amount(chain::token_data_t const& token) {
-    return std::visit([](auto&& arg) -> int64_t {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, chain::fungible>) {
-            return int64_t(arg.amount);
-        } else if constexpr (std::is_same_v<T, chain::both_kinds>) {
-            return int64_t(arg.first.amount);
-        }
-        return 0; // non_fungible only: no amount
-    }, token.data);
+    return int64_t(chain::get_amount(token));
 }
 
 } // namespace detail

--- a/src/domain/src/wallet/coin_selection.cpp
+++ b/src/domain/src/wallet/coin_selection.cpp
@@ -70,7 +70,7 @@ void track_nft_from_both_kinds(utxo const& u, coin_selection_result& result) {
     auto const& token = u.token_data().value();
     if (std::holds_alternative<both_kinds>(token.data)) {
         auto const& bk = std::get<both_kinds>(token.data);
-        result.collateral_nfts.emplace_back(token_data_t{token.id, bk.second});
+        result.collateral_nfts.emplace_back(token_data_t{token.id, bk.non_fungible_part});
     }
 }
 
@@ -90,9 +90,9 @@ void track_collateral(utxo const& u, hash_digest const& target_category,
     } else if (std::holds_alternative<both_kinds>(token.data)) {
         auto const& bk = std::get<both_kinds>(token.data);
         if (token.id != target_category) {
-            result.collateral_fts[token.id] += uint64_t(bk.first.amount);
+            result.collateral_fts[token.id] += uint64_t(bk.fungible_part.amount);
         }
-        result.collateral_nfts.emplace_back(token_data_t{token.id, bk.second});
+        result.collateral_nfts.emplace_back(token_data_t{token.id, bk.non_fungible_part});
     } else {
         // pure non_fungible
         result.collateral_nfts.emplace_back(token);

--- a/src/domain/test/chain/output.cpp
+++ b/src/domain/test/chain/output.cpp
@@ -385,8 +385,8 @@ TEST_CASE("output deserialization with both - immutable NFT 0-byte commitment - 
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{1});
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
@@ -411,8 +411,8 @@ TEST_CASE("output deserialization with both - immutable NFT 0-byte commitment - 
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{253});
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
@@ -437,8 +437,8 @@ TEST_CASE("output deserialization with both - immutable NFT 0-byte commitment - 
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{9223372036854775807});
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::none); // immutable
@@ -488,8 +488,8 @@ TEST_CASE("output deserialization with both - immutable NFT 1-byte commitment - 
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{252});
     REQUIRE(nft.commitment.size() == 1);
     REQUIRE(encode_base16(nft.commitment) == "cc");
@@ -515,8 +515,8 @@ TEST_CASE("output deserialization with both - immutable NFT 2-byte commitment - 
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{253});
     REQUIRE(nft.commitment.size() == 2);
     REQUIRE(encode_base16(nft.commitment) == "cccc");
@@ -542,8 +542,8 @@ TEST_CASE("output deserialization with both - immutable NFT 10-byte commitment -
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{65535});
     REQUIRE(nft.commitment.size() == 10);
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccc");
@@ -569,8 +569,8 @@ TEST_CASE("output deserialization with both - immutable NFT 40-byte commitment -
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{65536});
     REQUIRE(nft.commitment.size() == 40);
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
@@ -620,8 +620,8 @@ TEST_CASE("output deserialization with both - mutable NFT 0-byte commitment - FT
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{4294967295});
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::mut); // mutable
@@ -671,8 +671,8 @@ TEST_CASE("output deserialization with both - mutable NFT 1-byte commitment - FT
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{4294967296});
     REQUIRE(nft.commitment.size() == 1);
     REQUIRE(encode_base16(nft.commitment) == "cc");
@@ -698,8 +698,8 @@ TEST_CASE("output deserialization with both - mutable NFT 2-byte commitment - FT
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{9223372036854775807});
     REQUIRE(nft.commitment.size() == 2);
     REQUIRE(encode_base16(nft.commitment) == "cccc");
@@ -725,8 +725,8 @@ TEST_CASE("output deserialization with both - mutable NFT 10-byte commitment - F
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{1});
     REQUIRE(nft.commitment.size() == 10);
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccc");
@@ -752,8 +752,8 @@ TEST_CASE("output deserialization with both - mutable NFT 40-byte commitment - F
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{252});
     REQUIRE(nft.commitment.size() == 40);
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
@@ -803,8 +803,8 @@ TEST_CASE("output deserialization with both - minting NFT 0-byte commitment - FT
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{253});
     REQUIRE(nft.commitment.size() == 0);
     REQUIRE(nft.capability == chain::capability_t::minting); // minting
@@ -854,8 +854,8 @@ TEST_CASE("output deserialization with both - minting NFT 1-byte commitment - FT
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{65535});
     REQUIRE(nft.commitment.size() == 1);
     REQUIRE(encode_base16(nft.commitment) == "cc");
@@ -881,8 +881,8 @@ TEST_CASE("output deserialization with both - minting NFT 2-byte commitment - FT
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{65536});
     REQUIRE(nft.commitment.size() == 2);
     REQUIRE(encode_base16(nft.commitment) == "cccc");
@@ -908,8 +908,8 @@ TEST_CASE("output deserialization with both - minting NFT 10-byte commitment - F
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{4294967297});
     REQUIRE(nft.commitment.size() == 10);
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccc");
@@ -935,8 +935,8 @@ TEST_CASE("output deserialization with both - minting NFT 40-byte commitment - F
     REQUIRE(instance.token_data().has_value());
     REQUIRE(encode_base16(instance.token_data().value().id) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     REQUIRE(std::holds_alternative<chain::both_kinds>(instance.token_data().value().data));
-    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).first;
-    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).second;
+    auto const& ft = std::get<chain::both_kinds>(instance.token_data().value().data).fungible_part;
+    auto const& nft = std::get<chain::both_kinds>(instance.token_data().value().data).non_fungible_part;
     REQUIRE(ft.amount == chain::amount_t{9223372036854775807});
     REQUIRE(nft.commitment.size() == 40);
     REQUIRE(encode_base16(nft.commitment) == "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");


### PR DESCRIPTION
## Summary
Migrates \`chain/token_data\` to the const/mut typed-handle pattern shared by every other migrated chain class, removes a substantial chunk of dead code that had accumulated in \`token_data.hpp\`, and tightens the C++ design before exposing it through C.

### C++ \`token_data.hpp\`
- Switch \`amount_t\` underlying type from \`int64_t\` to \`uint64_t\` to match the rest of kth's amount types (\`output::value\`, \`utxo::amount\`) and to remove the silent narrowing from \`read_variable_little_endian()\` (which returns \`uint64_t\`) into a signed enum. CashTokens limits amounts to \`[0, INT64_MAX]\` so non-negativity is guaranteed by spec.
- Rename \`both_kinds\` from \`std::pair<fungible, non_fungible>\` to a named struct with \`fungible_part\` / \`non_fungible_part\` fields. Anonymous \`.first\` / \`.second\` accessors required tracing back to the alias every time.
- Switch \`commitment_t\` to \`data_chunk\` for grep parity with the rest of the codebase.
- Default \`operator<=>\` on every payload struct (C++20 derives \`==\` from it). Drops the redundant \`operator==\` / \`operator!=\` declarations the original carried alongside the (commented-out) \`<=>\`.
- Tighten \`is_valid(non_fungible)\`: require \`capability ∈ {none, mut, minting}\` via the new \`is_valid_capability\` helper.
- Add \`chain::kind\` enum + \`get_kind()\` observer to surface the variant arm without requiring callers to peek into \`std::variant\`.
- Add \`make_fungible\` / \`make_non_fungible\` / \`make_both\` factories and \`get_nft_capability\` / \`get_nft_commitment\` projection helpers so the binding layer can hit the surface through plain free functions.
- Delete ~100 lines of dead/commented code (lexicographical compare stub, \`from_data_old\`, templated \`from_data<T>\` sketch, concept sketches, unused \`detail::always_false_v\`, stray \`<version>\`).
- Inline the \`to_data(T) -> data_chunk\` overloads previously in \`token_data_serialization.hpp\`; that file stays as a one-line include shim.

### C-API surface
- \`token_data\` now has the same opaque-handle shape as every other migrated class: const/mut split, owned heap returns marked \`KTH_OWNED\`, \`KTH_PRECONDITION\` on null inputs, docstrings that actually describe the ownership / nullability contract.
- \`kth_token_data_t\` legacy void* typedef removed in favour of \`kth_token_data_const_t\` / \`kth_token_data_mut_t\`.
- \`kth_token_kind_t\` aligned with the new C++ \`kind\` enum (\`fungible_only\`, \`non_fungible_only\`, \`both\` — values 0, 1, 2).
- \`utxo\` bindings: \`set_fungible_token_data\` / \`set_token_amount\` switched from \`int64_t\` to \`uint64_t\`, matching the \`construct_*\` factories that were already \`uint64_t\`.

### Tests
- \`src/c-api/test/chain/token_data.cpp\` — 23 cases covering factories (safe + unsafe variants), copy / equals, \`get_kind\` discrimination, \`get_amount\` semantics for the three variant arms, \`to_data\` / \`from_data\` round-trip, and preconditions.

### Internal callers updated
\`interpreter.ipp\`, \`coin_selection.cpp\` and \`test/chain/output.cpp\` pick up the renamed \`both_kinds\` field accessors.

## Test plan
- [ ] C-API test suite compiles and passes, including the new \`[C-API TokenData]\` cases.
- [ ] Domain test suite compiles and passes (CashTokens VMB suite was the early-warning canary for the \`amount_t\` / \`get_amount\` semantics).
- [ ] No regressions in unrelated bindings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates CashTokens `token_data` C/C++ APIs and validation rules (amount/capability bounds, commitment size limits), which can change serialization/consensus-adjacent behavior and may break downstream C-API consumers due to signature/enum changes.
> 
> **Overview**
> **Refactors and expands the C-API surface for CashTokens `token_data`** to use the const/mut handle pattern with clearer ownership semantics, adding factories (`make_fungible`/`make_non_fungible`/`make_both`), copy/equality, richer getters (kind/amount/NFT fields/bitfield), and a new `construct_from_data` parser with explicit error codes.
> 
> **Tightens the domain `token_data` model and encoding/validation**: switches token amounts to `uint64_t` (bounded to `INT64_MAX`), replaces `both_kinds` `std::pair` with named `fungible_part`/`non_fungible_part`, validates NFT capability values, adds `get_kind`/projection helpers, and caps decoded NFT commitment size to `max_push_data_size_legacy`.
> 
> **Updates dependent code and tests**: adjusts UTXO setters to `uint64_t` with precondition checks, updates interpreter/wallet/output tests for the renamed `both_kinds` fields, and adds a comprehensive new C-API `token_data` Catch2 test suite wired into the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d4f4497e912d103add8c6d002bc94bc10e4791e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New token factories and richer token API: creation, copy, equality, serialization, setters, and getters for id, kind, amount, NFT capability and commitment.
  * Improved token validation and NFT introspection; safer/explicit serialization roundtrip.

* **Breaking Changes**
  * Token amounts now use unsigned 64-bit integers.
  * Token kind names/values changed (fungible_only, non_fungible_only, both).
  * Constructor/ownership semantics revised (owned handles and error-code construction).

* **Tests**
  * Added comprehensive TokenData C-API tests covering factories, serialization, predicates and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->