### PR TITLE
refactor(c-api): value_struct params by const* in the safe variant

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -159,6 +159,7 @@ endif()
 set(kth_sources
 
   src/node_info.cpp
+  src/secure_memory.cpp
   src/string_list.cpp
   src/double_list.cpp
   src/u32_list.cpp

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -79,6 +79,7 @@
 #include <kth/capi/double_list.h>
 #include <kth/capi/hash.h>
 #include <kth/capi/hash_list.h>
+#include <kth/capi/secure_memory.h>
 #include <kth/capi/string_list.h>
 #include <kth/capi/u32_list.h>
 #include <kth/capi/u64_list.h>

--- a/src/c-api/include/kth/capi/chain/double_spend_proof_spender.h
+++ b/src/c-api/include/kth/capi/chain/double_spend_proof_spender.h
@@ -83,24 +83,27 @@ void kth_chain_double_spend_proof_spender_set_out_sequence(kth_double_spend_proo
 KTH_EXPORT
 void kth_chain_double_spend_proof_spender_set_locktime(kth_double_spend_proof_spender_mut_t self, uint32_t value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_double_spend_proof_spender_set_prev_outs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value);
+void kth_chain_double_spend_proof_spender_set_prev_outs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_double_spend_proof_spender_set_prev_outs_hash_unsafe(kth_double_spend_proof_spender_mut_t self, uint8_t const* value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_double_spend_proof_spender_set_sequence_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value);
+void kth_chain_double_spend_proof_spender_set_sequence_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_double_spend_proof_spender_set_sequence_hash_unsafe(kth_double_spend_proof_spender_mut_t self, uint8_t const* value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_double_spend_proof_spender_set_outputs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value);
+void kth_chain_double_spend_proof_spender_set_outputs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_double_spend_proof_spender_set_outputs_hash_unsafe(kth_double_spend_proof_spender_mut_t self, uint8_t const* value);
 

--- a/src/c-api/include/kth/capi/chain/get_blocks.h
+++ b/src/c-api/include/kth/capi/chain/get_blocks.h
@@ -27,14 +27,15 @@ kth_error_code_t kth_chain_get_blocks_construct_from_data(uint8_t const* data, k
 /**
  * @return Owned `kth_get_blocks_mut_t`. Caller must release with `kth_chain_get_blocks_destruct`.
  * @param start Borrowed input. Copied by value into the resulting object; ownership of `start` stays with the caller.
+ * @param stop Borrowed input; must be non-null. Copied into the resulting object; ownership of `stop` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
-kth_get_blocks_mut_t kth_chain_get_blocks_construct(kth_hash_list_const_t start, kth_hash_t stop);
+kth_get_blocks_mut_t kth_chain_get_blocks_construct(kth_hash_list_const_t start, kth_hash_t const* stop);
 
 /**
  * @return Owned `kth_get_blocks_mut_t`. Caller must release with `kth_chain_get_blocks_destruct`.
  * @param start Borrowed input. Copied by value into the resulting object; ownership of `start` stays with the caller.
- * @warning `stop` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `stop` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_get_blocks_mut_t kth_chain_get_blocks_construct_unsafe(kth_hash_list_const_t start, uint8_t const* stop);
@@ -86,10 +87,11 @@ kth_hash_t kth_chain_get_blocks_stop_hash(kth_get_blocks_const_t self);
 KTH_EXPORT
 void kth_chain_get_blocks_set_start_hashes(kth_get_blocks_mut_t self, kth_hash_list_const_t value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_get_blocks_set_stop_hash(kth_get_blocks_mut_t self, kth_hash_t value);
+void kth_chain_get_blocks_set_stop_hash(kth_get_blocks_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_get_blocks_set_stop_hash_unsafe(kth_get_blocks_mut_t self, uint8_t const* value);
 

--- a/src/c-api/include/kth/capi/chain/get_headers.h
+++ b/src/c-api/include/kth/capi/chain/get_headers.h
@@ -27,14 +27,15 @@ kth_error_code_t kth_chain_get_headers_construct_from_data(uint8_t const* data, 
 /**
  * @return Owned `kth_get_headers_mut_t`. Caller must release with `kth_chain_get_headers_destruct`.
  * @param start Borrowed input. Copied by value into the resulting object; ownership of `start` stays with the caller.
+ * @param stop Borrowed input; must be non-null. Copied into the resulting object; ownership of `stop` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
-kth_get_headers_mut_t kth_chain_get_headers_construct(kth_hash_list_const_t start, kth_hash_t stop);
+kth_get_headers_mut_t kth_chain_get_headers_construct(kth_hash_list_const_t start, kth_hash_t const* stop);
 
 /**
  * @return Owned `kth_get_headers_mut_t`. Caller must release with `kth_chain_get_headers_destruct`.
  * @param start Borrowed input. Copied by value into the resulting object; ownership of `start` stays with the caller.
- * @warning `stop` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `stop` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_get_headers_mut_t kth_chain_get_headers_construct_unsafe(kth_hash_list_const_t start, uint8_t const* stop);
@@ -86,10 +87,11 @@ kth_hash_t kth_chain_get_headers_stop_hash(kth_get_headers_const_t self);
 KTH_EXPORT
 void kth_chain_get_headers_set_start_hashes(kth_get_headers_mut_t self, kth_hash_list_const_t value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_get_headers_set_stop_hash(kth_get_headers_mut_t self, kth_hash_t value);
+void kth_chain_get_headers_set_stop_hash(kth_get_headers_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_get_headers_set_stop_hash_unsafe(kth_get_headers_mut_t self, uint8_t const* value);
 

--- a/src/c-api/include/kth/capi/chain/header.h
+++ b/src/c-api/include/kth/capi/chain/header.h
@@ -24,14 +24,18 @@ kth_header_mut_t kth_chain_header_construct_default(void);
 KTH_EXPORT
 kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_header_mut_t* out);
 
-/** @return Owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`. */
+/**
+ * @return Owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`.
+ * @param previous_block_hash Borrowed input; must be non-null. Copied into the resulting object; ownership of `previous_block_hash` stays with the caller.
+ * @param merkle Borrowed input; must be non-null. Copied into the resulting object; ownership of `merkle` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_header_mut_t kth_chain_header_construct(uint32_t version, kth_hash_t previous_block_hash, kth_hash_t merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce);
+kth_header_mut_t kth_chain_header_construct(uint32_t version, kth_hash_t const* previous_block_hash, kth_hash_t const* merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce);
 
 /**
  * @return Owned `kth_header_mut_t`. Caller must release with `kth_chain_header_destruct`.
- * @warning `previous_block_hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
- * @warning `merkle` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `previous_block_hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ * @warning `merkle` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_header_mut_t kth_chain_header_construct_unsafe(uint32_t version, uint8_t const* previous_block_hash, uint8_t const* merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce);
@@ -96,17 +100,19 @@ uint32_t kth_chain_header_nonce(kth_header_const_t self);
 KTH_EXPORT
 void kth_chain_header_set_version(kth_header_mut_t self, uint32_t value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_header_set_previous_block_hash(kth_header_mut_t self, kth_hash_t value);
+void kth_chain_header_set_previous_block_hash(kth_header_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_header_set_previous_block_hash_unsafe(kth_header_mut_t self, uint8_t const* value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_header_set_merkle(kth_header_mut_t self, kth_hash_t value);
+void kth_chain_header_set_merkle(kth_header_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_header_set_merkle_unsafe(kth_header_mut_t self, uint8_t const* value);
 

--- a/src/c-api/include/kth/capi/chain/output_point.h
+++ b/src/c-api/include/kth/capi/chain/output_point.h
@@ -24,13 +24,16 @@ kth_output_point_mut_t kth_chain_output_point_construct_default(void);
 KTH_EXPORT
 kth_error_code_t kth_chain_output_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_output_point_mut_t* out);
 
-/** @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`. */
+/**
+ * @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`.
+ * @param hash Borrowed input; must be non-null. Copied into the resulting object; ownership of `hash` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(kth_hash_t hash, uint32_t index);
+kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(kth_hash_t const* hash, uint32_t index);
 
 /**
  * @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`.
- * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index_unsafe(uint8_t const* hash, uint32_t index);
@@ -87,10 +90,11 @@ uint64_t kth_chain_output_point_checksum(kth_output_point_const_t self);
 
 // Setters
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_output_point_set_hash(kth_output_point_mut_t self, kth_hash_t value);
+void kth_chain_output_point_set_hash(kth_output_point_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_output_point_set_hash_unsafe(kth_output_point_mut_t self, uint8_t const* value);
 

--- a/src/c-api/include/kth/capi/chain/point.h
+++ b/src/c-api/include/kth/capi/chain/point.h
@@ -24,13 +24,16 @@ kth_point_mut_t kth_chain_point_construct_default(void);
 KTH_EXPORT
 kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_size_t n, kth_bool_t wire, KTH_OUT_OWNED kth_point_mut_t* out);
 
-/** @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`. */
+/**
+ * @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`.
+ * @param hash Borrowed input; must be non-null. Copied into the resulting object; ownership of `hash` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_point_mut_t kth_chain_point_construct(kth_hash_t hash, uint32_t index);
+kth_point_mut_t kth_chain_point_construct(kth_hash_t const* hash, uint32_t index);
 
 /**
  * @return Owned `kth_point_mut_t`. Caller must release with `kth_chain_point_destruct`.
- * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_point_mut_t kth_chain_point_construct_unsafe(uint8_t const* hash, uint32_t index);
@@ -87,10 +90,11 @@ uint64_t kth_chain_point_checksum(kth_point_const_t self);
 
 // Setters
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_point_set_hash(kth_point_mut_t self, kth_hash_t value);
+void kth_chain_point_set_hash(kth_point_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_point_set_hash_unsafe(kth_point_mut_t self, uint8_t const* value);
 

--- a/src/c-api/include/kth/capi/chain/script.h
+++ b/src/c-api/include/kth/capi/chain/script.h
@@ -205,17 +205,19 @@ kth_error_code_t kth_chain_script_from_data_with_size(uint8_t const* data, kth_s
 KTH_EXPORT
 kth_hash_t kth_chain_script_generate_signature_hash(kth_transaction_const_t tx, uint32_t input_index, kth_script_const_t script_code, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size);
 
+/** @param signature Borrowed input; must be non-null. Read during the call; ownership of `signature` stays with the caller. */
 KTH_EXPORT
-kth_bool_t kth_chain_script_check_signature(kth_longhash_t signature, uint8_t sighash_type, uint8_t const* public_key, kth_size_t n, kth_script_const_t script_code, kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size);
+kth_bool_t kth_chain_script_check_signature(kth_longhash_t const* signature, uint8_t sighash_type, uint8_t const* public_key, kth_size_t n, kth_script_const_t script_code, kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size);
 
-/** @warning `signature` MUST point to a buffer of at least 64 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `signature` MUST point to a buffer of at least 64 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_longhash_t`. */
 KTH_EXPORT
 kth_bool_t kth_chain_script_check_signature_unsafe(uint8_t const* signature, uint8_t sighash_type, uint8_t const* public_key, kth_size_t n, kth_script_const_t script_code, kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size);
 
+/** @param secret Borrowed input; must be non-null. Read during the call; ownership of `secret` stays with the caller. */
 KTH_EXPORT
-kth_error_code_t kth_chain_script_create_endorsement(kth_hash_t secret, kth_script_const_t prevout_script, kth_transaction_const_t tx, uint32_t input_index, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_endorsement_type_t type, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size);
+kth_error_code_t kth_chain_script_create_endorsement(kth_hash_t const* secret, kth_script_const_t prevout_script, kth_transaction_const_t tx, uint32_t input_index, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_endorsement_type_t type, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size);
 
-/** @warning `secret` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `secret` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 kth_error_code_t kth_chain_script_create_endorsement_unsafe(uint8_t const* secret, kth_script_const_t prevout_script, kth_transaction_const_t tx, uint32_t input_index, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_endorsement_type_t type, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size);
 
@@ -227,13 +229,16 @@ kth_operation_list_mut_t kth_chain_script_to_null_data_pattern(uint8_t const* da
 KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_pattern(uint8_t const* point, kth_size_t n);
 
-/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+/**
+ * @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`.
+ * @param hash Borrowed input; must be non-null. Read during the call; ownership of `hash` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern(kth_shorthash_t hash);
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern(kth_shorthash_t const* hash);
 
 /**
  * @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`.
- * @warning `hash` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `hash` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_shorthash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unsafe(uint8_t const* hash);
@@ -250,24 +255,30 @@ kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern_unlocki
 KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern_unlocking_placeholder(kth_size_t script_size, kth_bool_t multisig);
 
-/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+/**
+ * @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`.
+ * @param hash Borrowed input; must be non-null. Read during the call; ownership of `hash` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern(kth_shorthash_t hash);
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern(kth_shorthash_t const* hash);
 
 /**
  * @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`.
- * @warning `hash` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `hash` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_shorthash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern_unsafe(uint8_t const* hash);
 
-/** @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`. */
+/**
+ * @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`.
+ * @param hash Borrowed input; must be non-null. Read during the call; ownership of `hash` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_32_pattern(kth_hash_t hash);
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_32_pattern(kth_hash_t const* hash);
 
 /**
  * @return Owned `kth_operation_list_mut_t`. Caller must release with `kth_chain_operation_list_destruct`.
- * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_32_pattern_unsafe(uint8_t const* hash);

--- a/src/c-api/include/kth/capi/chain/stealth_compact.h
+++ b/src/c-api/include/kth/capi/chain/stealth_compact.h
@@ -42,24 +42,27 @@ kth_hash_t kth_chain_stealth_compact_transaction_hash(kth_stealth_compact_const_
 
 // Setters
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_stealth_compact_set_ephemeral_public_key_hash(kth_stealth_compact_mut_t self, kth_hash_t value);
+void kth_chain_stealth_compact_set_ephemeral_public_key_hash(kth_stealth_compact_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_stealth_compact_set_ephemeral_public_key_hash_unsafe(kth_stealth_compact_mut_t self, uint8_t const* value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_stealth_compact_set_public_key_hash(kth_stealth_compact_mut_t self, kth_shorthash_t value);
+void kth_chain_stealth_compact_set_public_key_hash(kth_stealth_compact_mut_t self, kth_shorthash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_shorthash_t`. */
 KTH_EXPORT
 void kth_chain_stealth_compact_set_public_key_hash_unsafe(kth_stealth_compact_mut_t self, uint8_t const* value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_stealth_compact_set_transaction_hash(kth_stealth_compact_mut_t self, kth_hash_t value);
+void kth_chain_stealth_compact_set_transaction_hash(kth_stealth_compact_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_stealth_compact_set_transaction_hash_unsafe(kth_stealth_compact_mut_t self, uint8_t const* value);
 

--- a/src/c-api/include/kth/capi/chain/token_data.h
+++ b/src/c-api/include/kth/capi/chain/token_data.h
@@ -25,35 +25,44 @@ kth_error_code_t kth_chain_token_construct_from_data(uint8_t const* data, kth_si
 
 // Static factories
 
-/** @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`. */
+/**
+ * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
+ * @param id Borrowed input; must be non-null. Read during the call; ownership of `id` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_token_data_mut_t kth_chain_token_make_fungible(kth_hash_t id, uint64_t amount);
+kth_token_data_mut_t kth_chain_token_make_fungible(kth_hash_t const* id, uint64_t amount);
 
 /**
  * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
- * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_token_data_mut_t kth_chain_token_make_fungible_unsafe(uint8_t const* id, uint64_t amount);
 
-/** @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`. */
+/**
+ * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
+ * @param id Borrowed input; must be non-null. Read during the call; ownership of `id` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_token_data_mut_t kth_chain_token_make_non_fungible(kth_hash_t id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+kth_token_data_mut_t kth_chain_token_make_non_fungible(kth_hash_t const* id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
 
 /**
  * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
- * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_token_data_mut_t kth_chain_token_make_non_fungible_unsafe(uint8_t const* id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
 
-/** @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`. */
+/**
+ * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
+ * @param id Borrowed input; must be non-null. Read during the call; ownership of `id` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_token_data_mut_t kth_chain_token_make_both(kth_hash_t id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
+kth_token_data_mut_t kth_chain_token_make_both(kth_hash_t const* id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
 
 /**
  * @return Owned `kth_token_data_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_chain_token_data_destruct`.
- * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `id` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_token_data_mut_t kth_chain_token_make_both_unsafe(uint8_t const* id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n);
@@ -113,10 +122,11 @@ uint8_t kth_chain_token_data_bitfield(kth_token_data_const_t self);
 
 // Setters
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_chain_token_data_set_id(kth_token_data_mut_t self, kth_hash_t value);
+void kth_chain_token_data_set_id(kth_token_data_mut_t self, kth_hash_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_token_data_set_id_unsafe(kth_token_data_mut_t self, uint8_t const* value);
 

--- a/src/c-api/include/kth/capi/chain/transaction.h
+++ b/src/c-api/include/kth/capi/chain/transaction.h
@@ -36,14 +36,15 @@ kth_transaction_mut_t kth_chain_transaction_construct_from_version_locktime_inpu
 /**
  * @return Owned `kth_transaction_mut_t`. Caller must release with `kth_chain_transaction_destruct`.
  * @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller.
+ * @param hash Borrowed input; must be non-null. Copied into the resulting object; ownership of `hash` stays with the caller.
  */
 KTH_EXPORT KTH_OWNED
-kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash(kth_transaction_const_t x, kth_hash_t hash);
+kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash(kth_transaction_const_t x, kth_hash_t const* hash);
 
 /**
  * @return Owned `kth_transaction_mut_t`. Caller must release with `kth_chain_transaction_destruct`.
  * @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller.
- * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash_unsafe(kth_transaction_const_t x, uint8_t const* hash);

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -39,8 +39,35 @@
 #include <kth/node/full_node.hpp>
 // #endif
 
+#include <kth/capi/secure_memory.h>
+
 
 namespace kth {
+
+// RAII scrub for stack-local `kth::hash_digest` / `kth::hd_key` /
+// `kth::encrypted_seed` / WIF copies that the C-API impl materialises
+// from a `kth_xxx_t const*` input via `hash_to_cpp` / `hd_key_to_cpp` /
+// etc. The C-API leaves those copies on its own stack frame; a guard
+// scoped for the lifetime of the local wipes them on every return path
+// (including exceptions propagating past KTH_PRECONDITION / expected
+// error-returns) so key material does not linger beyond the call.
+//
+// Declared non-copyable / non-movable so accidental copies can't
+// duplicate the pointer in multiple guards that would double-scrub
+// (harmless but confusing if later changed to do more).
+struct secure_scrub {
+    void* p;
+    std::size_t n;
+
+    secure_scrub(void* p_, std::size_t n_) noexcept : p(p_), n(n_) {}
+    ~secure_scrub() noexcept { kth_core_secure_zero(p, n); }
+
+    secure_scrub(secure_scrub const&) = delete;
+    secure_scrub(secure_scrub&&) = delete;
+    secure_scrub& operator=(secure_scrub const&) = delete;
+    secure_scrub& operator=(secure_scrub&&) = delete;
+};
+
 namespace detail {
 
 // template <typename T>

--- a/src/c-api/include/kth/capi/secure_memory.h
+++ b/src/c-api/include/kth/capi/secure_memory.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_SECURE_MEMORY_H_
+#define KTH_CAPI_SECURE_MEMORY_H_
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Zero `n` bytes at `p` such that the compiler cannot optimize the
+ *        write away.
+ *
+ * High-level bindings (py-native, cs-api, ...) use this on their own
+ * stack-local value_struct buffers that carried cryptographic material
+ * (a raw secret, a WIF, an HD private key, an encrypted seed) during a
+ * C-API call. Scrubbing those locals on the way out closes the window
+ * where a memory dump, attached debugger, or swap-to-disk could recover
+ * the bytes from a no-longer-live stack frame.
+ *
+ * Routes to the platform's non-optimizable scrub primitive:
+ *   - glibc >= 2.25, BSD, macOS >= 10.12: `explicit_bzero`
+ *   - Windows: `SecureZeroMemory`
+ *   - C11 Annex K (when opted-in): `memset_s`
+ *   - Fallback: a `volatile`-pointer byte loop the optimizer cannot
+ *     collapse into a dead-store.
+ *
+ * Out of scope: side-channel leaks (cache, speculation, register
+ * spills the compiler chose). For those a pure scrub primitive is
+ * not a mitigation — binding authors need higher-level techniques.
+ *
+ * @param p Caller-owned buffer to wipe. Must not alias executable
+ *          memory. NULL or `n == 0` is a no-op.
+ * @param n Number of bytes to wipe.
+ */
+KTH_EXPORT
+void kth_core_secure_zero(void* p, kth_size_t n);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_SECURE_MEMORY_H_ */

--- a/src/c-api/include/kth/capi/wallet/ec_private.h
+++ b/src/c-api/include/kth/capi/wallet/ec_private.h
@@ -25,35 +25,44 @@ kth_ec_private_mut_t kth_wallet_ec_private_construct_default(void);
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_version(char const* wif, uint8_t version);
 
-/** @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`. */
+/**
+ * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
+ * @param wif_compressed Borrowed input; must be non-null. Copied into the resulting object; ownership of `wif_compressed` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version(kth_wif_compressed_t wif_compressed, uint8_t version);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version(kth_wif_compressed_t const* wif_compressed, uint8_t version);
 
 /**
  * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
- * @warning `wif_compressed` MUST point to a buffer of at least 38 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `wif_compressed` MUST point to a buffer of at least 38 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_wif_compressed_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version_unsafe(uint8_t const* wif_compressed, uint8_t version);
 
-/** @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`. */
+/**
+ * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
+ * @param wif_uncompressed Borrowed input; must be non-null. Copied into the resulting object; ownership of `wif_uncompressed` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version(kth_wif_uncompressed_t wif_uncompressed, uint8_t version);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version(kth_wif_uncompressed_t const* wif_uncompressed, uint8_t version);
 
 /**
  * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
- * @warning `wif_uncompressed` MUST point to a buffer of at least 37 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `wif_uncompressed` MUST point to a buffer of at least 37 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_wif_uncompressed_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version_unsafe(uint8_t const* wif_uncompressed, uint8_t version);
 
-/** @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`. */
+/**
+ * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
+ * @param secret Borrowed input; must be non-null. Copied into the resulting object; ownership of `secret` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(kth_hash_t secret, uint16_t version, kth_bool_t compress);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(kth_hash_t const* secret, uint16_t version, kth_bool_t compress);
 
 /**
  * @return Owned `kth_ec_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_private_destruct`.
- * @warning `secret` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `secret` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress_unsafe(uint8_t const* secret, uint16_t version, kth_bool_t compress);

--- a/src/c-api/include/kth/capi/wallet/ec_public.h
+++ b/src/c-api/include/kth/capi/wallet/ec_public.h
@@ -36,24 +36,30 @@ kth_ec_public_mut_t kth_wallet_ec_public_construct_from_decoded(uint8_t const* d
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_base16(char const* base16);
 
-/** @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`. */
+/**
+ * @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`.
+ * @param compressed_point Borrowed input; must be non-null. Copied into the resulting object; ownership of `compressed_point` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress(kth_ec_compressed_t compressed_point, kth_bool_t compress);
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress(kth_ec_compressed_t const* compressed_point, kth_bool_t compress);
 
 /**
  * @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`.
- * @warning `compressed_point` MUST point to a buffer of at least 33 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `compressed_point` MUST point to a buffer of at least 33 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ec_compressed_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress_unsafe(uint8_t const* compressed_point, kth_bool_t compress);
 
-/** @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`. */
+/**
+ * @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`.
+ * @param uncompressed_point Borrowed input; must be non-null. Copied into the resulting object; ownership of `uncompressed_point` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress(kth_ec_uncompressed_t uncompressed_point, kth_bool_t compress);
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress(kth_ec_uncompressed_t const* uncompressed_point, kth_bool_t compress);
 
 /**
  * @return Owned `kth_ec_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ec_public_destruct`.
- * @warning `uncompressed_point` MUST point to a buffer of at least 65 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `uncompressed_point` MUST point to a buffer of at least 65 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ec_uncompressed_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress_unsafe(uint8_t const* uncompressed_point, kth_bool_t compress);

--- a/src/c-api/include/kth/capi/wallet/hd_private.h
+++ b/src/c-api/include/kth/capi/wallet/hd_private.h
@@ -26,35 +26,44 @@ kth_hd_private_mut_t kth_wallet_hd_private_construct_default(void);
 KTH_EXPORT KTH_OWNED
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_seed_prefixes(uint8_t const* seed, kth_size_t n, uint64_t prefixes);
 
-/** @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`. */
+/**
+ * @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`.
+ * @param private_key Borrowed input; must be non-null. Copied into the resulting object; ownership of `private_key` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key(kth_hd_key_t private_key);
+kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key(kth_hd_key_t const* private_key);
 
 /**
  * @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`.
- * @warning `private_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `private_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hd_key_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_unsafe(uint8_t const* private_key);
 
-/** @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`. */
+/**
+ * @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`.
+ * @param private_key Borrowed input; must be non-null. Copied into the resulting object; ownership of `private_key` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefixes(kth_hd_key_t private_key, uint64_t prefixes);
+kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefixes(kth_hd_key_t const* private_key, uint64_t prefixes);
 
 /**
  * @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`.
- * @warning `private_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `private_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hd_key_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefixes_unsafe(uint8_t const* private_key, uint64_t prefixes);
 
-/** @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`. */
+/**
+ * @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`.
+ * @param private_key Borrowed input; must be non-null. Copied into the resulting object; ownership of `private_key` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix(kth_hd_key_t private_key, uint32_t prefix);
+kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix(kth_hd_key_t const* private_key, uint32_t prefix);
 
 /**
  * @return Owned `kth_hd_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_private_destruct`.
- * @warning `private_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `private_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hd_key_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix_unsafe(uint8_t const* private_key, uint32_t prefix);

--- a/src/c-api/include/kth/capi/wallet/hd_public.h
+++ b/src/c-api/include/kth/capi/wallet/hd_public.h
@@ -22,24 +22,30 @@ extern "C" {
 KTH_EXPORT KTH_OWNED
 kth_hd_public_mut_t kth_wallet_hd_public_construct_default(void);
 
-/** @return Owned `kth_hd_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_public_destruct`. */
+/**
+ * @return Owned `kth_hd_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_public_destruct`.
+ * @param public_key Borrowed input; must be non-null. Copied into the resulting object; ownership of `public_key` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key(kth_hd_key_t public_key);
+kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key(kth_hd_key_t const* public_key);
 
 /**
  * @return Owned `kth_hd_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_public_destruct`.
- * @warning `public_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `public_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hd_key_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_unsafe(uint8_t const* public_key);
 
-/** @return Owned `kth_hd_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_public_destruct`. */
+/**
+ * @return Owned `kth_hd_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_public_destruct`.
+ * @param public_key Borrowed input; must be non-null. Copied into the resulting object; ownership of `public_key` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_prefix(kth_hd_key_t public_key, uint32_t prefix);
+kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_prefix(kth_hd_key_t const* public_key, uint32_t prefix);
 
 /**
  * @return Owned `kth_hd_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_hd_public_destruct`.
- * @warning `public_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `public_key` MUST point to a buffer of at least 82 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hd_key_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_prefix_unsafe(uint8_t const* public_key, uint32_t prefix);

--- a/src/c-api/include/kth/capi/wallet/payment_address.h
+++ b/src/c-api/include/kth/capi/wallet/payment_address.h
@@ -21,13 +21,16 @@ extern "C" {
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_default(void);
 
-/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
+/**
+ * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
+ * @param decoded Borrowed input; must be non-null. Copied into the resulting object; ownership of `decoded` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded(kth_payment_t decoded);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded(kth_payment_t const* decoded);
 
 /**
  * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
- * @warning `decoded` MUST point to a buffer of at least 25 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `decoded` MUST point to a buffer of at least 25 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_payment_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded_unsafe(uint8_t const* decoded);
@@ -47,24 +50,30 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address(char
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address_net(char const* address, kth_network_t net);
 
-/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
+/**
+ * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
+ * @param short_hash Borrowed input; must be non-null. Copied into the resulting object; ownership of `short_hash` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t short_hash, uint8_t version);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t const* short_hash, uint8_t version);
 
 /**
  * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
- * @warning `short_hash` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `short_hash` MUST point to a buffer of at least 20 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_shorthash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version_unsafe(uint8_t const* short_hash, uint8_t version);
 
-/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
+/**
+ * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
+ * @param hash Borrowed input; must be non-null. Copied into the resulting object; ownership of `hash` stays with the caller.
+ */
 KTH_EXPORT KTH_OWNED
-kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version(kth_hash_t hash, uint8_t version);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version(kth_hash_t const* hash, uint8_t version);
 
 /**
  * @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`.
- * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value.
+ * @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
  */
 KTH_EXPORT KTH_OWNED
 kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version_unsafe(uint8_t const* hash, uint8_t version);

--- a/src/c-api/include/kth/capi/wallet/wallet_data.h
+++ b/src/c-api/include/kth/capi/wallet/wallet_data.h
@@ -53,10 +53,11 @@ void kth_wallet_wallet_data_set_mnemonics(kth_wallet_data_mut_t self, kth_string
 KTH_EXPORT
 void kth_wallet_wallet_data_set_xpub(kth_wallet_data_mut_t self, kth_hd_public_const_t value);
 
+/** @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller. */
 KTH_EXPORT
-void kth_wallet_wallet_data_set_encrypted_seed(kth_wallet_data_mut_t self, kth_encrypted_seed_t value);
+void kth_wallet_wallet_data_set_encrypted_seed(kth_wallet_data_mut_t self, kth_encrypted_seed_t const* value);
 
-/** @warning `value` MUST point to a buffer of at least 96 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a C struct by value. */
+/** @warning `value` MUST point to a buffer of at least 96 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_encrypted_seed_t`. */
 KTH_EXPORT
 void kth_wallet_wallet_data_set_encrypted_seed_unsafe(kth_wallet_data_mut_t self, uint8_t const* value);
 

--- a/src/c-api/src/chain/double_spend_proof_spender.cpp
+++ b/src/c-api/src/chain/double_spend_proof_spender.cpp
@@ -123,9 +123,10 @@ void kth_chain_double_spend_proof_spender_set_locktime(kth_double_spend_proof_sp
     kth::cpp_ref<cpp_t>(self).locktime = value;
 }
 
-void kth_chain_double_spend_proof_spender_set_prev_outs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value) {
+void kth_chain_double_spend_proof_spender_set_prev_outs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).prev_outs_hash = value_cpp;
 }
 
@@ -136,9 +137,10 @@ void kth_chain_double_spend_proof_spender_set_prev_outs_hash_unsafe(kth_double_s
     kth::cpp_ref<cpp_t>(self).prev_outs_hash = value_cpp;
 }
 
-void kth_chain_double_spend_proof_spender_set_sequence_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value) {
+void kth_chain_double_spend_proof_spender_set_sequence_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).sequence_hash = value_cpp;
 }
 
@@ -149,9 +151,10 @@ void kth_chain_double_spend_proof_spender_set_sequence_hash_unsafe(kth_double_sp
     kth::cpp_ref<cpp_t>(self).sequence_hash = value_cpp;
 }
 
-void kth_chain_double_spend_proof_spender_set_outputs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t value) {
+void kth_chain_double_spend_proof_spender_set_outputs_hash(kth_double_spend_proof_spender_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).outputs_hash = value_cpp;
 }
 

--- a/src/c-api/src/chain/get_blocks.cpp
+++ b/src/c-api/src/chain/get_blocks.cpp
@@ -37,10 +37,11 @@ kth_error_code_t kth_chain_get_blocks_construct_from_data(uint8_t const* data, k
     return kth_ec_success;
 }
 
-kth_get_blocks_mut_t kth_chain_get_blocks_construct(kth_hash_list_const_t start, kth_hash_t stop) {
+kth_get_blocks_mut_t kth_chain_get_blocks_construct(kth_hash_list_const_t start, kth_hash_t const* stop) {
     KTH_PRECONDITION(start != nullptr);
+    KTH_PRECONDITION(stop != nullptr);
     auto const& start_cpp = kth::cpp_ref<kth::hash_list>(start);
-    auto const stop_cpp = kth::hash_to_cpp(stop.hash);
+    auto const stop_cpp = kth::hash_to_cpp(stop->hash);
     return kth::leak<cpp_t>(start_cpp, stop_cpp);
 }
 
@@ -114,9 +115,10 @@ void kth_chain_get_blocks_set_start_hashes(kth_get_blocks_mut_t self, kth_hash_l
     kth::cpp_ref<cpp_t>(self).set_start_hashes(value_cpp);
 }
 
-void kth_chain_get_blocks_set_stop_hash(kth_get_blocks_mut_t self, kth_hash_t value) {
+void kth_chain_get_blocks_set_stop_hash(kth_get_blocks_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).set_stop_hash(value_cpp);
 }
 

--- a/src/c-api/src/chain/get_headers.cpp
+++ b/src/c-api/src/chain/get_headers.cpp
@@ -37,10 +37,11 @@ kth_error_code_t kth_chain_get_headers_construct_from_data(uint8_t const* data, 
     return kth_ec_success;
 }
 
-kth_get_headers_mut_t kth_chain_get_headers_construct(kth_hash_list_const_t start, kth_hash_t stop) {
+kth_get_headers_mut_t kth_chain_get_headers_construct(kth_hash_list_const_t start, kth_hash_t const* stop) {
     KTH_PRECONDITION(start != nullptr);
+    KTH_PRECONDITION(stop != nullptr);
     auto const& start_cpp = kth::cpp_ref<kth::hash_list>(start);
-    auto const stop_cpp = kth::hash_to_cpp(stop.hash);
+    auto const stop_cpp = kth::hash_to_cpp(stop->hash);
     return kth::leak<cpp_t>(start_cpp, stop_cpp);
 }
 
@@ -114,9 +115,10 @@ void kth_chain_get_headers_set_start_hashes(kth_get_headers_mut_t self, kth_hash
     kth::cpp_ref<cpp_t>(self).set_start_hashes(value_cpp);
 }
 
-void kth_chain_get_headers_set_stop_hash(kth_get_headers_mut_t self, kth_hash_t value) {
+void kth_chain_get_headers_set_stop_hash(kth_get_headers_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).set_stop_hash(value_cpp);
 }
 

--- a/src/c-api/src/chain/header.cpp
+++ b/src/c-api/src/chain/header.cpp
@@ -38,9 +38,11 @@ kth_error_code_t kth_chain_header_construct_from_data(uint8_t const* data, kth_s
     return kth_ec_success;
 }
 
-kth_header_mut_t kth_chain_header_construct(uint32_t version, kth_hash_t previous_block_hash, kth_hash_t merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce) {
-    auto const previous_block_hash_cpp = kth::hash_to_cpp(previous_block_hash.hash);
-    auto const merkle_cpp = kth::hash_to_cpp(merkle.hash);
+kth_header_mut_t kth_chain_header_construct(uint32_t version, kth_hash_t const* previous_block_hash, kth_hash_t const* merkle, uint32_t timestamp, uint32_t bits, uint32_t nonce) {
+    KTH_PRECONDITION(previous_block_hash != nullptr);
+    KTH_PRECONDITION(merkle != nullptr);
+    auto const previous_block_hash_cpp = kth::hash_to_cpp(previous_block_hash->hash);
+    auto const merkle_cpp = kth::hash_to_cpp(merkle->hash);
     return kth::leak<cpp_t>(version, previous_block_hash_cpp, merkle_cpp, timestamp, bits, nonce);
 }
 
@@ -139,9 +141,10 @@ void kth_chain_header_set_version(kth_header_mut_t self, uint32_t value) {
     kth::cpp_ref<cpp_t>(self).set_version(value);
 }
 
-void kth_chain_header_set_previous_block_hash(kth_header_mut_t self, kth_hash_t value) {
+void kth_chain_header_set_previous_block_hash(kth_header_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).set_previous_block_hash(value_cpp);
 }
 
@@ -152,9 +155,10 @@ void kth_chain_header_set_previous_block_hash_unsafe(kth_header_mut_t self, uint
     kth::cpp_ref<cpp_t>(self).set_previous_block_hash(value_cpp);
 }
 
-void kth_chain_header_set_merkle(kth_header_mut_t self, kth_hash_t value) {
+void kth_chain_header_set_merkle(kth_header_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).set_merkle(value_cpp);
 }
 

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -38,8 +38,9 @@ kth_error_code_t kth_chain_output_point_construct_from_data(uint8_t const* data,
     return kth_ec_success;
 }
 
-kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(kth_hash_t hash, uint32_t index) {
-    auto const hash_cpp = kth::hash_to_cpp(hash.hash);
+kth_output_point_mut_t kth_chain_output_point_construct_from_hash_index(kth_hash_t const* hash, uint32_t index) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto const hash_cpp = kth::hash_to_cpp(hash->hash);
     return kth::leak<cpp_t>(hash_cpp, index);
 }
 
@@ -117,9 +118,10 @@ uint64_t kth_chain_output_point_checksum(kth_output_point_const_t self) {
 
 // Setters
 
-void kth_chain_output_point_set_hash(kth_output_point_mut_t self, kth_hash_t value) {
+void kth_chain_output_point_set_hash(kth_output_point_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
 }
 

--- a/src/c-api/src/chain/point.cpp
+++ b/src/c-api/src/chain/point.cpp
@@ -38,8 +38,9 @@ kth_error_code_t kth_chain_point_construct_from_data(uint8_t const* data, kth_si
     return kth_ec_success;
 }
 
-kth_point_mut_t kth_chain_point_construct(kth_hash_t hash, uint32_t index) {
-    auto const hash_cpp = kth::hash_to_cpp(hash.hash);
+kth_point_mut_t kth_chain_point_construct(kth_hash_t const* hash, uint32_t index) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto const hash_cpp = kth::hash_to_cpp(hash->hash);
     return kth::leak<cpp_t>(hash_cpp, index);
 }
 
@@ -118,9 +119,10 @@ uint64_t kth_chain_point_checksum(kth_point_const_t self) {
 
 // Setters
 
-void kth_chain_point_set_hash(kth_point_mut_t self, kth_hash_t value) {
+void kth_chain_point_set_hash(kth_point_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).set_hash(value_cpp);
 }
 

--- a/src/c-api/src/chain/script.cpp
+++ b/src/c-api/src/chain/script.cpp
@@ -337,12 +337,13 @@ kth_hash_t kth_chain_script_generate_signature_hash(kth_transaction_const_t tx, 
     return kth::to_hash_t(pair_cpp.first);
 }
 
-kth_bool_t kth_chain_script_check_signature(kth_longhash_t signature, uint8_t sighash_type, uint8_t const* public_key, kth_size_t n, kth_script_const_t script_code, kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size) {
+kth_bool_t kth_chain_script_check_signature(kth_longhash_t const* signature, uint8_t sighash_type, uint8_t const* public_key, kth_size_t n, kth_script_const_t script_code, kth_transaction_const_t tx, uint32_t input_index, kth_script_flags_t active_flags, uint64_t value, kth_size_t* out_size) {
+    KTH_PRECONDITION(signature != nullptr);
     KTH_PRECONDITION(public_key != nullptr || n == 0);
     KTH_PRECONDITION(script_code != nullptr);
     KTH_PRECONDITION(tx != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const signature_cpp = kth::long_hash_to_cpp(signature.hash);
+    auto const signature_cpp = kth::long_hash_to_cpp(signature->hash);
     auto const public_key_cpp = n != 0 ? kth::data_chunk(public_key, public_key + n) : kth::data_chunk{};
     auto const& script_code_cpp = kth::cpp_ref<cpp_t>(script_code);
     auto const& tx_cpp = kth::cpp_ref<kth::domain::chain::transaction>(tx);
@@ -366,13 +367,15 @@ kth_bool_t kth_chain_script_check_signature_unsafe(uint8_t const* signature, uin
     return kth::bool_to_int(pair_cpp.first);
 }
 
-kth_error_code_t kth_chain_script_create_endorsement(kth_hash_t secret, kth_script_const_t prevout_script, kth_transaction_const_t tx, uint32_t input_index, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_endorsement_type_t type, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size) {
+kth_error_code_t kth_chain_script_create_endorsement(kth_hash_t const* secret, kth_script_const_t prevout_script, kth_transaction_const_t tx, uint32_t input_index, uint8_t sighash_type, kth_script_flags_t active_flags, uint64_t value, kth_endorsement_type_t type, KTH_OUT_OWNED uint8_t** out, kth_size_t* out_size) {
+    KTH_PRECONDITION(secret != nullptr);
     KTH_PRECONDITION(prevout_script != nullptr);
     KTH_PRECONDITION(tx != nullptr);
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const secret_cpp = kth::hash_to_cpp(secret.hash);
+    auto secret_cpp = kth::hash_to_cpp(secret->hash);
+    kth::secure_scrub secret_cpp_scrub{&secret_cpp, sizeof(secret_cpp)};
     auto const& prevout_script_cpp = kth::cpp_ref<cpp_t>(prevout_script);
     auto const& tx_cpp = kth::cpp_ref<kth::domain::chain::transaction>(tx);
     auto const type_cpp = kth::endorsement_type_to_cpp(type);
@@ -389,7 +392,8 @@ kth_error_code_t kth_chain_script_create_endorsement_unsafe(uint8_t const* secre
     KTH_PRECONDITION(out != nullptr);
     KTH_PRECONDITION(*out == nullptr);
     KTH_PRECONDITION(out_size != nullptr);
-    auto const secret_cpp = kth::hash_to_cpp(secret);
+    auto secret_cpp = kth::hash_to_cpp(secret);
+    kth::secure_scrub secret_cpp_scrub{&secret_cpp, sizeof(secret_cpp)};
     auto const& prevout_script_cpp = kth::cpp_ref<cpp_t>(prevout_script);
     auto const& tx_cpp = kth::cpp_ref<kth::domain::chain::transaction>(tx);
     auto const type_cpp = kth::endorsement_type_to_cpp(type);
@@ -415,8 +419,9 @@ kth_operation_list_mut_t kth_chain_script_to_pay_public_key_pattern(uint8_t cons
     return kth::leak_list<kth::domain::machine::operation>(std::move(cpp_result));
 }
 
-kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern(kth_shorthash_t hash) {
-    auto const hash_cpp = kth::short_hash_to_cpp(hash.hash);
+kth_operation_list_mut_t kth_chain_script_to_pay_public_key_hash_pattern(kth_shorthash_t const* hash) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto const hash_cpp = kth::short_hash_to_cpp(hash->hash);
     return kth::leak_list<kth::domain::machine::operation>(cpp_t::to_pay_public_key_hash_pattern(hash_cpp));
 }
 
@@ -448,8 +453,9 @@ kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern_unlocking_p
     return kth::leak_list<kth::domain::machine::operation>(cpp_t::to_pay_script_hash_pattern_unlocking_placeholder(script_size_cpp, multisig_cpp));
 }
 
-kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern(kth_shorthash_t hash) {
-    auto const hash_cpp = kth::short_hash_to_cpp(hash.hash);
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern(kth_shorthash_t const* hash) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto const hash_cpp = kth::short_hash_to_cpp(hash->hash);
     return kth::leak_list<kth::domain::machine::operation>(cpp_t::to_pay_script_hash_pattern(hash_cpp));
 }
 
@@ -459,8 +465,9 @@ kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_pattern_unsafe(uint
     return kth::leak_list<kth::domain::machine::operation>(cpp_t::to_pay_script_hash_pattern(hash_cpp));
 }
 
-kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_32_pattern(kth_hash_t hash) {
-    auto const hash_cpp = kth::hash_to_cpp(hash.hash);
+kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_32_pattern(kth_hash_t const* hash) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto const hash_cpp = kth::hash_to_cpp(hash->hash);
     return kth::leak_list<kth::domain::machine::operation>(cpp_t::to_pay_script_hash_32_pattern(hash_cpp));
 }
 

--- a/src/c-api/src/chain/stealth_compact.cpp
+++ b/src/c-api/src/chain/stealth_compact.cpp
@@ -52,9 +52,10 @@ kth_hash_t kth_chain_stealth_compact_transaction_hash(kth_stealth_compact_const_
 
 // Setters
 
-void kth_chain_stealth_compact_set_ephemeral_public_key_hash(kth_stealth_compact_mut_t self, kth_hash_t value) {
+void kth_chain_stealth_compact_set_ephemeral_public_key_hash(kth_stealth_compact_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).ephemeral_public_key_hash = value_cpp;
 }
 
@@ -65,9 +66,10 @@ void kth_chain_stealth_compact_set_ephemeral_public_key_hash_unsafe(kth_stealth_
     kth::cpp_ref<cpp_t>(self).ephemeral_public_key_hash = value_cpp;
 }
 
-void kth_chain_stealth_compact_set_public_key_hash(kth_stealth_compact_mut_t self, kth_shorthash_t value) {
+void kth_chain_stealth_compact_set_public_key_hash(kth_stealth_compact_mut_t self, kth_shorthash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::short_hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::short_hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).public_key_hash = value_cpp;
 }
 
@@ -78,9 +80,10 @@ void kth_chain_stealth_compact_set_public_key_hash_unsafe(kth_stealth_compact_mu
     kth::cpp_ref<cpp_t>(self).public_key_hash = value_cpp;
 }
 
-void kth_chain_stealth_compact_set_transaction_hash(kth_stealth_compact_mut_t self, kth_hash_t value) {
+void kth_chain_stealth_compact_set_transaction_hash(kth_stealth_compact_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).transaction_hash = value_cpp;
 }
 

--- a/src/c-api/src/chain/token_data.cpp
+++ b/src/c-api/src/chain/token_data.cpp
@@ -36,8 +36,9 @@ kth_error_code_t kth_chain_token_construct_from_data(uint8_t const* data, kth_si
 
 // Static factories
 
-kth_token_data_mut_t kth_chain_token_make_fungible(kth_hash_t id, uint64_t amount) {
-    auto const id_cpp = kth::hash_to_cpp(id.hash);
+kth_token_data_mut_t kth_chain_token_make_fungible(kth_hash_t const* id, uint64_t amount) {
+    KTH_PRECONDITION(id != nullptr);
+    auto const id_cpp = kth::hash_to_cpp(id->hash);
     return kth::leak_if_valid(kth::domain::chain::make_fungible(id_cpp, amount));
 }
 
@@ -47,9 +48,10 @@ kth_token_data_mut_t kth_chain_token_make_fungible_unsafe(uint8_t const* id, uin
     return kth::leak_if_valid(kth::domain::chain::make_fungible(id_cpp, amount));
 }
 
-kth_token_data_mut_t kth_chain_token_make_non_fungible(kth_hash_t id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+kth_token_data_mut_t kth_chain_token_make_non_fungible(kth_hash_t const* id, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+    KTH_PRECONDITION(id != nullptr);
     KTH_PRECONDITION(commitment != nullptr || n == 0);
-    auto const id_cpp = kth::hash_to_cpp(id.hash);
+    auto const id_cpp = kth::hash_to_cpp(id->hash);
     auto const capability_cpp = kth::token_capability_to_cpp(capability);
     auto const commitment_cpp = n != 0 ? kth::data_chunk(commitment, commitment + n) : kth::data_chunk{};
     return kth::leak_if_valid(kth::domain::chain::make_non_fungible(id_cpp, capability_cpp, commitment_cpp));
@@ -64,9 +66,10 @@ kth_token_data_mut_t kth_chain_token_make_non_fungible_unsafe(uint8_t const* id,
     return kth::leak_if_valid(kth::domain::chain::make_non_fungible(id_cpp, capability_cpp, commitment_cpp));
 }
 
-kth_token_data_mut_t kth_chain_token_make_both(kth_hash_t id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+kth_token_data_mut_t kth_chain_token_make_both(kth_hash_t const* id, uint64_t amount, kth_token_capability_t capability, uint8_t const* commitment, kth_size_t n) {
+    KTH_PRECONDITION(id != nullptr);
     KTH_PRECONDITION(commitment != nullptr || n == 0);
-    auto const id_cpp = kth::hash_to_cpp(id.hash);
+    auto const id_cpp = kth::hash_to_cpp(id->hash);
     auto const capability_cpp = kth::token_capability_to_cpp(capability);
     auto const commitment_cpp = n != 0 ? kth::data_chunk(commitment, commitment + n) : kth::data_chunk{};
     return kth::leak_if_valid(kth::domain::chain::make_both(id_cpp, amount, capability_cpp, commitment_cpp));
@@ -158,9 +161,10 @@ uint8_t kth_chain_token_data_bitfield(kth_token_data_const_t self) {
 
 // Setters
 
-void kth_chain_token_data_set_id(kth_token_data_mut_t self, kth_hash_t value) {
+void kth_chain_token_data_set_id(kth_token_data_mut_t self, kth_hash_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::hash_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::hash_to_cpp(value->hash);
     kth::cpp_ref<cpp_t>(self).id = value_cpp;
 }
 

--- a/src/c-api/src/chain/transaction.cpp
+++ b/src/c-api/src/chain/transaction.cpp
@@ -46,10 +46,11 @@ kth_transaction_mut_t kth_chain_transaction_construct_from_version_locktime_inpu
     return kth::leak<cpp_t>(version, locktime, inputs_cpp, outputs_cpp);
 }
 
-kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash(kth_transaction_const_t x, kth_hash_t hash) {
+kth_transaction_mut_t kth_chain_transaction_construct_from_transaction_hash(kth_transaction_const_t x, kth_hash_t const* hash) {
     KTH_PRECONDITION(x != nullptr);
+    KTH_PRECONDITION(hash != nullptr);
     auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
-    auto const hash_cpp = kth::hash_to_cpp(hash.hash);
+    auto const hash_cpp = kth::hash_to_cpp(hash->hash);
     return kth::leak<cpp_t>(x_cpp, hash_cpp);
 }
 

--- a/src/c-api/src/secure_memory.cpp
+++ b/src/c-api/src/secure_memory.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/secure_memory.h>
+
+#include <stddef.h>
+#if defined(_WIN32)
+#  include <windows.h>
+#elif (defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))) \
+    || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+// explicit_bzero is declared in <strings.h> (not <string.h>) on glibc
+// and the BSDs. Including the wrong header slips an implicit-function-
+// declaration warning that becomes a hard error under -Werror on
+// Clang 16+ / GCC 14+.
+#  include <strings.h>
+#endif
+
+extern "C" {
+
+void kth_core_secure_zero(void* p, kth_size_t n) {
+    if (p == nullptr || n == 0) return;
+#if defined(_WIN32)
+    // Windows: documented non-optimizable scrub.
+    SecureZeroMemory(p, n);
+#elif (defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))) \
+    || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    // glibc >= 2.25 and the BSDs ship `explicit_bzero` as a first-class
+    // scrub primitive. The `__GLIBC__ > 2 || ...` form is the safe
+    // multi-component version check (a hypothetical glibc 3.0 would
+    // still be covered).
+    explicit_bzero(p, n);
+#else
+    // Portable fallback (macOS, musl without explicit_bzero, exotic
+    // targets). macOS does not expose `explicit_bzero`, and while its
+    // libc provides `memset_s`, the C11 Annex K header dance
+    // (`__STDC_WANT_LIB_EXT1__` + `<string.h>`) is not reliably
+    // supported from C++ translation units across toolchains. Drop
+    // down to the `volatile`-pointer byte loop — slower but correct
+    // and portable.
+    volatile unsigned char* vp = static_cast<volatile unsigned char*>(p);
+    while (n--) *vp++ = 0;
+#  if defined(__GNUC__) || defined(__clang__)
+    // Belt-and-suspenders: empty asm with a memory clobber so LTO /
+    // whole-program optimizers cannot reason past the `volatile`
+    // boundary and prove the writes dead.
+    __asm__ __volatile__("" : : "r"(p) : "memory");
+#  endif
+#endif
+}
+
+} // extern "C"

--- a/src/c-api/src/wallet/ec_private.cpp
+++ b/src/c-api/src/wallet/ec_private.cpp
@@ -29,37 +29,46 @@ kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_version(char const
     return kth::leak_if_valid(cpp_t(wif_cpp, version));
 }
 
-kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version(kth_wif_compressed_t wif_compressed, uint8_t version) {
-    auto const wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed.data);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version(kth_wif_compressed_t const* wif_compressed, uint8_t version) {
+    KTH_PRECONDITION(wif_compressed != nullptr);
+    auto wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed->data);
+    kth::secure_scrub wif_compressed_cpp_scrub{&wif_compressed_cpp, sizeof(wif_compressed_cpp)};
     return kth::leak_if_valid(cpp_t(wif_compressed_cpp, version));
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_compressed_version_unsafe(uint8_t const* wif_compressed, uint8_t version) {
     KTH_PRECONDITION(wif_compressed != nullptr);
-    auto const wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed);
+    auto wif_compressed_cpp = kth::wif_compressed_to_cpp(wif_compressed);
+    kth::secure_scrub wif_compressed_cpp_scrub{&wif_compressed_cpp, sizeof(wif_compressed_cpp)};
     return kth::leak_if_valid(cpp_t(wif_compressed_cpp, version));
 }
 
-kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version(kth_wif_uncompressed_t wif_uncompressed, uint8_t version) {
-    auto const wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed.data);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version(kth_wif_uncompressed_t const* wif_uncompressed, uint8_t version) {
+    KTH_PRECONDITION(wif_uncompressed != nullptr);
+    auto wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed->data);
+    kth::secure_scrub wif_uncompressed_cpp_scrub{&wif_uncompressed_cpp, sizeof(wif_uncompressed_cpp)};
     return kth::leak_if_valid(cpp_t(wif_uncompressed_cpp, version));
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_wif_uncompressed_version_unsafe(uint8_t const* wif_uncompressed, uint8_t version) {
     KTH_PRECONDITION(wif_uncompressed != nullptr);
-    auto const wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed);
+    auto wif_uncompressed_cpp = kth::wif_uncompressed_to_cpp(wif_uncompressed);
+    kth::secure_scrub wif_uncompressed_cpp_scrub{&wif_uncompressed_cpp, sizeof(wif_uncompressed_cpp)};
     return kth::leak_if_valid(cpp_t(wif_uncompressed_cpp, version));
 }
 
-kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(kth_hash_t secret, uint16_t version, kth_bool_t compress) {
-    auto const secret_cpp = kth::hash_to_cpp(secret.hash);
+kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(kth_hash_t const* secret, uint16_t version, kth_bool_t compress) {
+    KTH_PRECONDITION(secret != nullptr);
+    auto secret_cpp = kth::hash_to_cpp(secret->hash);
+    kth::secure_scrub secret_cpp_scrub{&secret_cpp, sizeof(secret_cpp)};
     auto const compress_cpp = kth::int_to_bool(compress);
     return kth::leak_if_valid(cpp_t(secret_cpp, version, compress_cpp));
 }
 
 kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress_unsafe(uint8_t const* secret, uint16_t version, kth_bool_t compress) {
     KTH_PRECONDITION(secret != nullptr);
-    auto const secret_cpp = kth::hash_to_cpp(secret);
+    auto secret_cpp = kth::hash_to_cpp(secret);
+    kth::secure_scrub secret_cpp_scrub{&secret_cpp, sizeof(secret_cpp)};
     auto const compress_cpp = kth::int_to_bool(compress);
     return kth::leak_if_valid(cpp_t(secret_cpp, version, compress_cpp));
 }

--- a/src/c-api/src/wallet/ec_public.cpp
+++ b/src/c-api/src/wallet/ec_public.cpp
@@ -43,8 +43,9 @@ kth_ec_public_mut_t kth_wallet_ec_public_construct_from_base16(char const* base1
     return kth::leak_if_valid(cpp_t(base16_cpp));
 }
 
-kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress(kth_ec_compressed_t compressed_point, kth_bool_t compress) {
-    auto const compressed_point_cpp = kth::ec_compressed_to_cpp(compressed_point.data);
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compress(kth_ec_compressed_t const* compressed_point, kth_bool_t compress) {
+    KTH_PRECONDITION(compressed_point != nullptr);
+    auto const compressed_point_cpp = kth::ec_compressed_to_cpp(compressed_point->data);
     auto const compress_cpp = kth::int_to_bool(compress);
     return kth::leak_if_valid(cpp_t(compressed_point_cpp, compress_cpp));
 }
@@ -56,8 +57,9 @@ kth_ec_public_mut_t kth_wallet_ec_public_construct_from_compressed_point_compres
     return kth::leak_if_valid(cpp_t(compressed_point_cpp, compress_cpp));
 }
 
-kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress(kth_ec_uncompressed_t uncompressed_point, kth_bool_t compress) {
-    auto const uncompressed_point_cpp = kth::ec_uncompressed_to_cpp(uncompressed_point.data);
+kth_ec_public_mut_t kth_wallet_ec_public_construct_from_uncompressed_point_compress(kth_ec_uncompressed_t const* uncompressed_point, kth_bool_t compress) {
+    KTH_PRECONDITION(uncompressed_point != nullptr);
+    auto const uncompressed_point_cpp = kth::ec_uncompressed_to_cpp(uncompressed_point->data);
     auto const compress_cpp = kth::int_to_bool(compress);
     return kth::leak_if_valid(cpp_t(uncompressed_point_cpp, compress_cpp));
 }

--- a/src/c-api/src/wallet/hd_private.cpp
+++ b/src/c-api/src/wallet/hd_private.cpp
@@ -29,36 +29,45 @@ kth_hd_private_mut_t kth_wallet_hd_private_construct_from_seed_prefixes(uint8_t 
     return kth::leak_if_valid(cpp_t(seed_cpp, prefixes));
 }
 
-kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key(kth_hd_key_t private_key) {
-    auto const private_key_cpp = kth::hd_key_to_cpp(private_key.data);
+kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key(kth_hd_key_t const* private_key) {
+    KTH_PRECONDITION(private_key != nullptr);
+    auto private_key_cpp = kth::hd_key_to_cpp(private_key->data);
+    kth::secure_scrub private_key_cpp_scrub{&private_key_cpp, sizeof(private_key_cpp)};
     return kth::leak_if_valid(cpp_t(private_key_cpp));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_unsafe(uint8_t const* private_key) {
     KTH_PRECONDITION(private_key != nullptr);
-    auto const private_key_cpp = kth::hd_key_to_cpp(private_key);
+    auto private_key_cpp = kth::hd_key_to_cpp(private_key);
+    kth::secure_scrub private_key_cpp_scrub{&private_key_cpp, sizeof(private_key_cpp)};
     return kth::leak_if_valid(cpp_t(private_key_cpp));
 }
 
-kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefixes(kth_hd_key_t private_key, uint64_t prefixes) {
-    auto const private_key_cpp = kth::hd_key_to_cpp(private_key.data);
+kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefixes(kth_hd_key_t const* private_key, uint64_t prefixes) {
+    KTH_PRECONDITION(private_key != nullptr);
+    auto private_key_cpp = kth::hd_key_to_cpp(private_key->data);
+    kth::secure_scrub private_key_cpp_scrub{&private_key_cpp, sizeof(private_key_cpp)};
     return kth::leak_if_valid(cpp_t(private_key_cpp, prefixes));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefixes_unsafe(uint8_t const* private_key, uint64_t prefixes) {
     KTH_PRECONDITION(private_key != nullptr);
-    auto const private_key_cpp = kth::hd_key_to_cpp(private_key);
+    auto private_key_cpp = kth::hd_key_to_cpp(private_key);
+    kth::secure_scrub private_key_cpp_scrub{&private_key_cpp, sizeof(private_key_cpp)};
     return kth::leak_if_valid(cpp_t(private_key_cpp, prefixes));
 }
 
-kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix(kth_hd_key_t private_key, uint32_t prefix) {
-    auto const private_key_cpp = kth::hd_key_to_cpp(private_key.data);
+kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix(kth_hd_key_t const* private_key, uint32_t prefix) {
+    KTH_PRECONDITION(private_key != nullptr);
+    auto private_key_cpp = kth::hd_key_to_cpp(private_key->data);
+    kth::secure_scrub private_key_cpp_scrub{&private_key_cpp, sizeof(private_key_cpp)};
     return kth::leak_if_valid(cpp_t(private_key_cpp, prefix));
 }
 
 kth_hd_private_mut_t kth_wallet_hd_private_construct_from_private_key_prefix_unsafe(uint8_t const* private_key, uint32_t prefix) {
     KTH_PRECONDITION(private_key != nullptr);
-    auto const private_key_cpp = kth::hd_key_to_cpp(private_key);
+    auto private_key_cpp = kth::hd_key_to_cpp(private_key);
+    kth::secure_scrub private_key_cpp_scrub{&private_key_cpp, sizeof(private_key_cpp)};
     return kth::leak_if_valid(cpp_t(private_key_cpp, prefix));
 }
 

--- a/src/c-api/src/wallet/hd_public.cpp
+++ b/src/c-api/src/wallet/hd_public.cpp
@@ -23,8 +23,9 @@ kth_hd_public_mut_t kth_wallet_hd_public_construct_default(void) {
     return kth::leak<cpp_t>();
 }
 
-kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key(kth_hd_key_t public_key) {
-    auto const public_key_cpp = kth::hd_key_to_cpp(public_key.data);
+kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key(kth_hd_key_t const* public_key) {
+    KTH_PRECONDITION(public_key != nullptr);
+    auto const public_key_cpp = kth::hd_key_to_cpp(public_key->data);
     return kth::leak_if_valid(cpp_t(public_key_cpp));
 }
 
@@ -34,8 +35,9 @@ kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_unsafe(uint8_
     return kth::leak_if_valid(cpp_t(public_key_cpp));
 }
 
-kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_prefix(kth_hd_key_t public_key, uint32_t prefix) {
-    auto const public_key_cpp = kth::hd_key_to_cpp(public_key.data);
+kth_hd_public_mut_t kth_wallet_hd_public_construct_from_public_key_prefix(kth_hd_key_t const* public_key, uint32_t prefix) {
+    KTH_PRECONDITION(public_key != nullptr);
+    auto const public_key_cpp = kth::hd_key_to_cpp(public_key->data);
     return kth::leak_if_valid(cpp_t(public_key_cpp, prefix));
 }
 

--- a/src/c-api/src/wallet/payment_address.cpp
+++ b/src/c-api/src/wallet/payment_address.cpp
@@ -23,8 +23,9 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_default(void) {
     return kth::leak<cpp_t>();
 }
 
-kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded(kth_payment_t decoded) {
-    auto const decoded_cpp = kth::payment_to_cpp(decoded.hash);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_decoded(kth_payment_t const* decoded) {
+    KTH_PRECONDITION(decoded != nullptr);
+    auto const decoded_cpp = kth::payment_to_cpp(decoded->hash);
     return kth::leak_if_valid(cpp_t(decoded_cpp));
 }
 
@@ -53,8 +54,9 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_from_address_net(
     return kth::leak_if_valid(cpp_t(address_cpp, net_cpp));
 }
 
-kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t short_hash, uint8_t version) {
-    auto const short_hash_cpp = kth::short_hash_to_cpp(short_hash.hash);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_version(kth_shorthash_t const* short_hash, uint8_t version) {
+    KTH_PRECONDITION(short_hash != nullptr);
+    auto const short_hash_cpp = kth::short_hash_to_cpp(short_hash->hash);
     return kth::leak_if_valid(cpp_t(short_hash_cpp, version));
 }
 
@@ -64,8 +66,9 @@ kth_payment_address_mut_t kth_wallet_payment_address_construct_from_short_hash_v
     return kth::leak_if_valid(cpp_t(short_hash_cpp, version));
 }
 
-kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version(kth_hash_t hash, uint8_t version) {
-    auto const hash_cpp = kth::hash_to_cpp(hash.hash);
+kth_payment_address_mut_t kth_wallet_payment_address_construct_from_hash_version(kth_hash_t const* hash, uint8_t version) {
+    KTH_PRECONDITION(hash != nullptr);
+    auto const hash_cpp = kth::hash_to_cpp(hash->hash);
     return kth::leak_if_valid(cpp_t(hash_cpp, version));
 }
 

--- a/src/c-api/src/wallet/wallet_data.cpp
+++ b/src/c-api/src/wallet/wallet_data.cpp
@@ -69,16 +69,19 @@ void kth_wallet_wallet_data_set_xpub(kth_wallet_data_mut_t self, kth_hd_public_c
     kth::cpp_ref<cpp_t>(self).xpub = value_cpp;
 }
 
-void kth_wallet_wallet_data_set_encrypted_seed(kth_wallet_data_mut_t self, kth_encrypted_seed_t value) {
+void kth_wallet_wallet_data_set_encrypted_seed(kth_wallet_data_mut_t self, kth_encrypted_seed_t const* value) {
     KTH_PRECONDITION(self != nullptr);
-    auto const value_cpp = kth::encrypted_seed_to_cpp(value.hash);
+    KTH_PRECONDITION(value != nullptr);
+    auto value_cpp = kth::encrypted_seed_to_cpp(value->hash);
+    kth::secure_scrub value_cpp_scrub{&value_cpp, sizeof(value_cpp)};
     kth::cpp_ref<cpp_t>(self).encrypted_seed = value_cpp;
 }
 
 void kth_wallet_wallet_data_set_encrypted_seed_unsafe(kth_wallet_data_mut_t self, uint8_t const* value) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::encrypted_seed_to_cpp(value);
+    auto value_cpp = kth::encrypted_seed_to_cpp(value);
+    kth::secure_scrub value_cpp_scrub{&value_cpp, sizeof(value_cpp)};
     kth::cpp_ref<cpp_t>(self).encrypted_seed = value_cpp;
 }
 

--- a/src/c-api/test/chain/compact_block.cpp
+++ b/src/c-api/test/chain/compact_block.cpp
@@ -59,7 +59,7 @@ static uint8_t const kMinimalTx[10] = {
 
 static kth_header_mut_t make_header(void) {
     return kth_chain_header_construct(
-        kHdrVersion, kPrevHash, kMerkle, kHdrTimestamp, kHdrBits, kHdrNonce);
+        kHdrVersion, &kPrevHash, &kMerkle, kHdrTimestamp, kHdrBits, kHdrNonce);
 }
 
 static kth_transaction_mut_t make_tx(void) {

--- a/src/c-api/test/chain/double_spend_proof.cpp
+++ b/src/c-api/test/chain/double_spend_proof.cpp
@@ -189,9 +189,9 @@ TEST_CASE("C-API DspSpender - hash setters round-trip",
         kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
     REQUIRE(ec == kth_ec_success);
 
-    kth_chain_double_spend_proof_spender_set_prev_outs_hash(sp, kHashB);
-    kth_chain_double_spend_proof_spender_set_sequence_hash(sp, kHashC);
-    kth_chain_double_spend_proof_spender_set_outputs_hash(sp, kHashA);
+    kth_chain_double_spend_proof_spender_set_prev_outs_hash(sp, &kHashB);
+    kth_chain_double_spend_proof_spender_set_sequence_hash(sp, &kHashC);
+    kth_chain_double_spend_proof_spender_set_outputs_hash(sp, &kHashA);
 
     REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_prev_outs_hash(sp), kHashB) != 0);
     REQUIRE(kth_hash_equal(kth_chain_double_spend_proof_spender_sequence_hash(sp), kHashC) != 0);
@@ -314,6 +314,36 @@ TEST_CASE("C-API DspSpender - set_prev_outs_hash_unsafe null aborts",
     kth_chain_double_spend_proof_spender_destruct(sp);
 }
 
+TEST_CASE("C-API DspSpender - set_prev_outs_hash null aborts",
+          "[C-API DspSpender][precondition]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_spender_set_prev_outs_hash(sp, NULL));
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+TEST_CASE("C-API DspSpender - set_sequence_hash null aborts",
+          "[C-API DspSpender][precondition]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_spender_set_sequence_hash(sp, NULL));
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
+TEST_CASE("C-API DspSpender - set_outputs_hash null aborts",
+          "[C-API DspSpender][precondition]") {
+    kth_double_spend_proof_spender_mut_t sp = NULL;
+    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
+        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
+    REQUIRE(ec == kth_ec_success);
+    KTH_EXPECT_ABORT(kth_chain_double_spend_proof_spender_set_outputs_hash(sp, NULL));
+    kth_chain_double_spend_proof_spender_destruct(sp);
+}
+
 // ===========================================================================
 // DoubleSpendProof
 // ===========================================================================
@@ -342,7 +372,7 @@ TEST_CASE("C-API Dsp - destruct null is safe", "[C-API Dsp]") {
 
 TEST_CASE("C-API Dsp - construct with valid components is valid",
           "[C-API Dsp]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 7u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHashA, 7u);
     kth_double_spend_proof_spender_mut_t s1 = NULL;
     kth_double_spend_proof_spender_mut_t s2 = NULL;
     REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
@@ -377,7 +407,7 @@ TEST_CASE("C-API Dsp - construct with valid components is valid",
 
 TEST_CASE("C-API Dsp - serialized_size matches to_data length",
           "[C-API Dsp]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 0u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHashA, 0u);
     kth_double_spend_proof_spender_mut_t s1 = NULL;
     kth_double_spend_proof_spender_mut_t s2 = NULL;
     REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
@@ -413,7 +443,7 @@ TEST_CASE("C-API Dsp - setters replace fields",
     kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct_default();
     REQUIRE(dsp != NULL);
 
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashB, 42u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHashB, 42u);
     kth_chain_double_spend_proof_set_out_point(dsp, op);
     kth_output_point_const_t op_view = kth_chain_double_spend_proof_out_point(dsp);
     REQUIRE(kth_chain_output_point_index(op_view) == 42u);
@@ -440,7 +470,7 @@ TEST_CASE("C-API Dsp - setters replace fields",
 
 TEST_CASE("C-API Dsp - copy preserves equality and diverges after mutation",
           "[C-API Dsp]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 7u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHashA, 7u);
     kth_double_spend_proof_spender_mut_t s1 = NULL;
     kth_double_spend_proof_spender_mut_t s2 = NULL;
     REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
@@ -455,7 +485,7 @@ TEST_CASE("C-API Dsp - copy preserves equality and diverges after mutation",
     REQUIRE(kth_chain_double_spend_proof_equals(original, copy) != 0);
 
     // Mutate the copy — the two must diverge.
-    kth_output_point_mut_t other_op = kth_chain_output_point_construct_from_hash_index(kHashB, 99u);
+    kth_output_point_mut_t other_op = kth_chain_output_point_construct_from_hash_index(&kHashB, 99u);
     kth_chain_double_spend_proof_set_out_point(copy, other_op);
     REQUIRE(kth_chain_double_spend_proof_equals(original, copy) == 0);
 
@@ -473,7 +503,7 @@ TEST_CASE("C-API Dsp - copy preserves equality and diverges after mutation",
 
 TEST_CASE("C-API Dsp - hash is deterministic and mutation changes it",
           "[C-API Dsp]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 0u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHashA, 0u);
     kth_double_spend_proof_spender_mut_t s1 = NULL;
     kth_double_spend_proof_spender_mut_t s2 = NULL;
     REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
@@ -509,7 +539,7 @@ TEST_CASE("C-API Dsp - hash is deterministic and mutation changes it",
 
 TEST_CASE("C-API Dsp - reset drops to invalid state",
           "[C-API Dsp]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHashA, 7u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHashA, 7u);
     kth_double_spend_proof_spender_mut_t s1 = NULL;
     kth_double_spend_proof_spender_mut_t s2 = NULL;
     REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(

--- a/src/c-api/test/chain/get_blocks.cpp
+++ b/src/c-api/test/chain/get_blocks.cpp
@@ -70,7 +70,7 @@ TEST_CASE("C-API GetBlocks - default construct is invalid", "[C-API GetBlocks]")
 
 TEST_CASE("C-API GetBlocks - field constructor is valid", "[C-API GetBlocks]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
-    kth_get_blocks_mut_t gb = kth_chain_get_blocks_construct(starts, kStopHash);
+    kth_get_blocks_mut_t gb = kth_chain_get_blocks_construct(starts, &kStopHash);
     REQUIRE(gb != NULL);
     REQUIRE(kth_chain_get_blocks_is_valid(gb) != 0);
     kth_chain_get_blocks_destruct(gb);
@@ -82,7 +82,7 @@ TEST_CASE("C-API GetBlocks - construct_unsafe matches safe variant",
     kth_hash_list_mut_t starts = make_hash_list_of_two();
 
     kth_get_blocks_mut_t safe =
-        kth_chain_get_blocks_construct(starts, kStopHash);
+        kth_chain_get_blocks_construct(starts, &kStopHash);
     kth_get_blocks_mut_t unsafe =
         kth_chain_get_blocks_construct_unsafe(starts, kStopHash.hash);
 
@@ -105,7 +105,7 @@ TEST_CASE("C-API GetBlocks - to_data / from_data round-trip",
           "[C-API GetBlocks]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_blocks_mut_t original =
-        kth_chain_get_blocks_construct(starts, kStopHash);
+        kth_chain_get_blocks_construct(starts, &kStopHash);
 
     kth_size_t out_size = 0;
     uint8_t* raw =
@@ -132,7 +132,7 @@ TEST_CASE("C-API GetBlocks - serialized_size matches to_data length",
           "[C-API GetBlocks]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_blocks_mut_t gb =
-        kth_chain_get_blocks_construct(starts, kStopHash);
+        kth_chain_get_blocks_construct(starts, &kStopHash);
 
     kth_size_t expected =
         kth_chain_get_blocks_serialized_size(gb, kProtoVersion);
@@ -154,7 +154,7 @@ TEST_CASE("C-API GetBlocks - serialized_size matches to_data length",
 TEST_CASE("C-API GetBlocks - copy preserves equality", "[C-API GetBlocks]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_blocks_mut_t original =
-        kth_chain_get_blocks_construct(starts, kStopHash);
+        kth_chain_get_blocks_construct(starts, &kStopHash);
 
     kth_get_blocks_mut_t copy = kth_chain_get_blocks_copy(original);
     REQUIRE(copy != NULL);
@@ -170,7 +170,7 @@ TEST_CASE("C-API GetBlocks - equals distinguishes different instances",
     kth_hash_list_mut_t starts = make_hash_list_of_two();
 
     kth_get_blocks_mut_t a =
-        kth_chain_get_blocks_construct(starts, kStopHash);
+        kth_chain_get_blocks_construct(starts, &kStopHash);
     kth_get_blocks_mut_t b = kth_chain_get_blocks_construct_default();
 
     REQUIRE(kth_chain_get_blocks_equals(a, b) == 0);
@@ -187,7 +187,7 @@ TEST_CASE("C-API GetBlocks - equals distinguishes different instances",
 TEST_CASE("C-API GetBlocks - stop_hash round-trips by value",
           "[C-API GetBlocks]") {
     kth_get_blocks_mut_t gb = kth_chain_get_blocks_construct_default();
-    kth_chain_get_blocks_set_stop_hash(gb, kStopHash);
+    kth_chain_get_blocks_set_stop_hash(gb, &kStopHash);
 
     kth_hash_t got = kth_chain_get_blocks_stop_hash(gb);
     REQUIRE(memcmp(got.hash, kStopHash.hash, KTH_BITCOIN_HASH_SIZE) == 0);
@@ -232,7 +232,7 @@ TEST_CASE("C-API GetBlocks - start_hashes count reflects input list",
 TEST_CASE("C-API GetBlocks - reset clears the object", "[C-API GetBlocks]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_blocks_mut_t gb =
-        kth_chain_get_blocks_construct(starts, kStopHash);
+        kth_chain_get_blocks_construct(starts, &kStopHash);
 
     kth_chain_get_blocks_reset(gb);
 
@@ -249,7 +249,14 @@ TEST_CASE("C-API GetBlocks - reset clears the object", "[C-API GetBlocks]") {
 
 TEST_CASE("C-API GetBlocks - construct null start hashes aborts",
           "[C-API GetBlocks][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_get_blocks_construct(NULL, kStopHash));
+    KTH_EXPECT_ABORT(kth_chain_get_blocks_construct(NULL, &kStopHash));
+}
+
+TEST_CASE("C-API GetBlocks - construct null stop aborts",
+          "[C-API GetBlocks][precondition]") {
+    kth_hash_list_mut_t starts = make_hash_list_of_two();
+    KTH_EXPECT_ABORT(kth_chain_get_blocks_construct(starts, NULL));
+    kth_core_hash_list_destruct(starts);
 }
 
 TEST_CASE("C-API GetBlocks - construct_unsafe null stop aborts",
@@ -312,6 +319,13 @@ TEST_CASE("C-API GetBlocks - set_start_hashes null value aborts",
           "[C-API GetBlocks][precondition]") {
     kth_get_blocks_mut_t gb = kth_chain_get_blocks_construct_default();
     KTH_EXPECT_ABORT(kth_chain_get_blocks_set_start_hashes(gb, NULL));
+    kth_chain_get_blocks_destruct(gb);
+}
+
+TEST_CASE("C-API GetBlocks - set_stop_hash null aborts",
+          "[C-API GetBlocks][precondition]") {
+    kth_get_blocks_mut_t gb = kth_chain_get_blocks_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_get_blocks_set_stop_hash(gb, NULL));
     kth_chain_get_blocks_destruct(gb);
 }
 

--- a/src/c-api/test/chain/get_headers.cpp
+++ b/src/c-api/test/chain/get_headers.cpp
@@ -70,7 +70,7 @@ TEST_CASE("C-API GetHeaders - default construct is invalid", "[C-API GetHeaders]
 
 TEST_CASE("C-API GetHeaders - field constructor is valid", "[C-API GetHeaders]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
-    kth_get_headers_mut_t gh = kth_chain_get_headers_construct(starts, kStopHash);
+    kth_get_headers_mut_t gh = kth_chain_get_headers_construct(starts, &kStopHash);
     REQUIRE(gh != NULL);
     REQUIRE(kth_chain_get_headers_is_valid(gh) != 0);
     kth_chain_get_headers_destruct(gh);
@@ -82,7 +82,7 @@ TEST_CASE("C-API GetHeaders - construct_unsafe matches safe variant",
     kth_hash_list_mut_t starts = make_hash_list_of_two();
 
     kth_get_headers_mut_t safe =
-        kth_chain_get_headers_construct(starts, kStopHash);
+        kth_chain_get_headers_construct(starts, &kStopHash);
     kth_get_headers_mut_t unsafe =
         kth_chain_get_headers_construct_unsafe(starts, kStopHash.hash);
 
@@ -105,7 +105,7 @@ TEST_CASE("C-API GetHeaders - to_data / from_data round-trip",
           "[C-API GetHeaders]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_headers_mut_t original =
-        kth_chain_get_headers_construct(starts, kStopHash);
+        kth_chain_get_headers_construct(starts, &kStopHash);
 
     kth_size_t out_size = 0;
     uint8_t* raw =
@@ -132,7 +132,7 @@ TEST_CASE("C-API GetHeaders - serialized_size matches to_data length",
           "[C-API GetHeaders]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_headers_mut_t gh =
-        kth_chain_get_headers_construct(starts, kStopHash);
+        kth_chain_get_headers_construct(starts, &kStopHash);
 
     kth_size_t expected =
         kth_chain_get_headers_serialized_size(gh, kProtoVersion);
@@ -154,7 +154,7 @@ TEST_CASE("C-API GetHeaders - serialized_size matches to_data length",
 TEST_CASE("C-API GetHeaders - copy preserves equality", "[C-API GetHeaders]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_headers_mut_t original =
-        kth_chain_get_headers_construct(starts, kStopHash);
+        kth_chain_get_headers_construct(starts, &kStopHash);
 
     kth_get_headers_mut_t copy = kth_chain_get_headers_copy(original);
     REQUIRE(copy != NULL);
@@ -170,7 +170,7 @@ TEST_CASE("C-API GetHeaders - equals distinguishes different instances",
     kth_hash_list_mut_t starts = make_hash_list_of_two();
 
     kth_get_headers_mut_t a =
-        kth_chain_get_headers_construct(starts, kStopHash);
+        kth_chain_get_headers_construct(starts, &kStopHash);
     kth_get_headers_mut_t b = kth_chain_get_headers_construct_default();
 
     REQUIRE(kth_chain_get_headers_equals(a, b) == 0);
@@ -187,7 +187,7 @@ TEST_CASE("C-API GetHeaders - equals distinguishes different instances",
 TEST_CASE("C-API GetHeaders - stop_hash round-trips by value",
           "[C-API GetHeaders]") {
     kth_get_headers_mut_t gh = kth_chain_get_headers_construct_default();
-    kth_chain_get_headers_set_stop_hash(gh, kStopHash);
+    kth_chain_get_headers_set_stop_hash(gh, &kStopHash);
 
     kth_hash_t got = kth_chain_get_headers_stop_hash(gh);
     REQUIRE(memcmp(got.hash, kStopHash.hash, KTH_BITCOIN_HASH_SIZE) == 0);
@@ -232,7 +232,7 @@ TEST_CASE("C-API GetHeaders - start_hashes count reflects input list",
 TEST_CASE("C-API GetHeaders - reset clears the object", "[C-API GetHeaders]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_headers_mut_t gh =
-        kth_chain_get_headers_construct(starts, kStopHash);
+        kth_chain_get_headers_construct(starts, &kStopHash);
 
     kth_chain_get_headers_reset(gh);
 
@@ -249,7 +249,14 @@ TEST_CASE("C-API GetHeaders - reset clears the object", "[C-API GetHeaders]") {
 
 TEST_CASE("C-API GetHeaders - construct null start hashes aborts",
           "[C-API GetHeaders][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_get_headers_construct(NULL, kStopHash));
+    KTH_EXPECT_ABORT(kth_chain_get_headers_construct(NULL, &kStopHash));
+}
+
+TEST_CASE("C-API GetHeaders - construct null stop aborts",
+          "[C-API GetHeaders][precondition]") {
+    kth_hash_list_mut_t starts = make_hash_list_of_two();
+    KTH_EXPECT_ABORT(kth_chain_get_headers_construct(starts, NULL));
+    kth_core_hash_list_destruct(starts);
 }
 
 TEST_CASE("C-API GetHeaders - construct_unsafe null stop aborts",
@@ -312,6 +319,13 @@ TEST_CASE("C-API GetHeaders - set_start_hashes null value aborts",
           "[C-API GetHeaders][precondition]") {
     kth_get_headers_mut_t gh = kth_chain_get_headers_construct_default();
     KTH_EXPECT_ABORT(kth_chain_get_headers_set_start_hashes(gh, NULL));
+    kth_chain_get_headers_destruct(gh);
+}
+
+TEST_CASE("C-API GetHeaders - set_stop_hash null aborts",
+          "[C-API GetHeaders][precondition]") {
+    kth_get_headers_mut_t gh = kth_chain_get_headers_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_get_headers_set_stop_hash(gh, NULL));
     kth_chain_get_headers_destruct(gh);
 }
 

--- a/src/c-api/test/chain/header.cpp
+++ b/src/c-api/test/chain/header.cpp
@@ -58,7 +58,7 @@ TEST_CASE("C-API Header - default construct is invalid", "[C-API Header]") {
 
 TEST_CASE("C-API Header - field constructor preserves all fields", "[C-API Header]") {
     kth_header_mut_t header = kth_chain_header_construct(
-        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+        kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
 
     REQUIRE(kth_chain_header_is_valid(header) != 0);
     REQUIRE(kth_chain_header_version(header)   == kVersion);
@@ -90,7 +90,7 @@ TEST_CASE("C-API Header - from_data insufficient bytes fails", "[C-API Header]")
 
 TEST_CASE("C-API Header - to_data / from_data roundtrip", "[C-API Header]") {
     kth_header_mut_t expected = kth_chain_header_construct(
-        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+        kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
 
     kth_size_t size = 0;
     uint8_t* raw = kth_chain_header_to_data(expected, 1, &size);
@@ -126,7 +126,7 @@ TEST_CASE("C-API Header - previous_block_hash setter roundtrip", "[C-API Header]
     kth_header_mut_t header = kth_chain_header_construct_default();
     REQUIRE(kth_hash_is_null(kth_chain_header_previous_block_hash(header)) != 0);
 
-    kth_chain_header_set_previous_block_hash(header, kPrevHash);
+    kth_chain_header_set_previous_block_hash(header, &kPrevHash);
     REQUIRE(kth_hash_equal(kth_chain_header_previous_block_hash(header),
                            kPrevHash) != 0);
 
@@ -137,7 +137,7 @@ TEST_CASE("C-API Header - merkle setter roundtrip", "[C-API Header]") {
     kth_header_mut_t header = kth_chain_header_construct_default();
     REQUIRE(kth_hash_is_null(kth_chain_header_merkle(header)) != 0);
 
-    kth_chain_header_set_merkle(header, kMerkle);
+    kth_chain_header_set_merkle(header, &kMerkle);
     REQUIRE(kth_hash_equal(kth_chain_header_merkle(header),
                            kMerkle) != 0);
 
@@ -203,7 +203,7 @@ TEST_CASE("C-API Header - is_valid_proof_of_work bits exceed max false", "[C-API
 
 TEST_CASE("C-API Header - copy preserves all fields", "[C-API Header]") {
     kth_header_mut_t original = kth_chain_header_construct(
-        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+        kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
     kth_header_mut_t copy = kth_chain_header_copy(original);
 
     REQUIRE(kth_chain_header_is_valid(copy) != 0);
@@ -219,9 +219,9 @@ TEST_CASE("C-API Header - copy preserves all fields", "[C-API Header]") {
 
 TEST_CASE("C-API Header - equals duplicates", "[C-API Header]") {
     kth_header_mut_t a = kth_chain_header_construct(
-        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+        kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
     kth_header_mut_t b = kth_chain_header_construct(
-        kVersion, kPrevHash, kMerkle, kTimestamp, kBits, kNonce);
+        kVersion, &kPrevHash, &kMerkle, kTimestamp, kBits, kNonce);
     kth_header_mut_t c = kth_chain_header_construct_default();
 
     REQUIRE(kth_chain_header_equals(a, b) != 0);
@@ -263,10 +263,23 @@ TEST_CASE("C-API Header - construct_from_data NULL data with zero size returns e
     REQUIRE(out == NULL);
 }
 
-// The safe `kth_chain_header_construct` takes `kth_hash_t` by value, so
-// passing NULL is a compile error rather than a runtime abort. The
-// corresponding precondition still exists on the `_unsafe` companion,
-// where the C type system can no longer enforce the buffer length.
+// Both `kth_chain_header_construct` (safe, takes `kth_hash_t const*`)
+// and its `_unsafe` companion (takes raw `uint8_t const*`) enforce the
+// same runtime precondition that the hash pointers are non-null.
+TEST_CASE("C-API Header - construct null previous_block_hash aborts",
+          "[C-API Header][precondition]") {
+    KTH_EXPECT_ABORT(
+        kth_chain_header_construct(kVersion, NULL, &kMerkle,
+                                   kTimestamp, kBits, kNonce));
+}
+
+TEST_CASE("C-API Header - construct null merkle aborts",
+          "[C-API Header][precondition]") {
+    KTH_EXPECT_ABORT(
+        kth_chain_header_construct(kVersion, &kPrevHash, NULL,
+                                   kTimestamp, kBits, kNonce));
+}
+
 TEST_CASE("C-API Header - construct_unsafe null previous_block_hash aborts",
           "[C-API Header][precondition]") {
     KTH_EXPECT_ABORT(
@@ -288,10 +301,24 @@ TEST_CASE("C-API Header - to_data null out_size aborts",
     kth_chain_header_destruct(header);
 }
 
+TEST_CASE("C-API Header - set_previous_block_hash null aborts",
+          "[C-API Header][precondition]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_header_set_previous_block_hash(header, NULL));
+    kth_chain_header_destruct(header);
+}
+
 TEST_CASE("C-API Header - set_previous_block_hash_unsafe null aborts",
           "[C-API Header][precondition]") {
     kth_header_mut_t header = kth_chain_header_construct_default();
     KTH_EXPECT_ABORT(kth_chain_header_set_previous_block_hash_unsafe(header, NULL));
+    kth_chain_header_destruct(header);
+}
+
+TEST_CASE("C-API Header - set_merkle null aborts",
+          "[C-API Header][precondition]") {
+    kth_header_mut_t header = kth_chain_header_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_header_set_merkle(header, NULL));
     kth_chain_header_destruct(header);
 }
 

--- a/src/c-api/test/chain/input.cpp
+++ b/src/c-api/test/chain/input.cpp
@@ -52,7 +52,7 @@ static kth_script_mut_t make_script(void) {
 }
 
 static kth_output_point_mut_t make_outpoint(void) {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kPrevHash, 7);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kPrevHash, 7);
     REQUIRE(op != NULL);
     return op;
 }

--- a/src/c-api/test/chain/input_list.cpp
+++ b/src/c-api/test/chain/input_list.cpp
@@ -34,7 +34,7 @@ static kth_input_mut_t make_input(void) {
     kth_error_code_t ec = kth_chain_script_construct_from_data(
         kScriptBody, sizeof(kScriptBody), 0, &script);
     REQUIRE(ec == kth_ec_success);
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kPrevHash, 0);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kPrevHash, 0);
     REQUIRE(op != NULL);
     kth_input_mut_t in = kth_chain_input_construct(op, script, 0xffffffffu);
     REQUIRE(in != NULL);

--- a/src/c-api/test/chain/merkle_block.cpp
+++ b/src/c-api/test/chain/merkle_block.cpp
@@ -65,7 +65,7 @@ static uint8_t const kFlags[3] = { 0xFF, 0x0F, 0x00 };
 
 static kth_header_mut_t make_header(void) {
     return kth_chain_header_construct(
-        kHdrVersion, kPrevHash, kMerkle, kHdrTimestamp, kHdrBits, kHdrNonce);
+        kHdrVersion, &kPrevHash, &kMerkle, kHdrTimestamp, kHdrBits, kHdrNonce);
 }
 
 static kth_hash_list_mut_t make_two_hashes(void) {

--- a/src/c-api/test/chain/output_point.cpp
+++ b/src/c-api/test/chain/output_point.cpp
@@ -49,7 +49,7 @@ TEST_CASE("C-API OutputPoint - default construct is invalid", "[C-API OutputPoin
 }
 
 TEST_CASE("C-API OutputPoint - construct from hash and index", "[C-API OutputPoint]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHash, 1234u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHash, 1234u);
     REQUIRE(kth_chain_output_point_is_valid(op) != 0);
     REQUIRE(kth_chain_output_point_index(op) == 1234u);
     REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op), kHash) != 0);
@@ -57,7 +57,7 @@ TEST_CASE("C-API OutputPoint - construct from hash and index", "[C-API OutputPoi
 }
 
 TEST_CASE("C-API OutputPoint - construct from point preserves fields", "[C-API OutputPoint]") {
-    kth_point_mut_t pt = kth_chain_point_construct(kHash, 42u);
+    kth_point_mut_t pt = kth_chain_point_construct(&kHash, 42u);
     kth_output_point_mut_t op = kth_chain_output_point_construct_from_point(pt);
 
     REQUIRE(kth_chain_output_point_is_valid(op) != 0);
@@ -83,7 +83,7 @@ TEST_CASE("C-API OutputPoint - from_data insufficient bytes fails", "[C-API Outp
 
 TEST_CASE("C-API OutputPoint - to_data / from_data roundtrip", "[C-API OutputPoint]") {
     kth_output_point_mut_t expected =
-        kth_chain_output_point_construct_from_hash_index(kHash, 53213u);
+        kth_chain_output_point_construct_from_hash_index(&kHash, 53213u);
 
     kth_size_t size = 0;
     uint8_t* raw = kth_chain_output_point_to_data(expected, 1, &size);
@@ -125,13 +125,13 @@ TEST_CASE("C-API OutputPoint - construct_from_data NULL data with zero size retu
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API OutputPoint - serialized_size is fixed 36", "[C-API OutputPoint]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHash, 7u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHash, 7u);
     REQUIRE(kth_chain_output_point_serialized_size(op, 1) == 36u);
     kth_chain_output_point_destruct(op);
 }
 
 TEST_CASE("C-API OutputPoint - to_data fixed-size payload", "[C-API OutputPoint]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHash, 7u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHash, 7u);
 
     kth_size_t size = 0;
     uint8_t* raw = kth_chain_output_point_to_data(op, 1, &size);
@@ -156,7 +156,7 @@ TEST_CASE("C-API OutputPoint - hash setter roundtrip", "[C-API OutputPoint]") {
     kth_output_point_mut_t op = kth_chain_output_point_construct_default();
     REQUIRE(kth_hash_is_null(kth_chain_output_point_hash(op)) != 0);
 
-    kth_chain_output_point_set_hash(op, kHash);
+    kth_chain_output_point_set_hash(op, &kHash);
     REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op), kHash) != 0);
 
     kth_chain_output_point_destruct(op);
@@ -175,7 +175,7 @@ TEST_CASE("C-API OutputPoint - index setter roundtrip", "[C-API OutputPoint]") {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API OutputPoint - copy preserves fields", "[C-API OutputPoint]") {
-    kth_output_point_mut_t original = kth_chain_output_point_construct_from_hash_index(kHash, 524342u);
+    kth_output_point_mut_t original = kth_chain_output_point_construct_from_hash_index(&kHash, 524342u);
     kth_output_point_mut_t copy = kth_chain_output_point_copy(original);
 
     REQUIRE(kth_chain_output_point_is_valid(copy) != 0);
@@ -187,8 +187,8 @@ TEST_CASE("C-API OutputPoint - copy preserves fields", "[C-API OutputPoint]") {
 }
 
 TEST_CASE("C-API OutputPoint - equals duplicates", "[C-API OutputPoint]") {
-    kth_output_point_mut_t a = kth_chain_output_point_construct_from_hash_index(kHash, 524342u);
-    kth_output_point_mut_t b = kth_chain_output_point_construct_from_hash_index(kHash, 524342u);
+    kth_output_point_mut_t a = kth_chain_output_point_construct_from_hash_index(&kHash, 524342u);
+    kth_output_point_mut_t b = kth_chain_output_point_construct_from_hash_index(&kHash, 524342u);
     kth_output_point_mut_t c = kth_chain_output_point_construct_default();
 
     REQUIRE(kth_chain_output_point_equals(a, b) != 0);
@@ -204,7 +204,7 @@ TEST_CASE("C-API OutputPoint - equals duplicates", "[C-API OutputPoint]") {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API OutputPoint - checksum all ones", "[C-API OutputPoint]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kAllOnes, 0xffffffffu);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kAllOnes, 0xffffffffu);
     REQUIRE(kth_chain_output_point_checksum(op) == 0xffffffffffffffffull);
     kth_chain_output_point_destruct(op);
 }
@@ -212,7 +212,7 @@ TEST_CASE("C-API OutputPoint - checksum all ones", "[C-API OutputPoint]") {
 TEST_CASE("C-API OutputPoint - checksum all zeros", "[C-API OutputPoint]") {
     kth_hash_t zero;
     memset(zero.hash, 0, sizeof(zero.hash));
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(zero, 0u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&zero, 0u);
     REQUIRE(kth_chain_output_point_checksum(op) == 0ull);
     kth_chain_output_point_destruct(op);
 }
@@ -244,9 +244,15 @@ TEST_CASE("C-API OutputPoint - construct_from_data null out aborts",
     KTH_EXPECT_ABORT(kth_chain_output_point_construct_from_data(data, 10, 1, NULL));
 }
 
-// Safe `kth_chain_output_point_construct_from_hash_index` takes the hash
-// by value: passing NULL is a compile error. The runtime precondition
-// still applies on the `_unsafe` companion.
+// Both `kth_chain_output_point_construct_from_hash_index` (safe, takes
+// `kth_hash_t const*`) and its `_unsafe` companion (takes raw
+// `uint8_t const*`) enforce the same runtime precondition that the hash
+// pointer is non-null.
+TEST_CASE("C-API OutputPoint - construct_from_hash_index null hash aborts",
+          "[C-API OutputPoint][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_output_point_construct_from_hash_index(NULL, 0));
+}
+
 TEST_CASE("C-API OutputPoint - construct_from_hash_index_unsafe null hash aborts",
           "[C-API OutputPoint][precondition]") {
     KTH_EXPECT_ABORT(kth_chain_output_point_construct_from_hash_index_unsafe(NULL, 0));
@@ -267,6 +273,13 @@ TEST_CASE("C-API OutputPoint - to_data null out_size aborts",
 TEST_CASE("C-API OutputPoint - copy null self aborts",
           "[C-API OutputPoint][precondition]") {
     KTH_EXPECT_ABORT(kth_chain_output_point_copy(NULL));
+}
+
+TEST_CASE("C-API OutputPoint - set_hash null aborts",
+          "[C-API OutputPoint][precondition]") {
+    kth_output_point_mut_t op = kth_chain_output_point_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_output_point_set_hash(op, NULL));
+    kth_chain_output_point_destruct(op);
 }
 
 TEST_CASE("C-API OutputPoint - set_hash_unsafe null aborts",

--- a/src/c-api/test/chain/output_point_list.cpp
+++ b/src/c-api/test/chain/output_point_list.cpp
@@ -22,7 +22,7 @@ static kth_hash_t const kHash = {{
 }};
 
 static kth_output_point_mut_t make_outpoint(void) {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kHash, 7);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHash, 7);
     REQUIRE(op != NULL);
     return op;
 }

--- a/src/c-api/test/chain/point.cpp
+++ b/src/c-api/test/chain/point.cpp
@@ -48,7 +48,7 @@ TEST_CASE("C-API Point - default construct is invalid", "[C-API Point]") {
 }
 
 TEST_CASE("C-API Point - field constructor preserves hash and index", "[C-API Point]") {
-    kth_point_mut_t point = kth_chain_point_construct(kHash, 1234u);
+    kth_point_mut_t point = kth_chain_point_construct(&kHash, 1234u);
     REQUIRE(kth_chain_point_is_valid(point) != 0);
     REQUIRE(kth_chain_point_index(point) == 1234u);
     REQUIRE(kth_hash_equal(kth_chain_point_hash(point), kHash) != 0);
@@ -69,7 +69,7 @@ TEST_CASE("C-API Point - from_data insufficient bytes fails", "[C-API Point]") {
 }
 
 TEST_CASE("C-API Point - to_data / from_data roundtrip", "[C-API Point]") {
-    kth_point_mut_t expected = kth_chain_point_construct(kHash, 53213u);
+    kth_point_mut_t expected = kth_chain_point_construct(&kHash, 53213u);
 
     kth_size_t size = 0;
     uint8_t* raw = kth_chain_point_to_data(expected, 1, &size);
@@ -99,7 +99,7 @@ TEST_CASE("C-API Point - hash setter roundtrip", "[C-API Point]") {
     kth_point_mut_t point = kth_chain_point_construct_default();
     REQUIRE(kth_hash_is_null(kth_chain_point_hash(point)) != 0);
 
-    kth_chain_point_set_hash(point, kHash);
+    kth_chain_point_set_hash(point, &kHash);
     REQUIRE(kth_hash_equal(kth_chain_point_hash(point), kHash) != 0);
 
     kth_chain_point_destruct(point);
@@ -118,7 +118,7 @@ TEST_CASE("C-API Point - index setter roundtrip", "[C-API Point]") {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API Point - copy preserves fields", "[C-API Point]") {
-    kth_point_mut_t original = kth_chain_point_construct(kHash, 524342u);
+    kth_point_mut_t original = kth_chain_point_construct(&kHash, 524342u);
     kth_point_mut_t copy = kth_chain_point_copy(original);
 
     REQUIRE(kth_chain_point_is_valid(copy) != 0);
@@ -130,8 +130,8 @@ TEST_CASE("C-API Point - copy preserves fields", "[C-API Point]") {
 }
 
 TEST_CASE("C-API Point - equals duplicates", "[C-API Point]") {
-    kth_point_mut_t a = kth_chain_point_construct(kHash, 524342u);
-    kth_point_mut_t b = kth_chain_point_construct(kHash, 524342u);
+    kth_point_mut_t a = kth_chain_point_construct(&kHash, 524342u);
+    kth_point_mut_t b = kth_chain_point_construct(&kHash, 524342u);
     kth_point_mut_t c = kth_chain_point_construct_default();
 
     REQUIRE(kth_chain_point_equals(a, b) != 0);
@@ -147,7 +147,7 @@ TEST_CASE("C-API Point - equals duplicates", "[C-API Point]") {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API Point - checksum all ones returns all ones", "[C-API Point]") {
-    kth_point_mut_t point = kth_chain_point_construct(kAllOnes, 0xffffffffu);
+    kth_point_mut_t point = kth_chain_point_construct(&kAllOnes, 0xffffffffu);
     REQUIRE(kth_chain_point_checksum(point) == 0xffffffffffffffffull);
     kth_chain_point_destruct(point);
 }
@@ -155,7 +155,7 @@ TEST_CASE("C-API Point - checksum all ones returns all ones", "[C-API Point]") {
 TEST_CASE("C-API Point - checksum all zeros returns zero", "[C-API Point]") {
     kth_hash_t zero;
     memset(zero.hash, 0, sizeof(zero.hash));
-    kth_point_mut_t point = kth_chain_point_construct(zero, 0u);
+    kth_point_mut_t point = kth_chain_point_construct(&zero, 0u);
     REQUIRE(kth_chain_point_checksum(point) == 0ull);
     kth_chain_point_destruct(point);
 }
@@ -203,9 +203,14 @@ TEST_CASE("C-API Point - construct_from_data null out aborts",
     KTH_EXPECT_ABORT(kth_chain_point_construct_from_data(data, 10, 1, NULL));
 }
 
-// Safe `kth_chain_point_construct` takes `kth_hash_t` by value: passing
-// NULL is a compile error. The runtime precondition still applies on the
-// `_unsafe` companion.
+// Both `kth_chain_point_construct` (safe, takes `kth_hash_t const*`) and
+// its `_unsafe` companion (takes raw `uint8_t const*`) enforce the same
+// runtime precondition that the hash pointer is non-null.
+TEST_CASE("C-API Point - construct null hash aborts",
+          "[C-API Point][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_point_construct(NULL, 0));
+}
+
 TEST_CASE("C-API Point - construct_unsafe null hash aborts",
           "[C-API Point][precondition]") {
     KTH_EXPECT_ABORT(kth_chain_point_construct_unsafe(NULL, 0));
@@ -221,6 +226,13 @@ TEST_CASE("C-API Point - to_data null out_size aborts",
 TEST_CASE("C-API Point - copy null self aborts",
           "[C-API Point][precondition]") {
     KTH_EXPECT_ABORT(kth_chain_point_copy(NULL));
+}
+
+TEST_CASE("C-API Point - set_hash null aborts",
+          "[C-API Point][precondition]") {
+    kth_point_mut_t point = kth_chain_point_construct_default();
+    KTH_EXPECT_ABORT(kth_chain_point_set_hash(point, NULL));
+    kth_chain_point_destruct(point);
 }
 
 TEST_CASE("C-API Point - set_hash_unsafe null aborts",

--- a/src/c-api/test/chain/point_list.cpp
+++ b/src/c-api/test/chain/point_list.cpp
@@ -22,7 +22,7 @@ static kth_hash_t const kHash = {{
 }};
 
 static kth_point_mut_t make_point(void) {
-    kth_point_mut_t pt = kth_chain_point_construct(kHash, 42);
+    kth_point_mut_t pt = kth_chain_point_construct(&kHash, 42);
     REQUIRE(pt != NULL);
     return pt;
 }

--- a/src/c-api/test/chain/script.cpp
+++ b/src/c-api/test/chain/script.cpp
@@ -174,7 +174,7 @@ TEST_CASE("C-API Script - equals different scripts", "[C-API Script]") {
 TEST_CASE("C-API Script - to_pay_script_hash_pattern returns operation list",
           "[C-API Script]") {
     kth_operation_list_mut_t ops =
-        kth_chain_script_to_pay_script_hash_pattern(kShortHash);
+        kth_chain_script_to_pay_script_hash_pattern(&kShortHash);
     REQUIRE(ops != NULL);
     // We can't introspect operation_list element-by-element from the C-API
     // yet, but constructing a script from it should yield a valid script.
@@ -188,7 +188,7 @@ TEST_CASE("C-API Script - to_pay_script_hash_pattern returns operation list",
 TEST_CASE("C-API Script - to_pay_script_hash_32_pattern returns operation list",
           "[C-API Script]") {
     kth_operation_list_mut_t ops =
-        kth_chain_script_to_pay_script_hash_32_pattern(kHash32);
+        kth_chain_script_to_pay_script_hash_32_pattern(&kHash32);
     REQUIRE(ops != NULL);
     kth_script_mut_t script = kth_chain_script_construct_from_operations(ops);
     REQUIRE(kth_chain_script_is_valid(script) != 0);
@@ -311,7 +311,7 @@ TEST_CASE("C-API Script - to_pay_public_key_hash_pattern always returns a list",
     // empty-as-failure convention. Any 20-byte hash produces a valid
     // 5-op list, so the factory never returns NULL.
     kth_operation_list_mut_t ops =
-        kth_chain_script_to_pay_public_key_hash_pattern(kShortHash);
+        kth_chain_script_to_pay_public_key_hash_pattern(&kShortHash);
     REQUIRE(ops != NULL);
     kth_chain_operation_list_destruct(ops);
 }
@@ -401,9 +401,15 @@ TEST_CASE("C-API Script - equals null self aborts",
     kth_chain_script_destruct(other);
 }
 
-// Safe `kth_chain_script_to_pay_script_hash_pattern` takes the short
-// hash by value: passing NULL is a compile error. The runtime
-// precondition still applies on the `_unsafe` companion.
+// Both `kth_chain_script_to_pay_script_hash_pattern` (safe, takes
+// `kth_shorthash_t const*`) and its `_unsafe` companion (takes raw
+// `uint8_t const*`) enforce the same runtime precondition that the hash
+// pointer is non-null.
+TEST_CASE("C-API Script - to_pay_script_hash_pattern null hash aborts",
+          "[C-API Script][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_script_to_pay_script_hash_pattern(NULL));
+}
+
 TEST_CASE("C-API Script - to_pay_script_hash_pattern_unsafe null hash aborts",
           "[C-API Script][precondition]") {
     KTH_EXPECT_ABORT(kth_chain_script_to_pay_script_hash_pattern_unsafe(NULL));
@@ -427,6 +433,17 @@ TEST_CASE("C-API Script - at() out of bounds aborts",
     kth_chain_script_destruct(script);
 }
 
+TEST_CASE("C-API Script - check_signature null signature aborts",
+          "[C-API Script][precondition]") {
+    kth_transaction_mut_t tx = kth_chain_transaction_construct_default();
+    kth_script_mut_t script = kth_chain_script_construct_default();
+    kth_size_t out_size = 0;
+    KTH_EXPECT_ABORT(kth_chain_script_check_signature(
+        NULL, 0, NULL, 0, script, tx, 0, 0, 0, &out_size));
+    kth_chain_script_destruct(script);
+    kth_chain_transaction_destruct(tx);
+}
+
 // ---------------------------------------------------------------------------
 // Regression: null public_key with zero size must not UB
 // ---------------------------------------------------------------------------
@@ -442,7 +459,7 @@ TEST_CASE("C-API Script - check_signature with null public_key and zero size",
     // public_key=NULL, public_key_n=0 is valid per the precondition.
     // Must not crash (data_chunk(nullptr, nullptr+0) is UB).
     kth_bool_t result = kth_chain_script_check_signature(
-        sig, 0, NULL, 0, script, tx, 0, 0, 0, &out_size);
+        &sig, 0, NULL, 0, script, tx, 0, 0, 0, &out_size);
     (void)result;
 
     kth_chain_script_destruct(script);

--- a/src/c-api/test/chain/token_data.cpp
+++ b/src/c-api/test/chain/token_data.cpp
@@ -57,7 +57,7 @@ TEST_CASE("C-API TokenData - destruct null is safe", "[C-API TokenData]") {
 
 TEST_CASE("C-API TokenData - make_fungible builds a valid handle",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 1234u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategoryA, 1234u);
     REQUIRE(td != NULL);
     REQUIRE(kth_chain_token_data_is_valid(td) != 0);
     REQUIRE(kth_chain_token_data_get_kind(td) == kth_token_kind_fungible_only);
@@ -71,7 +71,7 @@ TEST_CASE("C-API TokenData - make_fungible builds a valid handle",
 
 TEST_CASE("C-API TokenData - make_fungible_unsafe builds the same handle",
           "[C-API TokenData]") {
-    kth_token_data_mut_t safe = kth_chain_token_make_fungible(kCategoryA, 7u);
+    kth_token_data_mut_t safe = kth_chain_token_make_fungible(&kCategoryA, 7u);
     kth_token_data_mut_t unsafe = kth_chain_token_make_fungible_unsafe(kCategoryA.hash, 7u);
 
     REQUIRE(safe != NULL);
@@ -89,7 +89,7 @@ TEST_CASE("C-API TokenData - make_fungible_unsafe builds the same handle",
 TEST_CASE("C-API TokenData - make_non_fungible mutable carries commitment and capability",
           "[C-API TokenData]") {
     kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
-        kCategoryA, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+        &kCategoryA, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
 
     REQUIRE(kth_chain_token_data_is_valid(td) != 0);
@@ -114,7 +114,7 @@ TEST_CASE("C-API TokenData - make_non_fungible mutable carries commitment and ca
 TEST_CASE("C-API TokenData - make_non_fungible immutable",
           "[C-API TokenData]") {
     kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
-        kCategoryA, kth_token_capability_none, kCommitment, sizeof(kCommitment));
+        &kCategoryA, kth_token_capability_none, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
     REQUIRE(kth_chain_token_data_is_immutable_nft(td) != 0);
     REQUIRE(kth_chain_token_data_is_mutable_nft(td) == 0);
@@ -125,7 +125,7 @@ TEST_CASE("C-API TokenData - make_non_fungible immutable",
 TEST_CASE("C-API TokenData - make_non_fungible minting",
           "[C-API TokenData]") {
     kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
-        kCategoryA, kth_token_capability_minting, kCommitment, sizeof(kCommitment));
+        &kCategoryA, kth_token_capability_minting, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
     REQUIRE(kth_chain_token_data_is_minting_nft(td) != 0);
     kth_chain_token_data_destruct(td);
@@ -134,7 +134,7 @@ TEST_CASE("C-API TokenData - make_non_fungible minting",
 TEST_CASE("C-API TokenData - make_non_fungible with empty commitment",
           "[C-API TokenData]") {
     kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
-        kCategoryA, kth_token_capability_none, NULL, 0);
+        &kCategoryA, kth_token_capability_none, NULL, 0);
     REQUIRE(td != NULL);
 
     kth_size_t commitment_size = 99u;
@@ -154,7 +154,7 @@ TEST_CASE("C-API TokenData - make_non_fungible with empty commitment",
 TEST_CASE("C-API TokenData - make_both carries amount, capability, commitment",
           "[C-API TokenData]") {
     kth_token_data_mut_t td = kth_chain_token_make_both(
-        kCategoryA, 9999u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+        &kCategoryA, 9999u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
 
     REQUIRE(kth_chain_token_data_is_valid(td) != 0);
@@ -184,7 +184,7 @@ TEST_CASE("C-API TokenData - make_fungible rejects amount 0",
     // Per the CashTokens spec a valid fungible amount is strictly
     // positive. The binding layer's `check_valid` gate sits on top of
     // `operator bool` (which delegates to is_valid), so 0 yields NULL.
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 0u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategoryA, 0u);
     REQUIRE(td == NULL);
 }
 
@@ -193,14 +193,14 @@ TEST_CASE("C-API TokenData - make_fungible rejects amounts above INT64_MAX",
     // The CHIP caps amounts at INT64_MAX. UINT64_MAX (all ones) is
     // provably outside the spec range and must be rejected.
     kth_token_data_mut_t td = kth_chain_token_make_fungible(
-        kCategoryA, (uint64_t)0xFFFFFFFFFFFFFFFFULL);
+        &kCategoryA, (uint64_t)0xFFFFFFFFFFFFFFFFULL);
     REQUIRE(td == NULL);
 }
 
 TEST_CASE("C-API TokenData - make_both rejects amount 0",
           "[C-API TokenData]") {
     kth_token_data_mut_t td = kth_chain_token_make_both(
-        kCategoryA, 0u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+        &kCategoryA, 0u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(td == NULL);
 }
 
@@ -215,7 +215,7 @@ TEST_CASE("C-API TokenData - get_amount returns 0 for pure NFT",
     // The consensus code in transaction_basis depends on this — see
     // the comment on `get_amount` in token_data.hpp.
     kth_token_data_mut_t td = kth_chain_token_make_non_fungible(
-        kCategoryA, kth_token_capability_none, kCommitment, sizeof(kCommitment));
+        &kCategoryA, kth_token_capability_none, kCommitment, sizeof(kCommitment));
     REQUIRE(td != NULL);
     REQUIRE(kth_chain_token_data_get_amount(td) == 0);
     kth_chain_token_data_destruct(td);
@@ -223,7 +223,7 @@ TEST_CASE("C-API TokenData - get_amount returns 0 for pure NFT",
 
 TEST_CASE("C-API TokenData - get_nft_capability is `none` for pure fungible",
           "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategoryA, 1u);
     REQUIRE(td != NULL);
     REQUIRE(kth_chain_token_data_get_nft_capability(td) == kth_token_capability_none);
     kth_chain_token_data_destruct(td);
@@ -235,7 +235,7 @@ TEST_CASE("C-API TokenData - get_nft_capability is `none` for pure fungible",
 
 TEST_CASE("C-API TokenData - copy preserves equality", "[C-API TokenData]") {
     kth_token_data_mut_t original = kth_chain_token_make_both(
-        kCategoryA, 42u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+        &kCategoryA, 42u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(original != NULL);
 
     kth_token_data_mut_t copy = kth_chain_token_data_copy(original);
@@ -248,8 +248,8 @@ TEST_CASE("C-API TokenData - copy preserves equality", "[C-API TokenData]") {
 
 TEST_CASE("C-API TokenData - different categories compare unequal",
           "[C-API TokenData]") {
-    kth_token_data_mut_t a = kth_chain_token_make_fungible(kCategoryA, 1u);
-    kth_token_data_mut_t b = kth_chain_token_make_fungible(kCategoryB, 1u);
+    kth_token_data_mut_t a = kth_chain_token_make_fungible(&kCategoryA, 1u);
+    kth_token_data_mut_t b = kth_chain_token_make_fungible(&kCategoryB, 1u);
 
     REQUIRE(kth_chain_token_data_equals(a, b) == 0);
 
@@ -259,8 +259,8 @@ TEST_CASE("C-API TokenData - different categories compare unequal",
 
 TEST_CASE("C-API TokenData - different amounts compare unequal",
           "[C-API TokenData]") {
-    kth_token_data_mut_t a = kth_chain_token_make_fungible(kCategoryA, 1u);
-    kth_token_data_mut_t b = kth_chain_token_make_fungible(kCategoryA, 2u);
+    kth_token_data_mut_t a = kth_chain_token_make_fungible(&kCategoryA, 1u);
+    kth_token_data_mut_t b = kth_chain_token_make_fungible(&kCategoryA, 2u);
 
     REQUIRE(kth_chain_token_data_equals(a, b) == 0);
 
@@ -274,7 +274,7 @@ TEST_CASE("C-API TokenData - different amounts compare unequal",
 
 TEST_CASE("C-API TokenData - to_data / from_data roundtrip (fungible)",
           "[C-API TokenData]") {
-    kth_token_data_mut_t original = kth_chain_token_make_fungible(kCategoryA, 7777u);
+    kth_token_data_mut_t original = kth_chain_token_make_fungible(&kCategoryA, 7777u);
     REQUIRE(original != NULL);
 
     kth_size_t size = 0;
@@ -296,7 +296,7 @@ TEST_CASE("C-API TokenData - to_data / from_data roundtrip (fungible)",
 TEST_CASE("C-API TokenData - to_data / from_data roundtrip (both)",
           "[C-API TokenData]") {
     kth_token_data_mut_t original = kth_chain_token_make_both(
-        kCategoryA, 12345u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
+        &kCategoryA, 12345u, kth_token_capability_mut, kCommitment, sizeof(kCommitment));
     REQUIRE(original != NULL);
 
     kth_size_t size = 0;
@@ -329,10 +329,10 @@ TEST_CASE("C-API TokenData - from_data with truncated input fails",
 // ---------------------------------------------------------------------------
 
 TEST_CASE("C-API TokenData - set_id replaces category", "[C-API TokenData]") {
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategoryA, 1u);
     REQUIRE(td != NULL);
 
-    kth_chain_token_data_set_id(td, kCategoryB);
+    kth_chain_token_data_set_id(td, &kCategoryB);
     REQUIRE(kth_hash_equal(kth_chain_token_data_id(td), kCategoryB) != 0);
 
     kth_chain_token_data_destruct(td);
@@ -360,7 +360,7 @@ TEST_CASE("C-API TokenData - construct_from_data null out aborts",
 
 TEST_CASE("C-API TokenData - construct_from_data non-null *out aborts",
           "[C-API TokenData][precondition]") {
-    kth_token_data_mut_t already = kth_chain_token_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t already = kth_chain_token_make_fungible(&kCategoryA, 1u);
     KTH_EXPECT_ABORT(
         kth_chain_token_construct_from_data(NULL, 0, &already));
     kth_chain_token_data_destruct(already);
@@ -368,7 +368,7 @@ TEST_CASE("C-API TokenData - construct_from_data non-null *out aborts",
 
 TEST_CASE("C-API TokenData - to_data null out_size aborts",
           "[C-API TokenData][precondition]") {
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategoryA, 1u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategoryA, 1u);
     KTH_EXPECT_ABORT(kth_chain_token_data_to_data(td, NULL));
     kth_chain_token_data_destruct(td);
 }
@@ -376,4 +376,29 @@ TEST_CASE("C-API TokenData - to_data null out_size aborts",
 TEST_CASE("C-API TokenData - make_fungible_unsafe null id aborts",
           "[C-API TokenData][precondition]") {
     KTH_EXPECT_ABORT(kth_chain_token_make_fungible_unsafe(NULL, 1u));
+}
+
+TEST_CASE("C-API TokenData - make_fungible null id aborts",
+          "[C-API TokenData][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_token_make_fungible(NULL, 1u));
+}
+
+TEST_CASE("C-API TokenData - make_non_fungible null id aborts",
+          "[C-API TokenData][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_token_make_non_fungible(
+        NULL, kth_token_capability_none, kCommitment, sizeof(kCommitment)));
+}
+
+TEST_CASE("C-API TokenData - make_both null id aborts",
+          "[C-API TokenData][precondition]") {
+    KTH_EXPECT_ABORT(kth_chain_token_make_both(
+        NULL, 1u, kth_token_capability_mut, kCommitment, sizeof(kCommitment)));
+}
+
+TEST_CASE("C-API TokenData - set_id null value aborts",
+          "[C-API TokenData][precondition]") {
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategoryA, 1u);
+    REQUIRE(td != NULL);
+    KTH_EXPECT_ABORT(kth_chain_token_data_set_id(td, NULL));
+    kth_chain_token_data_destruct(td);
 }

--- a/src/c-api/test/chain/transaction.cpp
+++ b/src/c-api/test/chain/transaction.cpp
@@ -64,7 +64,7 @@ static kth_input_list_mut_t make_inputs(void) {
     kth_input_list_mut_t list = kth_chain_input_list_construct_default();
     REQUIRE(list != NULL);
 
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kPrevHash, 0);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kPrevHash, 0);
     REQUIRE(op != NULL);
     kth_script_mut_t script = make_script();
     kth_input_mut_t in = kth_chain_input_construct(op, script, 0xffffffffu);

--- a/src/c-api/test/chain/utxo.cpp
+++ b/src/c-api/test/chain/utxo.cpp
@@ -63,7 +63,7 @@ TEST_CASE("C-API Utxo - construct_default builds a handle with zero fields",
 
 TEST_CASE("C-API Utxo - construct from point+amount yields engaged values",
           "[C-API Utxo]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kTxid, 7u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 7u);
     kth_utxo_mut_t u = kth_chain_utxo_construct(op, 5000u, NULL);
 
     REQUIRE(kth_chain_utxo_amount(u) == 5000u);
@@ -76,8 +76,8 @@ TEST_CASE("C-API Utxo - construct from point+amount yields engaged values",
 
 TEST_CASE("C-API Utxo - construct with token_data stores it",
           "[C-API Utxo]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kTxid, 0u);
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategory, 1234u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 0u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategory, 1234u);
     kth_utxo_mut_t u = kth_chain_utxo_construct(op, 1000u, td);
 
     kth_token_data_const_t got = kth_chain_utxo_token_data(u);
@@ -95,7 +95,7 @@ TEST_CASE("C-API Utxo - construct with token_data stores it",
 
 TEST_CASE("C-API Utxo - copy preserves fields and equals original",
           "[C-API Utxo]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kTxid, 3u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 3u);
     kth_utxo_mut_t u = kth_chain_utxo_construct(op, 999u, NULL);
     kth_chain_utxo_set_height(u, 42u);
 
@@ -113,7 +113,7 @@ TEST_CASE("C-API Utxo - copy preserves fields and equals original",
 
 TEST_CASE("C-API Utxo - mutating amount breaks equality",
           "[C-API Utxo]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kTxid, 1u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 1u);
     kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
     kth_utxo_mut_t b = kth_chain_utxo_copy(a);
 
@@ -128,7 +128,7 @@ TEST_CASE("C-API Utxo - mutating amount breaks equality",
 
 TEST_CASE("C-API Utxo - mutating height breaks equality",
           "[C-API Utxo]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kTxid, 1u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 1u);
     kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
     kth_utxo_mut_t b = kth_chain_utxo_copy(a);
 
@@ -143,12 +143,12 @@ TEST_CASE("C-API Utxo - mutating height breaks equality",
 
 TEST_CASE("C-API Utxo - mutating point breaks equality",
           "[C-API Utxo]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kTxid, 1u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 1u);
     kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
     kth_utxo_mut_t b = kth_chain_utxo_copy(a);
 
     REQUIRE(kth_chain_utxo_equals(a, b) != 0);
-    kth_output_point_mut_t op2 = kth_chain_output_point_construct_from_hash_index(kTxid, 99u);
+    kth_output_point_mut_t op2 = kth_chain_output_point_construct_from_hash_index(&kTxid, 99u);
     kth_chain_utxo_set_point(b, op2);
     REQUIRE(kth_chain_utxo_equals(a, b) == 0);
 
@@ -160,12 +160,12 @@ TEST_CASE("C-API Utxo - mutating point breaks equality",
 
 TEST_CASE("C-API Utxo - mutating token_data breaks equality",
           "[C-API Utxo]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kTxid, 1u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 1u);
     kth_utxo_mut_t a = kth_chain_utxo_construct(op, 10u, NULL);
     kth_utxo_mut_t b = kth_chain_utxo_copy(a);
 
     REQUIRE(kth_chain_utxo_equals(a, b) != 0);
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategory, 1u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategory, 1u);
     kth_chain_utxo_set_token_data(b, td);
     REQUIRE(kth_chain_utxo_equals(a, b) == 0);
 
@@ -188,11 +188,11 @@ TEST_CASE("C-API Utxo - setters round-trip through getters",
     REQUIRE(kth_chain_utxo_height(u) == 123u);
     REQUIRE(kth_chain_utxo_amount(u) == 456u);
 
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kTxid, 9u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 9u);
     kth_chain_utxo_set_point(u, op);
     REQUIRE(kth_chain_output_point_index(kth_chain_utxo_point(u)) == 9u);
 
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategory, 77u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategory, 77u);
     kth_chain_utxo_set_token_data(u, td);
     REQUIRE(kth_chain_utxo_token_data(u) != NULL);
     REQUIRE(kth_chain_token_data_get_amount(kth_chain_utxo_token_data(u)) == 77);
@@ -245,8 +245,8 @@ TEST_CASE("C-API Utxo - set_point null aborts",
 
 TEST_CASE("C-API Utxo - setters null self aborts",
           "[C-API Utxo][precondition]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(kTxid, 0u);
-    kth_token_data_mut_t td = kth_chain_token_make_fungible(kCategory, 1u);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kTxid, 0u);
+    kth_token_data_mut_t td = kth_chain_token_make_fungible(&kCategory, 1u);
 
     KTH_EXPECT_ABORT(kth_chain_utxo_set_height(NULL, 1u));
     KTH_EXPECT_ABORT(kth_chain_utxo_set_amount(NULL, 1u));

--- a/src/c-api/test/wallet/hd_private.cpp
+++ b/src/c-api/test/wallet/hd_private.cpp
@@ -94,7 +94,7 @@ TEST_CASE("C-API HdPrivate - to_hd_key round-trips", "[C-API HdPrivate]") {
     REQUIRE(original != NULL);
 
     kth_hd_key_t hd_key = kth_wallet_hd_private_to_hd_key(original);
-    kth_hd_private_mut_t reconstructed = kth_wallet_hd_private_construct_from_private_key(hd_key);
+    kth_hd_private_mut_t reconstructed = kth_wallet_hd_private_construct_from_private_key(&hd_key);
     REQUIRE(reconstructed != NULL);
     REQUIRE(kth_wallet_hd_private_equals(original, reconstructed) != 0);
 
@@ -189,4 +189,19 @@ TEST_CASE("C-API HdPrivate - copy null aborts",
 TEST_CASE("C-API HdPrivate - construct_from_seed null data with non-zero size aborts",
           "[C-API HdPrivate][precondition]") {
     KTH_EXPECT_ABORT(kth_wallet_hd_private_construct_from_seed_prefixes(NULL, 16, 0));
+}
+
+TEST_CASE("C-API HdPrivate - construct_from_private_key null aborts",
+          "[C-API HdPrivate][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_hd_private_construct_from_private_key(NULL));
+}
+
+TEST_CASE("C-API HdPrivate - construct_from_private_key_prefixes null aborts",
+          "[C-API HdPrivate][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_hd_private_construct_from_private_key_prefixes(NULL, 0));
+}
+
+TEST_CASE("C-API HdPrivate - construct_from_private_key_prefix null aborts",
+          "[C-API HdPrivate][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_hd_private_construct_from_private_key_prefix(NULL, 0));
 }

--- a/src/c-api/test/wallet/hd_public.cpp
+++ b/src/c-api/test/wallet/hd_public.cpp
@@ -76,7 +76,7 @@ TEST_CASE("C-API HdPublic - to_hd_key round-trips through construct_from_public_
     REQUIRE(original != NULL);
 
     kth_hd_key_t hd_key = kth_wallet_hd_public_to_hd_key(original);
-    kth_hd_public_mut_t reconstructed = kth_wallet_hd_public_construct_from_public_key(hd_key);
+    kth_hd_public_mut_t reconstructed = kth_wallet_hd_public_construct_from_public_key(&hd_key);
     REQUIRE(reconstructed != NULL);
     REQUIRE(kth_wallet_hd_public_equals(original, reconstructed) != 0);
 

--- a/src/domain/include/kth/domain/version.hpp
+++ b/src/domain/include/kth/domain/version.hpp
@@ -15,7 +15,7 @@
 namespace kth {
 
 // Version string from build system (conan -> cmake -> C++)
-inline constexpr std::string_view version = "0.80.1";
+inline constexpr std::string_view version = "0.81.0";
 
 // Currency identifier
 #if defined(KTH_CURRENCY_BCH)


### PR DESCRIPTION
## Summary

- Every C-API function with a fixed-size value_struct parameter now takes that parameter as `kth_xxx_t const*` in the non-`_unsafe` variant (hash, short_hash, payment, ec_compressed/uncompressed, wif_compressed/uncompressed, hd_key, encrypted_seed, long_hash).
- The `_unsafe` companions (taking `uint8_t const*`) are **unchanged** — they were already pointer-based for FFI consumers that cannot pass C structs by value.
- ABI break for external consumers of the affected `construct_from_*`, `set_*`, and `extract_*` entry points.

## Motivation

1. **Performance.** Every value_struct we expose is > 16 bytes. On x86_64 SysV the ABI spills the whole blob onto the callee's stack frame on by-value calls. `const*` keeps the bytes in the caller's buffer and hands the callee a register-sized pointer.

2. **Security.** For crypto material (secret, WIF, HD private key, encrypted seed) the callee-stack copy was a second scrub target that a caller-side `explicit_bzero` on its own local could not reach. With `const*` the C-API's stack frame only holds a pointer — scrubbing the caller's buffer is sufficient.

## What changed

Before:
```c
kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(
    kth_hash_t secret, uint16_t version, kth_bool_t compress);
```

After:
```c
kth_ec_private_mut_t kth_wallet_ec_private_construct_from_secret_version_compress(
    kth_hash_t const* secret, uint16_t version, kth_bool_t compress);
```

Caller side:
```c
// Before
kth_hash_t secret = { ... };
kth_ec_private_mut_t p = kth_wallet_ec_private_construct_from_secret_version_compress(
    secret, version, compress);

// After
kth_hash_t secret = { ... };
kth_ec_private_mut_t p = kth_wallet_ec_private_construct_from_secret_version_compress(
    &secret, version, compress);
```

## Scope

16 C-API headers, 16 C-API impls (regenerated), 16 hand-written test files (swept to pass `&var`) — ~93 call-site edits total.

Hand-written free functions in `capi/hash.h` (`kth_hash_equal`, `kth_hash_is_null`, `kth_hash_to_str`) and `capi/hash_list.h` (`kth_core_hash_list_push_back`, `_nth`) still take `kth_hash_t` by value — those live outside the generator and the same conversion can be folded in as a follow-up.

## Consumer impact

- **py-native**: the generator's py-native backend was updated in lockstep (`forward_args=[&name]`) so the Python wrappers consume the new C-API signatures after a regen. py-native migration lands in a separate PR once this merges and kth 0.81.0 is released.
- **C# / cs-api**: will break on recompile; migrate when picking up kth 0.81.0.
- **Direct C consumers**: need to add `&` at call sites.

## Test plan

- [x] `src/c-api/test/` updated at every affected call site.
- [x] Full build + C-API tests green against the new signatures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a broad **ABI-breaking** signature change across the C API (many call sites and downstream bindings must update), plus sensitive-memory scrubbing changes that touch wallet/crypto-related entry points.
> 
> **Overview**
> This PR makes the C API’s *safe* entry points accept fixed-size `value_struct` inputs (hashes, keys, WIF/payment structs, etc.) as `kth_xxx_t const*` instead of passing them by value, while keeping the existing `_unsafe` raw-buffer variants unchanged.
> 
> It also adds a new cross-platform `kth_core_secure_zero()` API plus an internal RAII `secure_scrub` guard, and uses it to scrub stack-local copies of sensitive material in wallet/script-related functions. Tests are updated to pass pointers and expanded with new death tests to enforce non-null preconditions for the newly-pointer-based parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6be75caa8cbeacb285cab205b3c935a24c5bdddf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Public C API: many functions now require non-null pointer parameters for hash/key/data inputs (calling with value-like inputs will fail).
* **New Features**
  * Added a secure memory zeroing function to reliably scrub sensitive data.
  * Project version bumped to 0.81.0.
* **Tests**
  * Expanded precondition/death tests to enforce non-null pointer requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->