### PR TITLE
feat(c-api): interpreter + debug_snapshot bindings

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -163,6 +163,7 @@ set(kth_sources
   src/double_list.cpp
   src/u32_list.cpp
   src/u64_list.cpp
+  src/bool_list.cpp
 
 
   src/chain/opcode.cpp
@@ -192,6 +193,9 @@ set(kth_sources
 
   src/node/settings.cpp
 
+  src/vm/debug_snapshot.cpp
+  src/vm/debug_snapshot_list.cpp
+  src/vm/function_table.cpp
   src/vm/interpreter.cpp
   src/vm/program.cpp
 
@@ -519,6 +523,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/wallet/wallet_data.cpp
         test/vm/program.cpp
         test/vm/interpreter.cpp
+        test/vm/function_table.cpp
     )
 
     target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})

--- a/src/c-api/include/kth/capi/bool_list.h
+++ b/src/c-api/include/kth/capi/bool_list.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_BOOL_LIST_H_
+#define KTH_CAPI_BOOL_LIST_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @return Owned `kth_bool_list_mut_t`. Caller must release with `kth_core_bool_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_bool_list_mut_t kth_core_bool_list_construct_default(void);
+
+KTH_EXPORT
+void kth_core_bool_list_push_back(kth_bool_list_mut_t list, kth_bool_t elem);
+
+/** No-op if `list` is null. */
+KTH_EXPORT
+void kth_core_bool_list_destruct(kth_bool_list_mut_t list);
+
+KTH_EXPORT
+kth_size_t kth_core_bool_list_count(kth_bool_list_const_t list);
+
+KTH_EXPORT
+kth_bool_t kth_core_bool_list_nth(kth_bool_list_const_t list, kth_size_t index);
+
+KTH_EXPORT
+void kth_core_bool_list_assign_at(kth_bool_list_mut_t list, kth_size_t index, kth_bool_t elem);
+
+KTH_EXPORT
+void kth_core_bool_list_erase(kth_bool_list_mut_t list, kth_size_t index);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_BOOL_LIST_H_ */

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -406,9 +406,18 @@ std::basic_string<CharT> create_cpp_str(CharT const* str) {
 template <typename N>
 inline
 uint8_t* create_c_array(kth::data_chunk const& arr, N& out_size) {
-    auto* ret = mnew<uint8_t>(arr.size());
-    out_size = arr.size();
-    std::copy_n(arr.begin(), arr.size(), ret);
+    // Allocate at least 1 byte so the returned pointer is non-NULL
+    // even when `arr.size() == 0`. `malloc(0)` is implementation-
+    // defined: some platforms return NULL, which would make
+    // present-but-empty buffers indistinguishable from an absent-key
+    // signal at call sites that use NULL to mean "not found" (e.g.
+    // map `at()` accessors). The caller still reads only
+    // `out_size == arr.size()` bytes; `kth_core_destruct_array` frees
+    // the buffer regardless of size.
+    auto const n = arr.size();
+    auto* ret = mnew<uint8_t>(n != 0 ? n : 1);
+    out_size = n;
+    std::copy_n(arr.begin(), n, ret);
     return ret;
 }
 

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -186,6 +186,8 @@ typedef void* kth_u32_list_mut_t;
 typedef void const* kth_u32_list_const_t;
 typedef void* kth_u64_list_mut_t;
 typedef void const* kth_u64_list_const_t;
+typedef void* kth_bool_list_mut_t;
+typedef void const* kth_bool_list_const_t;
 
 typedef void* kth_wallet_data_mut_t;
 typedef void const* kth_wallet_data_const_t;
@@ -206,6 +208,26 @@ typedef void* kth_metrics_mut_t;
 typedef void const* kth_metrics_const_t;
 typedef void* kth_program_mut_t;
 typedef void const* kth_program_const_t;
+typedef void* kth_debug_snapshot_mut_t;
+typedef void const* kth_debug_snapshot_const_t;
+typedef void* kth_debug_snapshot_list_mut_t;
+typedef void const* kth_debug_snapshot_list_const_t;
+typedef void* kth_function_table_mut_t;
+typedef void const* kth_function_table_const_t;
+
+// `interpreter::debug_step_until` predicate: fires on each post-step
+// snapshot. Return non-zero to stop stepping, zero to continue. The
+// snapshot handle is borrowed (do not destruct); `user_data` is the
+// pointer the caller passed alongside the predicate.
+//
+// MUST NOT throw (when compiled as C++): the C++ runtime does not
+// propagate exceptions across the `extern "C"` boundary, and an
+// exception thrown by this callback would unwind through
+// `interpreter::debug_step_until` — undefined behaviour. Convert
+// exceptional conditions in the predicate body into a "stop" signal
+// (return non-zero, stash the diagnostic in `user_data`) instead.
+typedef kth_bool_t (*kth_debug_step_predicate_t)(
+    kth_debug_snapshot_const_t snapshot, void* user_data);
 
 
 // helper functions

--- a/src/c-api/include/kth/capi/vm/debug_snapshot.h
+++ b/src/c-api/include/kth/capi/vm/debug_snapshot.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_VM_DEBUG_SNAPSHOT_H_
+#define KTH_CAPI_VM_DEBUG_SNAPSHOT_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/** @return Owned `kth_debug_snapshot_mut_t`. Caller must release with `kth_vm_debug_snapshot_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_mut_t kth_vm_debug_snapshot_construct_default(void);
+
+/**
+ * @return Owned `kth_debug_snapshot_mut_t`. Caller must release with `kth_vm_debug_snapshot_destruct`.
+ * @param p Borrowed input. Copied by value into the resulting object; ownership of `p` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_mut_t kth_vm_debug_snapshot_construct(kth_program_const_t p);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_vm_debug_snapshot_destruct(kth_debug_snapshot_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_debug_snapshot_mut_t`. Caller must release with `kth_vm_debug_snapshot_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_mut_t kth_vm_debug_snapshot_copy(kth_debug_snapshot_const_t self);
+
+
+// Getters
+
+/** @return Borrowed `kth_program_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_program_const_t kth_vm_debug_snapshot_prog(kth_debug_snapshot_const_t self);
+
+KTH_EXPORT
+kth_size_t kth_vm_debug_snapshot_step(kth_debug_snapshot_const_t self);
+
+KTH_EXPORT
+kth_error_code_t kth_vm_debug_snapshot_last(kth_debug_snapshot_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_debug_snapshot_done(kth_debug_snapshot_const_t self);
+
+/** @return Borrowed `kth_bool_list_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_bool_list_const_t kth_vm_debug_snapshot_control_stack(kth_debug_snapshot_const_t self);
+
+/** @return Owned `kth_u64_list_mut_t`. Caller must release with `kth_core_u64_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_u64_list_mut_t kth_vm_debug_snapshot_loop_stack(kth_debug_snapshot_const_t self);
+
+/** @return Borrowed `kth_function_table_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_function_table_const_t kth_vm_debug_snapshot_function_table(kth_debug_snapshot_const_t self);
+
+KTH_EXPORT
+kth_size_t kth_vm_debug_snapshot_invoke_depth(kth_debug_snapshot_const_t self);
+
+KTH_EXPORT
+kth_size_t kth_vm_debug_snapshot_outer_loop_depth(kth_debug_snapshot_const_t self);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_VM_DEBUG_SNAPSHOT_H_

--- a/src/c-api/include/kth/capi/vm/debug_snapshot_list.h
+++ b/src/c-api/include/kth/capi/vm/debug_snapshot_list.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_VM_DEBUG_SNAPSHOT_LIST_H_
+#define KTH_CAPI_VM_DEBUG_SNAPSHOT_LIST_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @return Owned `kth_debug_snapshot_list_mut_t`. Caller must release with `kth_vm_debug_snapshot_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_list_mut_t kth_vm_debug_snapshot_list_construct_default(void);
+
+KTH_EXPORT
+void kth_vm_debug_snapshot_list_push_back(kth_debug_snapshot_list_mut_t list, kth_debug_snapshot_const_t elem);
+
+/** No-op if `list` is null. */
+KTH_EXPORT
+void kth_vm_debug_snapshot_list_destruct(kth_debug_snapshot_list_mut_t list);
+
+KTH_EXPORT
+kth_size_t kth_vm_debug_snapshot_list_count(kth_debug_snapshot_list_const_t list);
+
+/** @return Borrowed `kth_debug_snapshot_const_t` view into the list. Do not destruct; the list retains ownership. Invalidated by any mutation of the list. */
+KTH_EXPORT
+kth_debug_snapshot_const_t kth_vm_debug_snapshot_list_nth(kth_debug_snapshot_list_const_t list, kth_size_t index);
+
+KTH_EXPORT
+void kth_vm_debug_snapshot_list_assign_at(kth_debug_snapshot_list_mut_t list, kth_size_t index, kth_debug_snapshot_const_t elem);
+
+KTH_EXPORT
+void kth_vm_debug_snapshot_list_erase(kth_debug_snapshot_list_mut_t list, kth_size_t index);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_VM_DEBUG_SNAPSHOT_LIST_H_ */

--- a/src/c-api/include/kth/capi/vm/function_table.h
+++ b/src/c-api/include/kth/capi/vm/function_table.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_VM_FUNCTION_TABLE_H_
+#define KTH_CAPI_VM_FUNCTION_TABLE_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @return Owned `kth_function_table_mut_t`. Caller must release with `kth_vm_function_table_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_function_table_mut_t kth_vm_function_table_construct_default(void);
+
+/** No-op if `map` is null. */
+KTH_EXPORT
+void kth_vm_function_table_destruct(kth_function_table_mut_t map);
+
+KTH_EXPORT
+kth_size_t kth_vm_function_table_count(kth_function_table_const_t map);
+
+/** Non-zero iff `key` is present. */
+KTH_EXPORT
+kth_bool_t kth_vm_function_table_contains(kth_function_table_const_t map, uint8_t const* key, kth_size_t key_n);
+
+/** @return Owned byte buffer (value bytes, length in `out_value_size`), or NULL if `key` is absent. Release non-NULL results with `kth_core_destruct_array`. */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_vm_function_table_at(kth_function_table_const_t map, uint8_t const* key, kth_size_t key_n, kth_size_t* out_value_size);
+
+/** Insert or overwrite the `key` → `value` mapping. */
+KTH_EXPORT
+void kth_vm_function_table_insert(kth_function_table_mut_t map, uint8_t const* key, kth_size_t key_n, uint8_t const* value, kth_size_t value_n);
+
+/** @return Non-zero iff a mapping was erased. */
+KTH_EXPORT
+kth_bool_t kth_vm_function_table_erase(kth_function_table_mut_t map, uint8_t const* key, kth_size_t key_n);
+
+/** Iterate entries by position in an implementation-defined order (`unordered_flat_map` iteration order is stable across reads but not defined w.r.t. insertion). Returns owned buffers for both the key and the value; release them with `kth_core_destruct_array`. No-op and leaves outputs untouched if `index >= count`. */
+KTH_EXPORT
+void kth_vm_function_table_nth(kth_function_table_const_t map, kth_size_t index,
+               KTH_OUT_OWNED uint8_t** out_key, kth_size_t* out_key_size,
+               KTH_OUT_OWNED uint8_t** out_value, kth_size_t* out_value_size);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_VM_FUNCTION_TABLE_H_ */

--- a/src/c-api/include/kth/capi/vm/interpreter.h
+++ b/src/c-api/include/kth/capi/vm/interpreter.h
@@ -1,9 +1,11 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef KTH_CAPI_VM_INTERPRETER_H_
 #define KTH_CAPI_VM_INTERPRETER_H_
+
+#include <stdint.h>
 
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
@@ -12,54 +14,43 @@
 extern "C" {
 #endif
 
-/// Run program script.
-
-    // static
-    // code run(program& program);
-
-    // /// Run individual operations (idependent of the script).
-    // /// For best performance use script runner for a sequence of operations.
-    // static
-    // code run(operation const& op, program& program);
-
+// Static utilities
 
 KTH_EXPORT
-kth_error_code_t kth_vm_interpreter_run(kth_program_mut_t program);
+kth_error_code_t kth_vm_interpreter_run_simple(kth_program_mut_t program);
 
 KTH_EXPORT
-kth_error_code_t kth_vm_interpreter_run_operation(kth_operation_t operation, kth_program_mut_t program);
+kth_error_code_t kth_vm_interpreter_run(kth_operation_const_t op, kth_program_mut_t program);
 
+/** @return Owned `kth_debug_snapshot_mut_t`. Caller must release with `kth_vm_debug_snapshot_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_begin(kth_program_const_t prog);
 
-// Debug step by step
-// ----------------------------------------------------------------------------
-    // static
-    // std::pair<code, size_t> debug_start(program const& program);
+/** @return Owned `kth_debug_snapshot_mut_t`. Caller must release with `kth_vm_debug_snapshot_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_step(kth_debug_snapshot_const_t snapshot);
 
-    // static
-    // bool debug_steps_available(program const& program, size_t step);
+/** @return Owned `kth_debug_snapshot_mut_t`. Caller must release with `kth_vm_debug_snapshot_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_step_n(kth_debug_snapshot_const_t snapshot, kth_size_t n);
 
-    // static
-    // std::tuple<code, size_t, program> debug_step(program program, size_t step);
+/** @return Owned `kth_debug_snapshot_mut_t`. Caller must release with `kth_vm_debug_snapshot_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_step_until(kth_debug_snapshot_const_t snapshot, kth_debug_step_predicate_t predicate, void* predicate_user_data);
 
-    // static
-    // code debug_end(program const& program);
+/** @return Owned `kth_debug_snapshot_mut_t`. Caller must release with `kth_vm_debug_snapshot_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_run(kth_debug_snapshot_const_t snapshot);
+
+/** @return Owned `kth_debug_snapshot_list_mut_t`. Caller must release with `kth_vm_debug_snapshot_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_debug_snapshot_list_mut_t kth_vm_interpreter_debug_run_traced(kth_debug_snapshot_const_t start);
 
 KTH_EXPORT
-kth_error_code_t kth_vm_interpreter_debug_start(kth_program_const_t program, kth_size_t* out_step);
-
-KTH_EXPORT
-kth_bool_t kth_vm_interpreter_debug_steps_available(kth_program_const_t program, kth_size_t step);
-
-KTH_EXPORT
-kth_error_code_t kth_vm_interpreter_debug_step(kth_program_const_t program, kth_size_t step, kth_size_t* out_step, kth_program_mut_t* out_program);
-
-KTH_EXPORT
-kth_error_code_t kth_vm_interpreter_debug_end(kth_program_const_t program);
-
+kth_error_code_t kth_vm_interpreter_debug_finalize(kth_debug_snapshot_const_t snapshot);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-
-#endif /* KTH_CAPI_VM_PROGRAM_H_ */
+#endif // KTH_CAPI_VM_INTERPRETER_H_

--- a/src/c-api/src/bool_list.cpp
+++ b/src/c-api/src/bool_list.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/bool_list.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+
+// File-local alias so `kth::list_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+//
+// NOTE: `cpp_t = bool` instantiates the standard-library
+// `std::vector<bool>` specialization, which uses a proxy
+// reference type. Every access below (`push_back(bool)`,
+// `vec[i] = <bool>`, `bool_to_int(vec[i])`, `vec.erase(...)`)
+// goes through the proxy correctly. Future accessors that
+// return `bool&` / take the address of an element would
+// silently break — that's the trade-off of staying on the
+// specialisation instead of backing the container with
+// `std::vector<uint8_t>`.
+namespace {
+using cpp_t = bool;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+kth_bool_list_mut_t kth_core_bool_list_construct_default(void) {
+    return kth::leak_list<cpp_t>();
+}
+
+void kth_core_bool_list_push_back(kth_bool_list_mut_t list, kth_bool_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    kth::list_ref<cpp_t>(list).push_back(kth::int_to_bool(elem));
+}
+
+void kth_core_bool_list_destruct(kth_bool_list_mut_t list) {
+    kth::del_list<cpp_t>(list);
+}
+
+kth_size_t kth_core_bool_list_count(kth_bool_list_const_t list) {
+    KTH_PRECONDITION(list != nullptr);
+    return kth::list_ref<cpp_t>(list).size();
+}
+
+kth_bool_t kth_core_bool_list_nth(kth_bool_list_const_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto const& vec = kth::list_ref<cpp_t>(list);
+    KTH_PRECONDITION(index < vec.size());
+    return kth::bool_to_int(vec[index]);
+}
+
+void kth_core_bool_list_assign_at(kth_bool_list_mut_t list, kth_size_t index, kth_bool_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    auto& vec = kth::list_ref<cpp_t>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec[index] = kth::int_to_bool(elem);
+}
+
+void kth_core_bool_list_erase(kth_bool_list_mut_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto& vec = kth::list_ref<cpp_t>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec.erase(vec.begin() + index);
+}
+
+} // extern "C"

--- a/src/c-api/src/vm/debug_snapshot.cpp
+++ b/src/c-api/src/vm/debug_snapshot.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/vm/debug_snapshot.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/machine/interpreter.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::machine::debug_snapshot;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_debug_snapshot_mut_t kth_vm_debug_snapshot_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_debug_snapshot_mut_t kth_vm_debug_snapshot_construct(kth_program_const_t p) {
+    KTH_PRECONDITION(p != nullptr);
+    auto const& p_cpp = kth::cpp_ref<kth::domain::machine::program>(p);
+    return kth::leak<cpp_t>(p_cpp);
+}
+
+
+// Destructor
+
+void kth_vm_debug_snapshot_destruct(kth_debug_snapshot_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_debug_snapshot_mut_t kth_vm_debug_snapshot_copy(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Getters
+
+kth_program_const_t kth_vm_debug_snapshot_prog(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<cpp_t>(self).prog);
+}
+
+kth_size_t kth_vm_debug_snapshot_step(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).step;
+}
+
+kth_error_code_t kth_vm_debug_snapshot_last(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::to_c_err(kth::cpp_ref<cpp_t>(self).last.error);
+}
+
+kth_bool_t kth_vm_debug_snapshot_done(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).done);
+}
+
+kth_bool_list_const_t kth_vm_debug_snapshot_control_stack(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<cpp_t>(self).control_stack);
+}
+
+kth_u64_list_mut_t kth_vm_debug_snapshot_loop_stack(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const cpp_result = kth::cpp_ref<cpp_t>(self).loop_stack;
+    return kth::leak_list<uint64_t>(cpp_result.begin(), cpp_result.end());
+}
+
+kth_function_table_const_t kth_vm_debug_snapshot_function_table(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<cpp_t>(self).function_table);
+}
+
+kth_size_t kth_vm_debug_snapshot_invoke_depth(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).invoke_depth;
+}
+
+kth_size_t kth_vm_debug_snapshot_outer_loop_depth(kth_debug_snapshot_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).outer_loop_depth;
+}
+
+} // extern "C"

--- a/src/c-api/src/vm/debug_snapshot_list.cpp
+++ b/src/c-api/src/vm/debug_snapshot_list.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/vm/debug_snapshot_list.h>
+
+#include <kth/capi/vm/debug_snapshot.h>
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+
+// File-local alias so `kth::list_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::machine::debug_snapshot;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+kth_debug_snapshot_list_mut_t kth_vm_debug_snapshot_list_construct_default(void) {
+    return kth::leak_list<cpp_t>();
+}
+
+void kth_vm_debug_snapshot_list_push_back(kth_debug_snapshot_list_mut_t list, kth_debug_snapshot_const_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    auto tmp = kth::cpp_ref<cpp_t>(elem);
+    kth::list_ref<cpp_t>(list).push_back(std::move(tmp));
+}
+
+void kth_vm_debug_snapshot_list_destruct(kth_debug_snapshot_list_mut_t list) {
+    kth::del_list<cpp_t>(list);
+}
+
+kth_size_t kth_vm_debug_snapshot_list_count(kth_debug_snapshot_list_const_t list) {
+    KTH_PRECONDITION(list != nullptr);
+    return kth::list_ref<cpp_t>(list).size();
+}
+
+kth_debug_snapshot_const_t kth_vm_debug_snapshot_list_nth(kth_debug_snapshot_list_const_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto const& vec = kth::list_ref<cpp_t>(list);
+    KTH_PRECONDITION(index < vec.size());
+    return &vec[index];
+}
+
+void kth_vm_debug_snapshot_list_assign_at(kth_debug_snapshot_list_mut_t list, kth_size_t index, kth_debug_snapshot_const_t elem) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    auto& vec = kth::list_ref<cpp_t>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec[index] = kth::cpp_ref<cpp_t>(elem);
+}
+
+void kth_vm_debug_snapshot_list_erase(kth_debug_snapshot_list_mut_t list, kth_size_t index) {
+    KTH_PRECONDITION(list != nullptr);
+    auto& vec = kth::list_ref<cpp_t>(list);
+    KTH_PRECONDITION(index < vec.size());
+    vec.erase(vec.begin() + index);
+}
+
+} // extern "C"

--- a/src/c-api/src/vm/function_table.cpp
+++ b/src/c-api/src/vm/function_table.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/vm/function_table.h>
+
+#include <cstring>
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <boost/unordered/unordered_flat_map.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = boost::unordered_flat_map<kth::data_chunk, kth::data_chunk>;
+using byte_vec = kth::data_chunk;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+kth_function_table_mut_t kth_vm_function_table_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+void kth_vm_function_table_destruct(kth_function_table_mut_t map) {
+    kth::del<cpp_t>(map);
+}
+
+kth_size_t kth_vm_function_table_count(kth_function_table_const_t map) {
+    KTH_PRECONDITION(map != nullptr);
+    return kth::cpp_ref<cpp_t>(map).size();
+}
+
+kth_bool_t kth_vm_function_table_contains(kth_function_table_const_t map, uint8_t const* key, kth_size_t key_n) {
+    KTH_PRECONDITION(map != nullptr);
+    KTH_PRECONDITION(key != nullptr || key_n == 0);
+    auto const k = key_n != 0 ? byte_vec(key, key + key_n) : byte_vec{};
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(map).contains(k));
+}
+
+uint8_t* kth_vm_function_table_at(kth_function_table_const_t map, uint8_t const* key, kth_size_t key_n, kth_size_t* out_value_size) {
+    KTH_PRECONDITION(map != nullptr);
+    KTH_PRECONDITION(key != nullptr || key_n == 0);
+    KTH_PRECONDITION(out_value_size != nullptr);
+    auto const k = key_n != 0 ? byte_vec(key, key + key_n) : byte_vec{};
+    auto const& m = kth::cpp_ref<cpp_t>(map);
+    auto const it = m.find(k);
+    if (it == m.end()) {
+        *out_value_size = 0;
+        return nullptr;
+    }
+    // Guard the empty-value path: `create_c_array` would route
+    // through `malloc(0)`, which is implementation-defined — some
+    // platforms return NULL, making a present-but-empty value
+    // indistinguishable from the absent-key signal above. Allocate
+    // 1 byte directly for that case so the returned pointer is
+    // always non-NULL for present keys.
+    if (it->second.empty()) {
+        *out_value_size = 0;
+        return kth::mnew<uint8_t>(1);
+    }
+    return kth::create_c_array(it->second, *out_value_size);
+}
+
+void kth_vm_function_table_insert(kth_function_table_mut_t map, uint8_t const* key, kth_size_t key_n, uint8_t const* value, kth_size_t value_n) {
+    KTH_PRECONDITION(map != nullptr);
+    KTH_PRECONDITION(key != nullptr || key_n == 0);
+    KTH_PRECONDITION(value != nullptr || value_n == 0);
+    auto k = key_n != 0 ? byte_vec(key, key + key_n) : byte_vec{};
+    auto v = value_n != 0 ? byte_vec(value, value + value_n) : byte_vec{};
+    kth::cpp_ref<cpp_t>(map).insert_or_assign(std::move(k), std::move(v));
+}
+
+kth_bool_t kth_vm_function_table_erase(kth_function_table_mut_t map, uint8_t const* key, kth_size_t key_n) {
+    KTH_PRECONDITION(map != nullptr);
+    KTH_PRECONDITION(key != nullptr || key_n == 0);
+    auto const k = key_n != 0 ? byte_vec(key, key + key_n) : byte_vec{};
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(map).erase(k) != 0);
+}
+
+void kth_vm_function_table_nth(kth_function_table_const_t map, kth_size_t index,
+               uint8_t** out_key, kth_size_t* out_key_size,
+               uint8_t** out_value, kth_size_t* out_value_size) {
+    KTH_PRECONDITION(map != nullptr);
+    KTH_PRECONDITION(out_key != nullptr && out_key_size != nullptr);
+    KTH_PRECONDITION(out_value != nullptr && out_value_size != nullptr);
+    auto const& m = kth::cpp_ref<cpp_t>(map);
+    if (index >= m.size()) return;
+    auto it = m.begin();
+    std::advance(it, index);
+    *out_key = kth::create_c_array(it->first, *out_key_size);
+    *out_value = kth::create_c_array(it->second, *out_value_size);
+}
+
+} // extern "C"

--- a/src/c-api/src/vm/interpreter.cpp
+++ b/src/c-api/src/vm/interpreter.cpp
@@ -4,58 +4,78 @@
 
 #include <kth/capi/vm/interpreter.h>
 
-#include <kth/capi/helpers.hpp>
 #include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/machine/interpreter.hpp>
 
-#include <kth/domain/machine/program.hpp>
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::machine::interpreter;
+} // namespace
 
 // ---------------------------------------------------------------------------
 extern "C" {
 
-kth_error_code_t kth_vm_interpreter_run(kth_program_mut_t program) {
-    auto const result = kth::domain::machine::interpreter::run(
-        kth::cpp_ref<kth::domain::machine::program>(program));
-    return kth::to_c_err(result.error);
+// Static utilities
+
+kth_error_code_t kth_vm_interpreter_run_simple(kth_program_mut_t program) {
+    KTH_PRECONDITION(program != nullptr);
+    auto& program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
+    return kth::to_c_err(cpp_t::run(program_cpp).error);
 }
 
-kth_error_code_t kth_vm_interpreter_run_operation(kth_operation_t operation, kth_program_mut_t program) {
-    auto const result = kth::domain::machine::interpreter::run(
-        kth::cpp_ref<kth::domain::machine::operation>(operation),
-        kth::cpp_ref<kth::domain::machine::program>(program)
-    );
-    return kth::to_c_err(result.error);
+kth_error_code_t kth_vm_interpreter_run(kth_operation_const_t op, kth_program_mut_t program) {
+    KTH_PRECONDITION(op != nullptr);
+    KTH_PRECONDITION(program != nullptr);
+    auto const& op_cpp = kth::cpp_ref<kth::domain::machine::operation>(op);
+    auto& program_cpp = kth::cpp_ref<kth::domain::machine::program>(program);
+    return kth::to_c_err(cpp_t::run(op_cpp, program_cpp).error);
 }
 
-
-// Debug-session bindings: the underlying C++ API was reshaped around
-// a value `debug_snapshot` that carries the program + last result +
-// done flag. The handle-based shims below stay in place just to keep
-// this translation unit compiling; they will be replaced with the
-// real opaque-handle bindings in a follow-up.
-
-kth_error_code_t kth_vm_interpreter_debug_start(kth_program_const_t program, kth_size_t* out_step) {
-    (void)program;
-    if (out_step != nullptr) *out_step = 0;
-    return kth::to_c_err(kth::error::not_implemented);
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_begin(kth_program_const_t prog) {
+    KTH_PRECONDITION(prog != nullptr);
+    auto const& prog_cpp = kth::cpp_ref<kth::domain::machine::program>(prog);
+    return kth::leak(cpp_t::debug_begin(prog_cpp));
 }
 
-kth_bool_t kth_vm_interpreter_debug_steps_available(kth_program_const_t program, kth_size_t step) {
-    (void)program;
-    (void)step;
-    return 0;
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_step(kth_debug_snapshot_const_t snapshot) {
+    KTH_PRECONDITION(snapshot != nullptr);
+    auto const& snapshot_cpp = kth::cpp_ref<kth::domain::machine::debug_snapshot>(snapshot);
+    return kth::leak(cpp_t::debug_step(snapshot_cpp));
 }
 
-kth_error_code_t kth_vm_interpreter_debug_step(kth_program_const_t program, kth_size_t step, kth_size_t* out_step, kth_program_mut_t* out_program) {
-    (void)program;
-    (void)step;
-    if (out_step != nullptr) *out_step = 0;
-    if (out_program != nullptr) *out_program = nullptr;
-    return kth::to_c_err(kth::error::not_implemented);
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_step_n(kth_debug_snapshot_const_t snapshot, kth_size_t n) {
+    KTH_PRECONDITION(snapshot != nullptr);
+    auto const& snapshot_cpp = kth::cpp_ref<kth::domain::machine::debug_snapshot>(snapshot);
+    auto const n_cpp = kth::sz(n);
+    return kth::leak(cpp_t::debug_step_n(snapshot_cpp, n_cpp));
 }
 
-kth_error_code_t kth_vm_interpreter_debug_end(kth_program_const_t program) {
-    (void)program;
-    return kth::to_c_err(kth::error::not_implemented);
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_step_until(kth_debug_snapshot_const_t snapshot, kth_debug_step_predicate_t predicate, void* predicate_user_data) {
+    KTH_PRECONDITION(snapshot != nullptr);
+    KTH_PRECONDITION(predicate != nullptr);
+    auto const& snapshot_cpp = kth::cpp_ref<kth::domain::machine::debug_snapshot>(snapshot);
+    auto const predicate_cpp = [predicate, predicate_user_data](kth::domain::machine::debug_snapshot const& snap) -> bool { return predicate(&snap, predicate_user_data) != 0; };
+    return kth::leak(cpp_t::debug_step_until(snapshot_cpp, predicate_cpp));
+}
+
+kth_debug_snapshot_mut_t kth_vm_interpreter_debug_run(kth_debug_snapshot_const_t snapshot) {
+    KTH_PRECONDITION(snapshot != nullptr);
+    auto const& snapshot_cpp = kth::cpp_ref<kth::domain::machine::debug_snapshot>(snapshot);
+    return kth::leak(cpp_t::debug_run(snapshot_cpp));
+}
+
+kth_debug_snapshot_list_mut_t kth_vm_interpreter_debug_run_traced(kth_debug_snapshot_const_t start) {
+    KTH_PRECONDITION(start != nullptr);
+    auto const& start_cpp = kth::cpp_ref<kth::domain::machine::debug_snapshot>(start);
+    return kth::leak_list<kth::domain::machine::debug_snapshot>(cpp_t::debug_run_traced(start_cpp));
+}
+
+kth_error_code_t kth_vm_interpreter_debug_finalize(kth_debug_snapshot_const_t snapshot) {
+    KTH_PRECONDITION(snapshot != nullptr);
+    auto const& snapshot_cpp = kth::cpp_ref<kth::domain::machine::debug_snapshot>(snapshot);
+    return kth::to_c_err(cpp_t::debug_finalize(snapshot_cpp).error);
 }
 
 } // extern "C"

--- a/src/c-api/test/vm/function_table.cpp
+++ b/src/c-api/test/vm/function_table.cpp
@@ -1,0 +1,249 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/vm/function_table.h>
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Two short distinct keys and two distinct values. Short enough to
+// make reasoning about the tests cheap; still covers the byte-buffer
+// (ptr, len) contract.
+static uint8_t const kKeyA[]   = { 0x01, 0x02 };
+static uint8_t const kKeyB[]   = { 0x03, 0x04, 0x05 };
+static uint8_t const kValueA[] = { 0xaa };
+static uint8_t const kValueB[] = { 0xbb, 0xbc };
+
+// ---------------------------------------------------------------------------
+// construct / destruct / count
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API FunctionTable - default construct is empty",
+          "[C-API FunctionTable]") {
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+    REQUIRE(m != NULL);
+    REQUIRE(kth_vm_function_table_count(m) == 0);
+    kth_vm_function_table_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// insert / contains / count
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API FunctionTable - insert grows the map and makes keys visible",
+          "[C-API FunctionTable]") {
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+
+    kth_vm_function_table_insert(m, kKeyA, sizeof(kKeyA),
+                                 kValueA, sizeof(kValueA));
+    REQUIRE(kth_vm_function_table_count(m) == 1);
+    REQUIRE(kth_vm_function_table_contains(m, kKeyA, sizeof(kKeyA)) != 0);
+    REQUIRE(kth_vm_function_table_contains(m, kKeyB, sizeof(kKeyB)) == 0);
+
+    kth_vm_function_table_insert(m, kKeyB, sizeof(kKeyB),
+                                 kValueB, sizeof(kValueB));
+    REQUIRE(kth_vm_function_table_count(m) == 2);
+    REQUIRE(kth_vm_function_table_contains(m, kKeyB, sizeof(kKeyB)) != 0);
+
+    kth_vm_function_table_destruct(m);
+}
+
+TEST_CASE("C-API FunctionTable - insert with the same key overwrites",
+          "[C-API FunctionTable]") {
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+
+    kth_vm_function_table_insert(m, kKeyA, sizeof(kKeyA),
+                                 kValueA, sizeof(kValueA));
+    kth_vm_function_table_insert(m, kKeyA, sizeof(kKeyA),
+                                 kValueB, sizeof(kValueB));
+
+    REQUIRE(kth_vm_function_table_count(m) == 1);  // no growth on overwrite
+
+    kth_size_t sz = 0;
+    uint8_t* v = kth_vm_function_table_at(m, kKeyA, sizeof(kKeyA), &sz);
+    REQUIRE(v != NULL);
+    REQUIRE(sz == sizeof(kValueB));
+    REQUIRE(memcmp(v, kValueB, sz) == 0);  // second insert wins
+    kth_core_destruct_array(v);
+
+    kth_vm_function_table_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// at — present vs absent
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API FunctionTable - at returns a fresh owned copy of the value",
+          "[C-API FunctionTable]") {
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+    kth_vm_function_table_insert(m, kKeyA, sizeof(kKeyA),
+                                 kValueA, sizeof(kValueA));
+
+    kth_size_t sz = 0;
+    uint8_t* got = kth_vm_function_table_at(m, kKeyA, sizeof(kKeyA), &sz);
+    REQUIRE(got != NULL);
+    REQUIRE(sz == sizeof(kValueA));
+    REQUIRE(memcmp(got, kValueA, sz) == 0);
+    kth_core_destruct_array(got);
+
+    kth_vm_function_table_destruct(m);
+}
+
+TEST_CASE("C-API FunctionTable - at on an absent key returns NULL with size 0",
+          "[C-API FunctionTable]") {
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+    kth_vm_function_table_insert(m, kKeyA, sizeof(kKeyA),
+                                 kValueA, sizeof(kValueA));
+
+    kth_size_t sz = 1234;  // deliberately non-zero to verify it gets reset
+    uint8_t* got = kth_vm_function_table_at(m, kKeyB, sizeof(kKeyB), &sz);
+    REQUIRE(got == NULL);
+    REQUIRE(sz == 0);
+
+    kth_vm_function_table_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// erase
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API FunctionTable - erase removes a present key",
+          "[C-API FunctionTable]") {
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+    kth_vm_function_table_insert(m, kKeyA, sizeof(kKeyA),
+                                 kValueA, sizeof(kValueA));
+
+    REQUIRE(kth_vm_function_table_erase(m, kKeyA, sizeof(kKeyA)) != 0);
+    REQUIRE(kth_vm_function_table_count(m) == 0);
+    REQUIRE(kth_vm_function_table_contains(m, kKeyA, sizeof(kKeyA)) == 0);
+
+    kth_vm_function_table_destruct(m);
+}
+
+TEST_CASE("C-API FunctionTable - erase on an absent key returns 0 without affecting state",
+          "[C-API FunctionTable]") {
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+    kth_vm_function_table_insert(m, kKeyA, sizeof(kKeyA),
+                                 kValueA, sizeof(kValueA));
+
+    REQUIRE(kth_vm_function_table_erase(m, kKeyB, sizeof(kKeyB)) == 0);
+    REQUIRE(kth_vm_function_table_count(m) == 1);
+    REQUIRE(kth_vm_function_table_contains(m, kKeyA, sizeof(kKeyA)) != 0);
+
+    kth_vm_function_table_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// nth — iteration
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API FunctionTable - nth yields every entry exactly once",
+          "[C-API FunctionTable]") {
+    // `unordered_flat_map` iteration order is implementation-defined,
+    // but the set of (key, value) pairs seen across positions
+    // [0, count) must exactly equal the inserted set.
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+    kth_vm_function_table_insert(m, kKeyA, sizeof(kKeyA),
+                                 kValueA, sizeof(kValueA));
+    kth_vm_function_table_insert(m, kKeyB, sizeof(kKeyB),
+                                 kValueB, sizeof(kValueB));
+
+    int saw_a = 0;
+    int saw_b = 0;
+    for (kth_size_t i = 0; i < kth_vm_function_table_count(m); ++i) {
+        uint8_t* key = NULL;
+        uint8_t* val = NULL;
+        kth_size_t key_n = 0;
+        kth_size_t val_n = 0;
+        kth_vm_function_table_nth(m, i, &key, &key_n, &val, &val_n);
+        REQUIRE(key != NULL);
+        REQUIRE(val != NULL);
+
+        if (key_n == sizeof(kKeyA) && memcmp(key, kKeyA, key_n) == 0) {
+            REQUIRE(val_n == sizeof(kValueA));
+            REQUIRE(memcmp(val, kValueA, val_n) == 0);
+            ++saw_a;
+        } else if (key_n == sizeof(kKeyB) && memcmp(key, kKeyB, key_n) == 0) {
+            REQUIRE(val_n == sizeof(kValueB));
+            REQUIRE(memcmp(val, kValueB, val_n) == 0);
+            ++saw_b;
+        } else {
+            FAIL("nth returned an unexpected key");
+        }
+
+        kth_core_destruct_array(key);
+        kth_core_destruct_array(val);
+    }
+    REQUIRE(saw_a == 1);
+    REQUIRE(saw_b == 1);
+
+    kth_vm_function_table_destruct(m);
+}
+
+TEST_CASE("C-API FunctionTable - nth out of range leaves outputs untouched",
+          "[C-API FunctionTable]") {
+    // Documented contract: when `index >= count`, `nth` is a no-op and
+    // must not touch any of the four output slots. Seed each slot with
+    // a sentinel and verify it survives.
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+    kth_vm_function_table_insert(m, kKeyA, sizeof(kKeyA),
+                                 kValueA, sizeof(kValueA));
+
+    uint8_t key_sentinel = 0;
+    uint8_t value_sentinel = 0;
+    uint8_t* key = &key_sentinel;
+    uint8_t* val = &value_sentinel;
+    kth_size_t key_n = 77;
+    kth_size_t val_n = 88;
+
+    kth_vm_function_table_nth(m, kth_vm_function_table_count(m),
+                              &key, &key_n, &val, &val_n);
+
+    REQUIRE(key == &key_sentinel);
+    REQUIRE(val == &value_sentinel);
+    REQUIRE(key_n == 77);
+    REQUIRE(val_n == 88);
+
+    kth_vm_function_table_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// Empty key / value — byte-buffer contract with (NULL, 0)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API FunctionTable - empty key and value roundtrip via (NULL, 0)",
+          "[C-API FunctionTable]") {
+    // The byte-buffer contract allows `(NULL, 0)` as a valid empty
+    // buffer; the map must accept it as both key and value, and
+    // `at()` must signal "present" on an empty-valued key distinctly
+    // from "absent" — the generator guards the empty-value path with
+    // a direct 1-byte allocation so `malloc(0)` implementation-
+    // defined behaviour doesn't leak through.
+    kth_function_table_mut_t m = kth_vm_function_table_construct_default();
+
+    kth_vm_function_table_insert(m, NULL, 0, NULL, 0);
+    REQUIRE(kth_vm_function_table_count(m) == 1);
+    REQUIRE(kth_vm_function_table_contains(m, NULL, 0) != 0);
+
+    kth_size_t sz = 999;  // deliberately non-zero to verify it gets reset
+    uint8_t* v = kth_vm_function_table_at(m, NULL, 0, &sz);
+    REQUIRE(v != NULL);
+    REQUIRE(sz == 0);
+    kth_core_destruct_array(v);
+
+    kth_vm_function_table_destruct(m);
+}

--- a/src/c-api/test/vm/interpreter.cpp
+++ b/src/c-api/test/vm/interpreter.cpp
@@ -12,13 +12,38 @@
 
 #include <stdint.h>
 
+#include <kth/capi/bool_list.h>
 #include <kth/capi/chain/opcode.h>
 #include <kth/capi/chain/operation.h>
+#include <kth/capi/chain/script.h>
 #include <kth/capi/primitives.h>
+#include <kth/capi/vm/debug_snapshot.h>
+#include <kth/capi/vm/debug_snapshot_list.h>
 #include <kth/capi/vm/interpreter.h>
 #include <kth/capi/vm/program.h>
 
 #include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixture — tiny script used by the debug-API smoke tests below
+// ---------------------------------------------------------------------------
+
+// Two-op script: `OP_1 OP_1` (bytes 0x51, 0x51). After running, the
+// stack holds two truthy elements; `debug_finalize` should report
+// success.
+static uint8_t const kTwoPushes[2] = { 0x51, 0x51 };
+
+static void build_two_push_program(kth_program_mut_t* out_prog,
+                                   kth_script_mut_t* out_script) {
+    kth_script_mut_t script = NULL;
+    kth_error_code_t ec = kth_chain_script_construct_from_data(
+        kTwoPushes, sizeof(kTwoPushes), 0, &script);
+    REQUIRE(ec == kth_ec_success);
+    kth_program_mut_t prog = kth_vm_program_construct_from_script(script);
+    REQUIRE(prog != NULL);
+    *out_prog = prog;
+    *out_script = script;
+}
 
 // ---------------------------------------------------------------------------
 // run_operation — OP_CODESEPARATOR has no standalone semantics
@@ -40,9 +65,147 @@ TEST_CASE("C-API Interpreter - run_operation rejects OP_CODESEPARATOR standalone
     // the test body immediately (Catch2 is exception-based), so any
     // destructor call after the REQUIRE would be skipped and leak
     // the handles; release first, then assert.
-    kth_error_code_t const ec = kth_vm_interpreter_run_operation(op, prog);
+    kth_error_code_t const ec = kth_vm_interpreter_run(op, prog);
     kth_chain_operation_destruct(op);
     kth_vm_program_destruct(prog);
 
     REQUIRE(ec == kth_ec_not_implemented);
+}
+
+// ---------------------------------------------------------------------------
+// debug_begin + snapshot accessors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Interpreter - debug_begin yields a fresh snapshot at step 0",
+          "[C-API Interpreter][debug]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_two_push_program(&prog, &script);
+
+    kth_debug_snapshot_mut_t snap = kth_vm_interpreter_debug_begin(prog);
+    REQUIRE(snap != NULL);
+    REQUIRE(kth_vm_debug_snapshot_step(snap) == 0);
+    REQUIRE(kth_vm_debug_snapshot_done(snap) == 0);
+    REQUIRE(kth_vm_debug_snapshot_last(snap) == kth_ec_success);
+
+    kth_vm_debug_snapshot_destruct(snap);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// debug_step / debug_step_n
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Interpreter - debug_step advances one op at a time",
+          "[C-API Interpreter][debug]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_two_push_program(&prog, &script);
+
+    kth_debug_snapshot_mut_t s0 = kth_vm_interpreter_debug_begin(prog);
+    kth_debug_snapshot_mut_t s1 = kth_vm_interpreter_debug_step(s0);
+    REQUIRE(kth_vm_debug_snapshot_step(s1) == 1);
+    REQUIRE(kth_vm_debug_snapshot_done(s1) == 0);
+
+    kth_debug_snapshot_mut_t s2 = kth_vm_interpreter_debug_step(s1);
+    REQUIRE(kth_vm_debug_snapshot_step(s2) == 2);
+    REQUIRE(kth_vm_debug_snapshot_done(s2) != 0);
+
+    kth_vm_debug_snapshot_destruct(s2);
+    kth_vm_debug_snapshot_destruct(s1);
+    kth_vm_debug_snapshot_destruct(s0);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Interpreter - debug_step_n advances by N or stops at done",
+          "[C-API Interpreter][debug]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_two_push_program(&prog, &script);
+
+    kth_debug_snapshot_mut_t s0 = kth_vm_interpreter_debug_begin(prog);
+    kth_debug_snapshot_mut_t s_many = kth_vm_interpreter_debug_step_n(s0, 10);
+    REQUIRE(kth_vm_debug_snapshot_done(s_many) != 0);
+
+    kth_vm_debug_snapshot_destruct(s_many);
+    kth_vm_debug_snapshot_destruct(s0);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// debug_run + debug_finalize
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Interpreter - debug_run + debug_finalize reach success",
+          "[C-API Interpreter][debug]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_two_push_program(&prog, &script);
+
+    kth_debug_snapshot_mut_t s0 = kth_vm_interpreter_debug_begin(prog);
+    kth_debug_snapshot_mut_t done = kth_vm_interpreter_debug_run(s0);
+    REQUIRE(kth_vm_debug_snapshot_done(done) != 0);
+    REQUIRE(kth_vm_interpreter_debug_finalize(done) == kth_ec_success);
+
+    kth_vm_debug_snapshot_destruct(done);
+    kth_vm_debug_snapshot_destruct(s0);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// debug_run_traced
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Interpreter - debug_run_traced records initial + per-step snapshots",
+          "[C-API Interpreter][debug]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_two_push_program(&prog, &script);
+
+    kth_debug_snapshot_mut_t start = kth_vm_interpreter_debug_begin(prog);
+    kth_debug_snapshot_list_mut_t trace = kth_vm_interpreter_debug_run_traced(start);
+    REQUIRE(trace != NULL);
+    // Initial + 2 step snapshots = 3 entries.
+    REQUIRE(kth_vm_debug_snapshot_list_count(trace) == 3);
+
+    kth_vm_debug_snapshot_list_destruct(trace);
+    kth_vm_debug_snapshot_destruct(start);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// debug_step_until (callback)
+// ---------------------------------------------------------------------------
+
+// Predicate: stop when `step == *target`. `user_data` carries the
+// target step index, mirroring the usual "threaded state" pattern
+// for C callbacks.
+static kth_bool_t stop_at_step(kth_debug_snapshot_const_t snap, void* user_data) {
+    kth_size_t const target = *(kth_size_t const*)user_data;
+    return kth_vm_debug_snapshot_step(snap) == target ? 1 : 0;
+}
+
+TEST_CASE("C-API Interpreter - debug_step_until stops when predicate fires",
+          "[C-API Interpreter][debug][callback]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_two_push_program(&prog, &script);
+
+    kth_debug_snapshot_mut_t start = kth_vm_interpreter_debug_begin(prog);
+    kth_size_t target = 1;
+    kth_debug_snapshot_mut_t stopped = kth_vm_interpreter_debug_step_until(
+        start, stop_at_step, &target);
+    REQUIRE(kth_vm_debug_snapshot_step(stopped) == 1);
+    // Predicate caught us mid-execution — not done yet.
+    REQUIRE(kth_vm_debug_snapshot_done(stopped) == 0);
+
+    kth_vm_debug_snapshot_destruct(stopped);
+    kth_vm_debug_snapshot_destruct(start);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
 }

--- a/src/domain/include/kth/domain/machine/interpreter.hpp
+++ b/src/domain/include/kth/domain/machine/interpreter.hpp
@@ -127,6 +127,96 @@ struct debug_snapshot {
 struct KD_API interpreter {
     using result = op_result;
 
+    /// Run program script end-to-end. On failure, `op_result::op`
+    /// names the opcode that raised the error (when one is
+    /// attributable — end-of-script structural errors leave it empty).
+    static
+    op_result run(program& program);
+
+    /// Run a single operation outside of the script driver. Prefer
+    /// `run(program&)` for a full script — this overload is for tests
+    /// and the C-API step-one-op path.
+    static
+    op_result run(operation const& op, program& program);
+
+
+// Debug step by step
+// ----------------------------------------------------------------------------
+//
+// All debug primitives take `debug_snapshot` by value so each call
+// naturally produces a new snapshot; the caller keeps prior
+// snapshots to rewind. `snapshot.step` is the program counter;
+// `snapshot.prog.size()` / `snapshot.prog.get_metrics()` and the
+// other `program` observers expose the live execution state.
+
+    /// Open a debug session. Validates the program and returns an
+    /// initial snapshot at step 0.
+    static
+    debug_snapshot debug_begin(program prog);
+
+    /// Execute one op, return the new snapshot. Caller keeps the
+    /// prior snapshot if they want to rewind.
+    static
+    debug_snapshot debug_step(debug_snapshot snapshot);
+
+    /// Execute up to `n` steps (or until done / error).
+    static
+    debug_snapshot debug_step_n(debug_snapshot snapshot, size_t n);
+
+    /// Step until the predicate returns `true` on the post-step
+    /// snapshot (or until done / error). Covers the usual debugger
+    /// breakpoints: by PC, by opcode, on error, on stack-depth
+    /// threshold, etc.
+    static
+    debug_snapshot debug_step_until(
+        debug_snapshot snapshot,
+        std::function<bool(debug_snapshot const&)> const& predicate);
+
+    /// Run to completion without stopping.
+    static
+    debug_snapshot debug_run(debug_snapshot snapshot);
+
+    /// Run to completion and return the full trace: the initial
+    /// snapshot at index 0, followed by one post-step snapshot per
+    /// op executed. For an N-op script the result has N + 1
+    /// entries. Use to record a trace for rewind / display /
+    /// analysis. Expensive for long scripts; prefer `debug_run`
+    /// when you only need the final state.
+    static
+    std::vector<debug_snapshot> debug_run_traced(debug_snapshot start);
+
+    /// Validate the "script closed" post-condition and return the
+    /// final result. Returns the earlier error if the snapshot
+    /// already recorded one.
+    static
+    op_result debug_finalize(debug_snapshot const& snapshot);
+
+
+private:
+    // All `op_*` helpers below are the dispatch targets of `run_op`
+    // (the internal per-opcode switch). They are kept `static` to
+    // match the free-function convention the interpreter was built
+    // around, but they are NOT part of the public C++/C-API surface
+    // — external callers should drive full scripts through `run(...)`
+    // or the debug API. The `private:` section hides them from the
+    // C-API generator so it doesn't produce bindings for 100+
+    // internal helpers.
+
+    static
+    result run_op(operation const& op, program& program);
+
+    /// Helper function for common Native Introspection validations
+    static
+    result validate_native_introspection(program const& program, opcode op_code);
+
+    /// Helper function for Token Introspection validations (requires bch_tokens)
+    static
+    result validate_token_introspection(program const& program, opcode op_code);
+
+    /// Helper function for post-processing Native Introspection push operations
+    static
+    void post_process_introspection_push(program& program, data_chunk const& data);
+
     // Operations (shared).
     //-----------------------------------------------------------------------------
 
@@ -439,83 +529,6 @@ struct KD_API interpreter {
     static
     result op_output_token_amount(program& program);
 
-    /// Run program script end-to-end. On failure, `op_result::op`
-    /// names the opcode that raised the error (when one is
-    /// attributable — end-of-script structural errors leave it empty).
-    static
-    op_result run(program& program);
-
-    /// Run a single operation outside of the script driver. Prefer
-    /// `run(program&)` for a full script — this overload is for tests
-    /// and the C-API step-one-op path.
-    static
-    op_result run(operation const& op, program& program);
-
-
-// Debug step by step
-// ----------------------------------------------------------------------------
-//
-// All debug primitives take `debug_snapshot` by value so each call
-// naturally produces a new snapshot; the caller keeps prior
-// snapshots to rewind. `snapshot.step` is the program counter;
-// `snapshot.prog.size()` / `snapshot.prog.get_metrics()` and the
-// other `program` observers expose the live execution state.
-
-    /// Open a debug session. Validates the program and returns an
-    /// initial snapshot at step 0.
-    static
-    debug_snapshot debug_begin(program prog);
-
-    /// Execute one op, return the new snapshot. Caller keeps the
-    /// prior snapshot if they want to rewind.
-    static
-    debug_snapshot debug_step(debug_snapshot snapshot);
-
-    /// Execute up to `n` steps (or until done / error).
-    static
-    debug_snapshot debug_step_n(debug_snapshot snapshot, size_t n);
-
-    /// Step until the predicate returns `true` on the post-step
-    /// snapshot (or until done / error). Covers the usual debugger
-    /// breakpoints: by PC, by opcode, on error, on stack-depth
-    /// threshold, etc.
-    static
-    debug_snapshot debug_step_until(
-        debug_snapshot snapshot,
-        std::function<bool(debug_snapshot const&)> const& predicate);
-
-    /// Run to completion without stopping.
-    static
-    debug_snapshot debug_run(debug_snapshot snapshot);
-
-    /// Run to completion and return every post-step snapshot,
-    /// including the initial one. Use to record a full trace for
-    /// rewind / display / analysis. Expensive for long scripts;
-    /// prefer `debug_run` when you only need the final state.
-    static
-    std::vector<debug_snapshot> debug_run_traced(debug_snapshot start);
-
-    /// Validate the "script closed" post-condition and return the
-    /// final result. Returns the earlier error if the snapshot
-    /// already recorded one.
-    static
-    op_result debug_finalize(debug_snapshot const& snapshot);
-
-private:
-    static
-    result run_op(operation const& op, program& program);
-
-    /// Helper function for common Native Introspection validations
-    static
-    result validate_native_introspection(program const& program, opcode op_code);
-
-    /// Helper function for Token Introspection validations (requires bch_tokens)
-    static
-    result validate_token_introspection(program const& program, opcode op_code);
-
-    /// Helper function for post-processing Native Introspection push operations
-    static
-    void post_process_introspection_push(program& program, data_chunk const& data);
 };
 
 } // namespace kth::domain::machine


### PR DESCRIPTION
## Summary

Closes out the interpreter / `debug_snapshot` C-API surface. The #271 reshape left it as `not_implemented` stubs; now that the underlying C++ types have settled, the bindings land — including the `function_table` map.

### Surface exposed

- Interpreter: `run`, `run` (single-op), `debug_begin`, `debug_step`, `debug_step_n`, `debug_step_until`, `debug_run`, `debug_run_traced`, `debug_finalize`.
- `debug_snapshot` opaque handle + accessors (`step` / `done` / `last` / `prog` / `control_stack` / `loop_stack` / `function_table` / `invoke_depth` / `outer_loop_depth`) and the matching `debug_snapshot_list` consumed by `debug_run_traced`.
- `kth_debug_step_predicate_t` callback typedef for `debug_step_until` — caller passes a function pointer and a `void* user_data` for closure state.
- `kth_bool_list_*` value-list type so `control_stack` (`std::vector<bool>`) has a natural C-side shape.
- `kth_function_table_*` map type (`construct` / `destruct` / `count` / `contains` / `at` / `insert` / `erase` / `nth`) so `debug_snapshot::function_table` is a first-class accessor.

### Domain changes

- `interpreter::op_*` dispatch helpers (100+) moved to `private:`. External callers never used them (internal targets of the `run_op` switch) and exposing them through C++/C-API surface was noise.

## Test plan

- [x] Full suite green.
- [x] New C-API tests cover every exposed debug entry point (`debug_begin` state, per-step advance, batch `step_n`, full `run` + `finalize`, `run_traced` snapshot list, and the callback path of `debug_step_until`) plus the full `function_table` surface (construct / destruct / count / insert / contains / at / erase / nth + overwrite semantics + empty-buffer contract).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new C-API surface area and changes interpreter entry points, plus new ownership/FFI patterns (snapshots, callback predicate, and empty-buffer handling) that could cause ABI/behavioral mismatches for consumers if misused.
> 
> **Overview**
> Adds first-class C bindings for VM debugging by introducing opaque `debug_snapshot` handles (with accessors) and snapshot tracing (`debug_snapshot_list`), and wiring the interpreter C-API to the new snapshot-based debug workflow (`debug_begin`, `debug_step(_n/_until)`, `debug_run(_traced)`, `debug_finalize`) alongside a renamed full-script entry point (`kth_vm_interpreter_run_simple`) and a single-op `kth_vm_interpreter_run`.
> 
> Introduces new C-API container types needed by snapshots: `kth_bool_list_*` for the control stack and `kth_function_table_*` for the VM function table, including careful handling of empty byte buffers so “present but empty” values don’t collapse to NULL.
> 
> Build/test wiring is updated to compile the new sources and add Catch2 coverage for the new `function_table` surface and interpreter debug flow; domain `interpreter` also hides internal `op_*` helpers under `private:` to avoid exposing them as public API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c79793dee107bf63842c4b40d3f00ed2614e825. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug snapshot API for step-by-step VM execution inspection
  * Added function table API for key-value storage operations
  * Added boolean list operations (construct, append, query, update, erase)
  * Added debug snapshot collection support for tracing execution sessions

* **API Changes**
  * Restructured interpreter execution API with improved separation of concerns
  * Transitioned debug control from state-based to snapshot-based interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->