### PR TITLE
test(blockchain): run/debug_run parity checks in vmlimits suite

### DIFF
--- a/src/blockchain/test/vmlimits_tests_generated.cpp
+++ b/src/blockchain/test/vmlimits_tests_generated.cpp
@@ -109,6 +109,52 @@ eval_result eval_native(data_stack initial_stack, script const& scr, script_flag
     };
 }
 
+// Parallel driver that runs the same program through the debug API
+// (`debug_begin` + `debug_run`) instead of `interpreter::run`. Every
+// `check_*` helper compares its output against `eval_native`'s so
+// that any future `run()` ↔ `debug_run()` divergence — ec, final
+// stack, sig_checks, hash_iters, op_cost — becomes a direct test
+// failure instead of a latent regression. The two bugs pinned by
+// hand-written tests in PR #271 (`OP_CODESEPARATOR` address-identity
+// and `OP_INVOKE` inner-opcode attribution) both slipped through
+// until they were hunted by code review; this parity harness keeps
+// the contract enforced across every generated case.
+eval_result eval_native_debug(data_stack initial_stack, script const& scr, script_flags_t flags) {
+    static chain::transaction const dummy_tx;
+    program prog(scr, dummy_tx, 0, flags, std::move(initial_stack), max_uint64);
+    auto snap = interpreter::debug_run(
+        interpreter::debug_begin(std::move(prog)));
+    // `run(program&)` ends with a `program.closed()` structural
+    // check — the debug API exposes that post-loop verdict through
+    // `debug_finalize`. Without it, the debug path returns `ok` for a
+    // script that ends mid-IF, while `run` correctly reports
+    // `invalid_stack_scope`. Equate both through `final_ec`.
+    auto const final_ec = interpreter::debug_finalize(snap);
+    auto& m = snap.prog.get_metrics();
+
+    int64_t const std_cost = m.op_cost()
+        + m.hash_digest_iterations() * machine::may2025::hash_iter_op_cost_factor(true)
+        + int64_t(m.sig_checks()) * ::kth::may2025::sig_check_cost_factor;
+    int64_t const nonstd_cost = m.op_cost()
+        + m.hash_digest_iterations() * machine::may2025::hash_iter_op_cost_factor(false)
+        + int64_t(m.sig_checks()) * ::kth::may2025::sig_check_cost_factor;
+
+    data_stack result_stack;
+    for (size_t i = snap.prog.size(); i > 0; --i) {
+        result_stack.push_back(snap.prog.item(i - 1));
+    }
+
+    return {
+        final_ec.error,  // bridge op_result → code via error_code_t
+        static_cast<int>(m.sig_checks()),
+        static_cast<int64_t>(m.hash_digest_iterations()),
+        static_cast<int64_t>(m.op_cost()),
+        std_cost,
+        nonstd_cost,
+        std::move(result_stack),
+    };
+}
+
 // ─── BCHN consensus interpreter ──────────────────────────────────────────────
 
 #ifdef WITH_CONSENSUS
@@ -197,6 +243,17 @@ void check_eval(data_stack const& initial, script const& scr, script_flags_t fla
     CHECK(n_std == expected_op_cost_std);
     CHECK(n_nonstd == expected_op_cost_nonstd);
 
+    // --- kth debug-path parity ---
+    // Every case run through `interpreter::run` is mirrored through
+    // `debug_begin` + `debug_run`; any divergence (ec, final stack,
+    // sig_checks, hash_iters, op_cost) fails the test.
+    auto [d_ec, d_sc, d_hi, d_oc, d_std, d_nonstd, d_stack] = eval_native_debug(initial, scr, flags);
+    CHECK(d_ec == ec);
+    CHECK(d_sc == n_sc);
+    CHECK(d_hi == n_hi);
+    CHECK(d_oc == n_oc);
+    CHECK(d_stack == n_stack);
+
 #ifdef WITH_CONSENSUS
     // --- BCHN consensus (standard) ---
     auto const flags_std = script_flags_to_verify_flags(flags, true);
@@ -250,6 +307,14 @@ void check_eval_fail(data_stack const& initial, script const& scr, script_flags_
     CHECK(n_hi == expected_hash_iters);
     CHECK(n_std == expected_op_cost_std);
     CHECK(n_nonstd == expected_op_cost_nonstd);
+
+    // --- kth debug-path parity (see check_eval) ---
+    auto [d_ec, d_sc, d_hi, d_oc, d_std, d_nonstd, d_stack] = eval_native_debug(initial, scr, flags);
+    CHECK(d_ec == ec);
+    CHECK(d_sc == n_sc);
+    CHECK(d_hi == n_hi);
+    CHECK(d_oc == n_oc);
+    CHECK(d_stack == n_stack);
 
 #ifdef WITH_CONSENSUS
     // --- BCHN consensus (standard) ---
@@ -351,6 +416,46 @@ eval_result eval_native_ctx(data_stack initial_stack, script const& scr, script_
     };
 }
 
+// Debug-path companion to `eval_native_ctx`. See `eval_native_debug`
+// for why we keep a parallel driver — same rationale, with tx
+// context.
+eval_result eval_native_ctx_debug(data_stack initial_stack, script const& scr, script_flags_t flags,
+                                  tx_context const& ctx) {
+    auto const utxo_value = ctx.tx.inputs()[ctx.input_index].previous_output().validation.cache.value();
+    program prog(scr, ctx.tx, ctx.input_index, flags, std::move(initial_stack), utxo_value);
+    auto snap = interpreter::debug_run(
+        interpreter::debug_begin(std::move(prog)));
+    // `run(program&)` ends with a `program.closed()` structural
+    // check — the debug API exposes that post-loop verdict through
+    // `debug_finalize`. Without it, the debug path returns `ok` for a
+    // script that ends mid-IF, while `run` correctly reports
+    // `invalid_stack_scope`. Equate both through `final_ec`.
+    auto const final_ec = interpreter::debug_finalize(snap);
+    auto& m = snap.prog.get_metrics();
+
+    int64_t const std_cost = m.op_cost()
+        + m.hash_digest_iterations() * machine::may2025::hash_iter_op_cost_factor(true)
+        + int64_t(m.sig_checks()) * ::kth::may2025::sig_check_cost_factor;
+    int64_t const nonstd_cost = m.op_cost()
+        + m.hash_digest_iterations() * machine::may2025::hash_iter_op_cost_factor(false)
+        + int64_t(m.sig_checks()) * ::kth::may2025::sig_check_cost_factor;
+
+    data_stack result_stack;
+    for (size_t i = snap.prog.size(); i > 0; --i) {
+        result_stack.push_back(snap.prog.item(i - 1));
+    }
+
+    return {
+        final_ec.error,  // bridge op_result → code via error_code_t
+        static_cast<int>(m.sig_checks()),
+        static_cast<int64_t>(m.hash_digest_iterations()),
+        static_cast<int64_t>(m.op_cost()),
+        std_cost,
+        nonstd_cost,
+        std::move(result_stack),
+    };
+}
+
 // Check evaluation with transaction context (for introspection opcode tests).
 void check_eval_ctx(data_stack const& initial, script const& scr, script_flags_t flags,
                     tx_context const& ctx,
@@ -374,6 +479,14 @@ void check_eval_ctx(data_stack const& initial, script const& scr, script_flags_t
     CHECK(n_hi == expected_hash_iters);
     CHECK(n_std == expected_op_cost_std);
     CHECK(n_nonstd == expected_op_cost_nonstd);
+
+    // --- kth debug-path parity with context (see check_eval) ---
+    auto [d_ec, d_sc, d_hi, d_oc, d_std, d_nonstd, d_stack] = eval_native_ctx_debug(initial, scr, flags, ctx);
+    CHECK(d_ec == ec);
+    CHECK(d_sc == n_sc);
+    CHECK(d_hi == n_hi);
+    CHECK(d_oc == n_oc);
+    CHECK(d_stack == n_stack);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

- Extends `transform_bchn_vmlimits_tests.py` (in `kth-tools`) to emit a parallel `eval_native_debug` / `eval_native_ctx_debug` driver that runs each case through `debug_begin` + `debug_run` + `debug_finalize`, and adds `CHECK` equality on `(ec, final stack, sig_checks, hash_iters, op_cost)` against `eval_native` in `check_eval` / `check_eval_fail` / `check_eval_ctx`.
- Closes out a stale rename drift (`forks_t` → `script_flags_t`, `ec` → `ec.error`) that had been applied by hand to the generated file but never to the generator — so regenerations would revert the rename.
- Regenerates `src/blockchain/test/vmlimits_tests_generated.cpp` (165 opcode tests).

## Why

Two run/debug parity bugs in PR #271 — `OP_CODESEPARATOR` address-identity lookup and `OP_INVOKE` inner-opcode attribution — slipped through until hunted by hand during code review. Extending the existing BCHN-sourced vmlimits suite turns every future divergence into a direct test failure across hundreds of cases. Closes #272.

As a bonus, the new harness immediately surfaced a real gap: `interpreter::run` ends with a `program.closed()` structural check (post-loop IF/ELSE balance) that lives in `debug_finalize` on the debug side. Callers of `debug_run` alone were missing the equivalent verdict; the generator's driver now calls `debug_finalize` so the paths are verifiably equivalent.

## Test plan

- [x] Regenerate and build — 4771/4771 pass.
- [x] Confirm diff against pre-change generator is zero for the rename-only portion (drift closure).
- [x] The parity harness fires as designed on the `OP_IF (fail)` / `OP_NOTIF (fail)` cases before the `debug_finalize` call is threaded through.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to generated VM-limits tests, adding extra assertions and a debug-path execution harness without affecting production interpreter behavior.
> 
> **Overview**
> Adds a parallel native evaluation path for the VM-limits generated tests that runs scripts via `interpreter::debug_begin` + `debug_run` + `debug_finalize`, and asserts parity with `interpreter::run` on error code, final stack, and execution metrics (sig checks, hash iterations, op cost).
> 
> Extends the same parity checks to failure cases and transaction-context (introspection) cases, ensuring any future `run()` vs debug API divergence becomes an immediate test failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3155e088c16a8af9fef612b10582906598ae7dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with comprehensive debug-path parity validation. New checks verify that debug execution paths produce identical results as standard execution paths for all metrics including error codes, stack items, signature checks, hash iterations, operation costs, and composite metrics across all test scenarios, including success/failure cases and transaction contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->