### PR TITLE
refactor(c-api): split primitives.h into handles.h + callbacks.h

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -313,6 +313,8 @@ set(kth_headers
   include/kth/capi/wallet/wallet_manager.h
 
   include/kth/capi/primitives.h
+  include/kth/capi/handles.h
+  include/kth/capi/callbacks.h
   include/kth/capi/hash_list.h
   include/kth/capi/error.h
   include/kth/capi/hash.h

--- a/src/c-api/include/kth/capi/callbacks.h
+++ b/src/c-api/include/kth/capi/callbacks.h
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is auto-generated. Do not edit manually.
+
+#ifndef KTH_CAPI_CALLBACKS_H_
+#define KTH_CAPI_CALLBACKS_H_
+
+#include <stdint.h>
+
+#include <kth/capi/error.h>
+#include <kth/capi/handles.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// VM
+// ----------------------------------------------------------------------------
+// `interpreter::debug_step_until` predicate: fires on each post-step
+// snapshot. Return non-zero to stop stepping, zero to continue. The
+// snapshot handle is borrowed (do not destruct); `user_data` is the
+// pointer the caller passed alongside the predicate.
+//
+// MUST NOT throw (when compiled as C++): the C++ runtime does not
+// propagate exceptions across the `extern "C"` boundary, and an
+// exception thrown by this callback would unwind through
+// `interpreter::debug_step_until` — undefined behaviour. Convert
+// exceptional conditions in the predicate body into a "stop" signal
+// (return non-zero, stash the diagnostic in `user_data`) instead.
+typedef kth_bool_t (*kth_debug_step_predicate_t)(kth_debug_snapshot_const_t snapshot, void* user_data);
+
+// Async safe_chain handler signatures
+// ----------------------------------------------------------------------------
+typedef void (*kth_run_handler_t)(kth_node_t, void*, kth_error_code_t);
+typedef void (*kth_stealth_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_stealth_compact_list_mut_t);
+
+// Owned: `block` (`kth_block_mut_t`) — caller must release with `kth_chain_block_destruct`.
+typedef void (*kth_block_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_block_mut_t block, kth_size_t);
+
+// Owned: `header` (`kth_header_mut_t`) — caller must release with `kth_chain_header_destruct`.
+// Owned: `tx_hashes` (`kth_hash_list_mut_t`) — caller must release with `kth_core_hash_list_destruct`.
+typedef void (*kth_block_header_txs_size_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_header_mut_t header, kth_size_t, kth_hash_list_mut_t tx_hashes, uint64_t);
+typedef void (*kth_blockhash_timestamp_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_hash_t, uint32_t, kth_size_t);
+typedef void (*kth_block_height_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_size_t);
+
+// Owned: `header` (`kth_header_mut_t`) — caller must release with `kth_chain_header_destruct`.
+typedef void (*kth_block_header_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_header_mut_t header, kth_size_t);
+
+// Owned: `block` (`kth_compact_block_mut_t`) — caller must release with `kth_chain_compact_block_destruct`.
+typedef void (*kth_compact_block_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_compact_block_mut_t block, kth_size_t);
+
+// Owned: `history` (`kth_history_compact_list_mut_t`) — caller must release with `kth_chain_history_compact_list_destruct`.
+typedef void (*kth_history_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_history_compact_list_mut_t history);
+typedef void (*kth_last_height_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_size_t);
+
+// Owned: `block` (`kth_merkle_block_mut_t`) — caller must release with `kth_chain_merkle_block_destruct`.
+typedef void (*kth_merkle_block_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_merkle_block_mut_t block, kth_size_t);
+typedef void (*kth_output_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_output_mut_t output);
+
+// Owned: `spend` (`kth_inputpoint_t`) — caller takes ownership; no public destructor exposed yet.
+typedef void (*kth_spend_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_inputpoint_t spend);
+
+// Owned: `tx` (`kth_transaction_mut_t`) — caller must release with `kth_chain_transaction_destruct`.
+typedef void (*kth_transaction_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_transaction_mut_t tx, kth_size_t, kth_size_t);
+typedef void (*kth_transaction_index_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_size_t, kth_size_t);
+typedef void (*kth_validate_tx_handler_t)(kth_chain_t, void*, kth_error_code_t, char const*);
+typedef void (*kth_block_locator_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_get_headers_mut_t);
+typedef void (*kth_result_handler_t)(kth_chain_t, void*, kth_error_code_t);
+
+// Owned: `tx_hashes` (`kth_hash_list_mut_t`) — caller must release with `kth_core_hash_list_destruct`.
+typedef void (*kth_transactions_by_address_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_hash_list_mut_t tx_hashes);
+
+// Owned: `incoming` (`kth_block_list_mut_t`) — caller must release with `kth_chain_block_list_destruct`.
+// Owned: `replaced` (`kth_block_list_mut_t`) — caller must release with `kth_chain_block_list_destruct`.
+typedef kth_bool_t (*kth_subscribe_blockchain_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_size_t, kth_block_list_mut_t incoming, kth_block_list_mut_t replaced);
+
+// Owned: `tx` (`kth_transaction_mut_t`) — caller must release with `kth_chain_transaction_destruct`.
+typedef kth_bool_t (*kth_subscribe_transaction_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_transaction_mut_t tx);
+
+// Owned: `ds_proof` (`kth_double_spend_proof_mut_t`) — caller must release with `kth_chain_double_spend_proof_destruct`.
+typedef kth_bool_t (*kth_subscribe_ds_proof_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_double_spend_proof_mut_t ds_proof);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_CALLBACKS_H_ */

--- a/src/c-api/include/kth/capi/handles.h
+++ b/src/c-api/include/kth/capi/handles.h
@@ -1,0 +1,234 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_HANDLES_H_
+#define KTH_CAPI_HANDLES_H_
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <kth/capi/visibility.h>
+
+#define KTH_PRECONDITION(expr) do { if (!(expr)) { abort(); } } while(0)
+
+// Marks a function whose return value (or one of its out-parameters) transfers
+// ownership to the caller. The caller is then responsible for releasing the
+// returned object via the matching destructor (`kth_<group>_<obj>_destruct`
+// for handles, `kth_core_destruct_array` for raw byte buffers,
+// `kth_core_destruct_string` for C strings).
+//
+// On compilers that support it, this also raises a warning when the result of
+// such a call is silently discarded, which would otherwise leak memory.
+#if defined(__GNUC__) || defined(__clang__)
+#define KTH_OWNED __attribute__((warn_unused_result))
+#else
+#define KTH_OWNED
+#endif
+
+// Parameter-level companion to KTH_OWNED. Marks an out-parameter that, on
+// successful completion, is filled with an object the caller now owns and
+// must release with the matching destructor. The marker is purely informative
+// at the C level (it expands to nothing) but is visible at the declaration
+// site and is greppable for non-C language backends.
+#define KTH_OUT_OWNED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Releases an owned byte buffer returned by a C-API function (e.g. the
+// payload of `kth_chain_*_to_data`). Internally a thin wrapper around
+// free(); kept as a dedicated entry point so the API does not commit to a
+// specific allocator and so language backends can wire it through their
+// SafeHandle / Drop equivalents.
+KTH_EXPORT
+void kth_core_destruct_array(uint8_t* arr);
+
+// Releases an owned C string returned by a C-API function. Same rationale
+// as kth_core_destruct_array.
+KTH_EXPORT
+void kth_core_destruct_string(char* str);
+
+#define KTH_BITCOIN_SHORT_HASH_SIZE 20
+#define KTH_BITCOIN_HASH_SIZE 32
+#define KTH_BITCOIN_LONG_HASH_SIZE 64
+#define KTH_BITCOIN_ENCRYPTED_SEED_SIZE 96
+
+#define KTH_BITCOIN_MINIMUM_SEED_BITS 128
+#define KTH_BITCOIN_BYTE_BITS 8
+#define KTH_BITCOIN_MINIMUM_SEED_SIZE (KTH_BITCOIN_MINIMUM_SEED_BITS / KTH_BITCOIN_BYTE_BITS)
+
+#define KTH_WALLET_HD_PUBLIC_MAINNET 76067358
+#define KTH_WALLET_HD_PUBLIC_TESTNET 70617039
+#define KTH_WALLET_HD_PRIVATE_MAINNET 326702167824577054
+#define KTH_WALLET_HD_PRIVATE_TESTNET 303293221666392015
+
+typedef int kth_bool_t;
+
+#if defined(__EMSCRIPTEN__)
+typedef uint32_t kth_size_t;    // It is std::size_t in the C++ code.
+#else
+typedef uint64_t kth_size_t;
+#endif
+
+#if defined(_WIN32)
+typedef wchar_t kth_char_t;
+#else
+typedef char kth_char_t;
+#endif
+
+typedef void* kth_node_t;
+typedef void* kth_chain_t;
+typedef void* kth_p2p_t;
+
+//typedef struct kth_outputpoint_t {
+//    uint8_t* hash;
+//    uint32_t index;
+//} kth_outputpoint_t;
+
+
+// TODO(fernando): check if we can encapsulate the pointer into a struct to make them more "type safe"
+typedef void* kth_block_mut_t;
+typedef void const* kth_block_const_t;
+typedef void* kth_block_list_mut_t;
+typedef void const* kth_block_list_const_t;
+typedef void* kth_compact_block_mut_t;
+typedef void const* kth_compact_block_const_t;
+typedef void* kth_double_spend_proof_mut_t;
+typedef void const* kth_double_spend_proof_const_t;
+typedef void* kth_double_spend_proof_spender_mut_t;
+typedef void const* kth_double_spend_proof_spender_const_t;
+typedef void* kth_header_mut_t;
+typedef void const* kth_header_const_t;
+typedef void* kth_chain_state_mut_t;
+typedef void const* kth_chain_state_const_t;
+typedef void* kth_history_compact_mut_t;
+typedef void const* kth_history_compact_const_t;
+typedef void* kth_history_compact_list_mut_t;
+typedef void const* kth_history_compact_list_const_t;
+typedef void* kth_input_mut_t;
+typedef void const* kth_input_const_t;
+typedef void* kth_input_list_mut_t;
+typedef void const* kth_input_list_const_t;
+typedef void* kth_utxo_list_mut_t;
+typedef void const* kth_utxo_list_const_t;
+typedef void* kth_inputpoint_t;
+typedef void* kth_merkle_block_mut_t;
+typedef void const* kth_merkle_block_const_t;
+typedef void* kth_prefilled_transaction_mut_t;
+typedef void const* kth_prefilled_transaction_const_t;
+typedef void* kth_prefilled_transaction_list_mut_t;
+typedef void const* kth_prefilled_transaction_list_const_t;
+typedef void* kth_script_mut_t;
+typedef void const* kth_script_const_t;
+typedef void* kth_token_data_t;
+typedef void* kth_token_data_mut_t;
+typedef void const* kth_token_data_const_t;
+
+typedef void* kth_operation_list_t;
+typedef void* kth_operation_list_mut_t;
+typedef void const* kth_operation_list_const_t;
+typedef void* kth_operation_t;
+typedef void* kth_operation_mut_t;
+typedef void const* kth_operation_const_t;
+
+typedef void* kth_output_list_mut_t;
+typedef void const* kth_output_list_const_t;
+typedef void* kth_output_mut_t;
+typedef void const* kth_output_const_t;
+typedef void* kth_output_point_mut_t;
+typedef void const* kth_output_point_const_t;
+typedef void* kth_utxo_mut_t;
+typedef void const* kth_utxo_const_t;
+typedef void* kth_point_mut_t;
+typedef void const* kth_point_const_t;
+typedef void* kth_point_list_mut_t;
+typedef void const* kth_point_list_const_t;
+typedef void* kth_output_point_list_mut_t;
+typedef void const* kth_output_point_list_const_t;
+typedef void* kth_transaction_mut_t;
+typedef void const* kth_transaction_const_t;
+typedef void* kth_transaction_list_mut_t;
+typedef void const* kth_transaction_list_const_t;
+typedef void* kth_mempool_transaction_t;
+typedef void* kth_mempool_transaction_list_t;
+typedef void* kth_get_blocks_mut_t;
+typedef void const* kth_get_blocks_const_t;
+typedef void* kth_get_headers_mut_t;
+typedef void const* kth_get_headers_const_t;
+typedef void* kth_payment_address_t;
+typedef void* kth_payment_address_mut_t;
+typedef void const* kth_payment_address_const_t;
+typedef void* kth_payment_address_list_t;
+typedef void* kth_payment_address_list_mut_t;
+typedef void const* kth_payment_address_list_const_t;
+typedef void* kth_binary_mut_t;
+typedef void const* kth_binary_const_t;
+typedef void* kth_stealth_compact_mut_t;
+typedef void const* kth_stealth_compact_const_t;
+typedef void* kth_stealth_compact_list_mut_t;
+typedef void const* kth_stealth_compact_list_const_t;
+typedef void* kth_hash_list_mut_t;
+typedef void const* kth_hash_list_const_t;
+typedef void* kth_string_list_mut_t;
+typedef void const* kth_string_list_const_t;
+typedef void* kth_double_list_mut_t;
+typedef void const* kth_double_list_const_t;
+typedef void* kth_u32_list_mut_t;
+typedef void const* kth_u32_list_const_t;
+typedef void* kth_u64_list_mut_t;
+typedef void const* kth_u64_list_const_t;
+typedef void* kth_bool_list_mut_t;
+typedef void const* kth_bool_list_const_t;
+
+typedef void* kth_wallet_data_mut_t;
+typedef void const* kth_wallet_data_const_t;
+
+typedef void* kth_ec_compressed_list_t;
+typedef void* kth_ec_compressed_list_mut_t;
+typedef void const* kth_ec_compressed_list_const_t;
+
+// Vector of byte buffers — used by Bitcoin script's runtime stack and by
+// `to_pay_multisig_pattern` for the signature variant. The owning C-API
+// type is opaque; element accessors are not exposed yet.
+typedef void* kth_data_stack_mut_t;
+typedef void const* kth_data_stack_const_t;
+
+
+// VM
+typedef void* kth_metrics_mut_t;
+typedef void const* kth_metrics_const_t;
+typedef void* kth_program_mut_t;
+typedef void const* kth_program_const_t;
+typedef void* kth_debug_snapshot_mut_t;
+typedef void const* kth_debug_snapshot_const_t;
+typedef void* kth_debug_snapshot_list_mut_t;
+typedef void const* kth_debug_snapshot_list_const_t;
+typedef void* kth_function_table_mut_t;
+typedef void const* kth_function_table_const_t;
+
+
+// Hash structs
+
+typedef struct kth_shorthash_t {
+    uint8_t hash[KTH_BITCOIN_SHORT_HASH_SIZE];  //kth::hash_size
+} kth_shorthash_t;
+
+typedef struct kth_hash_t {
+    uint8_t hash[KTH_BITCOIN_HASH_SIZE];        //kth::hash_size
+} kth_hash_t;
+
+typedef struct kth_longhash_t {
+    uint8_t hash[KTH_BITCOIN_LONG_HASH_SIZE];   //kth::long_hash_size
+} kth_longhash_t;
+
+typedef struct kth_encrypted_seed_t {
+    uint8_t hash[KTH_BITCOIN_ENCRYPTED_SEED_SIZE];
+} kth_encrypted_seed_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_HANDLES_H_ */

--- a/src/c-api/include/kth/capi/primitives.h
+++ b/src/c-api/include/kth/capi/primitives.h
@@ -5,8 +5,23 @@
 #ifndef KTH_CAPI_PRIMITIVES_H_
 #define KTH_CAPI_PRIMITIVES_H_
 
-#include <stdint.h>
-#include <stdlib.h>
+// Aggregator header. The actual content lives in three siblings split by
+// concern:
+//
+//   - `handles.h`      — scalar typedefs (`kth_size_t`, `kth_bool_t`, ...),
+//                        opaque void* handles, hash structs, allocation
+//                        contract macros (`KTH_OWNED`, `KTH_PRECONDITION`,
+//                        ...) and the destruct entry points.
+//   - `callbacks.h`    — every `kth_*_handler_t` callback typedef and the
+//                        `kth_debug_step_predicate_t` VM predicate.
+//   - the enum headers — `chain/endorsement_type.h`, `chain/point_kind.h`,
+//                        `config/*`, `error.h`, `node/start_modules.h`.
+//
+// Including `primitives.h` continues to expose the full surface so existing
+// translation units stay unchanged.
+
+#include <kth/capi/handles.h>
+#include <kth/capi/callbacks.h>
 
 #include <kth/capi/chain/endorsement_type.h>
 #include <kth/capi/chain/point_kind.h>
@@ -16,266 +31,5 @@
 #include <kth/capi/error.h>
 #include <kth/capi/node/start_modules.h>
 #include <kth/capi/visibility.h>
-
-#define KTH_PRECONDITION(expr) do { if (!(expr)) { abort(); } } while(0)
-
-// Marks a function whose return value (or one of its out-parameters) transfers
-// ownership to the caller. The caller is then responsible for releasing the
-// returned object via the matching destructor (`kth_<group>_<obj>_destruct`
-// for handles, `kth_core_destruct_array` for raw byte buffers,
-// `kth_core_destruct_string` for C strings).
-//
-// On compilers that support it, this also raises a warning when the result of
-// such a call is silently discarded, which would otherwise leak memory.
-#if defined(__GNUC__) || defined(__clang__)
-#define KTH_OWNED __attribute__((warn_unused_result))
-#else
-#define KTH_OWNED
-#endif
-
-// Parameter-level companion to KTH_OWNED. Marks an out-parameter that, on
-// successful completion, is filled with an object the caller now owns and
-// must release with the matching destructor. The marker is purely informative
-// at the C level (it expands to nothing) but is visible at the declaration
-// site and is greppable for non-C language backends.
-#define KTH_OUT_OWNED
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-// Releases an owned byte buffer returned by a C-API function (e.g. the
-// payload of `kth_chain_*_to_data`). Internally a thin wrapper around
-// free(); kept as a dedicated entry point so the API does not commit to a
-// specific allocator and so language backends can wire it through their
-// SafeHandle / Drop equivalents.
-KTH_EXPORT
-void kth_core_destruct_array(uint8_t* arr);
-
-// Releases an owned C string returned by a C-API function. Same rationale
-// as kth_core_destruct_array.
-KTH_EXPORT
-void kth_core_destruct_string(char* str);
-
-#define KTH_BITCOIN_SHORT_HASH_SIZE 20
-#define KTH_BITCOIN_HASH_SIZE 32
-#define KTH_BITCOIN_LONG_HASH_SIZE 64
-#define KTH_BITCOIN_ENCRYPTED_SEED_SIZE 96
-
-#define KTH_BITCOIN_MINIMUM_SEED_BITS 128
-#define KTH_BITCOIN_BYTE_BITS 8
-#define KTH_BITCOIN_MINIMUM_SEED_SIZE (KTH_BITCOIN_MINIMUM_SEED_BITS / KTH_BITCOIN_BYTE_BITS)
-
-#define KTH_WALLET_HD_PUBLIC_MAINNET 76067358
-#define KTH_WALLET_HD_PUBLIC_TESTNET 70617039
-#define KTH_WALLET_HD_PRIVATE_MAINNET 326702167824577054
-#define KTH_WALLET_HD_PRIVATE_TESTNET 303293221666392015
-
-typedef int kth_bool_t;
-
-#if defined(__EMSCRIPTEN__)
-typedef uint32_t kth_size_t;    // It is std::size_t in the C++ code.
-#else
-typedef uint64_t kth_size_t;
-#endif
-
-#if defined(_WIN32)
-typedef wchar_t kth_char_t;
-#else
-typedef char kth_char_t;
-#endif
-
-typedef void* kth_node_t;
-typedef void* kth_chain_t;
-typedef void* kth_p2p_t;
-
-//typedef struct kth_outputpoint_t {
-//    uint8_t* hash;
-//    uint32_t index;
-//} kth_outputpoint_t;
-
-
-// TODO(fernando): check if we can encapsulate the pointer into a struct to make them more "type safe"
-typedef void* kth_block_mut_t;
-typedef void const* kth_block_const_t;
-typedef void* kth_block_list_mut_t;
-typedef void const* kth_block_list_const_t;
-typedef void* kth_compact_block_mut_t;
-typedef void const* kth_compact_block_const_t;
-typedef void* kth_double_spend_proof_mut_t;
-typedef void const* kth_double_spend_proof_const_t;
-typedef void* kth_double_spend_proof_spender_mut_t;
-typedef void const* kth_double_spend_proof_spender_const_t;
-typedef void* kth_header_mut_t;
-typedef void const* kth_header_const_t;
-typedef void* kth_chain_state_mut_t;
-typedef void const* kth_chain_state_const_t;
-typedef void* kth_history_compact_mut_t;
-typedef void const* kth_history_compact_const_t;
-typedef void* kth_history_compact_list_mut_t;
-typedef void const* kth_history_compact_list_const_t;
-typedef void* kth_input_mut_t;
-typedef void const* kth_input_const_t;
-typedef void* kth_input_list_mut_t;
-typedef void const* kth_input_list_const_t;
-typedef void* kth_utxo_list_mut_t;
-typedef void const* kth_utxo_list_const_t;
-typedef void* kth_inputpoint_t;
-typedef void* kth_merkle_block_mut_t;
-typedef void const* kth_merkle_block_const_t;
-typedef void* kth_prefilled_transaction_mut_t;
-typedef void const* kth_prefilled_transaction_const_t;
-typedef void* kth_prefilled_transaction_list_mut_t;
-typedef void const* kth_prefilled_transaction_list_const_t;
-typedef void* kth_script_mut_t;
-typedef void const* kth_script_const_t;
-typedef void* kth_token_data_t;
-typedef void* kth_token_data_mut_t;
-typedef void const* kth_token_data_const_t;
-
-typedef void* kth_operation_list_t;
-typedef void* kth_operation_list_mut_t;
-typedef void const* kth_operation_list_const_t;
-typedef void* kth_operation_t;
-typedef void* kth_operation_mut_t;
-typedef void const* kth_operation_const_t;
-
-typedef void* kth_output_list_mut_t;
-typedef void const* kth_output_list_const_t;
-typedef void* kth_output_mut_t;
-typedef void const* kth_output_const_t;
-typedef void* kth_output_point_mut_t;
-typedef void const* kth_output_point_const_t;
-typedef void* kth_utxo_mut_t;
-typedef void const* kth_utxo_const_t;
-typedef void* kth_point_mut_t;
-typedef void const* kth_point_const_t;
-typedef void* kth_point_list_mut_t;
-typedef void const* kth_point_list_const_t;
-typedef void* kth_output_point_list_mut_t;
-typedef void const* kth_output_point_list_const_t;
-typedef void* kth_transaction_mut_t;
-typedef void const* kth_transaction_const_t;
-typedef void* kth_transaction_list_mut_t;
-typedef void const* kth_transaction_list_const_t;
-typedef void* kth_mempool_transaction_t;
-typedef void* kth_mempool_transaction_list_t;
-typedef void* kth_get_blocks_mut_t;
-typedef void const* kth_get_blocks_const_t;
-typedef void* kth_get_headers_mut_t;
-typedef void const* kth_get_headers_const_t;
-typedef void* kth_payment_address_t;
-typedef void* kth_payment_address_mut_t;
-typedef void const* kth_payment_address_const_t;
-typedef void* kth_payment_address_list_t;
-typedef void* kth_payment_address_list_mut_t;
-typedef void const* kth_payment_address_list_const_t;
-typedef void* kth_binary_mut_t;
-typedef void const* kth_binary_const_t;
-typedef void* kth_stealth_compact_mut_t;
-typedef void const* kth_stealth_compact_const_t;
-typedef void* kth_stealth_compact_list_mut_t;
-typedef void const* kth_stealth_compact_list_const_t;
-typedef void* kth_hash_list_mut_t;
-typedef void const* kth_hash_list_const_t;
-typedef void* kth_string_list_mut_t;
-typedef void const* kth_string_list_const_t;
-typedef void* kth_double_list_mut_t;
-typedef void const* kth_double_list_const_t;
-typedef void* kth_u32_list_mut_t;
-typedef void const* kth_u32_list_const_t;
-typedef void* kth_u64_list_mut_t;
-typedef void const* kth_u64_list_const_t;
-typedef void* kth_bool_list_mut_t;
-typedef void const* kth_bool_list_const_t;
-
-typedef void* kth_wallet_data_mut_t;
-typedef void const* kth_wallet_data_const_t;
-
-typedef void* kth_ec_compressed_list_t;
-typedef void* kth_ec_compressed_list_mut_t;
-typedef void const* kth_ec_compressed_list_const_t;
-
-// Vector of byte buffers — used by Bitcoin script's runtime stack and by
-// `to_pay_multisig_pattern` for the signature variant. The owning C-API
-// type is opaque; element accessors are not exposed yet.
-typedef void* kth_data_stack_mut_t;
-typedef void const* kth_data_stack_const_t;
-
-
-// VM
-typedef void* kth_metrics_mut_t;
-typedef void const* kth_metrics_const_t;
-typedef void* kth_program_mut_t;
-typedef void const* kth_program_const_t;
-typedef void* kth_debug_snapshot_mut_t;
-typedef void const* kth_debug_snapshot_const_t;
-typedef void* kth_debug_snapshot_list_mut_t;
-typedef void const* kth_debug_snapshot_list_const_t;
-typedef void* kth_function_table_mut_t;
-typedef void const* kth_function_table_const_t;
-
-// `interpreter::debug_step_until` predicate: fires on each post-step
-// snapshot. Return non-zero to stop stepping, zero to continue. The
-// snapshot handle is borrowed (do not destruct); `user_data` is the
-// pointer the caller passed alongside the predicate.
-//
-// MUST NOT throw (when compiled as C++): the C++ runtime does not
-// propagate exceptions across the `extern "C"` boundary, and an
-// exception thrown by this callback would unwind through
-// `interpreter::debug_step_until` — undefined behaviour. Convert
-// exceptional conditions in the predicate body into a "stop" signal
-// (return non-zero, stash the diagnostic in `user_data`) instead.
-typedef kth_bool_t (*kth_debug_step_predicate_t)(
-    kth_debug_snapshot_const_t snapshot, void* user_data);
-
-
-// helper functions
-
-typedef struct kth_shorthash_t {
-    uint8_t hash[KTH_BITCOIN_SHORT_HASH_SIZE];  //kth::hash_size
-} kth_shorthash_t;
-
-typedef struct kth_hash_t {
-    uint8_t hash[KTH_BITCOIN_HASH_SIZE];        //kth::hash_size
-} kth_hash_t;
-
-typedef struct kth_longhash_t {
-    uint8_t hash[KTH_BITCOIN_LONG_HASH_SIZE];   //kth::long_hash_size
-} kth_longhash_t;
-
-typedef struct kth_encrypted_seed_t {
-    uint8_t hash[KTH_BITCOIN_ENCRYPTED_SEED_SIZE];
-} kth_encrypted_seed_t;
-
-
-
-// Callback signatures ------------------------------------------------
-typedef void (*kth_run_handler_t)(kth_node_t, void*, kth_error_code_t);
-typedef void (*kth_stealth_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_stealth_compact_list_mut_t);
-typedef void (*kth_block_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_block_mut_t, kth_size_t);
-typedef void (*kth_block_header_txs_size_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_header_mut_t, kth_size_t, kth_hash_list_mut_t, uint64_t);
-typedef void (*kth_blockhash_timestamp_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_hash_t, uint32_t, kth_size_t);
-typedef void (*kth_block_height_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_size_t);
-typedef void (*kth_block_header_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_header_mut_t, kth_size_t);
-typedef void (*kth_compact_block_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_compact_block_mut_t, kth_size_t);
-typedef void (*kth_history_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_history_compact_list_mut_t);
-typedef void (*kth_last_height_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_size_t);
-typedef void (*kth_merkle_block_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_merkle_block_mut_t, kth_size_t);
-typedef void (*kth_output_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_output_mut_t output);
-typedef void (*kth_spend_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_inputpoint_t);
-typedef void (*kth_transaction_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_transaction_mut_t, kth_size_t, kth_size_t);
-typedef void (*kth_transaction_index_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_size_t, kth_size_t);
-typedef void (*kth_validate_tx_handler_t)(kth_chain_t, void*, kth_error_code_t, char const*);
-typedef void (*kth_block_locator_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_get_headers_mut_t);
-typedef void (*kth_result_handler_t)(kth_chain_t, void*, kth_error_code_t);
-typedef void (*kth_transactions_by_address_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_hash_list_mut_t);
-typedef kth_bool_t (*kth_subscribe_blockchain_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_size_t, kth_block_list_mut_t, kth_block_list_mut_t);
-typedef kth_bool_t (*kth_subscribe_transaction_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_transaction_mut_t);
-typedef kth_bool_t (*kth_subscribe_ds_proof_handler_t)(kth_node_t, kth_chain_t, void*, kth_error_code_t, kth_double_spend_proof_mut_t);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
 
 #endif /* KTH_CAPI_PRIMITIVES_H_ */


### PR DESCRIPTION
## Summary
- Split `primitives.h` (~280 lines, three concerns mixed) into `handles.h` (scalars + opaque handles + hash structs + allocation macros) and `callbacks.h` (every `kth_*_handler_t` typedef + the `kth_debug_step_predicate_t` VM predicate).
- `primitives.h` is now a slim aggregator that includes both new headers plus the existing enum headers, so consumers continue to see the full surface unchanged.
- No behavioural change. Pure header reorganisation; the C-API surface, the typedefs and the function declarations are byte-equivalent.

## Test plan
- [x] Local build (master config) compiles cleanly.
- [ ] CI: c-api + python-bindings targets stay green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure header re-organization with no functional logic changes; main risk is minor build/include-order fallout for downstream consumers that include internals directly.
> 
> **Overview**
> Refactors the C-API header surface by splitting the former monolithic `primitives.h` into two dedicated headers: `handles.h` (core scalar typedefs, opaque handle types, ownership/allocator macros, hash structs, and destruct entry points) and `callbacks.h` (all async handler and subscription callback typedefs, plus the VM `kth_debug_step_predicate_t`).
> 
> `primitives.h` is now a thin aggregator that includes the new headers plus existing enum headers to preserve the same public surface for current consumers, and `CMakeLists.txt` is updated to install/export the two new headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d7144090409acf435050e0f1803dc10759bcc88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * C API now provides explicit callback type definitions for async chain operations, subscription handlers, and debug stepping.

* **Refactor**
  * Reorganized C API type definitions: Core handle types, constants, and callback definitions are now available in dedicated headers (`handles.h` and `callbacks.h`) rather than consolidated in `primitives.h`, improving clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->