### PR TITLE
refactor(c-api): sync binding surface with current library policy

### DIFF
--- a/src/c-api/include/kth/capi/binary.h
+++ b/src/c-api/include/kth/capi/binary.h
@@ -102,7 +102,7 @@ void kth_core_binary_shift_left(kth_binary_mut_t self, kth_size_t distance);
 KTH_EXPORT
 void kth_core_binary_shift_right(kth_binary_mut_t self, kth_size_t distance);
 
-/** @return Owned `kth_binary_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_core_binary_destruct`. */
+/** @return Owned `kth_binary_mut_t`. Caller must release with `kth_core_binary_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_binary_mut_t kth_core_binary_substring(kth_binary_const_t self, kth_size_t start, kth_size_t length);
 

--- a/src/c-api/include/kth/capi/chain/block.h
+++ b/src/c-api/include/kth/capi/chain/block.h
@@ -36,27 +36,27 @@ kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transac
 
 // Static factories
 
-/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_mainnet(void);
 
-/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_testnet(void);
 
-/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_regtest(void);
 
-/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_testnet4(void);
 
-/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_scalenet(void);
 
-/** @return Owned `kth_block_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_block_destruct`. */
+/** @return Owned `kth_block_mut_t`. Caller must release with `kth_chain_block_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_block_mut_t kth_chain_block_genesis_chipnet(void);
 

--- a/src/c-api/include/kth/capi/chain/compact_block.h
+++ b/src/c-api/include/kth/capi/chain/compact_block.h
@@ -73,9 +73,9 @@ kth_header_const_t kth_chain_compact_block_header(kth_compact_block_const_t self
 KTH_EXPORT
 uint64_t kth_chain_compact_block_nonce(kth_compact_block_const_t self);
 
-/** @return Borrowed `kth_u64_list_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
-KTH_EXPORT
-kth_u64_list_const_t kth_chain_compact_block_short_ids(kth_compact_block_const_t self);
+/** @return Owned `kth_u64_list_mut_t`. Caller must release with `kth_core_u64_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_u64_list_mut_t kth_chain_compact_block_short_ids(kth_compact_block_const_t self);
 
 /** @return Borrowed `kth_prefilled_transaction_list_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
 KTH_EXPORT

--- a/src/c-api/include/kth/capi/chain/script.h
+++ b/src/c-api/include/kth/capi/chain/script.h
@@ -89,7 +89,7 @@ kth_operation_const_t kth_chain_script_back(kth_script_const_t self);
 KTH_EXPORT
 kth_operation_list_const_t kth_chain_script_operations(kth_script_const_t self);
 
-/** @return Owned `kth_operation_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_operation_destruct`. */
+/** @return Owned `kth_operation_mut_t`. Caller must release with `kth_chain_operation_destruct`. */
 KTH_EXPORT KTH_OWNED
 kth_operation_mut_t kth_chain_script_first_operation(kth_script_const_t self);
 
@@ -97,7 +97,7 @@ KTH_EXPORT
 kth_script_pattern_t kth_chain_script_pattern(kth_script_const_t self);
 
 KTH_EXPORT
-kth_script_pattern_t kth_chain_script_output_pattern(kth_script_const_t self);
+kth_script_pattern_t kth_chain_script_output_pattern_simple(kth_script_const_t self);
 
 KTH_EXPORT
 kth_script_pattern_t kth_chain_script_input_pattern(kth_script_const_t self);
@@ -185,6 +185,9 @@ void kth_chain_script_clear(kth_script_mut_t self);
 /** @return Borrowed `kth_operation_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
 KTH_EXPORT
 kth_operation_const_t kth_chain_script_at(kth_script_const_t self, kth_size_t index);
+
+KTH_EXPORT
+kth_script_pattern_t kth_chain_script_output_pattern(kth_script_const_t self, kth_script_flags_t flags);
 
 KTH_EXPORT
 kth_size_t kth_chain_script_sigops(kth_script_const_t self, kth_bool_t accurate);

--- a/src/c-api/include/kth/capi/wallet/wallet_data.h
+++ b/src/c-api/include/kth/capi/wallet/wallet_data.h
@@ -31,9 +31,9 @@ kth_wallet_data_mut_t kth_wallet_wallet_data_copy(kth_wallet_data_const_t self);
 
 // Getters
 
-/** @return Borrowed `kth_string_list_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
-KTH_EXPORT
-kth_string_list_const_t kth_wallet_wallet_data_mnemonics(kth_wallet_data_const_t self);
+/** @return Owned `kth_string_list_mut_t`. Caller must release with `kth_core_string_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_string_list_mut_t kth_wallet_wallet_data_mnemonics(kth_wallet_data_const_t self);
 
 /** @return Borrowed `kth_hd_public_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
 KTH_EXPORT

--- a/src/c-api/src/binary.cpp
+++ b/src/c-api/src/binary.cpp
@@ -162,7 +162,7 @@ kth_binary_mut_t kth_core_binary_substring(kth_binary_const_t self, kth_size_t s
     KTH_PRECONDITION(self != nullptr);
     auto const start_cpp = kth::sz(start);
     auto const length_cpp = kth::sz(length);
-    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).substring(start_cpp, length_cpp));
+    return kth::leak(kth::cpp_ref<cpp_t>(self).substring(start_cpp, length_cpp));
 }
 
 kth_bool_t kth_core_binary_less(kth_binary_const_t self, kth_binary_const_t x) {

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -50,27 +50,27 @@ kth_block_mut_t kth_chain_block_construct(kth_header_const_t header, kth_transac
 // Static factories
 
 kth_block_mut_t kth_chain_block_genesis_mainnet(void) {
-    return kth::leak_if_valid(cpp_t::genesis_mainnet());
+    return kth::leak(cpp_t::genesis_mainnet());
 }
 
 kth_block_mut_t kth_chain_block_genesis_testnet(void) {
-    return kth::leak_if_valid(cpp_t::genesis_testnet());
+    return kth::leak(cpp_t::genesis_testnet());
 }
 
 kth_block_mut_t kth_chain_block_genesis_regtest(void) {
-    return kth::leak_if_valid(cpp_t::genesis_regtest());
+    return kth::leak(cpp_t::genesis_regtest());
 }
 
 kth_block_mut_t kth_chain_block_genesis_testnet4(void) {
-    return kth::leak_if_valid(cpp_t::genesis_testnet4());
+    return kth::leak(cpp_t::genesis_testnet4());
 }
 
 kth_block_mut_t kth_chain_block_genesis_scalenet(void) {
-    return kth::leak_if_valid(cpp_t::genesis_scalenet());
+    return kth::leak(cpp_t::genesis_scalenet());
 }
 
 kth_block_mut_t kth_chain_block_genesis_chipnet(void) {
-    return kth::leak_if_valid(cpp_t::genesis_chipnet());
+    return kth::leak(cpp_t::genesis_chipnet());
 }
 
 

--- a/src/c-api/src/chain/compact_block.cpp
+++ b/src/c-api/src/chain/compact_block.cpp
@@ -99,9 +99,10 @@ uint64_t kth_chain_compact_block_nonce(kth_compact_block_const_t self) {
     return kth::cpp_ref<cpp_t>(self).nonce();
 }
 
-kth_u64_list_const_t kth_chain_compact_block_short_ids(kth_compact_block_const_t self) {
+kth_u64_list_mut_t kth_chain_compact_block_short_ids(kth_compact_block_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    return &(kth::cpp_ref<cpp_t>(self).short_ids());
+    auto const cpp_result = kth::cpp_ref<cpp_t>(self).short_ids();
+    return kth::leak_list<uint64_t>(cpp_result.begin(), cpp_result.end());
 }
 
 kth_prefilled_transaction_list_const_t kth_chain_compact_block_transactions(kth_compact_block_const_t self) {

--- a/src/c-api/src/chain/script.cpp
+++ b/src/c-api/src/chain/script.cpp
@@ -124,7 +124,7 @@ kth_operation_list_const_t kth_chain_script_operations(kth_script_const_t self) 
 
 kth_operation_mut_t kth_chain_script_first_operation(kth_script_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).first_operation());
+    return kth::leak(kth::cpp_ref<cpp_t>(self).first_operation());
 }
 
 kth_script_pattern_t kth_chain_script_pattern(kth_script_const_t self) {
@@ -132,7 +132,7 @@ kth_script_pattern_t kth_chain_script_pattern(kth_script_const_t self) {
     return kth::script_pattern_to_c(kth::cpp_ref<cpp_t>(self).pattern());
 }
 
-kth_script_pattern_t kth_chain_script_output_pattern(kth_script_const_t self) {
+kth_script_pattern_t kth_chain_script_output_pattern_simple(kth_script_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::script_pattern_to_c(kth::cpp_ref<cpp_t>(self).output_pattern());
 }
@@ -293,6 +293,11 @@ kth_operation_const_t kth_chain_script_at(kth_script_const_t self, kth_size_t in
     KTH_PRECONDITION(index < kth::cpp_ref<cpp_t>(self).size());
     auto const index_cpp = kth::sz(index);
     return &(kth::cpp_ref<cpp_t>(self).operator[](index_cpp));
+}
+
+kth_script_pattern_t kth_chain_script_output_pattern(kth_script_const_t self, kth_script_flags_t flags) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::script_pattern_to_c(kth::cpp_ref<cpp_t>(self).output_pattern(flags));
 }
 
 kth_size_t kth_chain_script_sigops(kth_script_const_t self, kth_bool_t accurate) {

--- a/src/c-api/src/wallet/wallet_data.cpp
+++ b/src/c-api/src/wallet/wallet_data.cpp
@@ -36,9 +36,10 @@ kth_wallet_data_mut_t kth_wallet_wallet_data_copy(kth_wallet_data_const_t self) 
 
 // Getters
 
-kth_string_list_const_t kth_wallet_wallet_data_mnemonics(kth_wallet_data_const_t self) {
+kth_string_list_mut_t kth_wallet_wallet_data_mnemonics(kth_wallet_data_const_t self) {
     KTH_PRECONDITION(self != nullptr);
-    return &(kth::cpp_ref<cpp_t>(self).mnemonics);
+    auto const cpp_result = kth::cpp_ref<cpp_t>(self).mnemonics;
+    return kth::leak_list<std::string>(cpp_result.begin(), cpp_result.end());
 }
 
 kth_hd_public_const_t kth_wallet_wallet_data_xpub(kth_wallet_data_const_t self) {


### PR DESCRIPTION
## Summary
Full-surface regeneration surfaced three buckets of drift that the per-class regens in recent PRs didn't reach:

1. **`leak_if_valid` → `leak`** on types without `operator bool`. Seven entry points (`binary::substring`, the six `block::genesis_*` factories, `compact_block` ctor, `script::first_operation`) now return bare owned handles. `_if_valid` was a no-op for these — `check_valid` always reports `true` — and the `@return ... or NULL if construction/parsing fails` doc clause went away so consumers don't write dead NULL checks. Pure correctness / doc improvement.
2. **`script::output_pattern` flag-aware / `*_simple` split.** The flagless entry-point is now `kth_chain_script_output_pattern_simple`; the canonical `kth_chain_script_output_pattern` takes `kth_script_flags_t`, mirroring the C++ overload added in #278. Same `*_simple` convention already applied to `kth_chain_transaction_is_standard` in that PR — this is the matching script-side catch-up.
3. **Scalar-value list accessors: borrowed → owned copy.** `compact_block::short_ids` (`std::vector<uint64_t>`) and `wallet_data::mnemonics` (`std::vector<std::string>`) used to return `kth_*_list_const_t` pointers into the parent's internal storage. They now return `KTH_OWNED kth_*_list_mut_t` materialised via `kth::leak_list<T>`; callers release the copy with the matching `kth_core_*_list_destruct`. Lists of opaque handles (transactions, inputs, operations, ...) remain borrowed views — the handle *is* the pointer, so the lifetime trade-off is different.

No in-tree consumer relied on the old names / flagless forms. The ownership change in (3) is the only semantic shift and is a strict safety win (no dangling-ref risk on long-lived list handles).

## Test plan
- [ ] CI stays green — all changes are in the generated surface of already-exercised bindings; the consumers of `script::output_pattern` and the renamed `_simple` variants are covered by the existing domain / c-api tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the C API surface/ABI (function rename, signature change, and ownership semantics), which can break downstream bindings and requires callers/tests to update memory management.
> 
> **Overview**
> Adjusts several C-API getters/factories to **always return owned handles** by replacing `leak_if_valid` with `leak` and updating docs to remove “NULL on failure” wording (e.g., `binary::substring`, `script::first_operation`, and `block::genesis_*`).
> 
> Splits script output-pattern classification into `kth_chain_script_output_pattern_simple()` (flagless) and a new flag-aware `kth_chain_script_output_pattern(script, flags)` API.
> 
> Changes scalar-vector accessors to return **owned list copies** instead of borrowed views: `kth_chain_compact_block_short_ids()` now returns an owned `kth_u64_list_mut_t`, and `kth_wallet_wallet_data_mnemonics()` returns an owned `kth_string_list_mut_t`, shifting responsibility to callers to destruct these lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55300037ef5fe00bb1820979cb9a76ba985ccdd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->