### PR TITLE
fix(domain): align double_spend_proof version parameter with sibling message classes

### DIFF
--- a/src/c-api/include/kth/capi/chain/double_spend_proof.h
+++ b/src/c-api/include/kth/capi/chain/double_spend_proof.h
@@ -58,10 +58,10 @@ kth_bool_t kth_chain_double_spend_proof_equals(kth_double_spend_proof_const_t se
 
 /** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
 KTH_EXPORT KTH_OWNED
-uint8_t* kth_chain_double_spend_proof_to_data(kth_double_spend_proof_const_t self, kth_size_t version, kth_size_t* out_size);
+uint8_t* kth_chain_double_spend_proof_to_data(kth_double_spend_proof_const_t self, uint32_t version, kth_size_t* out_size);
 
 KTH_EXPORT
-kth_size_t kth_chain_double_spend_proof_serialized_size(kth_double_spend_proof_const_t self, kth_size_t version);
+kth_size_t kth_chain_double_spend_proof_serialized_size(kth_double_spend_proof_const_t self, uint32_t version);
 
 
 // Getters

--- a/src/c-api/src/chain/double_spend_proof.cpp
+++ b/src/c-api/src/chain/double_spend_proof.cpp
@@ -74,18 +74,16 @@ kth_bool_t kth_chain_double_spend_proof_equals(kth_double_spend_proof_const_t se
 
 // Serialization
 
-uint8_t* kth_chain_double_spend_proof_to_data(kth_double_spend_proof_const_t self, kth_size_t version, kth_size_t* out_size) {
+uint8_t* kth_chain_double_spend_proof_to_data(kth_double_spend_proof_const_t self, uint32_t version, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const version_cpp = kth::sz(version);
-    auto const data = kth::cpp_ref<cpp_t>(self).to_data(version_cpp);
+    auto const data = kth::cpp_ref<cpp_t>(self).to_data(version);
     return kth::create_c_array(data, *out_size);
 }
 
-kth_size_t kth_chain_double_spend_proof_serialized_size(kth_double_spend_proof_const_t self, kth_size_t version) {
+kth_size_t kth_chain_double_spend_proof_serialized_size(kth_double_spend_proof_const_t self, uint32_t version) {
     KTH_PRECONDITION(self != nullptr);
-    auto const version_cpp = kth::sz(version);
-    return kth::cpp_ref<cpp_t>(self).serialized_size(version_cpp);
+    return kth::cpp_ref<cpp_t>(self).serialized_size(version);
 }
 
 

--- a/src/domain/include/kth/domain/message/double_spend_proof.hpp
+++ b/src/domain/include/kth/domain/message/double_spend_proof.hpp
@@ -129,12 +129,12 @@ struct KD_API double_spend_proof {
     void set_spender2(spender const& x);
 
     [[nodiscard]]
-    data_chunk to_data(size_t /*version*/) const;
+    data_chunk to_data(uint32_t /*version*/) const;
 
-    void to_data(size_t /*version*/, data_sink& stream) const;
+    void to_data(uint32_t /*version*/, data_sink& stream) const;
 
     template <typename W>
-    void to_data(size_t /*version*/, W& sink) const {
+    void to_data(uint32_t /*version*/, W& sink) const {
         out_point_.to_data(sink);
         spender1_.to_data(sink);
         spender2_.to_data(sink);
@@ -149,7 +149,7 @@ struct KD_API double_spend_proof {
     void reset();
 
     [[nodiscard]]
-    size_t serialized_size(size_t /*version*/) const {
+    size_t serialized_size(uint32_t /*version*/) const {
         return out_point_.serialized_size() +
             spender1_.serialized_size() +
             spender2_.serialized_size();

--- a/src/domain/src/message/double_spend_proof.cpp
+++ b/src/domain/src/message/double_spend_proof.cpp
@@ -107,7 +107,7 @@ expect<double_spend_proof> double_spend_proof::from_data(byte_reader& reader, ui
 // Serialization.
 //-----------------------------------------------------------------------------
 
-data_chunk double_spend_proof::to_data(size_t version) const {
+data_chunk double_spend_proof::to_data(uint32_t version) const {
     data_chunk data;
     auto const size = serialized_size(version);
     data.reserve(size);
@@ -118,7 +118,7 @@ data_chunk double_spend_proof::to_data(size_t version) const {
     return data;
 }
 
-void double_spend_proof::to_data(size_t version, data_sink& stream) const {
+void double_spend_proof::to_data(uint32_t version, data_sink& stream) const {
     ostream_writer sink_w(stream);
     to_data(version, sink_w);
 }


### PR DESCRIPTION
## Summary
`double_spend_proof::to_data(size_t)` and `serialized_size(size_t)` were the only two call sites in the message family using `size_t` for the protocol version. Every sibling (`merkle_block`, `compact_block`, `get_blocks`, `get_headers`, `prefilled_transaction`, `double_spend_proof::spender`) uses `uint32_t`, and so does `double_spend_proof::from_data` — the version field itself is declared `uint32_t version = 0;` inside `spender`.

The inconsistency mattered downstream: the C-API / py-native generator pipes `size_t` → `kth_size_t` → `Py_ssize_t` on the Python side, so the Python wrapper for DSP parsed an unsigned protocol version through a signed parser with a non-negativity check that's structurally unreachable for the real underlying type. A py-native reviewer caught it end-to-end while looking at the 0.80.0 regen.

This PR changes the four DSP entry points — `to_data(uint32_t) const`, `to_data(uint32_t, data_sink&) const`, the templated `to_data(uint32_t, W&)`, and `serialized_size(uint32_t) const` — to `uint32_t`. `.cpp` implementation signatures follow.

In-tree callers pass the integer literal `0` (both test cases), which works unchanged under either type.

C-API regenerated through the generator pipeline: the three entry points that previously carried `kth_size_t version` now carry `uint32_t version`, matching the signature shape that the rest of the message family ships.

## Test plan
- [ ] `kth_domain_test` stays green (no signature-dependent call sites besides the two `dsp.to_data(0)` / `dsp.serialized_size(0)` tests).
- [ ] CI `c-api-tests` picks up the regenerated `kth_chain_double_spend_proof_{to_data,serialized_size}` signature without breakage (no in-tree C-API caller was passing a non-zero version).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public C++ and C API signatures change from `size_t`/`kth_size_t` to `uint32_t`, which is source/binary breaking for downstream callers and bindings, though the behavioral logic is unchanged.
> 
> **Overview**
> Aligns `double_spend_proof` serialization APIs to take a `uint32_t` protocol `version` instead of `size_t` (C++ `to_data(...)` overloads and `serialized_size(...)`).
> 
> Regenerates the matching C-API surface (`kth_chain_double_spend_proof_to_data` / `kth_chain_double_spend_proof_serialized_size`) to accept `uint32_t` as well, removing the prior `kth_size_t` conversion path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73732bda1e0d090239ce0d1fa243ceec7cb59ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->