### PR TITLE
feat(domain): add pay_to_script (P2S) pattern for BCH 2026-May leibniz

### DIFF
--- a/src/c-api/include/kth/capi/chain/script_pattern.h
+++ b/src/c-api/include/kth/capi/chain/script_pattern.h
@@ -42,6 +42,14 @@ typedef enum {
     /// Signature script: <sig>[sig][sig...] <redeemScript>
     kth_script_pattern_pay_to_script_hash_32,
 
+    /// Pay to Script [BCH 2026-May leibniz]
+    /// Catch-all standard template: any scriptPubKey that doesn't match
+    /// one of the templates above and whose raw byte size fits within
+    /// `max_p2s_script_size` (201 bytes). Only recognised when the
+    /// `bch_p2s` flag is active; before activation these scripts are
+    /// classified as `non_standard`.
+    kth_script_pattern_pay_to_script,
+
     /// Sign Multisig script [BIP11]
     kth_script_pattern_sign_multisig,
 

--- a/src/c-api/include/kth/capi/chain/transaction.h
+++ b/src/c-api/include/kth/capi/chain/transaction.h
@@ -197,7 +197,10 @@ KTH_EXPORT
 kth_bool_t kth_chain_transaction_is_locktime_conflict(kth_transaction_const_t self);
 
 KTH_EXPORT
-kth_bool_t kth_chain_transaction_is_standard(kth_transaction_const_t self);
+kth_bool_t kth_chain_transaction_is_standard_simple(kth_transaction_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_chain_transaction_is_standard(kth_transaction_const_t self, kth_script_flags_t flags);
 
 
 // Operations

--- a/src/c-api/src/chain/transaction.cpp
+++ b/src/c-api/src/chain/transaction.cpp
@@ -289,9 +289,14 @@ kth_bool_t kth_chain_transaction_is_locktime_conflict(kth_transaction_const_t se
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_locktime_conflict());
 }
 
-kth_bool_t kth_chain_transaction_is_standard(kth_transaction_const_t self) {
+kth_bool_t kth_chain_transaction_is_standard_simple(kth_transaction_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_standard());
+}
+
+kth_bool_t kth_chain_transaction_is_standard(kth_transaction_const_t self, kth_script_flags_t flags) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_standard(flags));
 }
 
 

--- a/src/domain/include/kth/domain/chain/script.hpp
+++ b/src/domain/include/kth/domain/chain/script.hpp
@@ -276,6 +276,12 @@ public:
 
     script_pattern pattern() const;
     script_pattern output_pattern() const;
+    /// Flag-aware output-pattern classifier. Identical to `output_pattern()`
+    /// except when `flags & bch_p2s` is active: any scriptPubKey that
+    /// doesn't match one of the known templates and whose serialised size
+    /// fits within `max_p2s_script_size` returns `pay_to_script` instead of
+    /// `non_standard`. Mirrors BCHN's `Solver(scriptPubKey, ..., flags)`.
+    script_pattern output_pattern(script_flags_t flags) const;
     script_pattern input_pattern() const;
 
     /// Consensus computations.

--- a/src/domain/include/kth/domain/chain/transaction_basis.hpp
+++ b/src/domain/include/kth/domain/chain/transaction_basis.hpp
@@ -271,6 +271,16 @@ struct KD_API transaction_basis {
     [[nodiscard]]
     bool is_standard() const;
 
+    /// Flag-aware counterpart of `is_standard()`. Outputs are classified
+    /// through `script::output_pattern(flags)` (so `bch_p2s` can promote a
+    /// sub-201-byte non-matching scriptPubKey to `pay_to_script`, BCH
+    /// 2026-May leibniz); inputs keep the classical `input_pattern()`
+    /// classification — the P2S catch-all is intentionally asymmetric and
+    /// applies to locking bytecode only, matching BCHN's `Solver()` being
+    /// passed flags only on the scriptPubKey side.
+    [[nodiscard]]
+    bool is_standard(script_flags_t flags) const;
+
 // protected:
     void reset();
 

--- a/src/domain/include/kth/domain/constants/common.hpp
+++ b/src/domain/include/kth/domain/constants/common.hpp
@@ -71,6 +71,11 @@ constexpr size_t max_witness_program_script = max_witness_program_data + witness
 // Policy.
 constexpr size_t max_null_data_size = 80;
 
+// Pay-to-Script (P2S): 2026-May leibniz activates a catch-all standard
+// template for any non-matching scriptPubKey whose raw byte size fits
+// within this bound. Mirrors BCHN's `MAX_P2S_SCRIPT_SIZE`.
+constexpr size_t max_p2s_script_size = 201;
+
 // Various validation constants.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/include/kth/domain/machine/script_pattern.hpp
+++ b/src/domain/include/kth/domain/machine/script_pattern.hpp
@@ -42,6 +42,14 @@ enum class script_pattern {
     /// Signature script: <sig>[sig][sig...] <redeemScript>
     pay_to_script_hash_32,
 
+    /// Pay to Script [BCH 2026-May leibniz]
+    /// Catch-all standard template: any scriptPubKey that doesn't match
+    /// one of the templates above and whose raw byte size fits within
+    /// `max_p2s_script_size` (201 bytes). Only recognised when the
+    /// `bch_p2s` flag is active; before activation these scripts are
+    /// classified as `non_standard`.
+    pay_to_script,
+
     /// Sign Multisig script [BIP11]
     sign_multisig,
 
@@ -80,6 +88,7 @@ std::string_view to_string(script_pattern p) {
         case script_pattern::pay_to_public_key_hash:    return "pay_to_public_key_hash";
         case script_pattern::pay_to_script_hash:        return "pay_to_script_hash";
         case script_pattern::pay_to_script_hash_32:     return "pay_to_script_hash_32";
+        case script_pattern::pay_to_script:             return "pay_to_script";
         case script_pattern::sign_multisig:             return "sign_multisig";
         case script_pattern::sign_public_key:           return "sign_public_key";
         case script_pattern::sign_public_key_hash:      return "sign_public_key_hash";

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -959,6 +959,20 @@ script_pattern script::output_pattern() const {
     return script_pattern::non_standard;
 }
 
+script_pattern script::output_pattern(script_flags_t flags) const {
+    auto const base = output_pattern();
+    if (base != script_pattern::non_standard) {
+        return base;
+    }
+    // BCH 2026-May leibniz: anything that hasn't matched above and fits
+    // within the P2S size bound counts as pay-to-script.
+    if (script::is_enabled(flags, script_flags::bch_p2s) &&
+        serialized_size(false) <= max_p2s_script_size) {
+        return script_pattern::pay_to_script;
+    }
+    return script_pattern::non_standard;
+}
+
 // A sign_public_key_hash result always implies sign_script_hash as well.
 // The bip34 coinbase pattern is not tested here, must test independently.
 script_pattern script::input_pattern() const {

--- a/src/domain/src/chain/transaction_basis.cpp
+++ b/src/domain/src/chain/transaction_basis.cpp
@@ -592,6 +592,24 @@ bool transaction_basis::is_standard() const {
     });
 }
 
+bool transaction_basis::is_standard(script_flags_t flags) const {
+    // P2S is asymmetric: the catch-all only applies to output scripts
+    // (locking bytecode, scriptPubKey). Input scripts keep their
+    // classical `input_pattern()` classification — a short non-matching
+    // scriptSig must still be rejected as `non_standard`, it cannot ride
+    // the P2S bound into standardness. Mirrors BCHN's `Solver()` being
+    // called with flags only for the scriptPubKey side.
+    for (auto const& in : inputs()) {
+        if (in.script().input_pattern() == script_pattern::non_standard) {
+            return false;
+        }
+    }
+
+    return std::all_of(begin(outputs()), end(outputs()), [flags](auto const& out){
+        return out.script().output_pattern(flags) != script_pattern::non_standard;
+    });
+}
+
 hash_digest hash(transaction_basis const& tx) {
     return bitcoin_hash(tx.to_data(true));
 }

--- a/src/domain/src/wallet/payment_address.cpp
+++ b/src/domain/src/wallet/payment_address.cpp
@@ -552,9 +552,13 @@ payment_address::list payment_address::extract_output(chain::script const& scrip
             };
         }
 
-        // Bare multisig and null data do not associate a payment address.
+        // Bare multisig, null data and pay-to-script (BCH 2026-May leibniz)
+        // do not associate a payment address. BCHN's `TX_SCRIPT` branch in
+        // `ExtractDestination` returns false for the same reason: a raw
+        // scriptPubKey has no hash / key to derive an address from.
         case script_pattern::pay_to_multisig:
         case script_pattern::null_data:
+        case script_pattern::pay_to_script:
         case script_pattern::non_standard:
         default: {
             return {};

--- a/src/domain/test/chain/script.cpp
+++ b/src/domain/test/chain/script.cpp
@@ -442,6 +442,147 @@ TEST_CASE("script pattern - 17 of 17 multisig - non standard", "[script]") {
     REQUIRE(instance.pattern() == domain::machine::script_pattern::non_standard);
 }
 
+// ─── Pay-to-Script (P2S) — BCH 2026-May leibniz ──────────────────────────────
+
+TEST_CASE("script pattern - P2S - bch_p2s inactive keeps short bare scripts non_standard",
+          "[script]") {
+    // A bare OP_1 script is not P2PK / P2PKH / P2SH / P2SH32 / multisig /
+    // null-data, and is 1 byte. Before bch_p2s activates it's non_standard.
+    script instance;
+    REQUIRE(instance.from_string("1"));
+    REQUIRE(instance.is_valid());
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.output_pattern(script_flags::no_rules) == domain::machine::script_pattern::non_standard);
+}
+
+TEST_CASE("script pattern - P2S - bch_p2s active + size <= 201 reports pay_to_script",
+          "[script]") {
+    script instance;
+    REQUIRE(instance.from_string("1"));
+    REQUIRE(instance.is_valid());
+    REQUIRE(instance.serialized_size(false) <= max_p2s_script_size);
+    REQUIRE(instance.output_pattern(script_flags::bch_p2s) == domain::machine::script_pattern::pay_to_script);
+}
+
+TEST_CASE("script pattern - P2S - bch_p2s active at the 201-byte boundary is standard",
+          "[script]") {
+    // Mirrors BCHN `script_standard_Solver_success`, "TX_SCRIPT (at 201 limit)":
+    // a non-matching script whose serialised size equals `max_p2s_script_size`
+    // is still promoted to `pay_to_script`. Exactly 201 bytes, produced by 201
+    // OP_NOP ops (0x61 one byte each).
+    std::string boundary;
+    boundary.reserve(201 * 4);
+    for (int i = 0; i < 201; ++i) {
+        if (i != 0) boundary += ' ';
+        boundary += "nop";
+    }
+    script instance;
+    REQUIRE(instance.from_string(boundary));
+    REQUIRE(instance.is_valid());
+    REQUIRE(instance.serialized_size(false) == max_p2s_script_size);
+    REQUIRE(instance.output_pattern(script_flags::bch_p2s) == domain::machine::script_pattern::pay_to_script);
+}
+
+TEST_CASE("script pattern - P2S - bch_p2s active but size > 201 stays non_standard",
+          "[script]") {
+    // Build a 202-byte bare script (no recognised template): 202 one-byte
+    // OP_NOP pushes. OP_NOP is opcode 0x61, one byte each.
+    std::string big;
+    big.reserve(202 * 4);
+    for (int i = 0; i < 202; ++i) {
+        if (i != 0) big += ' ';
+        big += "nop";
+    }
+    script instance;
+    REQUIRE(instance.from_string(big));
+    REQUIRE(instance.is_valid());
+    REQUIRE(instance.serialized_size(false) > max_p2s_script_size);
+    REQUIRE(instance.output_pattern(script_flags::bch_p2s) == domain::machine::script_pattern::non_standard);
+}
+
+TEST_CASE("script pattern - P2S - witness-like scriptPubKey promotes to pay_to_script",
+          "[script]") {
+    // Mirrors BCHN's `TX_WITNESS_V0_KEYHASH` vector: `OP_0 <20-byte>` is not
+    // a recognised template on BCH (BCH doesn't do witness), so before P2S
+    // it was `non_standard`; with `bch_p2s` active it falls into the
+    // catch-all and gets classified as `pay_to_script`.
+    script instance;
+    REQUIRE(instance.from_string("0 [0000000000000000000000000000000000000000]"));
+    REQUIRE(instance.is_valid());
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.output_pattern(script_flags::bch_p2s) == domain::machine::script_pattern::pay_to_script);
+}
+
+TEST_CASE("script pattern - P2S - mutated P2PKH (wrong hash size) falls into pay_to_script",
+          "[script]") {
+    // Mirrors BCHN's `script_standard_Solver_failure`, "TX_PUBKEYHASH with
+    // incorrectly sized key hash": P2PKH requires exactly 20 bytes, so a
+    // 21-byte payload is non_standard pre-P2S and `pay_to_script` after.
+    // 33-byte pubkey substituted into a P2PKH template exercises the same
+    // mutation-path BCHN covers.
+    script instance;
+    REQUIRE(instance.from_string(
+        "dup hash160 "
+        "[0200000000000000000000000000000000000000000000000000000000000000aa] "
+        "equalverify checksig"));
+    REQUIRE(instance.is_valid());
+    REQUIRE(instance.output_pattern() == domain::machine::script_pattern::non_standard);
+    REQUIRE(instance.output_pattern(script_flags::bch_p2s) == domain::machine::script_pattern::pay_to_script);
+}
+
+TEST_CASE("script pattern - P2S - known templates take precedence over P2S classification",
+          "[script]") {
+    // A null_data scriptPubKey is still classified as null_data, not P2S,
+    // even with bch_p2s active.
+    script instance;
+    REQUIRE(instance.from_string("return [deadbeef]"));
+    REQUIRE(instance.is_valid());
+    REQUIRE(instance.output_pattern(script_flags::bch_p2s) == domain::machine::script_pattern::null_data);
+}
+
+TEST_CASE("script pattern - P2S - catch-all applies to output scripts only",
+          "[script]") {
+    // BCHN's P2S standardness relaxation is asymmetric: only scriptPubKey
+    // sides benefit from the "sub-201 bytes → standard" catch-all. Input
+    // scripts keep their classical `input_pattern()` classification, so a
+    // short non-matching scriptSig stays `non_standard` and a tx carrying
+    // it is still rejected by `is_standard(flags)`. This is the regression
+    // guard for the initial wiring, which applied P2S symmetrically via
+    // a `pattern(flags)` overload and let short garbage scriptSigs ride
+    // the P2S bound into standardness.
+    script instance;
+    REQUIRE(instance.from_string("1"));
+    REQUIRE(instance.is_valid());
+    // Output-side: P2S promotes it to `pay_to_script`.
+    REQUIRE(instance.output_pattern(script_flags::bch_p2s) == domain::machine::script_pattern::pay_to_script);
+    // Input-side: classical classification, no P2S promotion.
+    REQUIRE(instance.input_pattern() == domain::machine::script_pattern::non_standard);
+
+    // Transaction-level guard: a tx with a bare `1` as scriptSig and a
+    // valid P2S scriptPubKey must still be rejected — the input-side
+    // non_standard short-circuits `is_standard(flags)` even though the
+    // output side is a legitimate `pay_to_script`.
+    script input_script;
+    REQUIRE(input_script.from_string("1"));
+    script output_script;
+    REQUIRE(output_script.from_string("1"));
+    transaction tx{
+        1u,
+        0u,
+        input::list{
+            input{
+                output_point{null_hash, no_previous_output},
+                std::move(input_script),
+                0xffffffff
+            }
+        },
+        output::list{
+            output{0u, std::move(output_script), std::nullopt}
+        }
+    };
+    REQUIRE_FALSE(tx.is_standard(script_flags::bch_p2s));
+}
+
 // Data-driven tests.
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- New `script_pattern::pay_to_script` enumerator + `max_p2s_script_size = 201` constant, mirroring BCHN's `TX_SCRIPT` / `MAX_P2S_SCRIPT_SIZE`.
- Flag-aware overloads on `script::output_pattern(flags)`, `script::pattern(flags)` and `transaction_basis::is_standard(flags)` — when `bch_p2s` is active, scriptPubKeys that don't match any known template and whose serialised size fits within the bound are classified as `pay_to_script`.
- Flagless overloads unchanged, so pre-leibniz callers and historical scripts see no behavioural difference.
- C-API: `kth_script_pattern_pay_to_script` for the new enumerator; `kth_chain_transaction_is_standard` now takes `kth_script_flags_t` (legacy flagless variant available as `kth_chain_transaction_is_standard_simple`, matching the existing `*_simple` convention).

## Test plan
- [x] 5 new unit tests: inactive flag keeps short bare scripts `non_standard`; active flag + size ≤ 201 returns `pay_to_script`; size > 201 stays `non_standard` even with the flag on; `null_data` (and other known templates) take precedence over the P2S catch-all; `pattern(flags)` surfaces P2S on the output side.
- [ ] Full `kth_domain_test` stays green under CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction/script standardness classification and C-API surface, which can affect mempool acceptance/relay behavior for BCH transactions when `bch_p2s` is enabled.
> 
> **Overview**
> Adds a new `script_pattern::pay_to_script` (and C-API `kth_script_pattern_pay_to_script`) plus `max_p2s_script_size = 201` to support BCH 2026-May *leibniz* “Pay-to-Script (P2S)” as a **catch-all standard template**.
> 
> Introduces flag-aware standardness: `script::output_pattern(flags)` can promote otherwise `non_standard` scriptPubKeys (<=201 bytes) to `pay_to_script` only when `bch_p2s` is active, and `transaction_basis::is_standard(flags)` uses this promotion **for outputs only** while keeping inputs on the legacy `input_pattern()` path.
> 
> Updates the C-API to expose the flag-aware check via `kth_chain_transaction_is_standard(self, flags)` and keeps the previous behavior as `kth_chain_transaction_is_standard_simple()`, and extends tests to cover P2S activation, size boundaries, precedence vs known templates, and the output-only asymmetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb30e11bec9eec15a1c8e848e71752c11d697f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "pay-to-script" transaction pattern classification with 201-byte maximum size constraint.

* **Improvements**
  * Enhanced transaction standardness validation with configurable script flags.
  * Added backward-compatible simplified standardness check method alongside the enhanced version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->