### PR TITLE
refactor(c-api): extract primitives.h enums into their own headers

### DIFF
--- a/src/c-api/include/kth/capi/chain/coin_selection_algorithm.h
+++ b/src/c-api/include/kth/capi/chain/coin_selection_algorithm.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,11 +6,6 @@
 
 #ifndef KTH_CAPI_CHAIN_COIN_SELECTION_H_
 #define KTH_CAPI_CHAIN_COIN_SELECTION_H_
-
-#include <stdint.h>
-
-#include <kth/capi/primitives.h>
-#include <kth/capi/visibility.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/c-api/include/kth/capi/chain/endorsement_type.h
+++ b/src/c-api/include/kth/capi/chain/endorsement_type.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is auto-generated. Do not edit manually.
+
+#ifndef KTH_CAPI_CHAIN_ENDORSEMENT_TYPE_H_
+#define KTH_CAPI_CHAIN_ENDORSEMENT_TYPE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    kth_endorsement_type_ecdsa = 0,
+    kth_endorsement_type_schnorr = 1,
+} kth_endorsement_type_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_CHAIN_ENDORSEMENT_TYPE_H_ */

--- a/src/c-api/include/kth/capi/chain/opcode.h
+++ b/src/c-api/include/kth/capi/chain/opcode.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,9 +7,6 @@
 #ifndef KTH_CAPI_CHAIN_OPCODE_H_
 #define KTH_CAPI_CHAIN_OPCODE_H_
 
-#include <stdint.h>
-
-#include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
 
 #ifdef __cplusplus

--- a/src/c-api/include/kth/capi/chain/point_kind.h
+++ b/src/c-api/include/kth/capi/chain/point_kind.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is auto-generated. Do not edit manually.
+
+#ifndef KTH_CAPI_CHAIN_POINT_KIND_H_
+#define KTH_CAPI_CHAIN_POINT_KIND_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    kth_point_kind_output = 0,
+    kth_point_kind_spend = 1,
+} kth_point_kind_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_CHAIN_POINT_KIND_H_ */

--- a/src/c-api/include/kth/capi/chain/script_flags.h
+++ b/src/c-api/include/kth/capi/chain/script_flags.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,9 +8,6 @@
 #define KTH_CAPI_CHAIN_SCRIPT_FLAGS_H_
 
 #include <stdint.h>
-
-#include <kth/capi/primitives.h>
-#include <kth/capi/visibility.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/c-api/include/kth/capi/chain/script_pattern.h
+++ b/src/c-api/include/kth/capi/chain/script_pattern.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,11 +6,6 @@
 
 #ifndef KTH_CAPI_CHAIN_SCRIPT_PATTERN_H_
 #define KTH_CAPI_CHAIN_SCRIPT_PATTERN_H_
-
-#include <stdint.h>
-
-#include <kth/capi/primitives.h>
-#include <kth/capi/visibility.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/c-api/include/kth/capi/chain/script_version.h
+++ b/src/c-api/include/kth/capi/chain/script_version.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,11 +6,6 @@
 
 #ifndef KTH_CAPI_CHAIN_SCRIPT_VERSION_H_
 #define KTH_CAPI_CHAIN_SCRIPT_VERSION_H_
-
-#include <stdint.h>
-
-#include <kth/capi/primitives.h>
-#include <kth/capi/visibility.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/c-api/include/kth/capi/chain/sighash_algorithm.h
+++ b/src/c-api/include/kth/capi/chain/sighash_algorithm.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,11 +6,6 @@
 
 #ifndef KTH_CAPI_CHAIN_SIGHASH_ALGORITHM_H_
 #define KTH_CAPI_CHAIN_SIGHASH_ALGORITHM_H_
-
-#include <stdint.h>
-
-#include <kth/capi/primitives.h>
-#include <kth/capi/visibility.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/c-api/include/kth/capi/chain/token_capability.h
+++ b/src/c-api/include/kth/capi/chain/token_capability.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,11 +6,6 @@
 
 #ifndef KTH_CAPI_CHAIN_TOKEN_CAPABILITY_H_
 #define KTH_CAPI_CHAIN_TOKEN_CAPABILITY_H_
-
-#include <stdint.h>
-
-#include <kth/capi/primitives.h>
-#include <kth/capi/visibility.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/c-api/include/kth/capi/chain/token_kind.h
+++ b/src/c-api/include/kth/capi/chain/token_kind.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,11 +6,6 @@
 
 #ifndef KTH_CAPI_CHAIN_TOKEN_KIND_H_
 #define KTH_CAPI_CHAIN_TOKEN_KIND_H_
-
-#include <stdint.h>
-
-#include <kth/capi/primitives.h>
-#include <kth/capi/visibility.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/c-api/include/kth/capi/config/currency.h
+++ b/src/c-api/include/kth/capi/config/currency.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is auto-generated. Do not edit manually.
+
+#ifndef KTH_CAPI_CONFIG_CURRENCY_H_
+#define KTH_CAPI_CONFIG_CURRENCY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    kth_currency_bitcoin = 0,
+    kth_currency_bitcoin_cash = 1,
+    kth_currency_litecoin = 2,
+} kth_currency_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_CONFIG_CURRENCY_H_ */

--- a/src/c-api/include/kth/capi/config/db_mode.h
+++ b/src/c-api/include/kth/capi/config/db_mode.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is auto-generated. Do not edit manually.
+
+#ifndef KTH_CAPI_CONFIG_DB_MODE_H_
+#define KTH_CAPI_CONFIG_DB_MODE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// The C entry names (`pruned`, `normal`, `full_indexed`) diverge
+// from the C++ `kth::database::db_mode_type` enumerators (`pruned`,
+// `blocks`, `full`). Converters in `config/database_helpers.hpp`
+// rely on the integer values matching positionally; keep this file
+// and the C++ enum in lock-step when either changes.
+typedef enum {
+    kth_db_mode_pruned = 0,
+    kth_db_mode_normal = 1,
+    kth_db_mode_full_indexed = 2,
+} kth_db_mode_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_CONFIG_DB_MODE_H_ */

--- a/src/c-api/include/kth/capi/config/network.h
+++ b/src/c-api/include/kth/capi/config/network.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is auto-generated. Do not edit manually.
+
+#ifndef KTH_CAPI_CONFIG_NETWORK_H_
+#define KTH_CAPI_CONFIG_NETWORK_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    kth_network_mainnet = 0,
+    kth_network_testnet = 1,
+    kth_network_regtest = 2,
+#if defined(KTH_CURRENCY_BCH)
+    kth_network_testnet4 = 3,
+    kth_network_scalenet = 4,
+    kth_network_chipnet = 5,
+#endif
+} kth_network_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_CONFIG_NETWORK_H_ */

--- a/src/c-api/include/kth/capi/error.h
+++ b/src/c-api/include/kth/capi/error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/c-api/include/kth/capi/node/start_modules.h
+++ b/src/c-api/include/kth/capi/node/start_modules.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is auto-generated. Do not edit manually.
+
+#ifndef KTH_CAPI_NODE_START_MODULES_H_
+#define KTH_CAPI_NODE_START_MODULES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    kth_start_modules_all = 0,
+    kth_start_modules_just_chain = 1,
+    kth_start_modules_just_p2p = 2,
+} kth_start_modules_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_NODE_START_MODULES_H_ */

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -8,7 +8,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <kth/capi/chain/endorsement_type.h>
+#include <kth/capi/chain/point_kind.h>
+#include <kth/capi/config/currency.h>
+#include <kth/capi/config/db_mode.h>
+#include <kth/capi/config/network.h>
 #include <kth/capi/error.h>
+#include <kth/capi/node/start_modules.h>
 #include <kth/capi/visibility.h>
 
 #define KTH_PRECONDITION(expr) do { if (!(expr)) { abort(); } } while(0)
@@ -78,8 +84,6 @@ typedef wchar_t kth_char_t;
 #else
 typedef char kth_char_t;
 #endif
-
-typedef enum point_kind {output = 0, spend = 1} kth_point_kind_t;
 
 typedef void* kth_node_t;
 typedef void* kth_chain_t;
@@ -222,50 +226,6 @@ typedef struct kth_encrypted_seed_t {
     uint8_t hash[KTH_BITCOIN_ENCRYPTED_SEED_SIZE];
 } kth_encrypted_seed_t;
 
-
-
-// Currencies --------------------------------------------------------
-
-typedef enum {
-    kth_currency_bitcoin,
-    kth_currency_bitcoin_cash,
-    kth_currency_litecoin
-} kth_currency_t;
-
-// Network -----------------------------------------------------------
-typedef enum {
-      kth_network_mainnet
-    , kth_network_testnet
-    , kth_network_regtest
-#if defined(KTH_CURRENCY_BCH)
-    , kth_network_testnet4
-    , kth_network_scalenet
-    , kth_network_chipnet
-#endif
-} kth_network_t;
-
-// Start Modules -----------------------------------------------------
-typedef enum {
-      kth_start_modules_all
-    , kth_start_modules_just_chain
-    , kth_start_modules_just_p2p
-} kth_start_modules_t;
-
-
-// DB Modes -----------------------------------------------------------
-
-typedef enum {
-    kth_db_mode_pruned = 0,
-    kth_db_mode_normal = 1,
-    kth_db_mode_full_indexed = 2
-} kth_db_mode_t;
-
-
-// Endorsement type ----------------------------------------------------
-typedef enum {
-    kth_endorsement_type_ecdsa = 0,
-    kth_endorsement_type_schnorr = 1
-} kth_endorsement_type_t;
 
 
 // Callback signatures ------------------------------------------------


### PR DESCRIPTION
## Summary

The five enums that used to live as inline \`typedef enum { ... }\` blocks at the bottom of \`capi/primitives.h\` now live in dedicated headers:

| Enum | Path |
|---|---|
| \`kth_point_kind_t\` | \`capi/chain/point_kind.h\` |
| \`kth_endorsement_type_t\` | \`capi/chain/endorsement_type.h\` |
| \`kth_network_t\` | \`capi/config/network.h\` |
| \`kth_currency_t\` | \`capi/config/currency.h\` |
| \`kth_start_modules_t\` | \`capi/node/start_modules.h\` |
| \`kth_db_mode_t\` | \`capi/config/db_mode.h\` |

\`primitives.h\` now \`#include\`s all six so existing consumers that went through it (the normal entry point) see no surface change. \`capi.h\` already transitively pulls in \`primitives.h\`.

## Breaking surface change

\`kth_point_kind_t\` entries gained the \`kth_point_kind_\` prefix — the bare \`output\` / \`spend\` identifiers that used to sit at global scope via \`typedef enum point_kind {output = 0, spend = 1} kth_point_kind_t;\` are gone. A codebase grep found no direct references to either; only the \`kth_point_kind_t\` type name was used.

(This was the collision the earlier \`cpp_t\` alias work had to work around — removing it here closes the loophole.)

## Cosmetic changes

Headers pick up the standard cosmetics:

- \`// This file is auto-generated. Do not edit manually.\` marker.
- Trailing comma on the last enum entry.
- \`#endif /* NAME */\` style.

## Test plan

- [ ] Build with \`-DWITH_CAPI=ON\`.
- [ ] Run C-API tests.
- [ ] Spot-check: any consumer that used bare \`output\` / \`spend\` would fail to compile. None exist in this repo; external consumers should be audited.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a header-only refactor, but it changes the public C enum constants for `kth_point_kind_t` (removing unprefixed `output`/`spend`), which can break external consumers that referenced those names directly.
> 
> **Overview**
> Refactors the C-API headers by **extracting several enums from `primitives.h` into dedicated auto-generated headers** (currency, network, DB mode, start modules, endorsement type, and point kind), while keeping `primitives.h` as the central include by pulling those new headers in.
> 
> Also standardizes/cleans up several chain/config headers (copyright string and removing now-unneeded includes), and **updates `kth_point_kind_t` to use prefixed enumerators** (`kth_point_kind_output`/`kth_point_kind_spend`) instead of exporting bare `output`/`spend` into global scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d5127a16f1408ce22eaf8faf2b974bf77097b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated public type headers exposing several new configuration and enum types for network, currency, modes, endorsement and startup options.

* **Refactor**
  * Reorganized C API layout by extracting type/enum definitions from a monolithic header into separate, focused headers; public API surface and behavior unchanged.

* **Chores**
  * Updated copyright year ranges to "2016-present" across multiple headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->