### PR TITLE
chore(c-api): drop dead macro / wrapper comments

### DIFF
--- a/src/c-api/src/chain/chain_other.cpp
+++ b/src/c-api/src/chain/chain_other.cpp
@@ -181,38 +181,6 @@ kth_bool_t kth_chain_is_stale(kth_chain_t chain) {
 
 
 
-// ------------------------------------------------------------------
-//virtual void fetch_block_locator(chain::block::indexes const& heights, block_locator_fetch_handler handler) const = 0;
-
-//void kth_chain_fetch_block_locator(kth_chain_t chain, void* ctx, kth_block_indexes_t heights, kth_block_locator_fetch_handler_t handler) {
-//    auto const& heights_cpp = kth_chain_block_indexes_const_cpp(heights);
-//
-//    safe_chain(chain).fetch_block_locator(heights_cpp, [chain, ctx, handler](std::error_code const& ec, kth::get_headers_ptr headers) {
-//        //TODO: check if the pointer is set, before dereferencing
-//        auto* new_headers = new kth::domain::chain::get_headers(*headers);
-//        handler(chain, ctx, kth::to_c_err(ec), new_headers);
-//    });
-//}
-//
-
-//kth_error_code_t kth_chain_get_block_locator(kth_chain_t chain, kth_block_indexes_t heights, kth_get_headers_ptr_t* out_headers) {
-//    std::latch latch(1); //Note: workaround to fix an error on some versions of Boost.Threads
-//    kth_error_code_t res;
-//
-//    auto const& heights_cpp = kth_chain_block_indexes_const_cpp(heights);
-//
-//    safe_chain(chain).fetch_block_locator(heights_cpp, [&](std::error_code const& ec, kth::get_headers_ptr headers) {
-//        //TODO: check if the pointer is set, before dereferencing
-//        *out_headers = new kth::domain::chain::get_headers(*headers);
-//        res = kth::to_c_err(ec);
-//        latch.count_down();
-//    });
-//
-//    latch.wait();
-//    return res;
-//}
-
-
 
 // ------------------------------------------------------------------
 //virtual void fetch_locator_block_hashes(get_blocks_const_ptr locator, hash_digest const& threshold, size_t limit, inventory_fetch_handler handler) const = 0;

--- a/src/c-api/src/chain/opcode.cpp
+++ b/src/c-api/src/chain/opcode.cpp
@@ -7,8 +7,6 @@
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
 
-// KTH_CONV_DEFINE(chain, kth_operation_t, kth::domain::machine::operation, operation)
-
 // ---------------------------------------------------------------------------
 extern "C" {
 


### PR DESCRIPTION
## Summary
Two leftover references to pre-migration macros / helpers (`KTH_CONV_*`, `kth_chain_block_indexes_const_cpp`) that were deleted along with `list_creator.h` / `type_conversions.h`. The commented-out code is unreachable and cannot compile, so it only contributes noise:

- `src/c-api/src/chain/opcode.cpp` — one dead `KTH_CONV_DEFINE` comment line.
- `src/c-api/src/chain/chain_other.cpp` — a 30-line commented stub pair for the `fetch_block_locator` / `get_block_locator` wrappers that referenced the removed `kth_chain_block_indexes_*` helpers.

No behavioural change; pure dead-comment cleanup.

## Test plan
- [ ] CI stays green — the removed lines were inside `//` comment blocks, nothing references them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes only commented-out, unreachable code with no behavioral impact. Risk is limited to any downstream tooling that relied on those comments for documentation/search patterns.
> 
> **Overview**
> Cleans up the C API sources by deleting dead, commented-out remnants of pre-migration helpers.
> 
> Removes an unused `KTH_CONV_DEFINE` comment in `opcode.cpp` and drops a large commented stub for `fetch_block_locator`/`get_block_locator` in `chain_other.cpp` that referenced deleted conversion helpers, reducing noise without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f1070fd16f2d5ac34c251dcae7712055c42ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed commented-out code from internal C-API implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->