### PR TITLE
fix(c-api): migrate test to output_pattern_simple after rename

### DIFF
--- a/src/c-api/test/chain/script.cpp
+++ b/src/c-api/test/chain/script.cpp
@@ -347,7 +347,7 @@ TEST_CASE("C-API Script - bare OP_RETURN is non_standard",
     kth_script_mut_t script = NULL;
     REQUIRE(kth_chain_script_construct_from_data(
         kOpReturnPrefixed, sizeof(kOpReturnPrefixed), 1, &script) == kth_ec_success);
-    kth_script_pattern_t p = kth_chain_script_output_pattern(script);
+    kth_script_pattern_t p = kth_chain_script_output_pattern_simple(script);
     REQUIRE(p == kth_script_pattern_non_standard);
     kth_chain_script_destruct(script);
 }


### PR DESCRIPTION
## Summary
Hotfix for a build break introduced by #280: one c-api test still called the pre-rename `kth_chain_script_output_pattern(script)` (one-arg form), which #280 replaced with a flag-aware two-arg signature (the flagless form is now `*_simple`, matching the convention from #278). Update the call site to `kth_chain_script_output_pattern_simple(script)` so the test keeps its original intent — classifying a bare OP_RETURN as `non_standard` without any flag context.

My analysis in #280 missed the test tree. Verified post-fix that no remaining callers of the old flagless name exist anywhere under `src/` or `test/`.

## Test plan
- [ ] `kth_capi_test` compiles and the `C-API Script - bare OP_RETURN is non_standard` case keeps passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that updates a single call site to the new function name with no production logic impact.
> 
> **Overview**
> Updates the `C-API Script - bare OP_RETURN is non_standard` test to call `kth_chain_script_output_pattern_simple(script)` instead of the old one-argument `kth_chain_script_output_pattern`, aligning with the renamed/flag-aware output pattern API and fixing the build break.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472ba83b0d559c5b5dca453c301031d25db7d390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->