### PR TITLE
fix(c-api): declare explicit_bzero prototype to bypass feature-test gating

### DIFF
--- a/src/c-api/src/secure_memory.cpp
+++ b/src/c-api/src/secure_memory.cpp
@@ -7,13 +7,21 @@
 #include <stddef.h>
 #if defined(_WIN32)
 #  include <windows.h>
-#elif (defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))) \
-    || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
-// explicit_bzero is declared in <strings.h> (not <string.h>) on glibc
-// and the BSDs. Including the wrong header slips an implicit-function-
-// declaration warning that becomes a hard error under -Werror on
-// Clang 16+ / GCC 14+.
-#  include <strings.h>
+#endif
+
+// explicit_bzero on glibc/BSD is declared in <strings.h>, but glibc
+// gates the declaration behind `_DEFAULT_SOURCE` / `_GNU_SOURCE` /
+// `_BSD_SOURCE`. Those macros can be turned OFF by a higher-priority
+// macro the build system sets (e.g. `-D_POSIX_C_SOURCE=200809L` on
+// a `-std=c++23` TU), leaving the header included but the symbol
+// invisible — the failure mode that broke the first two attempts at
+// this file. Sidestep the feature-test dance entirely by declaring
+// the prototype ourselves: glibc >= 2.25 and the BSDs all export the
+// symbol, so the link resolves. macOS, which lacks `explicit_bzero`
+// altogether, falls through to the volatile-loop branch and never
+// references the symbol.
+#if !defined(_WIN32) && !defined(__APPLE__)
+extern "C" void explicit_bzero(void* s, size_t n);
 #endif
 
 extern "C" {
@@ -26,9 +34,10 @@ void kth_core_secure_zero(void* p, kth_size_t n) {
 #elif (defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))) \
     || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
     // glibc >= 2.25 and the BSDs ship `explicit_bzero` as a first-class
-    // scrub primitive. The `__GLIBC__ > 2 || ...` form is the safe
-    // multi-component version check (a hypothetical glibc 3.0 would
-    // still be covered).
+    // scrub primitive. We declared the prototype above to bypass any
+    // feature-test macro gating that would otherwise hide it. The
+    // `__GLIBC__ > 2 || ...` form is the safe multi-component version
+    // check (a hypothetical glibc 3.0 would still be covered).
     explicit_bzero(p, n);
 #else
     // Portable fallback (macOS, musl without explicit_bzero, exotic


### PR DESCRIPTION
## Summary

Build regression introduced by #285: `kth_core_secure_zero` calls `explicit_bzero` on glibc >= 2.25 / BSD, but the declaration in `<strings.h>` is gated behind feature-test macros (`_DEFAULT_SOURCE`, `_GNU_SOURCE`, `_BSD_SOURCE`). A higher-priority macro injected by the CMake/Conan toolchain (e.g. `-D_POSIX_C_SOURCE=200809L` on a `-std=c++23` TU) can turn those off, leaving `<strings.h>` included but the symbol invisible.

Symptom on strict C++ builds (Linux, glibc 2.x):

\`\`\`
src/c-api/src/secure_memory.cpp:46:5: error: 'explicit_bzero' was not declared in this scope
   46 |     explicit_bzero(p, n);
      |     ^~~~~~~~~~~~~~
\`\`\`

## Fix

An earlier attempt at this PR wrote `#define _DEFAULT_SOURCE 1` at the top of the TU, but that's still subject to override by whatever the toolchain injects later and did not resolve the build on at least one user's local conan rebuild. Sidestep the feature-test dance entirely: declare the `explicit_bzero` prototype ourselves as `extern "C"`.

- glibc >= 2.25 and the BSDs all export the symbol → link resolves.
- macOS does not ship `explicit_bzero` at all → falls through to the volatile-loop fallback branch, never references the symbol.

## Test plan

- [ ] Local `conan create` on Linux (previously failing) succeeds.
- [ ] Existing C-API tests continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a build/portability fix that only changes how `explicit_bzero` is declared for compilation under strict C++ modes, without altering the runtime scrubbing paths or logic.
> 
> **Overview**
> Fixes a strict-C++ build regression in `kth_core_secure_zero` by **removing the conditional `<strings.h>` include** and instead **declaring `explicit_bzero` explicitly** for non-Windows/non-macOS builds.
> 
> This avoids glibc/BSD feature-test macro gating that can hide the declaration under `-std=c++23`/strict builds, while keeping the existing platform-specific zeroing behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a47659369b9660dd4dc6bd5e55f2266d81042f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->