### PR TITLE
refactor(domain): move script_pattern to domain + rename pay_* to pay_to_*

### DIFF
--- a/src/c-api/include/kth/capi/chain/script_pattern.h
+++ b/src/c-api/include/kth/capi/chain/script_pattern.h
@@ -20,27 +20,27 @@ typedef enum {
     /// Pay to Multisig [BIP11]
     /// Pubkey script: <m> <A pubkey>[B pubkey][C pubkey...] <n> OP_CHECKMULTISIG
     /// Signature script: OP_0 <A sig>[B sig][C sig...]
-    kth_script_pattern_pay_multisig,
+    kth_script_pattern_pay_to_multisig,
 
     /// Pay to Public Key (obsolete)
-    kth_script_pattern_pay_public_key,
+    kth_script_pattern_pay_to_public_key,
 
     /// Pay to Public Key Hash [P2PKH]
     /// Pubkey script: OP_DUP OP_HASH160 <PubKeyHash> OP_EQUALVERIFY OP_CHECKSIG
     /// Signature script: <sig> <pubkey>
-    kth_script_pattern_pay_public_key_hash,
+    kth_script_pattern_pay_to_public_key_hash,
 
     /// Pay to Script Hash [P2SH/BIP16]
     /// The redeem script may be any pay type, but only multisig makes sense.
     /// Pubkey script: OP_HASH160 <Hash160(redeemScript)> OP_EQUAL
     /// Signature script: <sig>[sig][sig...] <redeemScript>
-    kth_script_pattern_pay_script_hash,
+    kth_script_pattern_pay_to_script_hash,
 
     /// Pay to Script Hash 32
     /// The redeem script may be any pay type, but only multisig makes sense.
     /// Pubkey script: OP_HASH256 <Hash256(redeemScript)> OP_EQUAL
     /// Signature script: <sig>[sig][sig...] <redeemScript>
-    kth_script_pattern_pay_script_hash_32,
+    kth_script_pattern_pay_to_script_hash_32,
 
     /// Sign Multisig script [BIP11]
     kth_script_pattern_sign_multisig,

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -607,13 +607,13 @@ kth::domain::machine::script_flags script_flags_to_cpp(kth_script_flags_t flags)
 // Script Pattern -----------------------------------------------------
 
 inline
-kth_script_pattern_t script_pattern_to_c(kth::infrastructure::machine::script_pattern pattern) {
+kth_script_pattern_t script_pattern_to_c(kth::domain::machine::script_pattern pattern) {
     return static_cast<kth_script_pattern_t>(pattern);
 }
 
 inline
-kth::infrastructure::machine::script_pattern script_pattern_to_cpp(kth_script_pattern_t pattern) {
-    return static_cast<kth::infrastructure::machine::script_pattern>(pattern);
+kth::domain::machine::script_pattern script_pattern_to_cpp(kth_script_pattern_t pattern) {
+    return static_cast<kth::domain::machine::script_pattern>(pattern);
 }
 
 // Script Version -----------------------------------------------------

--- a/src/c-api/test/chain/script.cpp
+++ b/src/c-api/test/chain/script.cpp
@@ -36,14 +36,14 @@
 static uint8_t const kOpReturnPrefixed[2] = { 0x01, 0x6a };
 static uint8_t const kOpReturnRaw[1]      = { 0x6a };
 
-// 20-byte short hash (used for pay_script_hash patterns).
+// 20-byte short hash (used for pay_to_script_hash patterns).
 static kth_shorthash_t const kShortHash = {{
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
     0x10, 0x11, 0x12, 0x13
 }};
 
-// 32-byte hash (used for pay_script_hash_32 patterns).
+// 32-byte hash (used for pay_to_script_hash_32 patterns).
 static kth_hash_t const kHash32 = {{
     0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72,
     0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7, 0x4f,
@@ -204,7 +204,7 @@ TEST_CASE("C-API Script - to_pay_script_hash_32_pattern returns operation list",
 
 // A valid 33-byte compressed secp256k1 public key (BIP32 test vector 1
 // master public key), usable to exercise the success path of the
-// pay_public_key factories.
+// pay_to_public_key factories.
 static uint8_t const kValidCompressedPoint[33] = {
     0x03, 0x39, 0xa3, 0x60, 0x13, 0x30, 0x15, 0x97,
     0xda, 0xef, 0x41, 0xfb, 0xe5, 0x93, 0xa0, 0x2c,

--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -408,6 +408,7 @@ set(kth_headers
     include/kth/domain/machine/interpreter.hpp
     include/kth/domain/machine/program.hpp
     include/kth/domain/machine/script_flags.hpp
+    include/kth/domain/machine/script_pattern.hpp
     include/kth/domain/math/limits.hpp
     include/kth/domain/math/stealth.hpp
     include/kth/domain/utility/property_tree.hpp

--- a/src/domain/include/kth/domain.hpp
+++ b/src/domain/include/kth/domain.hpp
@@ -35,6 +35,7 @@
 #include <kth/domain/machine/operation.hpp>
 #include <kth/domain/machine/program.hpp>
 #include <kth/domain/machine/script_flags.hpp>
+#include <kth/domain/machine/script_pattern.hpp>
 
 #include <kth/domain/math/stealth.hpp>
 

--- a/src/domain/include/kth/domain/chain/script.hpp
+++ b/src/domain/include/kth/domain/chain/script.hpp
@@ -23,7 +23,7 @@
 #include <kth/domain/machine/script_flags.hpp>
 
 #include <kth/infrastructure/error.hpp>
-#include <kth/infrastructure/machine/script_pattern.hpp>
+#include <kth/domain/machine/script_pattern.hpp>
 #include <kth/infrastructure/machine/script_version.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
@@ -48,7 +48,7 @@ struct KD_API script : script_basis {
 public:
     using operation = machine::operation;
     using script_flags = machine::script_flags;
-    using script_pattern = infrastructure::machine::script_pattern;
+    using script_pattern = domain::machine::script_pattern;
 #if ! defined(KTH_CURRENCY_BCH)
     using script_version = infrastructure::machine::script_version;
 #endif // ! KTH_CURRENCY_BCH

--- a/src/domain/include/kth/domain/chain/script_basis.hpp
+++ b/src/domain/include/kth/domain/chain/script_basis.hpp
@@ -22,7 +22,7 @@
 #include <kth/domain/wallet/ec_public.hpp>
 
 #include <kth/infrastructure/error.hpp>
-#include <kth/infrastructure/machine/script_pattern.hpp>
+#include <kth/domain/machine/script_pattern.hpp>
 #include <kth/infrastructure/machine/script_version.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
@@ -40,7 +40,7 @@ class transaction;
 struct KD_API script_basis {
     using operation = machine::operation;
     using script_flags = machine::script_flags;
-    using script_pattern = infrastructure::machine::script_pattern;
+    using script_pattern = domain::machine::script_pattern;
 #if ! defined(KTH_CURRENCY_BCH)
     using script_version = infrastructure::machine::script_version;
 #endif // ! KTH_CURRENCY_BCH

--- a/src/domain/include/kth/domain/machine/operation.hpp
+++ b/src/domain/include/kth/domain/machine/operation.hpp
@@ -18,7 +18,7 @@
 #include <kth/domain/define.hpp>
 //#include <kth/infrastructure/define.hpp>
 
-#include <kth/infrastructure/machine/script_pattern.hpp>
+#include <kth/domain/machine/script_pattern.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/container_sink.hpp>
 #include <kth/infrastructure/utility/data.hpp>

--- a/src/domain/include/kth/domain/machine/script_pattern.hpp
+++ b/src/domain/include/kth/domain/machine/script_pattern.hpp
@@ -2,14 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef KTH_INFRASTUCTURE_MACHINE_SCRIPT_PATTERN_HPP
-#define KTH_INFRASTUCTURE_MACHINE_SCRIPT_PATTERN_HPP
+#ifndef KTH_DOMAIN_MACHINE_SCRIPT_PATTERN_HPP
+#define KTH_DOMAIN_MACHINE_SCRIPT_PATTERN_HPP
 
 #include <string_view>
 
-namespace kth::infrastructure::machine {
+namespace kth::domain::machine {
 
-/// Script patterms.
+/// Script patterns.
 /// Comments from: bitcoin.org/en/developer-guide#signature-hash-types
 enum class script_pattern {
     /// Null Data
@@ -20,27 +20,27 @@ enum class script_pattern {
     /// Pay to Multisig [BIP11]
     /// Pubkey script: <m> <A pubkey>[B pubkey][C pubkey...] <n> OP_CHECKMULTISIG
     /// Signature script: OP_0 <A sig>[B sig][C sig...]
-    pay_multisig,
+    pay_to_multisig,
 
     /// Pay to Public Key (obsolete)
-    pay_public_key,
+    pay_to_public_key,
 
     /// Pay to Public Key Hash [P2PKH]
     /// Pubkey script: OP_DUP OP_HASH160 <PubKeyHash> OP_EQUALVERIFY OP_CHECKSIG
     /// Signature script: <sig> <pubkey>
-    pay_public_key_hash,
+    pay_to_public_key_hash,
 
     /// Pay to Script Hash [P2SH/BIP16]
     /// The redeem script may be any pay type, but only multisig makes sense.
     /// Pubkey script: OP_HASH160 <Hash160(redeemScript)> OP_EQUAL
     /// Signature script: <sig>[sig][sig...] <redeemScript>
-    pay_script_hash,
+    pay_to_script_hash,
 
     /// Pay to Script Hash 32
     /// The redeem script may be any pay type, but only multisig makes sense.
     /// Pubkey script: OP_HASH256 <Hash256(redeemScript)> OP_EQUAL
     /// Signature script: <sig>[sig][sig...] <redeemScript>
-    pay_script_hash_32,
+    pay_to_script_hash_32,
 
     /// Sign Multisig script [BIP11]
     sign_multisig,
@@ -74,22 +74,22 @@ enum class script_pattern {
 constexpr
 std::string_view to_string(script_pattern p) {
     switch (p) {
-        case script_pattern::null_data:             return "null_data";
-        case script_pattern::pay_multisig:          return "pay_multisig";
-        case script_pattern::pay_public_key:        return "pay_public_key";
-        case script_pattern::pay_public_key_hash:   return "pay_public_key_hash";
-        case script_pattern::pay_script_hash:       return "pay_script_hash";
-        case script_pattern::pay_script_hash_32:    return "pay_script_hash_32";
-        case script_pattern::sign_multisig:         return "sign_multisig";
-        case script_pattern::sign_public_key:       return "sign_public_key";
-        case script_pattern::sign_public_key_hash:  return "sign_public_key_hash";
-        case script_pattern::sign_script_hash:      return "sign_script_hash";
-        case script_pattern::witness_reservation:   return "witness_reservation";
-        case script_pattern::non_standard:          return "non_standard";
+        case script_pattern::null_data:                 return "null_data";
+        case script_pattern::pay_to_multisig:           return "pay_to_multisig";
+        case script_pattern::pay_to_public_key:         return "pay_to_public_key";
+        case script_pattern::pay_to_public_key_hash:    return "pay_to_public_key_hash";
+        case script_pattern::pay_to_script_hash:        return "pay_to_script_hash";
+        case script_pattern::pay_to_script_hash_32:     return "pay_to_script_hash_32";
+        case script_pattern::sign_multisig:             return "sign_multisig";
+        case script_pattern::sign_public_key:           return "sign_public_key";
+        case script_pattern::sign_public_key_hash:      return "sign_public_key_hash";
+        case script_pattern::sign_script_hash:          return "sign_script_hash";
+        case script_pattern::witness_reservation:       return "witness_reservation";
+        case script_pattern::non_standard:              return "non_standard";
     }
     return "non_standard";
 }
 
-} // namespace kth::infrastructure::machine
+} // namespace kth::domain::machine
 
 #endif

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -26,7 +26,7 @@
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
-#include <kth/infrastructure/machine/script_pattern.hpp>
+#include <kth/domain/machine/script_pattern.hpp>
 #include <kth/infrastructure/machine/script_version.hpp>
 #include <kth/infrastructure/machine/sighash_algorithm.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
@@ -933,15 +933,15 @@ script_pattern script::pattern() const {
 script_pattern script::output_pattern() const {
     // The first operations access must be method-based to guarantee the cache.
     if (is_pay_public_key_hash_pattern(operations())) {
-        return script_pattern::pay_public_key_hash;
+        return script_pattern::pay_to_public_key_hash;
     }
 
     if (is_pay_script_hash_pattern(operations_)) {
-        return script_pattern::pay_script_hash;
+        return script_pattern::pay_to_script_hash;
     }
 
     if (is_pay_script_hash_32_pattern(operations_)) {
-        return script_pattern::pay_script_hash_32;
+        return script_pattern::pay_to_script_hash_32;
     }
 
     if (is_null_data_pattern(operations_)) {
@@ -949,11 +949,11 @@ script_pattern script::output_pattern() const {
     }
 
     if (is_pay_public_key_pattern(operations_)) {
-        return script_pattern::pay_public_key;
+        return script_pattern::pay_to_public_key;
     }
 
     if (is_pay_multisig_pattern(operations_)) {
-        return script_pattern::pay_multisig;
+        return script_pattern::pay_to_multisig;
     }
 
     return script_pattern::non_standard;

--- a/src/domain/src/chain/script_basis.cpp
+++ b/src/domain/src/chain/script_basis.cpp
@@ -25,7 +25,7 @@
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
-#include <kth/infrastructure/machine/script_pattern.hpp>
+#include <kth/domain/machine/script_pattern.hpp>
 #include <kth/infrastructure/machine/script_version.hpp>
 #include <kth/infrastructure/machine/sighash_algorithm.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>

--- a/src/domain/src/chain/transaction_basis.cpp
+++ b/src/domain/src/chain/transaction_basis.cpp
@@ -34,6 +34,7 @@
 #include <kth/infrastructure/utility/ostream_writer.hpp>
 
 using namespace kth::infrastructure::machine;
+using namespace kth::domain::machine;
 
 #if defined(KTH_CURRENCY_BCH)
 #include <boost/container_hash/hash.hpp>

--- a/src/domain/src/chain/witness.cpp
+++ b/src/domain/src/chain/witness.cpp
@@ -20,7 +20,7 @@
 #include <kth/domain/machine/program.hpp>
 // #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/error.hpp>
-#include <kth/infrastructure/machine/script_pattern.hpp>
+#include <kth/domain/machine/script_pattern.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/collection.hpp>

--- a/src/domain/src/math/stealth.cpp
+++ b/src/domain/src/math/stealth.cpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <kth/domain/chain/script.hpp>
 #include <kth/domain/constants.hpp>
-#include <kth/infrastructure/machine/script_pattern.hpp>
+#include <kth/domain/machine/script_pattern.hpp>
 #include <kth/infrastructure/math/elliptic_curve.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/utility/binary.hpp>

--- a/src/domain/src/utility/property_tree.cpp
+++ b/src/domain/src/utility/property_tree.cpp
@@ -72,7 +72,7 @@ ptree property_tree(std::vector<config::header> const& headers, bool json) {
 ptree property_list(chain::input const& tx_input) {
     ptree tree;
 
-    // This does not support pay_multisig or pay_public_key (nonstandard).
+    // This does not support pay_to_multisig or pay_to_public_key (nonstandard).
     // This will have default versioning, but the address version is unused.
     auto const address = tx_input.address();
 
@@ -124,7 +124,7 @@ ptree property_tree(std::vector<config::input> const& inputs, bool json) {
 ptree property_list(const chain::output& tx_output) {
     ptree tree;
 
-    // This does not support pay_multisig or pay_public_key (nonstandard).
+    // This does not support pay_to_multisig or pay_to_public_key (nonstandard).
     // This will have default versioning, but the address version is unused.
     auto const address = tx_output.address();
 

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -24,6 +24,7 @@
 #endif  //KTH_CURRENCY_BCH
 
 using namespace kth::infrastructure::machine;
+using namespace kth::domain::machine;
 
 #if defined(KTH_CURRENCY_BCH)
 using namespace kth::domain::wallet;
@@ -529,30 +530,30 @@ payment_address::list payment_address::extract_output(chain::script const& scrip
     auto const pattern = script.output_pattern();
 
     switch (pattern) {
-        case script_pattern::pay_public_key_hash: {
+        case script_pattern::pay_to_public_key_hash: {
             return {
                 payment_address{to_array<short_hash_size>(script[2].data()), p2kh_version}
             };
         }
-        case script_pattern::pay_script_hash: {
+        case script_pattern::pay_to_script_hash: {
             return {
                 payment_address{to_array<short_hash_size>(script[1].data()), p2sh_version}
             };
         }
-        case script_pattern::pay_script_hash_32: {
+        case script_pattern::pay_to_script_hash_32: {
             return {
                 payment_address{to_array<hash_size>(script[1].data()), p2sh_version}
             };
         }
-        case script_pattern::pay_public_key: {
+        case script_pattern::pay_to_public_key: {
             return {
-                // pay_public_key is not p2kh but we conflate for tracking.
+                // pay_to_public_key is not p2kh but we conflate for tracking.
                 payment_address{ec_public{script[0].data()}, p2kh_version}
             };
         }
 
         // Bare multisig and null data do not associate a payment address.
-        case script_pattern::pay_multisig:
+        case script_pattern::pay_to_multisig:
         case script_pattern::null_data:
         case script_pattern::non_standard:
         default: {

--- a/src/domain/test/chain/script.cpp
+++ b/src/domain/test/chain/script.cpp
@@ -244,7 +244,7 @@ TEST_CASE("script from data to data roundtrips", "[script]") {
     REQUIRE(script.serialized_size(true) == 26u);
     REQUIRE(script.sigops(false) == 1u);
     REQUIRE(script.sigops(true) == 1u);
-    REQUIRE(script.pattern() == script_pattern::pay_public_key_hash);
+    REQUIRE(script.pattern() == script_pattern::pay_to_public_key_hash);
 
     auto const roundtrip = script.to_data(false);
     REQUIRE(roundtrip == normal_output_script);
@@ -345,101 +345,101 @@ TEST_CASE("script pattern - null data return only - non standard", "[script]") {
     script instance;
     instance.from_string(SCRIPT_RETURN);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::non_standard);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::non_standard);
 }
 
 TEST_CASE("script pattern - null data empty - null data", "[script]") {
     script instance;
     instance.from_string(SCRIPT_RETURN_EMPTY);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::null_data);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::null_data);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::null_data);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::null_data);
 }
 
 TEST_CASE("script pattern - null data 80 bytes - null data", "[script]") {
     script instance;
     instance.from_string(SCRIPT_RETURN_80);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::null_data);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::null_data);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::null_data);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::null_data);
 }
 
 TEST_CASE("script pattern - null data 81 bytes - non standard", "[script]") {
     script instance;
     instance.from_string(SCRIPT_RETURN_81);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::non_standard);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::non_standard);
 }
 
-// pay_multisig
+// pay_to_multisig
 
 TEST_CASE("script pattern - 0 of 3 multisig - non standard", "[script]") {
     script instance;
     instance.from_string(SCRIPT_0_OF_3_MULTISIG);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::non_standard);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::non_standard);
 }
 
 TEST_CASE("script pattern - 1 of 3 multisig - pay multisig", "[script]") {
     script instance;
     instance.from_string(SCRIPT_1_OF_3_MULTISIG);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::pay_multisig);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::pay_multisig);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::pay_to_multisig);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::pay_to_multisig);
 }
 
 TEST_CASE("script pattern - 2 of 3 multisig - pay multisig", "[script]") {
     script instance;
     instance.from_string(SCRIPT_2_OF_3_MULTISIG);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::pay_multisig);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::pay_multisig);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::pay_to_multisig);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::pay_to_multisig);
 }
 
 TEST_CASE("script pattern - 3 of 3 multisig - pay multisig", "[script]") {
     script instance;
     instance.from_string(SCRIPT_3_OF_3_MULTISIG);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::pay_multisig);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::pay_multisig);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::pay_to_multisig);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::pay_to_multisig);
 }
 
 TEST_CASE("script pattern - 4 of 3 multisig - non standard", "[script]") {
     script instance;
     instance.from_string(SCRIPT_4_OF_3_MULTISIG);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::non_standard);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::non_standard);
 }
 
 TEST_CASE("script pattern - 16 of 16 multisig - pay multisig", "[script]") {
     script instance;
     instance.from_string(SCRIPT_16_OF_16_MULTISIG);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::pay_multisig);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::pay_multisig);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::pay_to_multisig);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::pay_to_multisig);
 }
 
 TEST_CASE("script pattern - 17 of 17 multisig - non standard", "[script]") {
     script instance;
     instance.from_string(SCRIPT_17_OF_17_MULTISIG);
     REQUIRE(instance.is_valid());
-    REQUIRE(instance.output_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.input_pattern() == infrastructure::machine::script_pattern::non_standard);
-    REQUIRE(instance.pattern() == infrastructure::machine::script_pattern::non_standard);
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.pattern() == domain::machine::script_pattern::non_standard);
 }
 
 // Data-driven tests.

--- a/src/infrastructure/CMakeLists.txt
+++ b/src/infrastructure/CMakeLists.txt
@@ -285,7 +285,6 @@ set(kth_headers
     include/kth/infrastructure/path.hpp
 
     include/kth/infrastructure/machine/number.hpp
-    include/kth/infrastructure/machine/script_pattern.hpp
     include/kth/infrastructure/machine/sighash_algorithm.hpp
     include/kth/infrastructure/machine/script_version.hpp
 

--- a/src/infrastructure/include/kth/infrastructure.hpp
+++ b/src/infrastructure/include/kth/infrastructure.hpp
@@ -44,7 +44,6 @@
 #include <kth/infrastructure/log/sink.hpp>
 
 #include <kth/infrastructure/machine/number.hpp>
-#include <kth/infrastructure/machine/script_pattern.hpp>
 #include <kth/infrastructure/machine/script_version.hpp>
 #include <kth/infrastructure/machine/sighash_algorithm.hpp>
 


### PR DESCRIPTION
## Summary
- Move `script_pattern` from `kth::infrastructure::machine` to `kth::domain::machine` — it encodes Bitcoin Script semantics (P2PK, P2PKH, P2SH, multisig, ...), which is a domain-layer concern, not generic infrastructure.
- Rename every `pay_*` enumerator to `pay_to_*` to match BIP nomenclature: `pay_multisig`/`pay_public_key`/`pay_public_key_hash`/`pay_script_hash`/`pay_script_hash_32` → the same with `pay_to_*`. The `sign_*` family is intentionally untouched (it's the signature-script side, the "to" reading doesn't apply).
- C-API mirror tracks the rename (`kth_script_pattern_pay_to_*`).

Aside from the move and the rename, no behavioural change — 24 enum-variant call-sites updated across infrastructure, domain and the c-api layer.

## Test plan
- [ ] CI: every consumer of the renamed variants compiles cleanly.
- [ ] Domain tests pass (the renamed `script::pattern()` checks live in `domain/test/chain/script.cpp`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily an API-breaking rename/namespace move that touches many call sites and headers; risk is mismatched enum values or downstream build breaks rather than behavioral changes.
> 
> **Overview**
> Moves `script_pattern` from `kth::infrastructure::machine` into `kth::domain::machine`, wires it into public domain headers/build (adds `domain/machine/script_pattern.hpp`, updates includes/usings), and removes the infrastructure header/export.
> 
> Renames the *output* script pattern enum values from `pay_*` to `pay_to_*` across C++ and the C-API mirror (`kth_script_pattern_pay_to_*`), updating pattern classification (`script::output_pattern()`), address extraction, property tree comments, and both domain + C-API tests accordingly (no functional change intended beyond API/ABI rename).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64525122273748fb19ca852c841e7147883b39b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Script pattern enum constants renamed from `pay_*` to `pay_to_*` format for naming consistency (e.g., `pay_public_key_hash` → `pay_to_public_key_hash`, `pay_multisig` → `pay_to_multisig`). Update your code accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->