### PR TITLE
refactor(c-api): regenerate 5 standalone enum headers via unified generator

### DIFF
--- a/src/c-api/include/kth/capi/chain/coin_selection_algorithm.h
+++ b/src/c-api/include/kth/capi/chain/coin_selection_algorithm.h
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+// This file is auto-generated. Do not edit manually.
+
 #ifndef KTH_CAPI_CHAIN_COIN_SELECTION_H_
 #define KTH_CAPI_CHAIN_COIN_SELECTION_H_
 
@@ -15,18 +17,14 @@ extern "C" {
 #endif
 
 typedef enum {
-    kth_coin_selection_algorithm_smallest_first,     // Prioriza UTXOs más pequeños
-    kth_coin_selection_algorithm_largest_first,      // Prioriza UTXOs más grandes
-    // kth_coin_selection_algorithm_knapsack,           // Algoritmo de la mochila para optimizar
-    // kth_coin_selection_algorithm_fifo,               // Primero en entrar, primero en salir
-    // kth_coin_selection_algorithm_branch_and_bound,   // Branch and Bound para optimización global
-    kth_coin_selection_algorithm_manual,             // Mantiene el orden original de los UTXOs
-    // kth_coin_selection_algorithm_privacy,            // Prioriza privacidad (mismo tamaño de UTXOs)
-    kth_coin_selection_algorithm_send_all            // Usa todos los UTXOs disponibles
+    kth_coin_selection_algorithm_smallest_first,
+    kth_coin_selection_algorithm_largest_first,
+    kth_coin_selection_algorithm_manual,  // keeps the original UTXO order
+    kth_coin_selection_algorithm_send_all,  // uses all available UTXOs
 } kth_coin_selection_algorithm_t;
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif // KTH_CAPI_CHAIN_COIN_SELECTION_H_
+#endif /* KTH_CAPI_CHAIN_COIN_SELECTION_H_ */

--- a/src/c-api/include/kth/capi/chain/script_pattern.h
+++ b/src/c-api/include/kth/capi/chain/script_pattern.h
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+// This file is auto-generated. Do not edit manually.
+
 #ifndef KTH_CAPI_CHAIN_SCRIPT_PATTERN_H_
 #define KTH_CAPI_CHAIN_SCRIPT_PATTERN_H_
 
@@ -63,10 +65,8 @@ typedef enum {
     /// The script may be valid but does not conform to the common templates.
     /// Such scripts are always accepted if they are mined into blocks, but
     /// transactions with uncommon scripts may not be forwarded by peers.
-    kth_script_pattern_non_standard
-
+    kth_script_pattern_non_standard,
 } kth_script_pattern_t;
-
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/chain/script_version.h
+++ b/src/c-api/include/kth/capi/chain/script_version.h
@@ -1,7 +1,8 @@
-
 // Copyright (c) 2016-2025 Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is auto-generated. Do not edit manually.
 
 #ifndef KTH_CAPI_CHAIN_SCRIPT_VERSION_H_
 #define KTH_CAPI_CHAIN_SCRIPT_VERSION_H_
@@ -15,23 +16,22 @@
 extern "C" {
 #endif
 
-
 #if ! defined(KTH_CURRENCY_BCH)
 typedef enum {
-/// Defined by bip141.
+    /// Defined by bip141.
     kth_script_version_zero,
 
-/// All reserved script versions (1..16).
+    /// All reserved script versions (1..16).
     kth_script_version_reserved,
 
-    kth_script_version_unversioned
+    /// All unversioned scripts.
+    kth_script_version_unversioned,
 } kth_script_version_t;
 
-#endif // ! KTH_CURRENCY_BCH
-
+#endif // ! defined(KTH_CURRENCY_BCH)
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif // KTH_CAPI_CHAIN_SCRIPT_VERSION_H_
+#endif /* KTH_CAPI_CHAIN_SCRIPT_VERSION_H_ */

--- a/src/c-api/include/kth/capi/chain/token_capability.h
+++ b/src/c-api/include/kth/capi/chain/token_capability.h
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+// This file is auto-generated. Do not edit manually.
+
 #ifndef KTH_CAPI_CHAIN_TOKEN_CAPABILITY_H_
 #define KTH_CAPI_CHAIN_TOKEN_CAPABILITY_H_
 
@@ -15,13 +17,13 @@ extern "C" {
 #endif
 
 typedef enum {
-    kth_token_capability_none = 0x00, // The token lacks any capability or permission and is either a pure-fungible token or an immutable non-fungible token.
-    kth_token_capability_mut = 0x01,  // If the mutable capability is present, it means that the encoded token is a non-fungible token that can be altered.
-    kth_token_capability_minting = 0x02, // If the minting capability is present, it indicates that the encoded token is a non-fungible token used for minting.
+    kth_token_capability_none = 0x00,  // No capability: either fungible-only or immutable NFT.
+    kth_token_capability_mut = 0x01,  // Mutable NFT: the payload can be altered.
+    kth_token_capability_minting = 0x02,  // Minting NFT: used to mint new tokens of the category.
 } kth_token_capability_t;
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-#endif // KTH_CAPI_CHAIN_TOKEN_CAPABILITY_H_
+#endif /* KTH_CAPI_CHAIN_TOKEN_CAPABILITY_H_ */

--- a/src/c-api/include/kth/capi/chain/token_kind.h
+++ b/src/c-api/include/kth/capi/chain/token_kind.h
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+// This file is auto-generated. Do not edit manually.
+
 #ifndef KTH_CAPI_CHAIN_TOKEN_KIND_H_
 #define KTH_CAPI_CHAIN_TOKEN_KIND_H_
 
@@ -27,4 +29,4 @@ typedef enum {
 } // extern "C"
 #endif
 
-#endif // KTH_CAPI_CHAIN_TOKEN_KIND_H_
+#endif /* KTH_CAPI_CHAIN_TOKEN_KIND_H_ */


### PR DESCRIPTION
## Summary

Companion to [kth-tools#2](https://github.com/k-nuth/kth-tools/pull/2). The \`script_pattern\`, \`script_version\`, \`coin_selection_algorithm\`, \`token_capability\`, and \`token_kind\` headers are no longer hand-written — they're emitted from single \`EnumConfig\` entries in \`generate_capi_v2.py\`. Enum values are unchanged; this PR swaps the hand-maintained text for the regen output.

## Observable changes

- \`// This file is auto-generated. Do not edit manually.\` marker.
- Trailing comma on the last enum entry.
- \`#endif /* NAME */\` style (consistent with \`opcode.h\` / \`error.h\` / \`script_flags.h\`, which already use this form).
- Entry-level comments now mirror the C++ source of truth:
  - \`coin_selection_algorithm\`: Spanish comments swap back to the source's English; the commented-out \`knapsack\` / \`fifo\` / \`branch_and_bound\` / \`privacy\` entries are dropped (they carried no information a C-API consumer could act on).
  - \`token_capability\`: hand-expanded comments fall back to the shorter ones that live next to the C++ enum.
  - \`script_version\`: doc comments pick up the source's 4-space indent; the closing \`#endif // ! defined(KTH_CURRENCY_BCH)\` spells the condition the same way the matching \`#if\` does.

No API changes.

## Test plan

- [ ] Build with \`-DWITH_CAPI=ON\` — must be no behaviour change.
- [ ] Any code that consumed these headers (Python bindings, external consumers) still compiles against the identical enum values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to regenerated header formatting/comments for existing enums; the main risk is accidental ABI/source breakage if enum ordering/values were inadvertently altered.
> 
> **Overview**
> Regenerates five standalone C-API enum headers (coin selection, script pattern/version, token capability/kind) from a unified generator, adding an explicit *auto-generated* marker and aligning style (trailing commas, `#endif /* ... */` guards).
> 
> The enum *values remain the same*, but comments/documentation are normalized (e.g., Spanish-to-English, removal of commented-out enum entries, and minor preprocessor/indent consistency in `script_version.h`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4b2bf8f4b21688709b83ce68993116684bf7c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated C API header files to mark them as auto-generated with clarifying notices.
  * Improved formatting and documentation comments across multiple header files for consistency.
  * No functional changes to exported APIs or enum definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->