### PR TITLE
refactor(c-api): migrate wallet_data binding; rename wallet::create

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -516,6 +516,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/token_data.cpp
         test/wallet/hd_public.cpp
         test/wallet/hd_private.cpp
+        test/wallet/wallet_data.cpp
     )
 
     target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})

--- a/src/c-api/console/test_wallet_manager.c
+++ b/src/c-api/console/test_wallet_manager.c
@@ -40,16 +40,19 @@ void print_hex(uint8_t const* data, size_t n) {
 }
 
 int main(int argc, char* argv[]) {
-    kth_wallet_data_t wallet_data;
-    kth_error_code_t code = kth_wallet_create_wallet(
+    kth_wallet_data_mut_t wallet_data = NULL;
+    kth_error_code_t code = kth_wallet_create(
         "12345678",
         "",
         &wallet_data);
 
     printf("code: %d\n", code);
+    if (code != kth_ec_success) {
+        return 1;
+    }
     // printf("wallet_data: %s\n", kth_wallet_wallet_data_encoded(wallet_data));
 
-    kth_string_list_t mnemonics = kth_wallet_wallet_data_mnemonics(wallet_data);
+    kth_string_list_const_t mnemonics = kth_wallet_wallet_data_mnemonics(wallet_data);
 
     kth_size_t count = kth_core_string_list_count(mnemonics);
     printf("count: %d\n", count);

--- a/src/c-api/include/kth/capi/chain/token_data.h
+++ b/src/c-api/include/kth/capi/chain/token_data.h
@@ -20,43 +20,43 @@ extern "C" {
 
 /** @param[out] out Must point to a null `kth_token_data_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_token_data_destruct`. Untouched on error. */
 KTH_EXPORT
-kth_error_code_t kth_chain_token_data_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_token_data_mut_t* out);
+kth_error_code_t kth_chain_token_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_token_data_mut_t* out);
 
 
 // Static factories
 
 /** @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`. */
 KTH_EXPORT KTH_OWNED
-kth_token_data_mut_t kth_chain_token_data_make_fungible(kth_hash_t id, uint64_t amount);
+kth_token_data_mut_t kth_chain_token_make_fungible(kth_hash_t id, uint64_t amount);
 
 /**
  * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
  * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
-kth_token_data_mut_t kth_chain_token_data_make_fungible_unsafe(uint8_t const* id, uint64_t amount);
+kth_token_data_mut_t kth_chain_token_make_fungible_unsafe(uint8_t const* id, uint64_t amount);
 
 /** @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`. */
 KTH_EXPORT KTH_OWNED
-kth_token_data_mut_t kth_chain_token_data_make_non_fungible(kth_hash_t id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+kth_token_data_mut_t kth_chain_token_make_non_fungible(kth_hash_t id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
 
 /**
  * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
  * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
-kth_token_data_mut_t kth_chain_token_data_make_non_fungible_unsafe(uint8_t const* id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+kth_token_data_mut_t kth_chain_token_make_non_fungible_unsafe(uint8_t const* id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
 
 /** @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`. */
 KTH_EXPORT KTH_OWNED
-kth_token_data_mut_t kth_chain_token_data_make_both(kth_hash_t id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+kth_token_data_mut_t kth_chain_token_make_both(kth_hash_t id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
 
 /**
  * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
  * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
  */
 KTH_EXPORT KTH_OWNED
-kth_token_data_mut_t kth_chain_token_data_make_both_unsafe(uint8_t const* id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+kth_token_data_mut_t kth_chain_token_make_both_unsafe(uint8_t const* id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
 
 
 // Destructor
@@ -98,7 +98,7 @@ KTH_EXPORT
 kth_token_kind_t kth_chain_token_data_get_kind(kth_token_data_const_t self);
 
 KTH_EXPORT
-uint64_t kth_chain_token_data_get_amount(kth_token_data_const_t self);
+int64_t kth_chain_token_data_get_amount(kth_token_data_const_t self);
 
 KTH_EXPORT
 kth_token_capability_t kth_chain_token_data_get_nft_capability(kth_token_data_const_t self);

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -273,7 +273,9 @@ kth::domain::wallet::hd_private&       kth_wallet_hd_private_mut_cpp(kth_hd_priv
 kth::domain::wallet::payment_address const& kth_wallet_payment_address_const_cpp(kth_payment_address_const_t o);
 kth::domain::wallet::payment_address&       kth_wallet_payment_address_mut_cpp(kth_payment_address_mut_t o);
 
-KTH_CONV_DECLARE(wallet, kth_wallet_data_t, kth::domain::wallet::wallet_data, wallet_data)
+// wallet_data conversion functions. Defined in src/wallet/wallet_data.cpp.
+kth::domain::wallet::wallet_data const& kth_wallet_wallet_data_const_cpp(kth_wallet_data_const_t o);
+kth::domain::wallet::wallet_data&       kth_wallet_wallet_data_mut_cpp(kth_wallet_data_mut_t o);
 
 // payment_address_list — inline converters for the generated list binding.
 inline std::vector<kth::domain::wallet::payment_address> const&
@@ -289,9 +291,8 @@ kth_wallet_payment_address_list_mut_cpp(kth_payment_address_list_mut_t l) {
 // Core.
 // ------------------------------------------------------------------------------------
 
-// string_list — inline construct_from_cpp for wallet_data.cpp callers.
-inline kth_string_list_mut_t kth_core_string_list_construct_from_cpp(std::vector<std::string>& l) {
-    return &l;
+inline std::vector<std::string> const& kth_core_string_list_const_cpp(kth_string_list_const_t l) {
+    return *static_cast<std::vector<std::string> const*>(l);
 }
 
 

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -307,6 +307,11 @@ inline kth::domain::wallet::hd_key hd_key_to_cpp(uint8_t const* x) {
     return to_array_cpp<kth::domain::wallet::hd_key_size>(x);
 }
 
+// encrypted_seed (96 bytes)
+inline kth::domain::wallet::encrypted_seed_t encrypted_seed_to_cpp(uint8_t const* x) {
+    return to_array_cpp<std::tuple_size_v<kth::domain::wallet::encrypted_seed_t>>(x);
+}
+
 template <typename T>
 inline
 T* mnew(std::size_t n = 1) {

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -181,7 +181,8 @@ typedef void const* kth_u32_list_const_t;
 typedef void* kth_u64_list_mut_t;
 typedef void const* kth_u64_list_const_t;
 
-typedef void* kth_wallet_data_t;
+typedef void* kth_wallet_data_mut_t;
+typedef void const* kth_wallet_data_const_t;
 
 typedef void* kth_ec_compressed_list_t;
 typedef void* kth_ec_compressed_list_mut_t;

--- a/src/c-api/include/kth/capi/wallet/wallet_data.h
+++ b/src/c-api/include/kth/capi/wallet/wallet_data.h
@@ -1,36 +1,74 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef KTH_CAPI_WALLET_WALLET_DATA_H_
 #define KTH_CAPI_WALLET_WALLET_DATA_H_
 
+#include <stdint.h>
+
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
-
 #include <kth/capi/wallet/primitives.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// Destructor
+
+/** No-op if `self` is null. */
 KTH_EXPORT
-void kth_wallet_wallet_data_destruct(kth_wallet_data_t wallet_data);
+void kth_wallet_wallet_data_destruct(kth_wallet_data_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_wallet_data_mut_t`. Caller must release with `kth_wallet_wallet_data_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_wallet_data_mut_t kth_wallet_wallet_data_copy(kth_wallet_data_const_t self);
+
+
+// Getters
+
+/** @return Borrowed `kth_string_list_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_string_list_const_t kth_wallet_wallet_data_mnemonics(kth_wallet_data_const_t self);
+
+/** @return Borrowed `kth_hd_public_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_hd_public_const_t kth_wallet_wallet_data_xpub(kth_wallet_data_const_t self);
 
 KTH_EXPORT
-kth_string_list_mut_t kth_wallet_wallet_data_mnemonics(kth_wallet_data_t wallet_data);
+kth_encrypted_seed_t kth_wallet_wallet_data_encrypted_seed(kth_wallet_data_const_t self);
+
+
+// Setters
+
+/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
+KTH_EXPORT
+void kth_wallet_wallet_data_set_mnemonics(kth_wallet_data_mut_t self, kth_string_list_const_t value);
+
+/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
+KTH_EXPORT
+void kth_wallet_wallet_data_set_xpub(kth_wallet_data_mut_t self, kth_hd_public_const_t value);
 
 KTH_EXPORT
-kth_hd_public_t kth_wallet_wallet_data_xpub(kth_wallet_data_t wallet_data);
+void kth_wallet_wallet_data_set_encrypted_seed(kth_wallet_data_mut_t self, kth_encrypted_seed_t value);
 
+/** @warning `value` MUST point to a buffer of at least 96 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
 KTH_EXPORT
-kth_encrypted_seed_t kth_wallet_wallet_data_encrypted_seed(kth_wallet_data_t wallet_data);
+void kth_wallet_wallet_data_set_encrypted_seed_unsafe(kth_wallet_data_mut_t self, uint8_t const* value);
 
+
+// Static utilities
+
+/** @param[out] out Must point to a null `kth_wallet_data_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_wallet_data_destruct`. Untouched on error. */
 KTH_EXPORT
-void kth_wallet_wallet_data_encrypted_seed_out(kth_wallet_data_t wallet_data, kth_encrypted_seed_t* out_encrypted_seed);
+kth_error_code_t kth_wallet_create(char const* password, char const* normalized_passphrase, KTH_OUT_OWNED kth_wallet_data_mut_t* out);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif /* KTH_CAPI_WALLET_WALLET_DATA_H_ */
+#endif // KTH_CAPI_WALLET_WALLET_DATA_H_

--- a/src/c-api/include/kth/capi/wallet/wallet_manager.h
+++ b/src/c-api/include/kth/capi/wallet/wallet_manager.h
@@ -15,12 +15,6 @@ extern "C" {
 #endif
 
 KTH_EXPORT
-kth_error_code_t kth_wallet_create_wallet(
-    char const* password,
-    char const* normalized_passphrase,
-    kth_wallet_data_t* out_wallet_data);
-
-KTH_EXPORT
 kth_error_code_t kth_wallet_decrypt_seed(
     char const* password,
     kth_encrypted_seed_t const* encrypted_seed,

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -158,8 +158,7 @@ kth_transaction_list_const_t kth_chain_block_transactions(kth_block_const_t self
 
 kth_hash_t kth_chain_block_hash(kth_block_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_block_const_cpp(self).hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_block_const_cpp(self).hash());
 }
 
 uint64_t kth_chain_block_fees(kth_block_const_t self) {
@@ -174,8 +173,7 @@ uint64_t kth_chain_block_claim(kth_block_const_t self) {
 
 kth_hash_t kth_chain_block_generate_merkle_root(kth_block_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_block_const_cpp(self).generate_merkle_root();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_block_const_cpp(self).generate_merkle_root());
 }
 
 kth_error_code_t kth_chain_block_check_transactions(kth_block_const_t self) {

--- a/src/c-api/src/chain/double_spend_proof.cpp
+++ b/src/c-api/src/chain/double_spend_proof.cpp
@@ -111,8 +111,7 @@ kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender2(kth
 
 kth_hash_t kth_chain_double_spend_proof_hash(kth_double_spend_proof_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_double_spend_proof_const_cpp(self).hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_double_spend_proof_const_cpp(self).hash());
 }
 
 

--- a/src/c-api/src/chain/double_spend_proof_spender.cpp
+++ b/src/c-api/src/chain/double_spend_proof_spender.cpp
@@ -88,20 +88,17 @@ uint32_t kth_chain_double_spend_proof_spender_locktime(kth_double_spend_proof_sp
 
 kth_hash_t kth_chain_double_spend_proof_spender_prev_outs_hash(kth_double_spend_proof_spender_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_double_spend_proof_spender_const_cpp(self).prev_outs_hash;
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_double_spend_proof_spender_const_cpp(self).prev_outs_hash);
 }
 
 kth_hash_t kth_chain_double_spend_proof_spender_sequence_hash(kth_double_spend_proof_spender_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_double_spend_proof_spender_const_cpp(self).sequence_hash;
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_double_spend_proof_spender_const_cpp(self).sequence_hash);
 }
 
 kth_hash_t kth_chain_double_spend_proof_spender_outputs_hash(kth_double_spend_proof_spender_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_double_spend_proof_spender_const_cpp(self).outputs_hash;
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_double_spend_proof_spender_const_cpp(self).outputs_hash);
 }
 
 uint8_t* kth_chain_double_spend_proof_spender_push_data(kth_double_spend_proof_spender_const_t self, kth_size_t* out_size) {

--- a/src/c-api/src/chain/get_blocks.cpp
+++ b/src/c-api/src/chain/get_blocks.cpp
@@ -104,8 +104,7 @@ kth_hash_list_const_t kth_chain_get_blocks_start_hashes(kth_get_blocks_const_t s
 
 kth_hash_t kth_chain_get_blocks_stop_hash(kth_get_blocks_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_get_blocks_const_cpp(self).stop_hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_get_blocks_const_cpp(self).stop_hash());
 }
 
 

--- a/src/c-api/src/chain/get_headers.cpp
+++ b/src/c-api/src/chain/get_headers.cpp
@@ -104,8 +104,7 @@ kth_hash_list_const_t kth_chain_get_headers_start_hashes(kth_get_headers_const_t
 
 kth_hash_t kth_chain_get_headers_stop_hash(kth_get_headers_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_get_headers_const_cpp(self).stop_hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_get_headers_const_cpp(self).stop_hash());
 }
 
 

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -101,8 +101,7 @@ kth_size_t kth_chain_header_serialized_size(kth_header_const_t self, kth_bool_t 
 
 kth_hash_t kth_chain_header_hash_pow(kth_header_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_header_const_cpp(self).hash_pow();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_header_const_cpp(self).hash_pow());
 }
 
 uint32_t kth_chain_header_version(kth_header_const_t self) {
@@ -112,14 +111,12 @@ uint32_t kth_chain_header_version(kth_header_const_t self) {
 
 kth_hash_t kth_chain_header_previous_block_hash(kth_header_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_header_const_cpp(self).previous_block_hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_header_const_cpp(self).previous_block_hash());
 }
 
 kth_hash_t kth_chain_header_merkle(kth_header_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_header_const_cpp(self).merkle();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_header_const_cpp(self).merkle());
 }
 
 uint32_t kth_chain_header_timestamp(kth_header_const_t self) {

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -104,8 +104,7 @@ kth_size_t kth_chain_output_point_serialized_size(kth_output_point_const_t self,
 
 kth_hash_t kth_chain_output_point_hash(kth_output_point_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_output_point_const_cpp(self).hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_output_point_const_cpp(self).hash());
 }
 
 uint32_t kth_chain_output_point_index(kth_output_point_const_t self) {

--- a/src/c-api/src/chain/point.cpp
+++ b/src/c-api/src/chain/point.cpp
@@ -105,8 +105,7 @@ kth_size_t kth_chain_point_serialized_size(kth_point_const_t self, kth_bool_t wi
 
 kth_hash_t kth_chain_point_hash(kth_point_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_point_const_cpp(self).hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_point_const_cpp(self).hash());
 }
 
 uint32_t kth_chain_point_index(kth_point_const_t self) {

--- a/src/c-api/src/chain/stealth_compact.cpp
+++ b/src/c-api/src/chain/stealth_compact.cpp
@@ -39,20 +39,17 @@ kth_stealth_compact_mut_t kth_chain_stealth_compact_copy(kth_stealth_compact_con
 
 kth_hash_t kth_chain_stealth_compact_ephemeral_public_key_hash(kth_stealth_compact_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_stealth_compact_const_cpp(self).ephemeral_public_key_hash;
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_stealth_compact_const_cpp(self).ephemeral_public_key_hash);
 }
 
 kth_shorthash_t kth_chain_stealth_compact_public_key_hash(kth_stealth_compact_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_stealth_compact_const_cpp(self).public_key_hash;
-    return kth::to_shorthash_t(value_cpp);
+    return kth::to_shorthash_t(kth_chain_stealth_compact_const_cpp(self).public_key_hash);
 }
 
 kth_hash_t kth_chain_stealth_compact_transaction_hash(kth_stealth_compact_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_stealth_compact_const_cpp(self).transaction_hash;
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_stealth_compact_const_cpp(self).transaction_hash);
 }
 
 

--- a/src/c-api/src/chain/token_data.cpp
+++ b/src/c-api/src/chain/token_data.cpp
@@ -24,7 +24,7 @@ extern "C" {
 
 // Constructors
 
-kth_error_code_t kth_chain_token_data_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_token_data_mut_t* out) {
+kth_error_code_t kth_chain_token_construct_from_data(uint8_t const* data, kth_size_t n, KTH_OUT_OWNED kth_token_data_mut_t* out) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
@@ -38,18 +38,18 @@ kth_error_code_t kth_chain_token_data_construct_from_data(uint8_t const* data, k
 
 // Static factories
 
-kth_token_data_mut_t kth_chain_token_data_make_fungible(kth_hash_t id, uint64_t amount) {
+kth_token_data_mut_t kth_chain_token_make_fungible(kth_hash_t id, uint64_t amount) {
     auto const id_cpp = kth::hash_to_cpp(id.hash);
     return kth::make_leaked_if_valid(kth::domain::chain::make_fungible(id_cpp, amount));
 }
 
-kth_token_data_mut_t kth_chain_token_data_make_fungible_unsafe(uint8_t const* id, uint64_t amount) {
+kth_token_data_mut_t kth_chain_token_make_fungible_unsafe(uint8_t const* id, uint64_t amount) {
     KTH_PRECONDITION(id != nullptr);
     auto const id_cpp = kth::hash_to_cpp(id);
     return kth::make_leaked_if_valid(kth::domain::chain::make_fungible(id_cpp, amount));
 }
 
-kth_token_data_mut_t kth_chain_token_data_make_non_fungible(kth_hash_t id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+kth_token_data_mut_t kth_chain_token_make_non_fungible(kth_hash_t id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
     KTH_PRECONDITION(commitment != nullptr || n == 0);
     auto const id_cpp = kth::hash_to_cpp(id.hash);
     auto const capability_cpp = static_cast<kth::domain::chain::capability_t>(capability);
@@ -57,7 +57,7 @@ kth_token_data_mut_t kth_chain_token_data_make_non_fungible(kth_hash_t id, kth_t
     return kth::make_leaked_if_valid(kth::domain::chain::make_non_fungible(id_cpp, capability_cpp, commitment_cpp));
 }
 
-kth_token_data_mut_t kth_chain_token_data_make_non_fungible_unsafe(uint8_t const* id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+kth_token_data_mut_t kth_chain_token_make_non_fungible_unsafe(uint8_t const* id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
     KTH_PRECONDITION(id != nullptr);
     KTH_PRECONDITION(commitment != nullptr || n == 0);
     auto const id_cpp = kth::hash_to_cpp(id);
@@ -66,7 +66,7 @@ kth_token_data_mut_t kth_chain_token_data_make_non_fungible_unsafe(uint8_t const
     return kth::make_leaked_if_valid(kth::domain::chain::make_non_fungible(id_cpp, capability_cpp, commitment_cpp));
 }
 
-kth_token_data_mut_t kth_chain_token_data_make_both(kth_hash_t id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+kth_token_data_mut_t kth_chain_token_make_both(kth_hash_t id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
     KTH_PRECONDITION(commitment != nullptr || n == 0);
     auto const id_cpp = kth::hash_to_cpp(id.hash);
     auto const capability_cpp = static_cast<kth::domain::chain::capability_t>(capability);
@@ -74,7 +74,7 @@ kth_token_data_mut_t kth_chain_token_data_make_both(kth_hash_t id, uint64_t amou
     return kth::make_leaked_if_valid(kth::domain::chain::make_both(id_cpp, amount, capability_cpp, commitment_cpp));
 }
 
-kth_token_data_mut_t kth_chain_token_data_make_both_unsafe(uint8_t const* id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+kth_token_data_mut_t kth_chain_token_make_both_unsafe(uint8_t const* id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
     KTH_PRECONDITION(id != nullptr);
     KTH_PRECONDITION(commitment != nullptr || n == 0);
     auto const id_cpp = kth::hash_to_cpp(id);
@@ -128,8 +128,7 @@ uint8_t* kth_chain_token_data_to_data(kth_token_data_const_t self, kth_size_t* o
 
 kth_hash_t kth_chain_token_data_id(kth_token_data_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_token_data_const_cpp(self).id;
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_token_data_const_cpp(self).id);
 }
 
 kth_token_kind_t kth_chain_token_data_get_kind(kth_token_data_const_t self) {
@@ -137,7 +136,7 @@ kth_token_kind_t kth_chain_token_data_get_kind(kth_token_data_const_t self) {
     return static_cast<kth_token_kind_t>(kth::domain::chain::get_kind(kth_chain_token_data_const_cpp(self)));
 }
 
-uint64_t kth_chain_token_data_get_amount(kth_token_data_const_t self) {
+int64_t kth_chain_token_data_get_amount(kth_token_data_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::domain::chain::get_amount(kth_chain_token_data_const_cpp(self));
 }

--- a/src/c-api/src/chain/transaction.cpp
+++ b/src/c-api/src/chain/transaction.cpp
@@ -110,32 +110,27 @@ kth_size_t kth_chain_transaction_serialized_size(kth_transaction_const_t self, k
 
 kth_hash_t kth_chain_transaction_outputs_hash(kth_transaction_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_transaction_const_cpp(self).outputs_hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_transaction_const_cpp(self).outputs_hash());
 }
 
 kth_hash_t kth_chain_transaction_inpoints_hash(kth_transaction_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_transaction_const_cpp(self).inpoints_hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_transaction_const_cpp(self).inpoints_hash());
 }
 
 kth_hash_t kth_chain_transaction_sequences_hash(kth_transaction_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_transaction_const_cpp(self).sequences_hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_transaction_const_cpp(self).sequences_hash());
 }
 
 kth_hash_t kth_chain_transaction_utxos_hash(kth_transaction_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_transaction_const_cpp(self).utxos_hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_transaction_const_cpp(self).utxos_hash());
 }
 
 kth_hash_t kth_chain_transaction_hash(kth_transaction_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_chain_transaction_const_cpp(self).hash();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_chain_transaction_const_cpp(self).hash());
 }
 
 uint64_t kth_chain_transaction_fees(kth_transaction_const_t self) {

--- a/src/c-api/src/wallet/ec_private.cpp
+++ b/src/c-api/src/wallet/ec_private.cpp
@@ -107,8 +107,7 @@ char* kth_wallet_ec_private_encoded(kth_ec_private_const_t self) {
 
 kth_hash_t kth_wallet_ec_private_secret(kth_ec_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_ec_private_const_cpp(self).secret();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_wallet_ec_private_const_cpp(self).secret());
 }
 
 uint16_t kth_wallet_ec_private_version(kth_ec_private_const_t self) {

--- a/src/c-api/src/wallet/ec_public.cpp
+++ b/src/c-api/src/wallet/ec_public.cpp
@@ -126,8 +126,7 @@ char* kth_wallet_ec_public_encoded(kth_ec_public_const_t self) {
 
 kth_ec_compressed_t kth_wallet_ec_public_point(kth_ec_public_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_ec_public_const_cpp(self).point();
-    return kth::to_ec_compressed_t(value_cpp);
+    return kth::to_ec_compressed_t(kth_wallet_ec_public_const_cpp(self).point());
 }
 
 kth_bool_t kth_wallet_ec_public_compressed(kth_ec_public_const_t self) {

--- a/src/c-api/src/wallet/hd_private.cpp
+++ b/src/c-api/src/wallet/hd_private.cpp
@@ -118,14 +118,12 @@ char* kth_wallet_hd_private_encoded(kth_hd_private_const_t self) {
 
 kth_hash_t kth_wallet_hd_private_secret(kth_hd_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_hd_private_const_cpp(self).secret();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_wallet_hd_private_const_cpp(self).secret());
 }
 
 kth_hd_key_t kth_wallet_hd_private_to_hd_key(kth_hd_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_hd_private_const_cpp(self).to_hd_key();
-    return kth::to_hd_key_t(value_cpp);
+    return kth::to_hd_key_t(kth_wallet_hd_private_const_cpp(self).to_hd_key());
 }
 
 kth_hd_public_mut_t kth_wallet_hd_private_to_public(kth_hd_private_const_t self) {
@@ -140,20 +138,17 @@ kth_bool_t kth_wallet_hd_private_valid(kth_hd_private_const_t self) {
 
 kth_hash_t kth_wallet_hd_private_chain_code(kth_hd_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_hd_private_const_cpp(self).chain_code();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_wallet_hd_private_const_cpp(self).chain_code());
 }
 
 kth_hd_lineage_t kth_wallet_hd_private_lineage(kth_hd_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_hd_private_const_cpp(self).lineage();
-    return kth::to_c_struct<kth_hd_lineage_t>(value_cpp);
+    return kth::to_c_struct<kth_hd_lineage_t>(kth_wallet_hd_private_const_cpp(self).lineage());
 }
 
 kth_ec_compressed_t kth_wallet_hd_private_point(kth_hd_private_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_hd_private_const_cpp(self).point();
-    return kth::to_ec_compressed_t(value_cpp);
+    return kth::to_ec_compressed_t(kth_wallet_hd_private_const_cpp(self).point());
 }
 
 

--- a/src/c-api/src/wallet/hd_public.cpp
+++ b/src/c-api/src/wallet/hd_public.cpp
@@ -100,26 +100,22 @@ char* kth_wallet_hd_public_encoded(kth_hd_public_const_t self) {
 
 kth_hash_t kth_wallet_hd_public_chain_code(kth_hd_public_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_hd_public_const_cpp(self).chain_code();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_wallet_hd_public_const_cpp(self).chain_code());
 }
 
 kth_hd_lineage_t kth_wallet_hd_public_lineage(kth_hd_public_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_hd_public_const_cpp(self).lineage();
-    return kth::to_c_struct<kth_hd_lineage_t>(value_cpp);
+    return kth::to_c_struct<kth_hd_lineage_t>(kth_wallet_hd_public_const_cpp(self).lineage());
 }
 
 kth_ec_compressed_t kth_wallet_hd_public_point(kth_hd_public_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_hd_public_const_cpp(self).point();
-    return kth::to_ec_compressed_t(value_cpp);
+    return kth::to_ec_compressed_t(kth_wallet_hd_public_const_cpp(self).point());
 }
 
 kth_hd_key_t kth_wallet_hd_public_to_hd_key(kth_hd_public_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_hd_public_const_cpp(self).to_hd_key();
-    return kth::to_hd_key_t(value_cpp);
+    return kth::to_hd_key_t(kth_wallet_hd_public_const_cpp(self).to_hd_key());
 }
 
 

--- a/src/c-api/src/wallet/payment_address.cpp
+++ b/src/c-api/src/wallet/payment_address.cpp
@@ -158,20 +158,17 @@ uint8_t const* kth_wallet_payment_address_hash_span(kth_payment_address_const_t 
 
 kth_shorthash_t kth_wallet_payment_address_hash20(kth_payment_address_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_payment_address_const_cpp(self).hash20();
-    return kth::to_shorthash_t(value_cpp);
+    return kth::to_shorthash_t(kth_wallet_payment_address_const_cpp(self).hash20());
 }
 
 kth_hash_t kth_wallet_payment_address_hash32(kth_payment_address_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_payment_address_const_cpp(self).hash32();
-    return kth::to_hash_t(value_cpp);
+    return kth::to_hash_t(kth_wallet_payment_address_const_cpp(self).hash32());
 }
 
 kth_payment_t kth_wallet_payment_address_to_payment(kth_payment_address_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth_wallet_payment_address_const_cpp(self).to_payment();
-    return kth::to_payment_t(value_cpp);
+    return kth::to_payment_t(kth_wallet_payment_address_const_cpp(self).to_payment());
 }
 
 

--- a/src/c-api/src/wallet/wallet_data.cpp
+++ b/src/c-api/src/wallet/wallet_data.cpp
@@ -1,45 +1,103 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
 
 #include <kth/capi/wallet/wallet_data.h>
 
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
-#include <kth/capi/type_conversions.h>
+#include <kth/domain/wallet/wallet_manager.hpp>
 
-#include <kth/capi/wallet/conversions.hpp>
-
-
-KTH_CONV_DEFINE(wallet, kth_wallet_data_t, kth::domain::wallet::wallet_data, wallet_data)
+// Conversion functions
+kth::domain::wallet::wallet_data& kth_wallet_wallet_data_mut_cpp(kth_wallet_data_mut_t o) {
+    return *static_cast<kth::domain::wallet::wallet_data*>(o);
+}
+kth::domain::wallet::wallet_data const& kth_wallet_wallet_data_const_cpp(kth_wallet_data_const_t o) {
+    return *static_cast<kth::domain::wallet::wallet_data const*>(o);
+}
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
+// Destructor
 
-void kth_wallet_wallet_data_destruct(kth_wallet_data_t wallet_data) {
-    delete &kth_wallet_wallet_data_cpp(wallet_data);
+void kth_wallet_wallet_data_destruct(kth_wallet_data_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth_wallet_wallet_data_mut_cpp(self);
 }
 
-kth_string_list_mut_t kth_wallet_wallet_data_mnemonics(kth_wallet_data_t wallet_data) {
-    auto& mnemonics_cpp = kth_wallet_wallet_data_cpp(wallet_data).mnemonics;
-    return kth_core_string_list_construct_from_cpp(mnemonics_cpp);
+
+// Copy
+
+kth_wallet_data_mut_t kth_wallet_wallet_data_copy(kth_wallet_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return new kth::domain::wallet::wallet_data(kth_wallet_wallet_data_const_cpp(self));
 }
 
-kth_hd_public_t kth_wallet_wallet_data_xpub(kth_wallet_data_t wallet_data) {
-    auto const& xpub_cpp = kth_wallet_wallet_data_cpp(wallet_data).xpub;
-    return kth::make_leaked(std::move(xpub_cpp));
+
+// Getters
+
+kth_string_list_const_t kth_wallet_wallet_data_mnemonics(kth_wallet_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth_wallet_wallet_data_const_cpp(self).mnemonics);
 }
 
-kth_encrypted_seed_t kth_wallet_wallet_data_encrypted_seed(kth_wallet_data_t wallet_data) {
-    auto const& encrypted_seed_cpp = kth_wallet_wallet_data_cpp(wallet_data).encrypted_seed;
-    return kth::to_encrypted_seed_t(encrypted_seed_cpp);
+kth_hd_public_const_t kth_wallet_wallet_data_xpub(kth_wallet_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth_wallet_wallet_data_const_cpp(self).xpub);
 }
 
-void kth_wallet_wallet_data_encrypted_seed_out(kth_wallet_data_t wallet_data, kth_encrypted_seed_t* out_encrypted_seed) {
-    auto const& encrypted_seed_cpp = kth_wallet_wallet_data_cpp(wallet_data).encrypted_seed;
-    kth::copy_c_hash(encrypted_seed_cpp, out_encrypted_seed);
+kth_encrypted_seed_t kth_wallet_wallet_data_encrypted_seed(kth_wallet_data_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::to_encrypted_seed_t(kth_wallet_wallet_data_const_cpp(self).encrypted_seed);
+}
+
+
+// Setters
+
+void kth_wallet_wallet_data_set_mnemonics(kth_wallet_data_mut_t self, kth_string_list_const_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const& value_cpp = kth_core_string_list_const_cpp(value);
+    kth_wallet_wallet_data_mut_cpp(self).mnemonics = value_cpp;
+}
+
+void kth_wallet_wallet_data_set_xpub(kth_wallet_data_mut_t self, kth_hd_public_const_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const& value_cpp = kth_wallet_hd_public_const_cpp(value);
+    kth_wallet_wallet_data_mut_cpp(self).xpub = value_cpp;
+}
+
+void kth_wallet_wallet_data_set_encrypted_seed(kth_wallet_data_mut_t self, kth_encrypted_seed_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth::encrypted_seed_to_cpp(value.hash);
+    kth_wallet_wallet_data_mut_cpp(self).encrypted_seed = value_cpp;
+}
+
+void kth_wallet_wallet_data_set_encrypted_seed_unsafe(kth_wallet_data_mut_t self, uint8_t const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::encrypted_seed_to_cpp(value);
+    kth_wallet_wallet_data_mut_cpp(self).encrypted_seed = value_cpp;
+}
+
+
+// Static utilities
+
+kth_error_code_t kth_wallet_create(char const* password, char const* normalized_passphrase, KTH_OUT_OWNED kth_wallet_data_mut_t* out) {
+    KTH_PRECONDITION(password != nullptr);
+    KTH_PRECONDITION(normalized_passphrase != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const password_cpp = std::string(password);
+    auto const normalized_passphrase_cpp = std::string(normalized_passphrase);
+    auto result = kth::domain::wallet::create(password_cpp, normalized_passphrase_cpp);
+    if ( ! result) return static_cast<kth_error_code_t>(result.error().value());
+    *out = kth::make_leaked(std::move(*result));
+    return kth_ec_success;
 }
 
 } // extern "C"

--- a/src/c-api/src/wallet/wallet_manager.cpp
+++ b/src/c-api/src/wallet/wallet_manager.cpp
@@ -11,25 +11,6 @@
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_error_code_t kth_wallet_create_wallet(
-    char const* password,
-    char const* normalized_passphrase,
-    kth_wallet_data_t* out_wallet_data) {
-
-    auto res = kth::domain::wallet::create_wallet(
-        std::string(password),
-        std::string(normalized_passphrase)
-        // lexicon
-    );
-
-    if ( ! res) {
-        return kth::to_c_err(res.error());
-    }
-
-    *out_wallet_data = kth::make_leaked(std::move(res.value()));
-    return kth_ec_success;
-}
-
 kth_error_code_t kth_wallet_decrypt_seed(
     char const* password,
     kth_encrypted_seed_t const* encrypted_seed,

--- a/src/c-api/test/chain/token_data.cpp
+++ b/src/c-api/test/chain/token_data.cpp
@@ -57,13 +57,13 @@ TEST_CASE("C-API TokenData - destruct null is safe", "[C-API TokenData]") {
 
 TEST_CASE("C-API TokenData - make_fungible builds a valid handle",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 1234u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 1234u);
     REQUIRE(td != NULL);
     REQUIRE(kth_chain_token_data_is_valid(td) != 0);
     REQUIRE(kth_chain_token_data_get_kind(td) == kth_token_kind_fungible_only);
     REQUIRE(kth_chain_token_data_is_fungible_only(td) != 0);
     REQUIRE(kth_chain_token_data_has_nft(td) == 0);
-    REQUIRE(kth_chain_token_data_get_amount(td) == 1234u);
+    REQUIRE(kth_chain_token_data_get_amount(td) == 1234);
     REQUIRE(kth_hash_equal(kth_chain_token_data_id(td), kCategoryA) != 0);
 
     kth_chain_token_data_destruct(td);
@@ -71,8 +71,8 @@ TEST_CASE("C-API TokenData - make_fungible builds a valid handle",
 
 TEST_CASE("C-API TokenData - make_fungible_unsafe builds the same handle",
           "[C-API TokenData]") {
-    kth_token_data_mut_t safe = kth_chain_token_data_make_fungible(kCategoryA, 7u);
-    kth_token_data_mut_t unsafe = kth_chain_token_data_make_fungible_unsafe(kCategoryA.hash, 7u);
+    kth_token_data_mut_t safe = kth_chain_token_make_fungible(kCategoryA, 7u);
+    kth_token_data_mut_t unsafe = kth_chain_token_make_fungible_unsafe(kCategoryA.hash, 7u);
 
     REQUIRE(safe != NULL);
     REQUIRE(unsafe != NULL);
@@ -88,7 +88,7 @@ TEST_CASE("C-API TokenData - make_fungible_unsafe builds the same handle",
 
 TEST_CASE("C-API TokenData - make_non_fungible mutable carries commitment and capability",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+    kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
         kCategoryA, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
 
@@ -113,7 +113,7 @@ TEST_CASE("C-API TokenData - make_non_fungible mutable carries commitment and ca
 
 TEST_CASE("C-API TokenData - make_non_fungible immutable",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+    kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
         kCategoryA, kth_token_capability_none, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
     REQUIRE(kth_chain_token_data_is_immutable_nft(td) != 0);
@@ -124,7 +124,7 @@ TEST_CASE("C-API TokenData - make_non_fungible immutable",
 
 TEST_CASE("C-API TokenData - make_non_fungible minting",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+    kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
         kCategoryA, kth_token_capability_minting, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
     REQUIRE(kth_chain_token_data_is_minting_nft(td) != 0);
@@ -133,7 +133,7 @@ TEST_CASE("C-API TokenData - make_non_fungible minting",
 
 TEST_CASE("C-API TokenData - make_non_fungible with empty commitment",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+    kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
         kCategoryA, kth_token_capability_none, NULL, 0);
     REQUIRE(td != NULL);
 
@@ -153,7 +153,7 @@ TEST_CASE("C-API TokenData - make_non_fungible with empty commitment",
 
 TEST_CASE("C-API TokenData - make_both carries amount, capability, commitment",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_both(
+    kth_token_data_mut_t td = kth_chain_token_make_both(
         kCategoryA, 9999u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
 
@@ -163,7 +163,7 @@ TEST_CASE("C-API TokenData - make_both carries amount, capability, commitment",
     REQUIRE(kth_chain_token_data_is_fungible_only(td) == 0);
     REQUIRE(kth_chain_token_data_is_mutable_nft(td) != 0);
 
-    REQUIRE(kth_chain_token_data_get_amount(td) == 9999u);
+    REQUIRE(kth_chain_token_data_get_amount(td) == 9999);
     REQUIRE(kth_chain_token_data_get_nft_capability(td) == kth_token_capability_mut);
 
     kth_size_t commitment_size = 0;
@@ -184,7 +184,7 @@ TEST_CASE("C-API TokenData - make_fungible rejects amount 0",
     // Per the CashTokens spec a valid fungible amount is strictly
     // positive. The binding layer's `check_valid` gate sits on top of
     // `operator bool` (which delegates to is_valid), so 0 yields NULL.
-    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 0u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 0u);
     REQUIRE(td == NULL);
 }
 
@@ -192,14 +192,14 @@ TEST_CASE("C-API TokenData - make_fungible rejects amounts above INT64_MAX",
           "[C-API TokenData]") {
     // The CHIP caps amounts at INT64_MAX. UINT64_MAX (all ones) is
     // provably outside the spec range and must be rejected.
-    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(
         kCategoryA, (uint64_t)0xFFFFFFFFFFFFFFFFULL);
     REQUIRE(td == NULL);
 }
 
 TEST_CASE("C-API TokenData - make_both rejects amount 0",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_both(
+    kth_token_data_mut_t td = kth_chain_token_make_both(
         kCategoryA, 0u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(td == NULL);
 }
@@ -214,16 +214,16 @@ TEST_CASE("C-API TokenData - get_amount returns 0 for pure NFT",
     // positive, so `0` unambiguously signals "no fungible payload".
     // The consensus code in transaction_basis depends on this — see
     // the comment on `get_amount` in token_data.hpp.
-    kth_token_data_mut_t td = kth_chain_token_data_make_non_fungible(
+    kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
         kCategoryA, kth_token_capability_none, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
-    REQUIRE(kth_chain_token_data_get_amount(td) == 0u);
+    REQUIRE(kth_chain_token_data_get_amount(td) == 0);
     kth_chain_token_data_destruct(td);
 }
 
 TEST_CASE("C-API TokenData - get_nft_capability is `none` for pure fungible",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 1u);
     REQUIRE(td != NULL);
     REQUIRE(kth_chain_token_data_get_nft_capability(td) == kth_token_capability_none);
     kth_chain_token_data_destruct(td);
@@ -234,7 +234,7 @@ TEST_CASE("C-API TokenData - get_nft_capability is `none` for pure fungible",
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API TokenData - copy preserves equality", "[C-API TokenData]") {
-    kth_token_data_mut_t original = kth_chain_token_data_make_both(
+    kth_token_data_mut_t original = kth_chain_token_make_both(
         kCategoryA, 42u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(original != NULL);
 
@@ -248,8 +248,8 @@ TEST_CASE("C-API TokenData - copy preserves equality", "[C-API TokenData]") {
 
 TEST_CASE("C-API TokenData - different categories compare unequal",
           "[C-API TokenData]") {
-    kth_token_data_mut_t a = kth_chain_token_data_make_fungible(kCategoryA, 1u);
-    kth_token_data_mut_t b = kth_chain_token_data_make_fungible(kCategoryB, 1u);
+    kth_token_data_mut_t a = kth_chain_token_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t b = kth_chain_token_make_fungible(kCategoryB, 1u);
 
     REQUIRE(kth_chain_token_data_equals(a, b) == 0);
 
@@ -259,8 +259,8 @@ TEST_CASE("C-API TokenData - different categories compare unequal",
 
 TEST_CASE("C-API TokenData - different amounts compare unequal",
           "[C-API TokenData]") {
-    kth_token_data_mut_t a = kth_chain_token_data_make_fungible(kCategoryA, 1u);
-    kth_token_data_mut_t b = kth_chain_token_data_make_fungible(kCategoryA, 2u);
+    kth_token_data_mut_t a = kth_chain_token_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t b = kth_chain_token_make_fungible(kCategoryA, 2u);
 
     REQUIRE(kth_chain_token_data_equals(a, b) == 0);
 
@@ -274,7 +274,7 @@ TEST_CASE("C-API TokenData - different amounts compare unequal",
 
 TEST_CASE("C-API TokenData - to_data / from_data roundtrip (fungible)",
           "[C-API TokenData]") {
-    kth_token_data_mut_t original = kth_chain_token_data_make_fungible(kCategoryA, 7777u);
+    kth_token_data_mut_t original = kth_chain_token_make_fungible(kCategoryA, 7777u);
     REQUIRE(original != NULL);
 
     kth_size_t size = 0;
@@ -283,7 +283,7 @@ TEST_CASE("C-API TokenData - to_data / from_data roundtrip (fungible)",
     REQUIRE(size == kth_chain_token_data_serialized_size(original));
 
     kth_token_data_mut_t parsed = NULL;
-    kth_error_code_t ec = kth_chain_token_data_construct_from_data(raw, size, &parsed);
+    kth_error_code_t ec = kth_chain_token_construct_from_data(raw, size, &parsed);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(parsed != NULL);
     REQUIRE(kth_chain_token_data_equals(original, parsed) != 0);
@@ -295,7 +295,7 @@ TEST_CASE("C-API TokenData - to_data / from_data roundtrip (fungible)",
 
 TEST_CASE("C-API TokenData - to_data / from_data roundtrip (both)",
           "[C-API TokenData]") {
-    kth_token_data_mut_t original = kth_chain_token_data_make_both(
+    kth_token_data_mut_t original = kth_chain_token_make_both(
         kCategoryA, 12345u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(original != NULL);
 
@@ -304,7 +304,7 @@ TEST_CASE("C-API TokenData - to_data / from_data roundtrip (both)",
     REQUIRE(raw != NULL);
 
     kth_token_data_mut_t parsed = NULL;
-    kth_error_code_t ec = kth_chain_token_data_construct_from_data(raw, size, &parsed);
+    kth_error_code_t ec = kth_chain_token_construct_from_data(raw, size, &parsed);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(parsed != NULL);
     REQUIRE(kth_chain_token_data_equals(original, parsed) != 0);
@@ -319,7 +319,7 @@ TEST_CASE("C-API TokenData - from_data with truncated input fails",
     uint8_t const truncated[5] = {0x00, 0x00, 0x00, 0x00, 0x00};
     kth_token_data_mut_t parsed = NULL;
     kth_error_code_t ec =
-        kth_chain_token_data_construct_from_data(truncated, sizeof(truncated), &parsed);
+        kth_chain_token_construct_from_data(truncated, sizeof(truncated), &parsed);
     REQUIRE(ec != kth_ec_success);
     REQUIRE(parsed == NULL);
 }
@@ -329,7 +329,7 @@ TEST_CASE("C-API TokenData - from_data with truncated input fails",
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API TokenData - set_id replaces category", "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 1u);
     REQUIRE(td != NULL);
 
     kth_chain_token_data_set_id(td, kCategoryB);
@@ -355,25 +355,25 @@ TEST_CASE("C-API TokenData - get_kind null aborts",
 TEST_CASE("C-API TokenData - construct_from_data null out aborts",
           "[C-API TokenData][precondition]") {
     KTH_EXPECT_ABORT(
-        kth_chain_token_data_construct_from_data(NULL, 0, NULL));
+        kth_chain_token_construct_from_data(NULL, 0, NULL));
 }
 
 TEST_CASE("C-API TokenData - construct_from_data non-null *out aborts",
           "[C-API TokenData][precondition]") {
-    kth_token_data_mut_t already = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t already = kth_chain_token_make_fungible(kCategoryA, 1u);
     KTH_EXPECT_ABORT(
-        kth_chain_token_data_construct_from_data(NULL, 0, &already));
+        kth_chain_token_construct_from_data(NULL, 0, &already));
     kth_chain_token_data_destruct(already);
 }
 
 TEST_CASE("C-API TokenData - to_data null out_size aborts",
           "[C-API TokenData][precondition]") {
-    kth_token_data_mut_t td = kth_chain_token_data_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 1u);
     KTH_EXPECT_ABORT(kth_chain_token_data_to_data(td, NULL));
     kth_chain_token_data_destruct(td);
 }
 
 TEST_CASE("C-API TokenData - make_fungible_unsafe null id aborts",
           "[C-API TokenData][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_token_data_make_fungible_unsafe(NULL, 1u));
+    KTH_EXPECT_ABORT(kth_chain_token_make_fungible_unsafe(NULL, 1u));
 }

--- a/src/c-api/test/wallet/wallet_data.cpp
+++ b/src/c-api/test/wallet/wallet_data.cpp
@@ -1,0 +1,166 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/string_list.h>
+#include <kth/capi/wallet/hd_public.h>
+#include <kth/capi/wallet/wallet_data.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API WalletData - destruct null is safe", "[C-API WalletData]") {
+    kth_wallet_wallet_data_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API WalletData - create with English default returns a handle",
+          "[C-API WalletData]") {
+    kth_wallet_data_mut_t wd = NULL;
+    kth_error_code_t ec = kth_wallet_create(
+        "testpassword", "testpassphrase", &wd);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(wd != NULL);
+
+    // mnemonics: 24-word BIP39 seed phrase (256-bit entropy default).
+    kth_string_list_const_t mnemonics = kth_wallet_wallet_data_mnemonics(wd);
+    REQUIRE(mnemonics != NULL);
+    REQUIRE(kth_core_string_list_count(mnemonics) == 24u);
+
+    // xpub: a non-null borrowed view.
+    kth_hd_public_const_t xpub = kth_wallet_wallet_data_xpub(wd);
+    REQUIRE(xpub != NULL);
+    REQUIRE(kth_wallet_hd_public_valid(xpub) != 0);
+
+    // encrypted_seed: fixed 96-byte struct (salt + iv + encrypted long_hash).
+    kth_encrypted_seed_t seed = kth_wallet_wallet_data_encrypted_seed(wd);
+    // Accessible; content is pseudo-random — not meaningful to assert a value.
+    (void)seed;
+
+    kth_wallet_wallet_data_destruct(wd);
+}
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API WalletData - copy preserves mnemonics count and xpub validity",
+          "[C-API WalletData]") {
+    kth_wallet_data_mut_t original = NULL;
+    REQUIRE(kth_wallet_create(
+        "pwd", "passphrase", &original) == kth_ec_success);
+
+    kth_wallet_data_mut_t copy = kth_wallet_wallet_data_copy(original);
+    REQUIRE(copy != NULL);
+    REQUIRE(copy != original);  // different heap allocations
+
+    REQUIRE(kth_core_string_list_count(kth_wallet_wallet_data_mnemonics(copy))
+            == kth_core_string_list_count(kth_wallet_wallet_data_mnemonics(original)));
+    REQUIRE(kth_wallet_hd_public_valid(kth_wallet_wallet_data_xpub(copy)) != 0);
+
+    kth_wallet_wallet_data_destruct(copy);
+    kth_wallet_wallet_data_destruct(original);
+}
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API WalletData - set_mnemonics replaces the word list",
+          "[C-API WalletData]") {
+    kth_wallet_data_mut_t wd = NULL;
+    REQUIRE(kth_wallet_create(
+        "p", "p", &wd) == kth_ec_success);
+
+    kth_string_list_mut_t replacement = kth_core_string_list_construct_default();
+    kth_core_string_list_push_back(replacement, "word-one");
+    kth_core_string_list_push_back(replacement, "word-two");
+
+    kth_wallet_wallet_data_set_mnemonics(wd, replacement);
+    REQUIRE(kth_core_string_list_count(kth_wallet_wallet_data_mnemonics(wd)) == 2u);
+
+    kth_core_string_list_destruct(replacement);
+    kth_wallet_wallet_data_destruct(wd);
+}
+
+TEST_CASE("C-API WalletData - set_encrypted_seed_unsafe round-trip",
+          "[C-API WalletData]") {
+    kth_wallet_data_mut_t wd = NULL;
+    REQUIRE(kth_wallet_create(
+        "p", "p", &wd) == kth_ec_success);
+
+    uint8_t replacement[96];
+    for (int i = 0; i < 96; ++i) replacement[i] = (uint8_t)(i & 0xff);
+
+    kth_wallet_wallet_data_set_encrypted_seed_unsafe(wd, replacement);
+
+    kth_encrypted_seed_t got = kth_wallet_wallet_data_encrypted_seed(wd);
+    REQUIRE(memcmp(got.hash, replacement, 96) == 0);
+
+    kth_wallet_wallet_data_destruct(wd);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API WalletData - copy null aborts",
+          "[C-API WalletData][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_wallet_data_copy(NULL));
+}
+
+TEST_CASE("C-API WalletData - mnemonics getter null aborts",
+          "[C-API WalletData][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_wallet_data_mnemonics(NULL));
+}
+
+TEST_CASE("C-API WalletData - create null out aborts",
+          "[C-API WalletData][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_create("p", "p", NULL));
+}
+
+TEST_CASE("C-API WalletData - create null password aborts",
+          "[C-API WalletData][precondition]") {
+    kth_wallet_data_mut_t wd = NULL;
+    KTH_EXPECT_ABORT(kth_wallet_create(NULL, "p", &wd));
+}
+
+TEST_CASE("C-API WalletData - create null passphrase aborts",
+          "[C-API WalletData][precondition]") {
+    kth_wallet_data_mut_t wd = NULL;
+    KTH_EXPECT_ABORT(kth_wallet_create("p", NULL, &wd));
+}
+
+TEST_CASE("C-API WalletData - create non-null *out aborts",
+          "[C-API WalletData][precondition]") {
+    kth_wallet_data_mut_t already = NULL;
+    REQUIRE(kth_wallet_create("p", "p", &already) == kth_ec_success);
+    KTH_EXPECT_ABORT(kth_wallet_create("p", "p", &already));
+    kth_wallet_wallet_data_destruct(already);
+}
+
+TEST_CASE("C-API WalletData - set_encrypted_seed_unsafe null aborts",
+          "[C-API WalletData][precondition]") {
+    kth_wallet_data_mut_t wd = NULL;
+    REQUIRE(kth_wallet_create("p", "p", &wd) == kth_ec_success);
+    KTH_EXPECT_ABORT(kth_wallet_wallet_data_set_encrypted_seed_unsafe(wd, NULL));
+    kth_wallet_wallet_data_destruct(wd);
+}

--- a/src/domain/include/kth/domain/chain/token_data.hpp
+++ b/src/domain/include/kth/domain/chain/token_data.hpp
@@ -127,12 +127,10 @@ using token_data_opt = std::optional<token_data_t>;
 
 // Factories.
 // ---------------------------------------------------------------------------
-// Free-function constructors for each variant arm. The generator
-// picks them up via the extra_namespaces scan and emits matching
-// `kth_chain_token_data_make_*` entry points in the C API. Taking
-// `uint64_t` instead of `amount_t` in the C++ signature keeps the
-// generated C bindings working with plain integral types without
-// the binding layer needing to know about the strong enum.
+// Free-function constructors for each variant arm. Taking `uint64_t`
+// instead of `amount_t` in the C++ signature keeps the C bindings
+// working with plain integral types without the binding layer
+// needing to know about the strong enum.
 
 inline
 token_data_t make_fungible(token_id_t id, uint64_t amount) {
@@ -220,17 +218,18 @@ token_data_t::operator bool() const {
 // ---------------------------------------------------------------------------
 
 // Returns the fungible amount carried by the token, or `0` when the
-// token has no fungible payload (i.e. it is a pure NFT). The
-// consensus code in `transaction_basis.cpp` calls this on every
-// token-bearing input/output and tallies the results by category, so
-// returning `0` for the "no fungible" case lets the math work
-// without per-token branching. Per the CashTokens spec a valid
-// fungible amount is strictly positive, so `0` unambiguously means
-// "no fungible payload" and never collides with a legitimate value.
+// token has no fungible payload (i.e. it is a pure NFT). The return
+// type is `int64_t` on purpose: `amount_t` stores the raw VLQ as
+// `uint64_t` for wire-format parity, but the CashTokens CHIP caps
+// valid amounts at `INT64_MAX`, so any observer value is guaranteed
+// to fit. The signed return also matches Bitcoin Core's `CAmount`
+// convention and keeps the consensus-code `if (a < 0) reject` guard
+// safe: an out-of-range `uint64_t` wraps to a negative `int64_t`
+// here and trips the check without callers needing to pre-validate.
 inline
-uint64_t get_amount(token_data_t const& td) {
-    if (auto const* f = std::get_if<fungible>(&td.data)) return uint64_t(f->amount);
-    if (auto const* b = std::get_if<both_kinds>(&td.data)) return uint64_t(b->fungible_part.amount);
+int64_t get_amount(token_data_t const& td) {
+    if (auto const* f = std::get_if<fungible>(&td.data)) return int64_t(f->amount);
+    if (auto const* b = std::get_if<both_kinds>(&td.data)) return int64_t(b->fungible_part.amount);
     return 0;
 }
 

--- a/src/domain/include/kth/domain/wallet/wallet_manager.hpp
+++ b/src/domain/include/kth/domain/wallet/wallet_manager.hpp
@@ -62,10 +62,16 @@ struct wallet_data {
 };
 
 std::expected<wallet_data, std::error_code>
-create_wallet(
+create(
     std::string const& password,
     std::string const& normalized_passphrase,
-    kth::domain::wallet::dictionary const& lexicon=kth::domain::wallet::language::en);
+    kth::domain::wallet::dictionary const& lexicon);
+
+inline
+std::expected<wallet_data, std::error_code>
+create(std::string const& password, std::string const& normalized_passphrase) {
+    return create(password, normalized_passphrase, kth::domain::wallet::language::en);
+}
 
 std::expected<long_hash, std::error_code>
 decrypt_seed(

--- a/src/domain/src/wallet/wallet_manager.cpp
+++ b/src/domain/src/wallet/wallet_manager.cpp
@@ -39,10 +39,10 @@ void clear_hd(T& hd) {
 }
 
 std::expected<wallet_data, std::error_code>
-create_wallet(
+create(
     std::string const& password,
     std::string const& normalized_passphrase,
-    kth::domain::wallet::dictionary const& lexicon /* =kth::domain::wallet::language::en */) {
+    kth::domain::wallet::dictionary const& lexicon) {
 
     using kth::domain::wallet::create_mnemonic;
     using kth::domain::wallet::decode_mnemonic;


### PR DESCRIPTION
## Summary

- Migrate **wallet_data** C-API to the shared const/mut split. Hardened
  factory/copy/getter/setter contracts, added the matching test suite.
- Rename `kth::domain::wallet::create_wallet` → `kth::domain::wallet::create`
  (two overloads; no default `dictionary` parameter). The C surface now
  exposes a single English-default factory `kth_wallet_create`; the old
  `kth_wallet_create_wallet` in `wallet_manager.{h,cpp}` is retired.
- Change `kth::domain::chain::get_amount` return type from `uint64_t` to
  `int64_t`. Storage stays `uint64_t` (`amount_t`) for wire-format parity,
  but the observer returns the signed `CAmount`-style value so the
  consensus `a < 0 => reject` guard is safe even on out-of-range inputs
  without per-caller narrowing. C-API and tests follow.

## Test plan

- [x] `kth_capi_test` green (new `wallet_data` tests + existing suite)
- [x] Built on Linux release
- [ ] Downstream py-native rebind (tracked separately; waiting for C-API release)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes public C-API surface (renamed functions, new const/mut handle types, and `token_data` amount type change), which can break downstream bindings and subtly affect callers’ numeric assumptions.
> 
> **Overview**
> Refactors the C-API `wallet_data` binding to a const/mut handle split (`kth_wallet_data_const_t`/`kth_wallet_data_mut_t`) and adds explicit lifecycle/copy and setter APIs; wallet creation is moved to a new `kth_wallet_create` factory (retiring `kth_wallet_create_wallet`) and the console sample is updated accordingly.
> 
> Renames `token_data` construction/factory entry points from `kth_chain_token_data_*` to `kth_chain_token_*` and changes `kth_chain_token_data_get_amount` to return `int64_t` (propagating through the domain `get_amount` accessor and tests). Adds a new Catch2 test suite for `wallet_data` and wires it into the CMake test target, plus minor cleanup in several chain/wallet getters to inline hash conversions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d17c1fee788a98ed3d6a212196ded612ba95ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet data API improved with explicit creation, copy, and setter operations; clearer const/mutable handle semantics and safer creation behavior.

* **Bug Fixes**
  * Token amount representation changed to signed integers to avoid value-range issues.

* **Tests**
  * Added comprehensive tests covering wallet data creation, copying, setters, encrypted-seed round‑trips, and precondition checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->