### PR TITLE
fix(wallet): harden cashtoken_minting input validation

### DIFF
--- a/src/domain/include/kth/domain/wallet/cashtoken_minting.hpp
+++ b/src/domain/include/kth/domain/wallet/cashtoken_minting.hpp
@@ -62,13 +62,18 @@ inline constexpr size_t max_op_return_payload_size = 220;
 // a counter (`0`, `1`, ... `N`) and by mint covenants that advance the
 // counter in the preserved minting NFT.
 //
-// Notes:
-//   - Returns an empty `data_chunk` for `value == 0` (VM-number 0 is
-//     the empty byte string).
-//   - `int64_t` is the VM's native signed-number type; negative values
-//     round-trip correctly but are not expected for counter use.
+// Returns the encoded bytes on success; `std::unexpected` when `value`
+// is outside the VM script-number range (the encoder rejects
+// `INT64_MIN` because its two's-complement negation overflows, which
+// the spec forbids — BCHN's `CScriptNum::serialize` has the same guard
+// via `validRange`). Value `0` encodes as an empty `data_chunk`
+// distinctly from the error case, so the success `.value()` is
+// unambiguous.
+//
+// `int64_t` is the VM's native signed-number type; negative values
+// round-trip correctly but are not expected for counter use.
 KD_API
-data_chunk encode_nft_number(int64_t value);
+std::expected<data_chunk, std::error_code> encode_nft_number(int64_t value);
 
 
 // ---------------------------------------------------------------------------

--- a/src/domain/src/wallet/cashtoken_minting.cpp
+++ b/src/domain/src/wallet/cashtoken_minting.cpp
@@ -23,10 +23,14 @@ namespace kth::domain::wallet::cashtoken {
 // Commitment helpers
 // ---------------------------------------------------------------------------
 
-data_chunk encode_nft_number(int64_t value) {
-    auto const n = infrastructure::machine::number::from_int(value);
+std::expected<data_chunk, std::error_code> encode_nft_number(int64_t value) {
+    auto n = infrastructure::machine::number::from_int(value);
     if ( ! n.has_value()) {
-        return data_chunk{};
+        // Propagate the underlying error (e.g. `INT64_MIN`). Returning
+        // an empty `data_chunk` here would collide with the valid
+        // encoding of `0`, silently turning an invalid input into a
+        // valid-looking commitment.
+        return std::unexpected(make_error_code(n.error()));
     }
     return n->data();
 }
@@ -668,12 +672,17 @@ create_token_transfer(token_transfer_params const& params) {
     if (want_ft == want_nft) {
         return std::unexpected(kth::error::operation_failed);
     }
-    // An explicit zero fungible amount is treated as an out-of-range
-    // request (matches `create_token_genesis`, which rejects `ft == 0`
-    // with `token_amount_overflow`). This disambiguates "forgot what to
-    // send" from "asked to send zero".
-    if (want_ft && *params.ft_amount == 0) {
-        return std::unexpected(kth::error::token_amount_overflow);
+    // The fungible amount must be in the valid VM-number range
+    // `[1, INT64_MAX]` — same check as `create_token_genesis`. A zero
+    // amount is also rejected so "forgot what to send" is distinct from
+    // "asked to send zero"; above-`INT64_MAX` values would otherwise
+    // reach `make_fungible` and produce an unsigned transaction that
+    // only fails at broadcast time with a token-validation error.
+    if (want_ft) {
+        uint64_t const ft = *params.ft_amount;
+        if (ft == 0 || ft > static_cast<uint64_t>(INT64_MAX)) {
+            return std::unexpected(kth::error::token_amount_overflow);
+        }
     }
 
     // The NFT spec, if provided, must carry a valid capability byte.

--- a/src/domain/test/wallet/cashtoken_minting.cpp
+++ b/src/domain/test/wallet/cashtoken_minting.cpp
@@ -95,42 +95,57 @@ utxo make_both_utxo(hash_digest const& parent, uint32_t index,
 TEST_CASE("encode_nft_number: BCHN reference vectors", "[cashtoken_minting]") {
     // Sourced from bitcoin-cash-node/src/test/scriptnum_tests.cpp,
     // the canonical CScriptNum serialization suite.
-    REQUIRE(encode_nft_number(0)    == data_chunk{});
-    REQUIRE(encode_nft_number(1)    == data_chunk{0x01});
-    REQUIRE(encode_nft_number(-1)   == data_chunk{0x81});
-    REQUIRE(encode_nft_number(127)  == data_chunk{0x7f});
-    REQUIRE(encode_nft_number(128)  == (data_chunk{0x80, 0x00}));
-    REQUIRE(encode_nft_number(256)  == (data_chunk{0x00, 0x01}));
-    REQUIRE(encode_nft_number(-255) == (data_chunk{0xff, 0x80}));
+    REQUIRE(encode_nft_number(0).value()    == data_chunk{});
+    REQUIRE(encode_nft_number(1).value()    == data_chunk{0x01});
+    REQUIRE(encode_nft_number(-1).value()   == data_chunk{0x81});
+    REQUIRE(encode_nft_number(127).value()  == data_chunk{0x7f});
+    REQUIRE(encode_nft_number(128).value()  == (data_chunk{0x80, 0x00}));
+    REQUIRE(encode_nft_number(256).value()  == (data_chunk{0x00, 0x01}));
+    REQUIRE(encode_nft_number(-255).value() == (data_chunk{0xff, 0x80}));
 }
 
 TEST_CASE("encode_nft_number: power-of-two boundaries", "[cashtoken_minting]") {
     // Just-under / just-over boundaries where the encoded length grows
     // by one byte. These are the exact transitions BCHN exercises in
     // its `offsets` loop.
-    REQUIRE(encode_nft_number(0x7f).size()   == 1);   // 127 = 7-bit max positive
-    REQUIRE(encode_nft_number(0x80).size()   == 2);   // 128 forces a new byte
-    REQUIRE(encode_nft_number(0x7fff).size() == 2);   // 15-bit max positive
-    REQUIRE(encode_nft_number(0x8000).size() == 3);   // 32768 forces a new byte
-    REQUIRE(encode_nft_number(0xffff).size() == 3);
-    REQUIRE(encode_nft_number(0x10000).size() == 3);
+    REQUIRE(encode_nft_number(0x7f)->size()   == 1);   // 127 = 7-bit max positive
+    REQUIRE(encode_nft_number(0x80)->size()   == 2);   // 128 forces a new byte
+    REQUIRE(encode_nft_number(0x7fff)->size() == 2);   // 15-bit max positive
+    REQUIRE(encode_nft_number(0x8000)->size() == 3);   // 32768 forces a new byte
+    REQUIRE(encode_nft_number(0xffff)->size() == 3);
+    REQUIRE(encode_nft_number(0x10000)->size() == 3);
 }
 
 TEST_CASE("encode_nft_number: realistic NFT counter sizes", "[cashtoken_minting]") {
     // A counter commitment for a 10k-NFT collection fits in 2 bytes;
     // a 1M-NFT collection in 3 bytes — well under the 40-byte Descartes
     // cap and the 128-byte Leibniz cap.
-    REQUIRE(encode_nft_number(500).size()       == 2);
-    REQUIRE(encode_nft_number(9999).size()      == 2);
-    REQUIRE(encode_nft_number(1'000'000).size() == 3);
+    REQUIRE(encode_nft_number(500)->size()       == 2);
+    REQUIRE(encode_nft_number(9999)->size()      == 2);
+    REQUIRE(encode_nft_number(1'000'000)->size() == 3);
 }
 
 TEST_CASE("encode_nft_number: round-trip sanity for negatives", "[cashtoken_minting]") {
     // NFT counters are positive in practice, but the encoder must
     // preserve the full script-number range so callers can use it for
     // any commitment value they can derive from an integer.
-    REQUIRE(encode_nft_number(-128) == (data_chunk{0x80, 0x80}));
-    REQUIRE(encode_nft_number(-256) == (data_chunk{0x00, 0x81}));
+    REQUIRE(encode_nft_number(-128).value() == (data_chunk{0x80, 0x80}));
+    REQUIRE(encode_nft_number(-256).value() == (data_chunk{0x00, 0x81}));
+}
+
+TEST_CASE("encode_nft_number: INT64_MIN rejected with distinct error", "[cashtoken_minting]") {
+    // `INT64_MIN` cannot be negated in two's complement and therefore
+    // has no valid VM-number encoding. The function must surface this
+    // as an error, NOT collide with the empty-chunk encoding of `0`.
+    auto const r = encode_nft_number(std::numeric_limits<int64_t>::min());
+    REQUIRE( ! r.has_value());
+}
+
+TEST_CASE("encode_nft_number: INT64_MAX encodes to a valid 8-byte vector", "[cashtoken_minting]") {
+    // The upper bound of the VM-number range must round-trip.
+    auto const r = encode_nft_number(std::numeric_limits<int64_t>::max());
+    REQUIRE(r.has_value());
+    REQUIRE(r->size() == 8);
 }
 
 // ===========================================================================
@@ -446,6 +461,38 @@ TEST_CASE("create_token_transfer rejects insufficient fungible supply", "[cashto
     auto result = create_token_transfer(params);
     REQUIRE( ! result.has_value());
     REQUIRE(result.error() == kth::error::token_fungible_insufficient);
+}
+
+TEST_CASE("create_token_transfer rejects zero fungible amount", "[cashtoken_minting]") {
+    token_transfer_params params{};
+    params.token_utxos.push_back(make_ft_utxo(parent_tx_a, 0, category_a, 1000));
+    params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
+    params.destination = make_addr(0x22);
+    params.ft_amount = 0;
+    params.token_change_address = make_addr(0x11);
+
+    auto result = create_token_transfer(params);
+    REQUIRE( ! result.has_value());
+    REQUIRE(result.error() == kth::error::token_amount_overflow);
+}
+
+TEST_CASE("create_token_transfer rejects fungible amount above INT64_MAX", "[cashtoken_minting]") {
+    // Values above `INT64_MAX` are outside the VM token-amount range;
+    // `make_fungible` would otherwise accept the out-of-range value and
+    // the transaction would only fail at broadcast-time token
+    // validation — returning a clear API error here is the difference
+    // between a loud compile-time-quality rejection and a silent
+    // unrelayable TX handed back to the caller.
+    token_transfer_params params{};
+    params.token_utxos.push_back(make_ft_utxo(parent_tx_a, 0, category_a, 1000));
+    params.fee_utxos.push_back(make_bch_utxo(parent_tx_b, 0, 50000));
+    params.destination = make_addr(0x22);
+    params.ft_amount = static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1;
+    params.token_change_address = make_addr(0x11);
+
+    auto result = create_token_transfer(params);
+    REQUIRE( ! result.has_value());
+    REQUIRE(result.error() == kth::error::token_amount_overflow);
 }
 
 TEST_CASE("create_token_transfer rejects UTXOs from different categories", "[cashtoken_minting]") {


### PR DESCRIPTION
Follow-up to #288. Addresses two post-merge review findings from Cursor Bugbot.

## Changes

### 1. \`encode_nft_number\` returns \`std::expected\`

Before, the helper returned a bare \`data_chunk\` and produced an empty
vector both for the valid encoding of \`0\` AND on the error path
(e.g. \`INT64_MIN\`, whose two's-complement negation is UB and is
rejected by the underlying \`number::from_int\`). Callers couldn't tell
a successful \`0\` from a silently corrupted input.

New signature:

\`\`\`diff
- data_chunk encode_nft_number(int64_t value);
+ std::expected<data_chunk, std::error_code> encode_nft_number(int64_t value);
\`\`\`

BCHN's \`CScriptNum::serialize\` guards \`INT64_MIN\` the same way (\`validRange\`
check before negation); libauth's \`bigIntToVmNumber\` sidesteps the
problem entirely by taking a \`bigint\`. With \`int64_t\` we propagate the
error up so the caller's \`.value()\` is unambiguous.

Tests: BCHN reference vectors, power-of-two boundaries, realistic
counter sizes, negative round-trips — all updated to use \`.value()\` /
\`->size()\`. Two new cases assert that \`INT64_MIN\` is rejected with an
error and that \`INT64_MAX\` round-trips to an 8-byte encoding.

### 2. \`create_token_transfer\` rejects out-of-range fungible amounts

Previously \`ft_amount\` was only checked against zero. A value above
\`INT64_MAX\` would reach \`make_fungible\` and produce an unsigned
transaction that only failed at broadcast-time token validation. The
genesis builder already had the correct check; this adds the matching
check to transfer.

\`\`\`diff
- if (want_ft && *params.ft_amount == 0) {
-     return std::unexpected(kth::error::token_amount_overflow);
- }
+ if (want_ft) {
+     uint64_t const ft = *params.ft_amount;
+     if (ft == 0 || ft > static_cast<uint64_t>(INT64_MAX)) {
+         return std::unexpected(kth::error::token_amount_overflow);
+     }
+ }
\`\`\`

Two new test cases: reject \`ft_amount == 0\` and reject \`ft_amount > INT64_MAX\`.

## Not addressed (by design)

Cursor Bugbot also flagged that \`script_flags\` has no in-class
initialiser, so \`params p;\` (default-init without braces) reads
indeterminate. This was an explicit design decision in #288 ("no le
pongas default a los flags porque es algo crucial"): callers are
required to initialise the field. \`params{}\` (aggregate value-init)
still gives 0 (Descartes) safely, which is the documented usage.

## Test plan

- [ ] \`cmake --build . --target domain\` succeeds
- [ ] \`./src/domain/kth_domain_test [cashtoken_minting]\` — all tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet token-building APIs by altering `encode_nft_number`’s return type and tightening fungible-amount validation; callers may need updates and behavior now fails fast on previously-accepted edge cases.
> 
> **Overview**
> **Hardens CashTokens minting/transfer validation.** `encode_nft_number` now returns `std::expected<data_chunk, std::error_code>` and propagates VM-number encoding failures (notably rejecting `INT64_MIN`) instead of returning an empty chunk that could be confused with the valid encoding of `0`.
> 
> `create_token_transfer` now rejects fungible transfer amounts outside the VM range (`0` or `> INT64_MAX`) to prevent building transactions that only fail later during network token validation. Tests are updated for the new `expected` API and add coverage for the new edge-case rejections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b186f01064ba525c625202277f9fb592c0ea190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for NFT and fungible token amount validation with proper rejection of out-of-range numeric values.
  * Enhanced boundary checks to catch invalid amounts earlier in token transfer operations, preventing invalid values from progressing undetected.

* **Tests**
  * Expanded test coverage for numeric boundary conditions and token amount validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->