### PR TITLE
refactor(c-api): move opcode helpers to opcode.h; regen sighash_algorithm.h via generator

### DIFF
--- a/src/c-api/include/kth/capi/chain/opcode.h
+++ b/src/c-api/include/kth/capi/chain/opcode.h
@@ -327,6 +327,22 @@ typedef enum {
     kth_opcode_reserved_255 = 0xff,   // 255
 } kth_opcode_t;
 
+/// Convert the opcode to a mnemonic string.
+KTH_EXPORT
+char const* kth_chain_opcode_to_string(kth_opcode_t value, uint64_t active_flags);
+
+/// Convert a string to an opcode.
+KTH_EXPORT
+kth_bool_t kth_chain_opcode_from_string(kth_opcode_t* out_code, char const* value);
+
+/// Convert any opcode to a string hexadecimal representation.
+KTH_EXPORT
+char const* kth_chain_opcode_to_hexadecimal(kth_opcode_t code);
+
+// Convert any hexadecimal byte to an opcode.
+KTH_EXPORT
+kth_bool_t kth_chain_opcode_from_hexadecimal(kth_opcode_t* out_code, char const* value);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/c-api/include/kth/capi/chain/sighash_algorithm.h
+++ b/src/c-api/include/kth/capi/chain/sighash_algorithm.h
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+// This file is auto-generated. Do not edit manually.
+
 #ifndef KTH_CAPI_CHAIN_SIGHASH_ALGORITHM_H_
 #define KTH_CAPI_CHAIN_SIGHASH_ALGORITHM_H_
 
@@ -33,6 +35,7 @@ typedef enum {
     /// in the signature. The sequence numbers of other inputs are not
     /// included in the signature, and can be updated.
     kth_sighash_algorithm_single = 0x03,
+
 
 
 #if defined(KTH_CURRENCY_BCH)
@@ -68,26 +71,8 @@ typedef enum {
     kth_sighash_algorithm_anyone_can_pay_single = kth_sighash_algorithm_single | kth_sighash_algorithm_anyone_can_pay,
 
     /// Used to mask unused bits in the signature hash byte.
-    kth_sighash_algorithm_mask = 0x1f
-
+    kth_sighash_algorithm_mask = 0x1f,
 } kth_sighash_algorithm_t;
-
-
-/// Convert the opcode to a mnemonic string.
-KTH_EXPORT
-char const* kth_chain_opcode_to_string(kth_opcode_t value, uint64_t active_flags);
-
-/// Convert a string to an opcode.
-KTH_EXPORT
-kth_bool_t kth_chain_opcode_from_string(kth_opcode_t* out_code, char const* value);
-
-/// Convert any opcode to a string hexadecimal representation.
-KTH_EXPORT
-char const* kth_chain_opcode_to_hexadecimal(kth_opcode_t code);
-
-// Convert any hexadecimal byte to an opcode.
-KTH_EXPORT
-kth_bool_t kth_chain_opcode_from_hexadecimal(kth_opcode_t* out_code, char const* value);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
## Summary

Companion to kth-tools@298c368. The four opcode helper declarations (\`kth_chain_opcode_to_string\`, \`_from_string\`, \`_to_hexadecimal\`, \`_from_hexadecimal\`) used to live under \`sighash_algorithm.h\` purely as an accident of the pre-auto-gen layout — they operate on \`kth_opcode_t\`, so they belong in \`opcode.h\`. This PR regenerates both headers through the unified enum generator, which lands those declarations next to the enum they actually reference and turns \`sighash_algorithm.h\` into a pure enum header.

## Changes

- \`opcode.h\` gains the four \`KTH_EXPORT\` declarations at the end (moved, not new).
- \`sighash_algorithm.h\` loses those declarations and picks up the auto-generated marker, a trailing comma on the last enum entry, and \`#endif /* NAME */\` style — now consistent with every other auto-generated enum header.

No C++ implementation changes; \`opcode.cpp\` still defines the four functions and remains untouched.

Consumers going through \`capi.h\` (the normal entry point) see no surface change — both headers are bundled there, and \`kth_chain_opcode_to_string\` resolves through the \`opcode.h\` transitive include that every chain header already pulls in.

## Test plan

- [ ] Build with \`-DWITH_CAPI=ON\` — no behaviour change expected.
- [ ] \`grep\` the codebase for direct \`#include\`s of \`sighash_algorithm.h\` — any caller that was leaning on it for the opcode helpers would need to add \`opcode.h\` (today only \`capi.h\` includes it; no work needed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk header-only refactor: it relocates opcode helper declarations and regenerates an enum header, with no implementation or behavioral changes. Main risk is limited to downstream builds that included `sighash_algorithm.h` solely to access these opcode helpers and may now need to include `opcode.h` explicitly.
> 
> **Overview**
> Moves the four exported opcode conversion helper declarations (to/from mnemonic and to/from hex) out of `sighash_algorithm.h` and into `opcode.h`, colocating them with `kth_opcode_t`.
> 
> Regenerates `sighash_algorithm.h` as a pure auto-generated enum header (adds the auto-generated marker, normalizes enum trailing comma, and cleans up header formatting), without changing any underlying C++ implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d4baa3dddc945a16655169346380f7ecb7134e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->