### PR TITLE
refactor(domain): metrics cleanup + kth-native VM_LIMITS_STANDARD flag

### DIFF
--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -574,6 +574,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/machine/interpreter.cpp
         test/machine/interpreter_function_table_stack_budget.cpp
         test/machine/interpreter_nested_invoke.cpp
+        test/machine/metrics.cpp
         test/machine/opcode.cpp
         test/machine/operation.cpp
         test/machine/program.cpp

--- a/src/domain/include/kth/domain/machine/metrics.hpp
+++ b/src/domain/include/kth/domain/machine/metrics.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,83 +10,113 @@
 
 #include <kth/domain/constants/common.hpp>
 #include <kth/domain/define.hpp>
+#include <kth/domain/machine/script_flags.hpp>
 #include <kth/domain/machine/script_limits.hpp>
 
 namespace kth::domain::machine {
 
+// True when the active flag set requests the stricter "standard"
+// (relay-policy) costing for the May-2025 VM limits: per BCH's
+// CHIP-2021-05-vm-limits, hash-iteration cost is 3x higher in
+// standard/relay mode than in consensus (block-validation) mode.
+// The flag is meaningful only when `bch_vm_limits` is also active —
+// it has no effect on pre-Galois scripts. Parameter name is `flags`
+// (not `script_flags`) to avoid shadowing the enum name.
 inline constexpr
-bool is_vm_limits_standard(uint32_t script_flags) {
-    // This constant is defined in consensus lib, but we also need it here.
-    constexpr uint32_t verify_flags_enable_vm_limits_standard = (1U << 29); //SCRIPT_VM_LIMITS_STANDARD
-    return script_flags & verify_flags_enable_vm_limits_standard;
+bool is_vm_limits_standard(script_flags_t flags) {
+    return (flags & script_flags::bch_vm_limits_standard) != 0;
 }
 
 struct KD_API metrics {
     using script_limits_opt_t = std::optional<may2025::script_limits>;
 
     // Getters
+    [[nodiscard]]
     uint32_t sig_checks() const {
         return sig_checks_;
     }
 
+    [[nodiscard]]
     uint64_t op_cost() const {
         return op_cost_;
     }
 
+    [[nodiscard]]
     uint64_t hash_digest_iterations() const {
         return hash_digest_iterations_;
     }
 
-    // Setters
+    // Setters / tallyers
     void add_op_cost(uint32_t cost) {
-        op_cost_ += int64_t(cost);
+        op_cost_ += cost;
+    }
+
+    // Semantic alias of `add_op_cost` for PUSH operations, where the
+    // tallied cost is the pushed stack item's length. Matches BCHN's
+    // `TallyPushOp` — splitting the two names makes call sites in the
+    // interpreter self-documenting (you can tell at a glance whether
+    // a given tally is an opcode-dispatch cost or a push cost).
+    void add_push_op(uint32_t stack_item_length) {
+        op_cost_ += stack_item_length;
     }
 
     void add_hash_iterations(uint32_t message_length, bool is_two_round_hash /* set to true iff OP_HASH256 or OP_HASH160 */) {
         hash_digest_iterations_ += may2025::calculate_hash_iters(message_length, is_two_round_hash);
     }
 
-    void add_sig_checks(int n_checks) {
+    // `n_checks` is always non-negative in practice (every caller
+    // passes `1` or a validated push-derived key count). Using
+    // `uint32_t` here matches the field type and removes the
+    // signed/unsigned mixing that the original `add_sig_checks(int)`
+    // signature introduced.
+    void add_sig_checks(uint32_t n_checks) {
         sig_checks_ += n_checks;
     }
 
     // Checks
-    bool is_over_op_cost_limit(uint32_t script_flags) const {
-        return script_limits && composite_op_cost(script_flags) > script_limits->op_cost_limit();
+    [[nodiscard]]
+    bool is_over_op_cost_limit(script_flags_t flags) const {
+        return script_limits_ && composite_op_cost(flags) > script_limits_->op_cost_limit();
     }
 
     // Non-standard (block validation) op_cost check for the native interpreter.
+    [[nodiscard]]
     bool is_over_op_cost_limit() const {
-        return script_limits && composite_op_cost(false) > script_limits->op_cost_limit();
+        return script_limits_ && composite_op_cost(false) > script_limits_->op_cost_limit();
     }
 
+    [[nodiscard]]
     bool is_over_hash_iters_limit() const {
-        return script_limits && hash_digest_iterations() > script_limits->hash_iters_limit();
+        return script_limits_ && hash_digest_iterations() > script_limits_->hash_iters_limit();
     }
 
+    [[nodiscard]]
     bool has_valid_script_limits() const {
-        return script_limits.has_value();
+        return script_limits_.has_value();
     }
 
-    void set_script_limits(uint32_t script_flags, uint64_t script_sig_size) {
-        script_limits.emplace(is_vm_limits_standard(script_flags), script_sig_size);
+    void set_script_limits(script_flags_t flags, uint64_t script_sig_size) {
+        script_limits_.emplace(is_vm_limits_standard(flags), script_sig_size);
     }
 
     // For the native interpreter (uses bool standard directly, not consensus flags).
     void set_native_script_limits(bool standard, uint64_t script_sig_size) {
-        script_limits.emplace(standard, script_sig_size);
+        script_limits_.emplace(standard, script_sig_size);
     }
 
+    [[nodiscard]]
     script_limits_opt_t const& get_script_limits() const {
-        return script_limits;
+        return script_limits_;
     }
 
     // Returns the composite value that is: nOpCost + nHashDigestIterators * {192 or 64} + nSigChecks * 26,000
     // Consensus code uses a 64 for the hashing iter cost, standard/relay code uses the more restrictive cost of 192.
-    uint64_t composite_op_cost(uint32_t script_flags) const {
-        return composite_op_cost(is_vm_limits_standard(script_flags));
+    [[nodiscard]]
+    uint64_t composite_op_cost(script_flags_t flags) const {
+        return composite_op_cost(is_vm_limits_standard(flags));
     }
 
+    [[nodiscard]]
     uint64_t composite_op_cost(bool standard) const {
         uint64_t const factor = may2025::hash_iter_op_cost_factor(standard);
         return op_cost_
@@ -100,9 +130,7 @@ private:
     /** CHIP-2021-05-vm-limits: Targeted Virtual Machine Limits */
     uint64_t op_cost_ = 0;
     uint64_t hash_digest_iterations_ = 0;
-    script_limits_opt_t script_limits;
-
-    uint64_t get_hash_iter_cost_factor(uint32_t script_flags) const;
+    script_limits_opt_t script_limits_;
 };
 
 } // namespace kth::domain::machine

--- a/src/domain/include/kth/domain/machine/script_flags.hpp
+++ b/src/domain/include/kth/domain/machine/script_flags.hpp
@@ -97,6 +97,7 @@ enum script_flags : script_flags_t {
     bch_2027_may             = 1ULL << 31,   //2027-May cantor (xxxxxxxxx)
 
     // Policy/standardness flags (grow from bit 61 downward, not enforced in block validation)
+    bch_vm_limits_standard         = 1ULL << 57, // strict (relay) VM limit costing — 3x hash iter cost (BCHN: SCRIPT_VM_LIMITS_STANDARD). Only meaningful when bch_vm_limits is active.
     bch_minimalif                  = 1ULL << 58, // OP_IF/NOTIF minimal encoding (BCHN: SCRIPT_VERIFY_MINIMALIF)
     bch_input_sigchecks            = 1ULL << 59, // per-input sigcheck density limit (BCHN: SCRIPT_VERIFY_INPUT_SIGCHECKS)
     bch_discourage_upgradable_nops = 1ULL << 60, // rejects NOP1, NOP4-NOP10
@@ -119,9 +120,9 @@ enum script_flags : script_flags_t {
     /// Sentinel bit to indicate tx has not been validated.
     unverified = 1ULL << 63,
 
-    /// Policy/standardness flags mask (bits 58-61, grow downward).
+    /// Policy/standardness flags mask (bits 57-61, grow downward).
     all_policy_flags = bch_disallow_segwit_recovery | bch_discourage_upgradable_nops
-                     | bch_input_sigchecks | bch_minimalif,
+                     | bch_input_sigchecks | bch_minimalif | bch_vm_limits_standard,
 
     /// All consensus rules (excludes policy flags, retarget, and unverified).
     all_rules = 0xffffffffffffffff & ~all_policy_flags & ~retarget & ~unverified,

--- a/src/domain/src/chain/transaction.cpp
+++ b/src/domain/src/chain/transaction.cpp
@@ -704,9 +704,17 @@ code verify(transaction const& tx, uint32_t input_index, script_flags_t flags, s
 
     // INPUT_SIGCHECKS: density limit on signature checks per input.
     // Formula from BCHN: scriptSig.size() >= sigChecks * 43 - 60
+    //
+    // The RHS can legitimately be negative when sig_checks is zero or
+    // very small — compute it in int64_t so the intermediate
+    // `uint32_t * int` product doesn't promote the whole expression
+    // to unsigned and wrap a negative RHS around to a huge positive.
     if (script::is_enabled(flags, machine::script_flags::bch_input_sigchecks)) {
-        auto const sig_size = int(input_script.serialized_size(false));
-        if (sig_size < int(total_sig_checks) * sigchecks_input_density_factor - sigchecks_input_density_offset) {
+        int64_t const sig_size = int64_t(input_script.serialized_size(false));
+        int64_t const min_sig_size =
+            int64_t(total_sig_checks) * sigchecks_input_density_factor
+            - sigchecks_input_density_offset;
+        if (sig_size < min_sig_size) {
             return error::invalid_script;
         }
     }

--- a/src/domain/test/machine/metrics.cpp
+++ b/src/domain/test/machine/metrics.cpp
@@ -1,0 +1,268 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <kth/domain/machine/metrics.hpp>
+#include <kth/domain/machine/script_flags.hpp>
+#include <kth/domain/machine/script_limits.hpp>
+
+using namespace kth;
+using namespace kth::domain::machine;
+
+namespace {
+
+// Constants from `script_limits.hpp` reproduced here so the assertions
+// below spell out the expected values instead of depending on the
+// implementation's private constants.
+constexpr uint64_t hash_iter_factor_consensus = 64;     // non-standard
+constexpr uint64_t hash_iter_factor_standard  = 192;    // 64 * 3
+constexpr uint64_t sig_check_cost_factor_val  = 26'000; // may2025::sig_check_cost_factor
+
+// Handy anchor for script_limits computations: `op_cost_limit = (n + 41) * 800`,
+// `hash_iters_limit = ((n + 41) * factor) / 2` with factor ∈ {1 consensus, 7 non-standard}.
+constexpr uint64_t kScriptSigSize = 100; // → op_cost_limit = 141 * 800 = 112'800
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Default construction
+// ---------------------------------------------------------------------------
+
+TEST_CASE("default metrics: all counters zero, no script limits", "[metrics]") {
+    metrics m;
+    REQUIRE(m.sig_checks() == 0);
+    REQUIRE(m.op_cost() == 0);
+    REQUIRE(m.hash_digest_iterations() == 0);
+    REQUIRE(m.has_valid_script_limits() == false);
+}
+
+TEST_CASE("without script_limits, every is_over_*_limit is false", "[metrics]") {
+    // Before `set_script_limits` is called, the limit predicates must
+    // short-circuit on the absent `script_limits_` — otherwise a caller
+    // that forgot to initialise limits would silently over-report limit
+    // violations based on an uninitialised ceiling.
+    metrics m;
+    m.add_op_cost(1'000'000'000);
+    m.add_hash_iterations(1 << 20, true);
+    REQUIRE(m.is_over_op_cost_limit() == false);
+    REQUIRE(m.is_over_op_cost_limit(0) == false);
+    REQUIRE(m.is_over_hash_iters_limit() == false);
+}
+
+// ---------------------------------------------------------------------------
+// add_op_cost / add_push_op (semantic alias)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("add_op_cost accumulates", "[metrics]") {
+    metrics m;
+    m.add_op_cost(10);
+    m.add_op_cost(20);
+    m.add_op_cost(100);
+    REQUIRE(m.op_cost() == 130);
+}
+
+TEST_CASE("add_push_op is an alias of add_op_cost", "[metrics]") {
+    // `add_push_op` is the BCHN-TallyPushOp-shaped alias that exists for
+    // documentation purposes in the interpreter. It must be
+    // byte-for-byte equivalent to `add_op_cost` — verify by comparing
+    // two fresh instances driven through equivalent sequences.
+    metrics via_push;
+    via_push.add_push_op(5);
+    via_push.add_push_op(17);
+
+    metrics via_op_cost;
+    via_op_cost.add_op_cost(5);
+    via_op_cost.add_op_cost(17);
+
+    REQUIRE(via_push.op_cost() == via_op_cost.op_cost());
+    REQUIRE(via_push.op_cost() == 22);
+}
+
+// ---------------------------------------------------------------------------
+// add_hash_iterations
+// ---------------------------------------------------------------------------
+
+TEST_CASE("add_hash_iterations: one-round hasher on short message", "[metrics]") {
+    // Formula (script_limits.hpp): iters = is_two_round + 1 + ((msg_len + 8) / 64)
+    // For msg_len = 0, one-round: 0 + 1 + (8 / 64) = 1
+    metrics m;
+    m.add_hash_iterations(0, false);
+    REQUIRE(m.hash_digest_iterations() == 1);
+}
+
+TEST_CASE("add_hash_iterations: two-round hasher on short message", "[metrics]") {
+    // For msg_len = 0, two-round: 1 + 1 + (8 / 64) = 2
+    metrics m;
+    m.add_hash_iterations(0, true);
+    REQUIRE(m.hash_digest_iterations() == 2);
+}
+
+TEST_CASE("add_hash_iterations: one-round hasher on one block of message", "[metrics]") {
+    // For msg_len = 56 (just enough to fill 64 bytes with the 8-byte
+    // length suffix), one-round: 0 + 1 + ((56 + 8) / 64) = 2.
+    metrics m;
+    m.add_hash_iterations(56, false);
+    REQUIRE(m.hash_digest_iterations() == 2);
+}
+
+TEST_CASE("add_hash_iterations accumulates across calls", "[metrics]") {
+    metrics m;
+    m.add_hash_iterations(0, false);   // 1
+    m.add_hash_iterations(0, true);    // 2
+    m.add_hash_iterations(56, false);  // 2
+    REQUIRE(m.hash_digest_iterations() == 5);
+}
+
+// ---------------------------------------------------------------------------
+// add_sig_checks
+// ---------------------------------------------------------------------------
+
+TEST_CASE("add_sig_checks accumulates", "[metrics]") {
+    metrics m;
+    m.add_sig_checks(1);
+    m.add_sig_checks(1);
+    m.add_sig_checks(15);    // e.g. 15-key multisig
+    REQUIRE(m.sig_checks() == 17);
+}
+
+// ---------------------------------------------------------------------------
+// composite_op_cost — bool overload (native interpreter path)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("composite_op_cost on zero metrics is zero", "[metrics]") {
+    metrics m;
+    REQUIRE(m.composite_op_cost(false) == 0);
+    REQUIRE(m.composite_op_cost(true) == 0);
+}
+
+TEST_CASE("composite_op_cost contribution from sig_checks only", "[metrics]") {
+    // Isolating the sig-check contribution: 3 sig checks with
+    // everything else zero → 3 * 26'000 = 78'000. Factor for
+    // hash iters is moot because hash_digest_iterations_ is 0.
+    metrics m;
+    m.add_sig_checks(3);
+    REQUIRE(m.composite_op_cost(false) == 3 * sig_check_cost_factor_val);
+    REQUIRE(m.composite_op_cost(true)  == 3 * sig_check_cost_factor_val);
+}
+
+TEST_CASE("composite_op_cost contribution from hash iters varies with standard flag", "[metrics]") {
+    metrics m;
+    m.add_hash_iterations(0, false);  // +1 hash_digest_iteration
+    REQUIRE(m.composite_op_cost(false) == 1 * hash_iter_factor_consensus); // 64
+    REQUIRE(m.composite_op_cost(true)  == 1 * hash_iter_factor_standard);  // 192
+}
+
+TEST_CASE("composite_op_cost composes op_cost + hash_iters + sig_checks", "[metrics]") {
+    // All three contributors at once. Consensus (standard==false)
+    // factor is 64, so: 500 (op_cost) + 2 * 64 (hash iters) + 1 * 26'000
+    // (sig_checks) = 500 + 128 + 26'000 = 26'628.
+    metrics m;
+    m.add_op_cost(500);
+    m.add_hash_iterations(0, true);   // +2 (two-round on empty msg)
+    m.add_sig_checks(1);
+    REQUIRE(m.composite_op_cost(false)
+            == 500 + 2 * hash_iter_factor_consensus + 1 * sig_check_cost_factor_val);
+}
+
+// ---------------------------------------------------------------------------
+// composite_op_cost — script_flags_t overload
+// ---------------------------------------------------------------------------
+
+TEST_CASE("composite_op_cost(flags) routes through is_vm_limits_standard", "[metrics]") {
+    // With `bch_vm_limits_standard` in the flag set, the
+    // `script_flags_t`-taking overload must agree with
+    // `composite_op_cost(true)`. Without the flag, it must agree with
+    // `composite_op_cost(false)`.
+    metrics m;
+    m.add_hash_iterations(0, false);
+
+    REQUIRE(m.composite_op_cost(script_flags::bch_vm_limits_standard)
+            == m.composite_op_cost(true));
+    REQUIRE(m.composite_op_cost(script_flags_t{0})
+            == m.composite_op_cost(false));
+}
+
+// ---------------------------------------------------------------------------
+// is_vm_limits_standard (free function)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("is_vm_limits_standard detects the policy bit", "[metrics][flags]") {
+    REQUIRE(is_vm_limits_standard(0) == false);
+    REQUIRE(is_vm_limits_standard(script_flags::bch_vm_limits_standard) == true);
+    // Any unrelated bit set on its own must not spuriously flip the flag.
+    REQUIRE(is_vm_limits_standard(script_flags::bch_bitwise_ops) == false);
+    // But combined with the real flag, the predicate stays true.
+    REQUIRE(is_vm_limits_standard(script_flags::bch_vm_limits_standard
+                                | script_flags::bch_bitwise_ops) == true);
+}
+
+// ---------------------------------------------------------------------------
+// set_script_limits / set_native_script_limits
+// ---------------------------------------------------------------------------
+
+TEST_CASE("set_script_limits activates the ceiling derived from flags+scriptsig", "[metrics]") {
+    metrics m;
+    REQUIRE(m.has_valid_script_limits() == false);
+
+    m.set_script_limits(script_flags_t{0}, kScriptSigSize);
+    REQUIRE(m.has_valid_script_limits() == true);
+
+    // op_cost_limit on a consensus-mode 100-byte scriptSig:
+    // (100 + 41) * 800 = 112'800.
+    auto const& limits = m.get_script_limits();
+    REQUIRE(limits.has_value());
+    REQUIRE(limits->op_cost_limit() == 112'800);
+}
+
+TEST_CASE("set_native_script_limits picks factor 192 vs 64 based on 'standard' bool", "[metrics]") {
+    metrics consensus;
+    consensus.set_native_script_limits(false, kScriptSigSize);
+    consensus.add_hash_iterations(0, false);  // +1 iter
+
+    metrics standard;
+    standard.set_native_script_limits(true, kScriptSigSize);
+    standard.add_hash_iterations(0, false);   // +1 iter
+
+    // Same input, different factor: standard weighs the iter 3x.
+    REQUIRE(consensus.composite_op_cost(false) == hash_iter_factor_consensus);
+    REQUIRE(standard.composite_op_cost(true)   == hash_iter_factor_standard);
+}
+
+// ---------------------------------------------------------------------------
+// is_over_op_cost_limit / is_over_hash_iters_limit
+// ---------------------------------------------------------------------------
+
+TEST_CASE("is_over_op_cost_limit crosses when the composite exceeds the ceiling", "[metrics]") {
+    metrics m;
+    m.set_native_script_limits(false, kScriptSigSize);
+    // op_cost_limit here is 112'800. Push op_cost right below it via
+    // `add_op_cost` only (no iters, no sig checks → composite == op_cost_).
+    m.add_op_cost(112'800);
+    REQUIRE(m.is_over_op_cost_limit() == false);
+
+    // One more unit tips us over.
+    m.add_op_cost(1);
+    REQUIRE(m.is_over_op_cost_limit() == true);
+}
+
+TEST_CASE("is_over_hash_iters_limit crosses when iters exceed the ceiling", "[metrics]") {
+    // hash_iters_limit on non-standard (bonus 7x) 100-byte scriptSig:
+    // ((100 + 41) * 7) / 2 = 987 / 2 = 493.
+    metrics m;
+    m.set_native_script_limits(false, kScriptSigSize);
+    // `add_hash_iterations(msg_len=0, two_round=true)` adds 2 per call.
+    // To reach exactly 494 iterations we call add_hash_iterations 247
+    // times — but that's churn. Drive the internal counter directly
+    // via two-round calls to cross 493 in one step: 247 two-round
+    // calls = 494 iters. Easier: one call with a large msg_len.
+    //
+    // For msg_len = 30'000, one-round: 0 + 1 + (30'008 / 64) = 470.
+    // We want 494 iters to cross 493. Go bigger: msg_len = 31'552,
+    // one-round: 0 + 1 + (31'560 / 64) = 494. Crosses.
+    m.add_hash_iterations(30'000, false);   // +470
+    REQUIRE(m.is_over_hash_iters_limit() == false);
+    m.add_hash_iterations(30'000, false);   // +470 → 940 total
+    REQUIRE(m.is_over_hash_iters_limit() == true);
+}


### PR DESCRIPTION
## Summary

Housekeeping pass on \`kth::domain::machine::metrics\` plus a small policy-flag addition that takes the hardcoded \`1U << 29\` magic number out of the class.

## Class-local cleanups

- Drop the dead \`get_hash_iter_cost_factor\` private declaration. Never had a definition; the equivalent free function \`kth::may2025::hash_iter_op_cost_factor(bool)\` already exists and is already used by \`composite_op_cost\`.
- Drop the spurious \`int64_t(cost)\` cast in \`add_op_cost\` (source is \`uint32_t\`, target is \`uint64_t\`).
- \`add_sig_checks\` parameter goes \`int\` → \`uint32_t\` to match the \`uint32_t sig_checks_\` field type. Every existing call site passes a non-negative value (\`1\` or a validated key-count), so no semantic change.
- Field rename \`script_limits\` → \`script_limits_\` to follow the same trailing-underscore convention as the other private fields.
- \`[[nodiscard]]\` on every pure getter and predicate.
- New \`add_push_op(uint32_t stack_item_length)\` — semantic alias of \`add_op_cost\` that mirrors BCHN's \`TallyPushOp\`. Splitting the name makes interpreter call sites self-documenting without changing behaviour.

## Kth-native \`SCRIPT_VM_LIMITS_STANDARD\` flag

Previously \`is_vm_limits_standard\` hardcoded \`(1U << 29)\` to alias BCHN's \`SCRIPT_VM_LIMITS_STANDARD\` bit. In kth's 64-bit \`script_flags\` enum, bit 29 is \`bch_bitwise_ops\` (a completely different consensus feature), so passing kth flags to the function would have returned the wrong answer the day it got wired up.

- Add \`bch_vm_limits_standard = 1ULL << 57\` in the policy block of \`script_flags\`. Sum it into \`all_policy_flags\`.
- \`is_vm_limits_standard\` now takes \`script_flags_t\` and tests the new kth flag directly.
- Widen the \`uint32_t\` parameter on \`set_script_limits\`, \`composite_op_cost\`, and \`is_over_op_cost_limit\` to \`script_flags_t\`. None of those overloads is called from kth today — they're the slots the future relay-policy pipeline will use; aligning the type now avoids a silent truncation the day someone wires them up.

## Consumer update

- \`src/domain/src/chain/transaction.cpp\`'s \`INPUT_SIGCHECKS\` density check originally computed \`uint32_t * int - int\`, which promotes the whole expression to unsigned and silently wraps a legitimately-negative RHS into a huge positive. Rewritten in explicit \`int64_t\` so the subtraction stays signed; the two \`int(...)\` casts that were forcing signed arithmetic disappear.

## Motivation

Pre-req for the next PR that exposes \`metrics\` via the C-API (currently \`kth_vm_program_get_metrics\` returns a handle but \`kth/capi/vm/metrics.h\` has no getters, so nothing can inspect it). Wanted to land the cleanup first so the regenerated binding picks up the fixed signatures.

## Test plan

- [ ] \`cmake --build\` succeeds (no ABI-affecting changes to external consumers).
- [ ] Existing domain tests still pass, in particular the \`INPUT_SIGCHECKS\` density tests.
- [ ] Consensus-vendored \`src/consensus/src/bch-rules/script/script_metrics.h\` is untouched on purpose — it's the BCHN vendored copy and uses BCHN's own flag layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes script flag semantics for VM limits costing and adjusts script validation arithmetic (`INPUT_SIGCHECKS`), which can affect transaction acceptance/standardness if misapplied.
> 
> **Overview**
> Refactors `kth::domain::machine::metrics` to use `script_flags_t` end-to-end (including `set_script_limits`, `is_over_op_cost_limit`, and `composite_op_cost`), removes a hardcoded flag bit check, adds `[[nodiscard]]` to getters/predicates, and introduces `add_push_op()` as a semantic alias for push-cost tallying.
> 
> Adds a new policy/standardness bit `script_flags::bch_vm_limits_standard` (and includes it in `all_policy_flags`) so “standard” (relay) VM-limits costing can be selected explicitly without colliding with consensus feature bits.
> 
> Fixes `transaction.cpp`’s `INPUT_SIGCHECKS` density check to compute the RHS in signed `int64_t`, preventing unsigned wraparound when the minimum size expression is negative, and adds a new `test/machine/metrics.cpp` suite (wired into CMake) covering metrics accumulation, composite cost factoring (64 vs 192), limit checks, and the new flag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc4ae56507524480f9b6d3bc2e53456095b6b4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->