### PR TITLE
fix(c-api): fill in missing vm + bool_list headers in kth/capi.h aggregator

### DIFF
--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -73,9 +73,13 @@
 
 #include <kth/capi/p2p/p2p.h>
 
+#include <kth/capi/vm/debug_snapshot.h>
+#include <kth/capi/vm/debug_snapshot_list.h>
+#include <kth/capi/vm/function_table.h>
 #include <kth/capi/vm/interpreter.h>
 #include <kth/capi/vm/program.h>
 
+#include <kth/capi/bool_list.h>
 #include <kth/capi/double_list.h>
 #include <kth/capi/hash.h>
 #include <kth/capi/hash_list.h>


### PR DESCRIPTION
## Summary

\`src/c-api/include/kth/capi/capi.h\` is the public entry-point header consumers are told to include exclusively. Several headers that have shipped as part of the C-API were reachable only by fully-qualified path, not through the aggregator:

- \`kth/capi/vm/debug_snapshot.h\` + \`vm/debug_snapshot_list.h\` (shipped in #275).
- \`kth/capi/vm/function_table.h\` — the inspection surface for the \`kth_function_table_const_t\` handle that \`debug_snapshot\` hands out. Without it, consumers could obtain a function-table pointer but had no API to read it. (Cursor Bugbot finding.)
- \`kth/capi/bool_list.h\` — referenced by \`debug_snapshot.h\` (\`kth_bool_list_const_t control_stack\`) but absent from the aggregator, which left the type forward-declared only.

All four headers already ship in the C-API tarball; this change is purely the aggregator wiring.

## Why it matters

Unblocks py-native's VM bindings: the generator emits \`#include <kth/capi.h>\` in each wrapper, and \`interpreter\`-side code that materialises \`debug_snapshot\` / the \`control_stack\` \`bool_list\` now resolves end-to-end against a single header.

## Test plan

- [ ] Build kth + C-API tests still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only include aggregation change with no behavior changes; risk is limited to potential include-order/build issues for downstream consumers.
> 
> **Overview**
> Updates the `kth/capi.h` umbrella header to include the VM debug snapshot APIs by default, adding `vm/debug_snapshot.h` and `vm/debug_snapshot_list.h` (plus related `vm/function_table.h`) so consumers don’t need to include VM headers directly.
> 
> Also adds `bool_list.h` to the aggregator to ensure the full C-API surface is reachable from the single public entry point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c908b19c534aacc66447f90eab6cbb83f5bf3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->