### PR TITLE
refactor(c-api): migrate vm::program binding; forward rvalue-ref params properly

### DIFF
--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -425,6 +425,14 @@ T* make_leaked(Args&&... args) {
     return new T(std::forward<Args>(args)...);
 }
 
+// Copy an opaque handle: deref it back into `T const&` via `cpp_ref`
+// and heap-allocate a fresh copy via `make_leaked`. Collapses the
+// generated copy-ctor body to a one-liner.
+template <typename T>
+inline T* clone(void const* h) {
+    return make_leaked<T>(cpp_ref<T>(h));
+}
+
 // Same as `make_leaked`, but gates the leak on `check_valid(&x)`.
 // The validity of the heap copy mirrors the source's validity (the
 // constructor doesn't change `operator bool`), so we test `x` BEFORE

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -198,9 +198,9 @@ typedef void const* kth_data_stack_const_t;
 
 
 // VM
-typedef void* kth_metrics_t;
-typedef void* kth_program_t;
-
+typedef void* kth_metrics_mut_t;
+typedef void const* kth_metrics_const_t;
+typedef void* kth_program_mut_t;
 typedef void const* kth_program_const_t;
 
 

--- a/src/c-api/include/kth/capi/vm/interpreter.h
+++ b/src/c-api/include/kth/capi/vm/interpreter.h
@@ -24,10 +24,10 @@ extern "C" {
 
 
 KTH_EXPORT
-kth_error_code_t kth_vm_interpreter_run(kth_program_t program);
+kth_error_code_t kth_vm_interpreter_run(kth_program_mut_t program);
 
 KTH_EXPORT
-kth_error_code_t kth_vm_interpreter_run_operation(kth_operation_t operation, kth_program_t program);
+kth_error_code_t kth_vm_interpreter_run_operation(kth_operation_t operation, kth_program_mut_t program);
 
 
 // Debug step by step
@@ -51,7 +51,7 @@ KTH_EXPORT
 kth_bool_t kth_vm_interpreter_debug_steps_available(kth_program_const_t program, kth_size_t step);
 
 KTH_EXPORT
-kth_error_code_t kth_vm_interpreter_debug_step(kth_program_const_t program, kth_size_t step, kth_size_t* out_step, kth_program_t* out_program);
+kth_error_code_t kth_vm_interpreter_debug_step(kth_program_const_t program, kth_size_t step, kth_size_t* out_step, kth_program_mut_t* out_program);
 
 KTH_EXPORT
 kth_error_code_t kth_vm_interpreter_debug_end(kth_program_const_t program);

--- a/src/c-api/include/kth/capi/vm/program.h
+++ b/src/c-api/include/kth/capi/vm/program.h
@@ -1,306 +1,247 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef KTH_CAPI_VM_PROGRAM_H_
 #define KTH_CAPI_VM_PROGRAM_H_
 
+#include <stdint.h>
+
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
+#include <kth/capi/chain/script_flags.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// class KD_API program {
-// public:
-//     using value_type = data_stack::value_type;
-//     using op_iterator = operation::iterator;
-//     using stack_iterator = data_stack::const_iterator;
-//     using stack_mutable_iterator = data_stack::iterator;
+// Constructors
 
+/** @return Owned `kth_program_mut_t`. Caller must release with `kth_vm_program_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_program_mut_t kth_vm_program_construct_default(void);
+
+/**
+ * @return Owned `kth_program_mut_t`. Caller must release with `kth_vm_program_destruct`.
+ * @param script Borrowed input. Copied by value into the resulting object; ownership of `script` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_program_mut_t kth_vm_program_construct_from_script(kth_script_const_t script);
+
+/**
+ * @return Owned `kth_program_mut_t`. Caller must release with `kth_vm_program_destruct`.
+ * @param script Borrowed input. Copied by value into the resulting object; ownership of `script` stays with the caller.
+ * @param transaction Borrowed input. Copied by value into the resulting object; ownership of `transaction` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_program_mut_t kth_vm_program_construct_from_script_transaction_input_index_flags_value(kth_script_const_t script, kth_transaction_const_t transaction, uint32_t input_index, kth_script_flags_t flags, uint64_t value);
+
+/**
+ * @return Owned `kth_program_mut_t`. Caller must release with `kth_vm_program_destruct`.
+ * @param script Borrowed input. Copied by value into the resulting object; ownership of `script` stays with the caller.
+ * @param transaction Borrowed input. Copied by value into the resulting object; ownership of `transaction` stays with the caller.
+ * @param stack Borrowed input. Copied by value into the resulting object; ownership of `stack` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_program_mut_t kth_vm_program_construct_from_script_transaction_input_index_flags_stack_value(kth_script_const_t script, kth_transaction_const_t transaction, uint32_t input_index, kth_script_flags_t flags, kth_data_stack_const_t stack, uint64_t value);
+
+/**
+ * @return Owned `kth_program_mut_t`. Caller must release with `kth_vm_program_destruct`.
+ * @param script Borrowed input. Copied by value into the resulting object; ownership of `script` stays with the caller.
+ * @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_program_mut_t kth_vm_program_construct_from_script_program(kth_script_const_t script, kth_program_const_t x);
+
+/**
+ * @return Owned `kth_program_mut_t`. Caller must release with `kth_vm_program_destruct`.
+ * @param script Borrowed input. Copied by value into the resulting object; ownership of `script` stays with the caller.
+ * @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_program_mut_t kth_vm_program_construct_from_script_program_move(kth_script_const_t script, kth_program_const_t x, kth_bool_t move);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_vm_program_destruct(kth_program_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_program_mut_t`. Caller must release with `kth_vm_program_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_program_mut_t kth_vm_program_copy(kth_program_const_t self);
+
+
+// Getters
+
+/** @return Borrowed `kth_metrics_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_metrics_const_t kth_vm_program_get_metrics(kth_program_const_t self);
 
 KTH_EXPORT
-void kth_vm_program_destruct(kth_program_t program);
-
-/// Create an instance that does not expect to verify signatures.
-/// This is useful for script utilities but not with input validation.
-/// This can only run individual operations via run(op, program).
-KTH_EXPORT
-kth_program_t kth_vm_program_construct_default(void);
-
-/// Create an instance that does not expect to verify signatures.
-/// This is useful for script utilities but not with input validation.
-/// This can run ops via run(op, program) or the script via run(program).
-KTH_EXPORT
-kth_program_t kth_vm_program_construct_from_script(kth_script_const_t script);
-
-/// Create an instance with empty stacks, value unused/max (input run).
-// program(chain::script const& script, chain::transaction const& transaction, uint32_t input_index, uint64_t forks);
-KTH_EXPORT
-kth_program_t kth_vm_program_construct_from_script_transaction(kth_script_const_t script, kth_transaction_const_t transaction, uint32_t input_index, uint64_t forks);
-
-
-/// Create an instance with initialized stack (witness run, v0 by default).
-// program(chain::script const& script, chain::transaction const& transaction, uint32_t input_index, uint64_t forks, data_stack&& stack, uint64_t value, script_version version = script_version::zero);
-// KTH_EXPORT
-// kth_program_t kth_vm_program_construct_from_script_transaction_stack(kth_script_t script, kth_transaction_t transaction, uint32_t input_index, uint64_t forks, kth_data_stack_t stack, uint64_t value, kth_script_version_t version);
-
-
-/// Create using copied tx, input, forks, value, stack (prevout run).
-// program(chain::script const& script, const program& x);
-KTH_EXPORT
-kth_program_t kth_vm_program_construct_from_script_program(kth_script_const_t script, kth_program_t program);
-
-
-/// Create using copied tx, input, forks, value and moved stack (p2sh run).
-// program(chain::script const& script, program&& x, bool move);
-KTH_EXPORT
-kth_program_t kth_vm_program_construct_from_script_program_move(kth_script_const_t script, kth_program_t program, kth_bool_t move);
+kth_script_flags_t kth_vm_program_flags(kth_program_const_t self);
 
 KTH_EXPORT
-kth_metrics_t kth_vm_program_get_metrics(kth_program_t program);
-
-// KTH_EXPORT
-// kth_metrics_t kth_vm_program_get_metrics_const(kth_program_t program);
+kth_size_t kth_vm_program_max_script_element_size(kth_program_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_vm_program_is_valid(kth_program_t program);
+kth_size_t kth_vm_program_max_integer_size_legacy(kth_program_const_t self);
 
 KTH_EXPORT
-uint64_t kth_vm_program_flags(kth_program_t program);
+kth_size_t kth_vm_program_max_integer_size(kth_program_const_t self);
 
 KTH_EXPORT
-kth_size_t kth_vm_program_max_script_element_size(kth_program_t program);
+uint32_t kth_vm_program_input_index(kth_program_const_t self);
 
 KTH_EXPORT
-kth_size_t kth_vm_program_max_integer_size_legacy(kth_program_t program);
+uint64_t kth_vm_program_value(kth_program_const_t self);
+
+/** @return Borrowed `kth_transaction_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_transaction_const_t kth_vm_program_transaction(kth_program_const_t self);
+
+/** @return Borrowed `kth_script_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_script_const_t kth_vm_program_get_script(kth_program_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_vm_program_is_chip_vm_limits_enabled(kth_program_t program);
+kth_size_t kth_vm_program_operation_count(kth_program_const_t self);
 
 KTH_EXPORT
-uint32_t kth_vm_program_input_index(kth_program_t program);
+kth_bool_t kth_vm_program_empty(kth_program_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_vm_program_top(kth_program_const_t self, kth_size_t* out_size);
+
+/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_operation_list_mut_t kth_vm_program_subscript(kth_program_const_t self);
 
 KTH_EXPORT
-uint64_t kth_vm_program_value(kth_program_t program);
-
-// KTH_EXPORT
-// kth_script_version_t kth_vm_program_version(kth_program_t program);
+kth_size_t kth_vm_program_size(kth_program_const_t self);
 
 KTH_EXPORT
-kth_transaction_const_t kth_vm_program_transaction(kth_program_t program);
-
-
-//     /// Program registers.
-//     [[nodiscard]]
-//     op_iterator begin() const;
-
-//     [[nodiscard]]
-//     op_iterator jump() const;
-
-//     [[nodiscard]]
-//     op_iterator end() const;
-
-
-// KTH_EXPORT
-// kth_operation_t kth_vm_program_begin(kth_program_t program);
-
-// KTH_EXPORT
-// kth_operation_t kth_vm_program_jump(kth_program_t program);
-
-// KTH_EXPORT
-// kth_operation_t kth_vm_program_end(kth_program_t program);
+kth_size_t kth_vm_program_conditional_stack_size(kth_program_const_t self);
 
 KTH_EXPORT
-kth_size_t kth_vm_program_operation_count(kth_program_t program);
-
-/// Instructions.
-KTH_EXPORT
-kth_error_code_t kth_vm_program_evaluate(kth_program_t program);
+kth_bool_t kth_vm_program_empty_alternate(kth_program_const_t self);
 
 KTH_EXPORT
-kth_error_code_t kth_vm_program_evaluate_operation(kth_program_t program, kth_operation_t op);
+kth_bool_t kth_vm_program_closed(kth_program_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_vm_program_increment_operation_count(kth_program_t program, kth_operation_t op);
+kth_bool_t kth_vm_program_succeeded(kth_program_const_t self);
+
+
+// Setters
+
+/** @param op Borrowed input. Copied by value into the resulting object; ownership of `op` stays with the caller. */
+KTH_EXPORT
+kth_bool_t kth_vm_program_set_jump_register(kth_program_mut_t self, kth_operation_const_t op, int32_t offset);
+
+
+// Predicates
 
 KTH_EXPORT
-kth_bool_t kth_vm_program_increment_operation_count_public_keys(kth_program_t program, int32_t public_keys);
+kth_bool_t kth_vm_program_is_valid(kth_program_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_vm_program_set_jump_register(kth_program_t program, kth_operation_t op, int32_t offset);
+kth_bool_t kth_vm_program_is_chip_vm_limits_enabled(kth_program_const_t self);
 
-
-// Primary stack.
-//-------------------------------------------------------------------------
-
-/// Primary push.
 KTH_EXPORT
-void kth_vm_program_push(kth_program_t program, kth_bool_t value);
+kth_bool_t kth_vm_program_is_bigint_enabled(kth_program_const_t self);
 
-// KTH_EXPORT
-// void kth_vm_program_push_move(kth_program_t program, kth_value_type_t item);
-
-// KTH_EXPORT
-// void kth_vm_program_push_copy(kth_program_t program, kth_value_type_t item);
-
-/// Primary pop.
-
-//     data_chunk pop();
 KTH_EXPORT
-uint8_t const* kth_vm_program_pop(kth_program_t program, kth_size_t* out_size);
+kth_bool_t kth_vm_program_is_stack_overflow_simple(kth_program_const_t self);
 
-//     bool pop(int32_t& out_value);
 KTH_EXPORT
-kth_bool_t kth_vm_program_pop_int32_t(kth_program_t program, int32_t* out_value);
+kth_bool_t kth_vm_program_is_stack_overflow(kth_program_const_t self, kth_size_t extra);
 
-//     bool pop(int64_t& out_value);
+
+// Operations
+
 KTH_EXPORT
-kth_bool_t kth_vm_program_pop_int64_t(kth_program_t program, int64_t* out_value);
+void kth_vm_program_reset_active_script(kth_program_mut_t self);
 
-//     bool pop(number& out_number, size_t maximum_size);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_number(kth_program_t program, kth_number_t out_number, kth_size_t maximum_size);
-
-//     bool pop_binary(number& first, number& second);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_binary(kth_program_t program, kth_number_t out_first, kth_number_t out_second);
-
-//     bool pop_ternary(number& first, number& second, number& third);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_ternary(kth_program_t program, kth_number_t out_first, kth_number_t out_second, kth_number_t out_third);
-
-//     bool pop_position(stack_iterator& out_position);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_position(kth_program_t program, kth_stack_iterator_t out_position);
-
-//     bool pop(data_stack& section, size_t count);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_data_stack(kth_program_t program, kth_data_stack_t out_section, kth_size_t count);
-
-/// Primary push/pop optimizations (active).
-//     void duplicate(size_t index);
 KTH_EXPORT
-void kth_vm_program_duplicate(kth_program_t program, kth_size_t index);
+kth_error_code_t kth_vm_program_evaluate_simple(kth_program_mut_t self);
 
-//     void swap(size_t index_left, size_t index_right);
 KTH_EXPORT
-void kth_vm_program_swap(kth_program_t program, kth_size_t index_left, kth_size_t index_right);
+kth_error_code_t kth_vm_program_evaluate(kth_program_mut_t self, kth_operation_const_t op);
 
-//     void erase(stack_iterator const& position);
-// KTH_EXPORT
-// void kth_vm_program_erase(kth_program_t program, kth_stack_iterator_t position);
-
-//     void erase(stack_iterator const& first, stack_iterator const& last);
-// KTH_EXPORT
-// void kth_vm_program_erase_range(kth_program_t program, kth_stack_iterator_t first, kth_stack_iterator_t last);
-
-/// Primary push/pop optimizations (passive).
-
-//     bool empty() const;
 KTH_EXPORT
-kth_bool_t kth_vm_program_empty(kth_program_t program);
+kth_bool_t kth_vm_program_increment_operation_count_operation(kth_program_mut_t self, kth_operation_const_t op);
 
-//     bool stack_true(bool clean) const;
 KTH_EXPORT
-kth_bool_t kth_vm_program_stack_true(kth_program_t program, kth_bool_t clean);
+kth_bool_t kth_vm_program_increment_operation_count_int32(kth_program_mut_t self, int32_t public_keys);
 
-//     bool stack_result(bool clean) const;
 KTH_EXPORT
-kth_bool_t kth_vm_program_stack_result(kth_program_t program, kth_bool_t clean);
+void kth_vm_program_push(kth_program_mut_t self, kth_bool_t value);
 
-//     bool is_stack_overflow() const;
 KTH_EXPORT
-kth_bool_t kth_vm_program_is_stack_overflow(kth_program_t program);
+void kth_vm_program_push_move(kth_program_mut_t self, uint8_t const* item, kth_size_t n);
 
-//     bool if_(operation const& op) const;
 KTH_EXPORT
-kth_bool_t kth_vm_program_if(kth_program_t program, kth_operation_t op);
+void kth_vm_program_push_copy(kth_program_mut_t self, uint8_t const* item, kth_size_t n);
 
-//     value_type const& item(size_t index) const;
 KTH_EXPORT
-uint8_t const* kth_vm_program_item(kth_program_t program, kth_size_t index, kth_size_t* out_size);
+void kth_vm_program_drop(kth_program_mut_t self);
 
-//     value_type& item(size_t index);
-// KTH_EXPORT
-// kth_value_type_t kth_vm_program_item_mutable(kth_program_t program, kth_size_t index);
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_vm_program_pop(kth_program_mut_t self, kth_size_t* out_size);
 
-//     data_chunk& top();
 KTH_EXPORT
-uint8_t const* kth_vm_program_top(kth_program_t program, kth_size_t* out_size);
+kth_error_code_t kth_vm_program_pop_int32(kth_program_mut_t self, int32_t* out);
 
-//     bool top(number& out_number, size_t maximum_size) const;
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_top_number(kth_program_t program, kth_number_t out_number, kth_size_t maximum_size);
-
-//     stack_iterator position(size_t index) const;
-// KTH_EXPORT
-// kth_stack_iterator_t kth_vm_program_position(kth_program_t program, kth_size_t index);
-
-//     stack_mutable_iterator position(size_t index);
-// KTH_EXPORT
-// kth_stack_mutable_iterator_t kth_vm_program_position_mutable(kth_program_t program, kth_size_t index);
-
-//     size_t index(stack_iterator const& position) const;
-// KTH_EXPORT
-// kth_size_t kth_vm_program_index(kth_program_t program, kth_stack_iterator_t position);
-
-//     operation::list subscript() const;
 KTH_EXPORT
-kth_operation_list_t kth_vm_program_subscript(kth_program_t program);
+kth_error_code_t kth_vm_program_pop_int64(kth_program_mut_t self, int64_t* out);
 
-//     size_t size() const;
 KTH_EXPORT
-kth_size_t kth_vm_program_size(kth_program_t program);
+kth_error_code_t kth_vm_program_pop_index(kth_program_mut_t self, uint32_t* out);
 
-
-// Alternate stack.
-
-//     bool empty_alternate() const;
 KTH_EXPORT
-kth_bool_t kth_vm_program_empty_alternate(kth_program_t program);
+void kth_vm_program_duplicate(kth_program_mut_t self, kth_size_t index);
 
-//     void push_alternate(value_type&& value);
-// KTH_EXPORT
-// void kth_vm_program_push_alternate(kth_program_t program, kth_value_type_t value);
-
-//     value_type pop_alternate();
-// KTH_EXPORT
-// kth_value_type_t kth_vm_program_pop_alternate(kth_program_t program);
-
-// Conditional stack.
-//-------------------------------------------------------------------------
-
-//     void open(bool value);
 KTH_EXPORT
-void kth_vm_program_open(kth_program_t program, kth_bool_t value);
+void kth_vm_program_swap(kth_program_mut_t self, kth_size_t index_left, kth_size_t index_right);
 
-//     void negate();
 KTH_EXPORT
-void kth_vm_program_negate(kth_program_t program);
+kth_bool_t kth_vm_program_stack_true(kth_program_const_t self, kth_bool_t clean);
 
-//     void close();
 KTH_EXPORT
-void kth_vm_program_close(kth_program_t program);
+kth_bool_t kth_vm_program_stack_result(kth_program_const_t self, kth_bool_t clean);
 
-//     bool closed() const;
 KTH_EXPORT
-kth_bool_t kth_vm_program_closed(kth_program_t program);
+kth_bool_t kth_vm_program_if_(kth_program_const_t self, kth_operation_const_t op);
 
-//     bool succeeded() const;
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_vm_program_item(kth_program_const_t self, kth_size_t index, kth_size_t* out_size);
+
 KTH_EXPORT
-kth_bool_t kth_vm_program_succeeded(kth_program_t program);
+void kth_vm_program_push_alternate(kth_program_mut_t self, uint8_t const* value, kth_size_t n);
 
-//     size_t conditional_stack_size() const;
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_vm_program_pop_alternate(kth_program_mut_t self, kth_size_t* out_size);
+
 KTH_EXPORT
-kth_size_t kth_vm_program_conditional_stack_size(kth_program_t program);
+void kth_vm_program_open(kth_program_mut_t self, kth_bool_t value);
 
+KTH_EXPORT
+void kth_vm_program_negate(kth_program_mut_t self);
 
+KTH_EXPORT
+void kth_vm_program_close(kth_program_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-
-#endif /* KTH_CAPI_VM_PROGRAM_H_ */
+#endif // KTH_CAPI_VM_PROGRAM_H_

--- a/src/c-api/src/vm/interpreter.cpp
+++ b/src/c-api/src/vm/interpreter.cpp
@@ -25,12 +25,12 @@ extern "C" {
     // code run(operation const& op, program& program);
 
 
-kth_error_code_t kth_vm_interpreter_run(kth_program_t program) {
+kth_error_code_t kth_vm_interpreter_run(kth_program_mut_t program) {
     auto const result = kth::domain::machine::interpreter::run(kth::cpp_ref<kth::domain::machine::program>(program));
     return kth::to_c_err(result);
 }
 
-kth_error_code_t kth_vm_interpreter_run_operation(kth_operation_t operation, kth_program_t program) {
+kth_error_code_t kth_vm_interpreter_run_operation(kth_operation_t operation, kth_program_mut_t program) {
     auto const result = kth::domain::machine::interpreter::run(
         kth::cpp_ref<kth::domain::machine::operation>(operation),
         kth::cpp_ref<kth::domain::machine::program>(program)
@@ -63,7 +63,7 @@ kth_bool_t kth_vm_interpreter_debug_steps_available(kth_program_const_t program,
     return kth::domain::machine::interpreter::debug_steps_available(kth::cpp_ref<kth::domain::machine::program>(program), step);
 }
 
-kth_error_code_t kth_vm_interpreter_debug_step(kth_program_const_t program, kth_size_t step, kth_size_t* out_step, kth_program_t* out_program) {
+kth_error_code_t kth_vm_interpreter_debug_step(kth_program_const_t program, kth_size_t step, kth_size_t* out_step, kth_program_mut_t* out_program) {
     auto const [err, new_step, new_program_cpp] = kth::domain::machine::interpreter::debug_step(kth::cpp_ref<kth::domain::machine::program>(program), step);
     *out_step = new_step;
     *out_program = kth::make_leaked(std::move(new_program_cpp));

--- a/src/c-api/src/vm/program.cpp
+++ b/src/c-api/src/vm/program.cpp
@@ -1,456 +1,372 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <kth/capi/vm/program.h>
 
-#include <kth/capi/helpers.hpp>
 #include <kth/capi/conversions.hpp>
-
+#include <kth/capi/helpers.hpp>
 #include <kth/domain/machine/program.hpp>
+
 // ---------------------------------------------------------------------------
 extern "C" {
 
-void kth_vm_program_destruct(kth_program_t program) {
-    delete &kth::cpp_ref<kth::domain::machine::program>(program);
+// Constructors
+
+kth_program_mut_t kth_vm_program_construct_default(void) {
+    return kth::make_leaked<kth::domain::machine::program>();
 }
 
-// kth_payment_address_t kth_wallet_payment_address_construct_from_string(char const* address) {
-//     return new kth::domain::wallet::payment_address(std::string(address));
-// }
-
-kth_program_t kth_vm_program_construct_default() {
-    return new kth::domain::machine::program();
-}
-
-kth_program_t kth_vm_program_construct_from_script(kth_script_const_t script) {
+kth_program_mut_t kth_vm_program_construct_from_script(kth_script_const_t script) {
+    KTH_PRECONDITION(script != nullptr);
     auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
-    return new kth::domain::machine::program(script_cpp);
+    return kth::make_leaked<kth::domain::machine::program>(script_cpp);
 }
 
-// program(chain::script const& script, chain::transaction const& transaction, uint32_t input_index, uint64_t forks);
-kth_program_t kth_vm_program_construct_from_script_transaction(kth_script_const_t script, kth_transaction_const_t transaction, uint32_t input_index, uint64_t forks) {
+kth_program_mut_t kth_vm_program_construct_from_script_transaction_input_index_flags_value(kth_script_const_t script, kth_transaction_const_t transaction, uint32_t input_index, kth_script_flags_t flags, uint64_t value) {
+    KTH_PRECONDITION(script != nullptr);
+    KTH_PRECONDITION(transaction != nullptr);
     auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
     auto const& transaction_cpp = kth::cpp_ref<kth::domain::chain::transaction>(transaction);
-    return new kth::domain::machine::program(script_cpp, transaction_cpp, input_index, forks);
+    return kth::make_leaked<kth::domain::machine::program>(script_cpp, transaction_cpp, input_index, flags, value);
 }
 
-// program(chain::script const& script, chain::transaction const& transaction, uint32_t input_index, uint64_t forks, data_stack&& stack, uint64_t value, script_version version = script_version::zero);
-// kth_program_t kth_vm_program_construct_from_script_transaction_stack(kth_script_t script, kth_transaction_t transaction, uint32_t input_index, uint64_t forks, kth_data_stack_t stack, uint64_t value, kth_script_version_t version);
-
-// program(chain::script const& script, program const& x);
-kth_program_t kth_vm_program_construct_from_script_program(kth_script_const_t script, kth_program_t program) {
+kth_program_mut_t kth_vm_program_construct_from_script_transaction_input_index_flags_stack_value(kth_script_const_t script, kth_transaction_const_t transaction, uint32_t input_index, kth_script_flags_t flags, kth_data_stack_const_t stack, uint64_t value) {
+    KTH_PRECONDITION(script != nullptr);
+    KTH_PRECONDITION(transaction != nullptr);
+    KTH_PRECONDITION(stack != nullptr);
     auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
-    auto const& program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return new kth::domain::machine::program(script_cpp, kth::cpp_ref<kth::domain::machine::program>(program));
+    auto const& transaction_cpp = kth::cpp_ref<kth::domain::chain::transaction>(transaction);
+    auto stack_cpp = kth::cpp_ref<kth::data_stack>(stack);
+    return kth::make_leaked<kth::domain::machine::program>(script_cpp, transaction_cpp, input_index, flags, std::move(stack_cpp), value);
 }
 
-// // program(chain::script const& script, program&& x, bool move);
-// kth_program_t kth_vm_program_construct_from_script_program_move(kth_script_t script, kth_program_t program, kth_bool_t move) {
-//     auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
-//     auto const& program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-//     return new kth::domain::machine::program(script_cpp, std::move(), kth::int_to_bool(move));
-// }
-
-kth_metrics_t kth_vm_program_get_metrics(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::ref_to_c(kth::cpp_ref<kth::domain::machine::program>(program).get_metrics());
+kth_program_mut_t kth_vm_program_construct_from_script_program(kth_script_const_t script, kth_program_const_t x) {
+    KTH_PRECONDITION(script != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
+    auto const& x_cpp = kth::cpp_ref<kth::domain::machine::program>(x);
+    return kth::make_leaked<kth::domain::machine::program>(script_cpp, x_cpp);
 }
 
-// KTH_EXPORT
-// kth_metrics_t kth_vm_program_get_metrics_const(kth_program_t program);
-
-kth_bool_t kth_vm_program_is_valid(kth_program_t program) {
-    // auto const& program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).is_valid());
-}
-
-uint64_t kth_vm_program_flags(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::cpp_ref<kth::domain::machine::program>(program).flags();
-}
-
-kth_size_t kth_vm_program_max_script_element_size(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::cpp_ref<kth::domain::machine::program>(program).max_script_element_size();
-}
-
-kth_size_t kth_vm_program_max_integer_size_legacy(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::cpp_ref<kth::domain::machine::program>(program).max_integer_size_legacy();
-}
-
-kth_bool_t kth_vm_program_is_chip_vm_limits_enabled(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).is_chip_vm_limits_enabled());
-}
-
-uint32_t kth_vm_program_input_index(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::cpp_ref<kth::domain::machine::program>(program).input_index();
-}
-
-uint64_t kth_vm_program_value(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::cpp_ref<kth::domain::machine::program>(program).value();
-}
-
-// TODO:
-// kth_script_version_t kth_vm_program_version(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-//     return kth::cpp_ref<kth::domain::machine::program>(program).version();
-// }
-
-
-kth_transaction_const_t kth_vm_program_transaction(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    // return kth::ref_to_c(kth::cpp_ref<kth::domain::machine::program>(program).transaction());
-    return &kth::cpp_ref<kth::domain::machine::program>(program).transaction();
+kth_program_mut_t kth_vm_program_construct_from_script_program_move(kth_script_const_t script, kth_program_const_t x, kth_bool_t move) {
+    KTH_PRECONDITION(script != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
+    auto x_cpp = kth::cpp_ref<kth::domain::machine::program>(x);
+    auto const move_cpp = kth::int_to_bool(move);
+    return kth::make_leaked<kth::domain::machine::program>(script_cpp, std::move(x_cpp), move_cpp);
 }
 
 
-//     /// Program registers.
-//     [[nodiscard]]
-//     op_iterator begin() const;
+// Destructor
 
-//     [[nodiscard]]
-//     op_iterator jump() const;
-
-//     [[nodiscard]]
-//     op_iterator end() const;
-
-
-// KTH_EXPORT
-// kth_operation_t kth_vm_program_begin(kth_program_t program);
-
-// KTH_EXPORT
-// kth_operation_t kth_vm_program_jump(kth_program_t program);
-
-// KTH_EXPORT
-// kth_operation_t kth_vm_program_end(kth_program_t program);
-
-kth_size_t kth_vm_program_operation_count(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::cpp_ref<kth::domain::machine::program>(program).operation_count();
+void kth_vm_program_destruct(kth_program_mut_t self) {
+    if (self == nullptr) return;
+    delete &kth::cpp_ref<kth::domain::machine::program>(self);
 }
 
-kth_error_code_t kth_vm_program_evaluate(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::to_c_err(kth::cpp_ref<kth::domain::machine::program>(program).evaluate());
+
+// Copy
+
+kth_program_mut_t kth_vm_program_copy(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<kth::domain::machine::program>(self);
 }
 
-kth_error_code_t kth_vm_program_evaluate_operation(kth_program_t program, kth_operation_t op) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    auto op_cpp = kth::cpp_ref<kth::domain::machine::operation>(op);
-    return kth::to_c_err(kth::cpp_ref<kth::domain::machine::program>(program).evaluate(op_cpp));
+
+// Getters
+
+kth_metrics_const_t kth_vm_program_get_metrics(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<kth::domain::machine::program>(self).get_metrics());
 }
 
-kth_bool_t kth_vm_program_increment_operation_count(kth_program_t program, kth_operation_t op) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    auto op_cpp = kth::cpp_ref<kth::domain::machine::operation>(op);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).increment_operation_count(op_cpp));
+kth_script_flags_t kth_vm_program_flags(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<kth::domain::machine::program>(self).flags();
 }
 
-kth_bool_t kth_vm_program_increment_operation_count_public_keys(kth_program_t program, int32_t public_keys) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).increment_operation_count(public_keys));
+kth_size_t kth_vm_program_max_script_element_size(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<kth::domain::machine::program>(self).max_script_element_size();
 }
 
-kth_bool_t kth_vm_program_set_jump_register(kth_program_t program, kth_operation_t op, int32_t offset) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    auto op_cpp = kth::cpp_ref<kth::domain::machine::operation>(op);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).set_jump_register(op_cpp, offset));
+kth_size_t kth_vm_program_max_integer_size_legacy(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<kth::domain::machine::program>(self).max_integer_size_legacy();
 }
 
-void kth_vm_program_push(kth_program_t program, kth_bool_t value) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    kth::cpp_ref<kth::domain::machine::program>(program).push(kth::int_to_bool(value));
+kth_size_t kth_vm_program_max_integer_size(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<kth::domain::machine::program>(self).max_integer_size();
 }
 
-// void kth_vm_program_push_move(kth_program_t program, kth_value_type_t item) {
-//     auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-//     kth::cpp_ref<kth::domain::machine::program>(program).push_move(item);
-// }
+uint32_t kth_vm_program_input_index(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<kth::domain::machine::program>(self).input_index();
+}
 
-// void kth_vm_program_push_copy(kth_program_t program, kth_value_type_t item) {
-//     auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-//     kth::cpp_ref<kth::domain::machine::program>(program).push_copy(item);
-// }
+uint64_t kth_vm_program_value(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<kth::domain::machine::program>(self).value();
+}
 
+kth_transaction_const_t kth_vm_program_transaction(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<kth::domain::machine::program>(self).transaction());
+}
 
-uint8_t const* kth_vm_program_pop(kth_program_t program, kth_size_t* out_size) {
-    auto data = kth::cpp_ref<kth::domain::machine::program>(program).pop();
+kth_script_const_t kth_vm_program_get_script(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<kth::domain::machine::program>(self).get_script());
+}
+
+kth_size_t kth_vm_program_operation_count(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<kth::domain::machine::program>(self).operation_count();
+}
+
+kth_bool_t kth_vm_program_empty(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).empty());
+}
+
+uint8_t* kth_vm_program_top(kth_program_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const& data = kth::cpp_ref<kth::domain::machine::program>(self).top();
     return kth::create_c_array(data, *out_size);
 }
 
-//     std::expected<int32_t, error_code_t> pop_int32();
-kth_bool_t kth_vm_program_pop_int32_t(kth_program_t program, int32_t* out_value) {
-    auto result = kth::cpp_ref<kth::domain::machine::program>(program).pop_int32();
-    if ( ! result) return kth::bool_to_int(false);
-    *out_value = *result;
-    return kth::bool_to_int(true);
+kth_operation_list_mut_t kth_vm_program_subscript(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::make_leaked<kth::domain::machine::operation::list>(kth::cpp_ref<kth::domain::machine::program>(self).subscript());
 }
 
-//     std::expected<int64_t, error_code_t> pop_int64();
-kth_bool_t kth_vm_program_pop_int64_t(kth_program_t program, int64_t* out_value) {
-    auto result = kth::cpp_ref<kth::domain::machine::program>(program).pop_int64();
-    if ( ! result) return kth::bool_to_int(false);
-    *out_value = *result;
-    return kth::bool_to_int(true);
+kth_size_t kth_vm_program_size(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<kth::domain::machine::program>(self).size();
 }
 
-//     bool pop(number& out_number, size_t maximum_size);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_number(kth_program_t program, kth_number_t out_number, kth_size_t maximum_size);
-
-//     bool pop_binary(number& first, number& second);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_binary(kth_program_t program, kth_number_t out_first, kth_number_t out_second);
-
-//     bool pop_ternary(number& first, number& second, number& third);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_ternary(kth_program_t program, kth_number_t out_first, kth_number_t out_second, kth_number_t out_third);
-
-//     bool pop_position(stack_iterator& out_position);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_position(kth_program_t program, kth_stack_iterator_t out_position);
-
-//     bool pop(data_stack& section, size_t count);
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_pop_data_stack(kth_program_t program, kth_data_stack_t out_section, kth_size_t count);
-
-//     void duplicate(size_t index);
-void kth_vm_program_duplicate(kth_program_t program, kth_size_t index) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    kth::cpp_ref<kth::domain::machine::program>(program).duplicate(index);
+kth_size_t kth_vm_program_conditional_stack_size(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<kth::domain::machine::program>(self).conditional_stack_size();
 }
 
-//     void swap(size_t index_left, size_t index_right);
-void kth_vm_program_swap(kth_program_t program, kth_size_t index_left, kth_size_t index_right) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    kth::cpp_ref<kth::domain::machine::program>(program).swap(index_left, index_right);
+kth_bool_t kth_vm_program_empty_alternate(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).empty_alternate());
 }
 
-//     void erase(stack_iterator const& position);
-// KTH_EXPORT
-// void kth_vm_program_erase(kth_program_t program, kth_stack_iterator_t position);
-
-//     void erase(stack_iterator const& first, stack_iterator const& last);
-// KTH_EXPORT
-// void kth_vm_program_erase_range(kth_program_t program, kth_stack_iterator_t first, kth_stack_iterator_t last);
-
-/// Primary push/pop optimizations (passive).
-
-//     bool empty() const;
-kth_bool_t kth_vm_program_empty(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).empty());
+kth_bool_t kth_vm_program_closed(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).closed());
 }
 
-//     bool stack_true(bool clean) const;
-kth_bool_t kth_vm_program_stack_true(kth_program_t program, kth_bool_t clean) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).stack_true(kth::int_to_bool(clean)));
+kth_bool_t kth_vm_program_succeeded(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).succeeded());
 }
 
-//     bool stack_result(bool clean) const;
-kth_bool_t kth_vm_program_stack_result(kth_program_t program, kth_bool_t clean) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).stack_result(kth::int_to_bool(clean)));
+
+// Setters
+
+kth_bool_t kth_vm_program_set_jump_register(kth_program_mut_t self, kth_operation_const_t op, int32_t offset) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(op != nullptr);
+    auto const& op_cpp = kth::cpp_ref<kth::domain::machine::operation>(op);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).set_jump_register(op_cpp, offset));
 }
 
-//     bool is_stack_overflow() const;
-kth_bool_t kth_vm_program_is_stack_overflow(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).is_stack_overflow());
+
+// Predicates
+
+kth_bool_t kth_vm_program_is_valid(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).is_valid());
 }
 
-//     bool if_(operation const& op) const;
-kth_bool_t kth_vm_program_if(kth_program_t program, kth_operation_t op) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    auto op_cpp = kth::cpp_ref<kth::domain::machine::operation>(op);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).if_(op_cpp));
+kth_bool_t kth_vm_program_is_chip_vm_limits_enabled(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).is_chip_vm_limits_enabled());
 }
 
-//     value_type const& item(size_t index) const;
-// kth_value_type_t kth_vm_program_item(kth_program_t program, kth_size_t index) {
-//     auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-//     return kth::cpp_ref<kth::domain::machine::program>(program).item(index);
-// }
-uint8_t const* kth_vm_program_item(kth_program_t program, kth_size_t index, kth_size_t* out_size) {
-    auto data = kth::cpp_ref<kth::domain::machine::program>(program).item(index);
+kth_bool_t kth_vm_program_is_bigint_enabled(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).is_bigint_enabled());
+}
+
+kth_bool_t kth_vm_program_is_stack_overflow_simple(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).is_stack_overflow());
+}
+
+kth_bool_t kth_vm_program_is_stack_overflow(kth_program_const_t self, kth_size_t extra) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const extra_cpp = static_cast<size_t>(extra);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).is_stack_overflow(extra_cpp));
+}
+
+
+// Operations
+
+void kth_vm_program_reset_active_script(kth_program_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<kth::domain::machine::program>(self).reset_active_script();
+}
+
+kth_error_code_t kth_vm_program_evaluate_simple(kth_program_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::to_c_err(kth::cpp_ref<kth::domain::machine::program>(self).evaluate());
+}
+
+kth_error_code_t kth_vm_program_evaluate(kth_program_mut_t self, kth_operation_const_t op) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(op != nullptr);
+    auto const& op_cpp = kth::cpp_ref<kth::domain::machine::operation>(op);
+    return kth::to_c_err(kth::cpp_ref<kth::domain::machine::program>(self).evaluate(op_cpp));
+}
+
+kth_bool_t kth_vm_program_increment_operation_count_operation(kth_program_mut_t self, kth_operation_const_t op) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(op != nullptr);
+    auto const& op_cpp = kth::cpp_ref<kth::domain::machine::operation>(op);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).increment_operation_count(op_cpp));
+}
+
+kth_bool_t kth_vm_program_increment_operation_count_int32(kth_program_mut_t self, int32_t public_keys) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).increment_operation_count(public_keys));
+}
+
+void kth_vm_program_push(kth_program_mut_t self, kth_bool_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth::int_to_bool(value);
+    kth::cpp_ref<kth::domain::machine::program>(self).push(value_cpp);
+}
+
+void kth_vm_program_push_move(kth_program_mut_t self, uint8_t const* item, kth_size_t n) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(item != nullptr || n == 0);
+    auto item_cpp = n != 0 ? kth::data_chunk(item, item + n) : kth::data_chunk{};
+    kth::cpp_ref<kth::domain::machine::program>(self).push_move(std::move(item_cpp));
+}
+
+void kth_vm_program_push_copy(kth_program_mut_t self, uint8_t const* item, kth_size_t n) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(item != nullptr || n == 0);
+    auto const item_cpp = n != 0 ? kth::data_chunk(item, item + n) : kth::data_chunk{};
+    kth::cpp_ref<kth::domain::machine::program>(self).push_copy(item_cpp);
+}
+
+void kth_vm_program_drop(kth_program_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<kth::domain::machine::program>(self).drop();
+}
+
+uint8_t* kth_vm_program_pop(kth_program_mut_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth::cpp_ref<kth::domain::machine::program>(self).pop();
     return kth::create_c_array(data, *out_size);
 }
 
-//     value_type& item(size_t index);
-// KTH_EXPORT
-// kth_value_type_t kth_vm_program_item_mutable(kth_program_t program, kth_size_t index);
+kth_error_code_t kth_vm_program_pop_int32(kth_program_mut_t self, int32_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    auto const result = kth::cpp_ref<kth::domain::machine::program>(self).pop_int32();
+    if ( ! result) return static_cast<kth_error_code_t>(result.error());
+    *out = static_cast<int32_t>(*result);
+    return kth_ec_success;
+}
 
-//     data_chunk& top();
-uint8_t const* kth_vm_program_top(kth_program_t program, kth_size_t* out_size) {
-    auto data = kth::cpp_ref<kth::domain::machine::program>(program).top();
+kth_error_code_t kth_vm_program_pop_int64(kth_program_mut_t self, int64_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    auto const result = kth::cpp_ref<kth::domain::machine::program>(self).pop_int64();
+    if ( ! result) return static_cast<kth_error_code_t>(result.error());
+    *out = static_cast<int64_t>(*result);
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_vm_program_pop_index(kth_program_mut_t self, uint32_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    auto const result = kth::cpp_ref<kth::domain::machine::program>(self).pop_index();
+    if ( ! result) return static_cast<kth_error_code_t>(result.error());
+    *out = static_cast<uint32_t>(*result);
+    return kth_ec_success;
+}
+
+void kth_vm_program_duplicate(kth_program_mut_t self, kth_size_t index) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const index_cpp = static_cast<size_t>(index);
+    kth::cpp_ref<kth::domain::machine::program>(self).duplicate(index_cpp);
+}
+
+void kth_vm_program_swap(kth_program_mut_t self, kth_size_t index_left, kth_size_t index_right) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const index_left_cpp = static_cast<size_t>(index_left);
+    auto const index_right_cpp = static_cast<size_t>(index_right);
+    kth::cpp_ref<kth::domain::machine::program>(self).swap(index_left_cpp, index_right_cpp);
+}
+
+kth_bool_t kth_vm_program_stack_true(kth_program_const_t self, kth_bool_t clean) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const clean_cpp = kth::int_to_bool(clean);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).stack_true(clean_cpp));
+}
+
+kth_bool_t kth_vm_program_stack_result(kth_program_const_t self, kth_bool_t clean) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const clean_cpp = kth::int_to_bool(clean);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).stack_result(clean_cpp));
+}
+
+kth_bool_t kth_vm_program_if_(kth_program_const_t self, kth_operation_const_t op) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(op != nullptr);
+    auto const& op_cpp = kth::cpp_ref<kth::domain::machine::operation>(op);
+    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(self).if_(op_cpp));
+}
+
+uint8_t* kth_vm_program_item(kth_program_const_t self, kth_size_t index, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const index_cpp = static_cast<size_t>(index);
+    auto const& data = kth::cpp_ref<kth::domain::machine::program>(self).item(index_cpp);
     return kth::create_c_array(data, *out_size);
 }
 
-//     bool top(number& out_number, size_t maximum_size) const;
-// KTH_EXPORT
-// kth_bool_t kth_vm_program_top_number(kth_program_t program, kth_number_t out_number, kth_size_t maximum_size);
-
-//     stack_iterator position(size_t index) const;
-// KTH_EXPORT
-// kth_stack_iterator_t kth_vm_program_position(kth_program_t program, kth_size_t index);
-
-//     stack_mutable_iterator position(size_t index);
-// KTH_EXPORT
-// kth_stack_mutable_iterator_t kth_vm_program_position_mutable(kth_program_t program, kth_size_t index);
-
-//     size_t index(stack_iterator const& position) const;
-// KTH_EXPORT
-// kth_size_t kth_vm_program_index(kth_program_t program, kth_stack_iterator_t position);
-
-//     operation::list subscript() const;
-kth_operation_list_t kth_vm_program_subscript(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    auto ops = kth::cpp_ref<kth::domain::machine::program>(program).subscript();
-    return kth::make_leaked(std::move(ops));
+void kth_vm_program_push_alternate(kth_program_mut_t self, uint8_t const* value, kth_size_t n) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(value != nullptr || n == 0);
+    auto value_cpp = n != 0 ? kth::data_chunk(value, value + n) : kth::data_chunk{};
+    kth::cpp_ref<kth::domain::machine::program>(self).push_alternate(std::move(value_cpp));
 }
 
-//     size_t size() const;
-kth_size_t kth_vm_program_size(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::cpp_ref<kth::domain::machine::program>(program).size();
+uint8_t* kth_vm_program_pop_alternate(kth_program_mut_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth::cpp_ref<kth::domain::machine::program>(self).pop_alternate();
+    return kth::create_c_array(data, *out_size);
 }
 
-//     bool empty_alternate() const;
-kth_bool_t kth_vm_program_empty_alternate(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).empty_alternate());
+void kth_vm_program_open(kth_program_mut_t self, kth_bool_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const value_cpp = kth::int_to_bool(value);
+    kth::cpp_ref<kth::domain::machine::program>(self).open(value_cpp);
 }
 
-//     void push_alternate(value_type&& value);
-// KTH_EXPORT
-// void kth_vm_program_push_alternate(kth_program_t program, kth_value_type_t value);
-
-//     value_type pop_alternate();
-// KTH_EXPORT
-// kth_value_type_t kth_vm_program_pop_alternate(kth_program_t program);
-
-// Conditional stack.
-//-------------------------------------------------------------------------
-
-//     void open(bool value);
-void kth_vm_program_open(kth_program_t program, kth_bool_t value) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    kth::cpp_ref<kth::domain::machine::program>(program).open(kth::int_to_bool(value));
+void kth_vm_program_negate(kth_program_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<kth::domain::machine::program>(self).negate();
 }
 
-//     void negate();
-void kth_vm_program_negate(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    kth::cpp_ref<kth::domain::machine::program>(program).negate();
+void kth_vm_program_close(kth_program_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<kth::domain::machine::program>(self).close();
 }
-
-//     void close();
-void kth_vm_program_close(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    kth::cpp_ref<kth::domain::machine::program>(program).close();
-}
-
-//     bool closed() const;
-kth_bool_t kth_vm_program_closed(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).closed());
-}
-
-//     bool succeeded() const;
-kth_bool_t kth_vm_program_succeeded(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::bool_to_int(kth::cpp_ref<kth::domain::machine::program>(program).succeeded());
-}
-
-//     size_t conditional_stack_size() const;
-kth_size_t kth_vm_program_conditional_stack_size(kth_program_t program) {
-    // auto program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
-    return kth::cpp_ref<kth::domain::machine::program>(program).conditional_stack_size();
-}
-
-
-
-
-// kth_payment_address_t kth_wallet_payment_address_construct_from_short_hash(kth_shorthash_t const* hash, uint8_t version) {
-//     auto const hash_cpp = kth::short_hash_to_cpp(hash->hash);
-//     return new kth::domain::wallet::payment_address(hash_cpp, version);
-// }
-
-// kth_payment_address_t kth_wallet_payment_address_construct_from_point(kth_ec_public_t point, uint8_t version) {
-//     auto const point_cpp = kth::cpp_ref<kth::domain::wallet::ec_public>(point);
-//     return new kth::domain::wallet::payment_address(point_cpp, version);
-// }
-
-// kth_payment_address_t kth_wallet_payment_address_construct_from_script(kth_script_t script, uint8_t version) {
-//     auto const& script_cpp = kth::cpp_ref<kth::domain::chain::script>(script);
-//     return new kth::domain::wallet::payment_address(script_cpp, version);
-// }
-
-// void kth_wallet_payment_address_destruct(kth_payment_address_t payment_address) {
-//     delete &kth_wallet_payment_address_cpp(payment_address);
-// }
-
-// #if defined(KTH_CURRENCY_BCH)
-// void kth_wallet_payment_address_set_cashaddr_prefix(char const* prefix) {
-//     std::string prefix_cpp(prefix);
-//     kth::set_cashaddr_prefix(prefix_cpp);
-// }
-// #endif //KTH_CURRENCY_BCH
-
-// //User is responsible for releasing return value memory
-// char* kth_wallet_payment_address_encoded_legacy(kth_payment_address_t payment_address) {
-//     std::string str = kth::cpp_ref<kth::domain::wallet::payment_address>(payment_address).encoded_legacy();
-//     return kth::create_c_str(str);
-// }
-
-// #if defined(KTH_CURRENCY_BCH)
-// //User is responsible for releasing return value memory
-// char* kth_wallet_payment_address_encoded_cashaddr(kth_payment_address_t payment_address, kth_bool_t token_aware) {
-//     std::string str = kth::cpp_ref<kth::domain::wallet::payment_address>(payment_address).encoded_cashaddr(token_aware);
-//     return kth::create_c_str(str);
-// }
-// #endif //KTH_CURRENCY_BCH
-
-// kth_shorthash_t kth_wallet_payment_address_hash20(kth_payment_address_t payment_address) {
-//     auto hash_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(payment_address).hash20();
-//     return kth::to_shorthash_t(hash_cpp);
-// }
-
-// kth_hash_t kth_wallet_payment_address_hash32(kth_payment_address_t payment_address) {
-//     auto hash_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(payment_address).hash32();
-//     return kth::to_hash_t(hash_cpp);
-// }
-
-// uint8_t kth_wallet_payment_address_version(kth_payment_address_t payment_address) {
-//     return kth::cpp_ref<kth::domain::wallet::payment_address>(payment_address).version();
-// }
-
-// kth_bool_t kth_wallet_payment_address_is_valid(kth_payment_address_t payment_address) {
-//     return kth::bool_to_int(bool(kth::cpp_ref<kth::domain::wallet::payment_address>(payment_address)));
-// }
-
-// // payment_address_list_t kth_wallet_payment_address_extract(chain::script_t const* script, uint8_t p2kh_version, uint8_t p2sh_version) {
-// //     kth::chain::script kth_script = kth::cpp_ref<kth::domain::chain::script>(script);
-// //     auto list = kth::domain::wallet::payment_address::extract(kth_script, p2kh_version, p2sh_version);
-// //     return kth_wallet_payment_address_list_to_capi(new std::vector<kth::domain::wallet::payment_address>(list));
-// // }
-
-// // payment_address_list_t kth_wallet_payment_address_extract_input(chain::script_t const* script, uint8_t p2kh_version, uint8_t p2sh_version) {
-// //     kth::chain::script kth_script = kth::cpp_ref<kth::domain::chain::script>(script);
-// //     auto list = kth::domain::wallet::payment_address::extract_input(kth_script, p2kh_version, p2sh_version);
-// //     return kth_wallet_payment_address_list_to_capi(new std::vector<kth::domain::wallet::payment_address>(list));
-// // }
-
-// // payment_address_list_t kth_wallet_payment_address_extract_output(chain::script_t const* script, uint8_t p2kh_version, uint8_t p2sh_version) {
-// //     kth::chain::script kth_script = kth::cpp_ref<kth::domain::chain::script>(script);
-// //     auto list = kth::domain::wallet::payment_address::extract_output(kth_script, p2kh_version, p2sh_version);
-// //     return kth_wallet_payment_address_list_to_capi(new std::vector<kth::domain::wallet::payment_address>(list));
-// // }
 
 } // extern "C"


### PR DESCRIPTION
> Based on #264 (rvalue-ref handling in the binding tool lives there). Review scope of this PR is only the program / interpreter migration — merge #264 first and this PR rebases cleanly.

## Summary

- Migrate **vm::program** to the shared const/mut handle split. Generated binding covers: simple observers (`is_valid`, `flags`, `input_index`, `value`, `operation_count`, `get_metrics`, `get_script`, `transaction`, `max_script_element_size`, `max_integer_size{,_legacy}`, `is_chip_vm_limits_enabled`, `is_bigint_enabled`), basic stack ops (`push`, `push_copy`, `push_move`, `drop`, `pop`, `duplicate`, `swap`, `empty`, `stack_true`, `stack_result`, `is_stack_overflow`, `item`, `top`, `subscript`, `size`), alternate stack (`push_alternate`, `pop_alternate`, `empty_alternate`), conditional stack (`open`, `negate`, `close`, `closed`, `succeeded`, `conditional_stack_size`), `evaluate{,_simple}`, the four non-iterator constructors, `copy`, `destruct`, `reset_active_script`, `set_jump_register`, `increment_operation_count_{operation,int}`, `if_`.
- Teach the binding tool to forward non-scalar rvalue-reference parameters correctly. Byte buffers, opaque handles and lists that flow into a C++ method as `T&&` are now materialised into a mutable local and passed with `std::move(...)`, so `push_move`, `push_alternate`, `construct_from_script_transaction_input_index_flags_stack_value` and `construct_from_script_program_move` round-trip input instead of losing it. Non-const lvalue-ref byte buffers keep the existing output-parameter path.
- Split `kth_program_t` / `kth_metrics_t` into the `_mut_t` / `_const_t` pair. Update `interpreter.{h,cpp}` to take the mutable handle.

## Intentionally skipped

- Iterator surface: `begin`, `end`, `jump`, `position`, `index`, `erase` — the C-API has no representation for `std::vector::iterator`.
- `std::expected<pair<…>>` / `expected<tuple<…>>` stack-pop overloads: `pop_int`, `pop_number`, `pop_binary`, `pop_ternary`, `pop_data_stack`, `pop_position`, `top_number`.
- `version` — only exists when `KTH_CURRENCY_BCH` is **not** defined; the parser runs with that flag on.

Those were hand-written before and require iterator/pair/tuple/\#ifdef support in the tool, which is out of scope here.

## Test plan

- [x] Release build clean on Linux.
- [x] \`kth_capi_test\` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to broad C-API signature and ownership/ABI changes across VM program/interpreter entry points, which can break downstream bindings or introduce lifetime mistakes if callers aren’t updated.
> 
> **Overview**
> Migrates the VM C-API to an explicit **const vs mutable handle split**: `kth_program_t`/`kth_metrics_t` are replaced by `kth_program_mut_t`/`kth_program_const_t` and `kth_metrics_mut_t`/`kth_metrics_const_t`, and `kth_vm_interpreter_*` APIs now take mutable program handles where mutation occurs.
> 
> Overhauls `kth_vm_program_*` to match this model: constructors are renamed/expanded to include transaction/input/flags/value/stack variants, a new `kth_vm_program_copy` is added (backed by a new `helpers.hpp` `clone<T>` utility), many observers now return borrowed `*_const_t` views, and stack/alternate-stack/pop helpers now return **owned** byte buffers with explicit destruct requirements plus stricter `KTH_PRECONDITION` checks and corrected move-forwarding for “move” entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee521b21213a8d63b7ac47d059fd07eaae96ffbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Updated VM program API with explicit const/mutable handle designations for enhanced type safety
  * Modified constructor signatures to support explicit script, transaction, and flag parameters

* **New Features**
  * Added program copy constructor and new state introspection methods
  * Enhanced stack operations with improved ownership semantics
  * New program predicates for stack overflow detection and validity checks
  * Added alternate stack operations support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->