### PR TITLE
feat(c-api): expose vm::metrics binding + tests + vm_limits_standard flag

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -198,6 +198,7 @@ set(kth_sources
   src/vm/debug_snapshot_list.cpp
   src/vm/function_table.cpp
   src/vm/interpreter.cpp
+  src/vm/metrics.cpp
   src/vm/program.cpp
 
 
@@ -346,6 +347,7 @@ set(kth_headers
   include/kth/capi/libconfig/libconfig.h
 
   include/kth/capi/vm/interpreter.h
+  include/kth/capi/vm/metrics.h
   include/kth/capi/vm/program.h
 
   include/kth/capi.h
@@ -528,6 +530,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/vm/interpreter.cpp
         test/vm/debug_snapshot.cpp
         test/vm/function_table.cpp
+        test/vm/metrics.cpp
     )
 
     target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -77,6 +77,7 @@
 #include <kth/capi/vm/debug_snapshot_list.h>
 #include <kth/capi/vm/function_table.h>
 #include <kth/capi/vm/interpreter.h>
+#include <kth/capi/vm/metrics.h>
 #include <kth/capi/vm/program.h>
 
 #include <kth/capi/bool_list.h>

--- a/src/c-api/include/kth/capi/chain/script_flags.h
+++ b/src/c-api/include/kth/capi/chain/script_flags.h
@@ -77,6 +77,7 @@ typedef uint64_t kth_script_flags_t;
 #define kth_script_flags_bch_2027_may                      (1ULL << 31)   // 2027-May cantor (xxxxxxxxx)
 
 // Policy/standardness flags (grow from bit 61 downward, not enforced in block validation)
+#define kth_script_flags_bch_vm_limits_standard            (1ULL << 57)   // strict (relay) VM limit costing — 3x hash iter cost (BCHN: SCRIPT_VM_LIMITS_STANDARD). Only meaningful when bch_vm_limits is active.
 #define kth_script_flags_bch_minimalif                     (1ULL << 58)   // OP_IF/NOTIF minimal encoding (BCHN: SCRIPT_VERIFY_MINIMALIF)
 #define kth_script_flags_bch_input_sigchecks               (1ULL << 59)   // per-input sigcheck density limit (BCHN: SCRIPT_VERIFY_INPUT_SIGCHECKS)
 #define kth_script_flags_bch_discourage_upgradable_nops    (1ULL << 60)   // rejects NOP1, NOP4-NOP10
@@ -99,8 +100,8 @@ typedef uint64_t kth_script_flags_t;
 /// Sentinel bit to indicate tx has not been validated.
 #define kth_script_flags_unverified                        (1ULL << 63)
 
-/// Policy/standardness flags mask (bits 58-61, grow downward).
-#define kth_script_flags_all_policy_flags                  (kth_script_flags_bch_disallow_segwit_recovery | kth_script_flags_bch_discourage_upgradable_nops | kth_script_flags_bch_input_sigchecks | kth_script_flags_bch_minimalif)
+/// Policy/standardness flags mask (bits 57-61, grow downward).
+#define kth_script_flags_all_policy_flags                  (kth_script_flags_bch_disallow_segwit_recovery | kth_script_flags_bch_discourage_upgradable_nops | kth_script_flags_bch_input_sigchecks | kth_script_flags_bch_minimalif | kth_script_flags_bch_vm_limits_standard)
 
 /// All consensus rules (excludes policy flags, retarget, and unverified).
 #define kth_script_flags_all_rules                         (0xffffffffffffffff & ~kth_script_flags_all_policy_flags & ~kth_script_flags_retarget & ~kth_script_flags_unverified)

--- a/src/c-api/include/kth/capi/vm/metrics.h
+++ b/src/c-api/include/kth/capi/vm/metrics.h
@@ -1,24 +1,92 @@
-// Copyright (c) 2016-2025 Knuth Project developers.
+// Copyright (c) 2016-present Knuth Project developers.
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef KTH_CAPI_VM_METRICS_H_
 #define KTH_CAPI_VM_METRICS_H_
 
+#include <stdint.h>
+
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
+#include <kth/capi/chain/script_flags.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// KTH_EXPORT
-// kth_bool_t kth_wallet_secret_to_public(kth_ec_compressed_t* out, kth_ec_secret_t secret);
+// Destructor
 
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_vm_metrics_destruct(kth_metrics_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_metrics_mut_t`. Caller must release with `kth_vm_metrics_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_metrics_mut_t kth_vm_metrics_copy(kth_metrics_const_t self);
+
+
+// Getters
+
+KTH_EXPORT
+uint32_t kth_vm_metrics_sig_checks(kth_metrics_const_t self);
+
+KTH_EXPORT
+uint64_t kth_vm_metrics_op_cost(kth_metrics_const_t self);
+
+KTH_EXPORT
+uint64_t kth_vm_metrics_hash_digest_iterations(kth_metrics_const_t self);
+
+
+// Setters
+
+KTH_EXPORT
+void kth_vm_metrics_set_script_limits(kth_metrics_mut_t self, kth_script_flags_t flags, uint64_t script_sig_size);
+
+KTH_EXPORT
+void kth_vm_metrics_set_native_script_limits(kth_metrics_mut_t self, kth_bool_t standard, uint64_t script_sig_size);
+
+
+// Predicates
+
+KTH_EXPORT
+kth_bool_t kth_vm_metrics_is_over_op_cost_limit(kth_metrics_const_t self, kth_script_flags_t flags);
+
+KTH_EXPORT
+kth_bool_t kth_vm_metrics_is_over_op_cost_limit_simple(kth_metrics_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_metrics_is_over_hash_iters_limit(kth_metrics_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_metrics_has_valid_script_limits(kth_metrics_const_t self);
+
+
+// Operations
+
+KTH_EXPORT
+void kth_vm_metrics_add_op_cost(kth_metrics_mut_t self, uint32_t cost);
+
+KTH_EXPORT
+void kth_vm_metrics_add_push_op(kth_metrics_mut_t self, uint32_t stack_item_length);
+
+KTH_EXPORT
+void kth_vm_metrics_add_hash_iterations(kth_metrics_mut_t self, uint32_t message_length, kth_bool_t is_two_round_hash);
+
+KTH_EXPORT
+void kth_vm_metrics_add_sig_checks(kth_metrics_mut_t self, uint32_t n_checks);
+
+KTH_EXPORT
+uint64_t kth_vm_metrics_composite_op_cost_script_flags(kth_metrics_const_t self, kth_script_flags_t flags);
+
+KTH_EXPORT
+uint64_t kth_vm_metrics_composite_op_cost_bool(kth_metrics_const_t self, kth_bool_t standard);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
-
 
 #endif // KTH_CAPI_VM_METRICS_H_

--- a/src/c-api/src/vm/metrics.cpp
+++ b/src/c-api/src/vm/metrics.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/vm/metrics.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/machine/metrics.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::machine::metrics;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Destructor
+
+void kth_vm_metrics_destruct(kth_metrics_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_metrics_mut_t kth_vm_metrics_copy(kth_metrics_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Getters
+
+uint32_t kth_vm_metrics_sig_checks(kth_metrics_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).sig_checks();
+}
+
+uint64_t kth_vm_metrics_op_cost(kth_metrics_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).op_cost();
+}
+
+uint64_t kth_vm_metrics_hash_digest_iterations(kth_metrics_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).hash_digest_iterations();
+}
+
+
+// Setters
+
+void kth_vm_metrics_set_script_limits(kth_metrics_mut_t self, kth_script_flags_t flags, uint64_t script_sig_size) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<cpp_t>(self).set_script_limits(flags, script_sig_size);
+}
+
+void kth_vm_metrics_set_native_script_limits(kth_metrics_mut_t self, kth_bool_t standard, uint64_t script_sig_size) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const standard_cpp = kth::int_to_bool(standard);
+    kth::cpp_ref<cpp_t>(self).set_native_script_limits(standard_cpp, script_sig_size);
+}
+
+
+// Predicates
+
+kth_bool_t kth_vm_metrics_is_over_op_cost_limit(kth_metrics_const_t self, kth_script_flags_t flags) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_over_op_cost_limit(flags));
+}
+
+kth_bool_t kth_vm_metrics_is_over_op_cost_limit_simple(kth_metrics_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_over_op_cost_limit());
+}
+
+kth_bool_t kth_vm_metrics_is_over_hash_iters_limit(kth_metrics_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_over_hash_iters_limit());
+}
+
+kth_bool_t kth_vm_metrics_has_valid_script_limits(kth_metrics_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).has_valid_script_limits());
+}
+
+
+// Operations
+
+void kth_vm_metrics_add_op_cost(kth_metrics_mut_t self, uint32_t cost) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<cpp_t>(self).add_op_cost(cost);
+}
+
+void kth_vm_metrics_add_push_op(kth_metrics_mut_t self, uint32_t stack_item_length) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<cpp_t>(self).add_push_op(stack_item_length);
+}
+
+void kth_vm_metrics_add_hash_iterations(kth_metrics_mut_t self, uint32_t message_length, kth_bool_t is_two_round_hash) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const is_two_round_hash_cpp = kth::int_to_bool(is_two_round_hash);
+    kth::cpp_ref<cpp_t>(self).add_hash_iterations(message_length, is_two_round_hash_cpp);
+}
+
+void kth_vm_metrics_add_sig_checks(kth_metrics_mut_t self, uint32_t n_checks) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<cpp_t>(self).add_sig_checks(n_checks);
+}
+
+uint64_t kth_vm_metrics_composite_op_cost_script_flags(kth_metrics_const_t self, kth_script_flags_t flags) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).composite_op_cost(flags);
+}
+
+uint64_t kth_vm_metrics_composite_op_cost_bool(kth_metrics_const_t self, kth_bool_t standard) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const standard_cpp = kth::int_to_bool(standard);
+    return kth::cpp_ref<cpp_t>(self).composite_op_cost(standard_cpp);
+}
+
+} // extern "C"

--- a/src/c-api/test/vm/metrics.cpp
+++ b/src/c-api/test/vm/metrics.cpp
@@ -1,0 +1,376 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+
+#include <kth/capi/chain/script_flags.h>
+#include <kth/capi/primitives.h>
+#include <kth/capi/vm/metrics.h>
+#include <kth/capi/vm/program.h>
+#include <kth/capi/chain/script.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Constants (mirrors of `script_limits.hpp`)
+// ---------------------------------------------------------------------------
+
+// Reproduced here so the assertions spell out the expected values
+// instead of depending on the implementation's private constants.
+static uint64_t const kHashIterFactorConsensus = 64;     // non-standard
+static uint64_t const kHashIterFactorStandard  = 192;    // 64 * 3
+static uint64_t const kSigCheckCostFactor      = 26000;  // may2025::sig_check_cost_factor
+
+// Handy anchor for script_limits computations:
+//   op_cost_limit   = (n + 41) * 800
+//   hash_iters_limit = ((n + 41) * factor) / 2, factor ∈ {1 consensus, 7 non-standard}
+// With n = 100: op_cost_limit = 112'800, hash_iters_limit (non-std) = 493.
+static uint64_t const kScriptSigSize = 100;
+
+// ---------------------------------------------------------------------------
+// Fixture — a freshly-constructed `metrics` via `program.get_metrics()`
+// ---------------------------------------------------------------------------
+
+// metrics has no explicit C-API constructor. We obtain a standalone,
+// owned `kth_metrics_mut_t` by constructing a dummy program and copying
+// its default-initialised metrics (copy returns an owned handle).
+static kth_metrics_mut_t fresh_metrics(void) {
+    uint8_t const one_push[1] = { 0x51 };
+    kth_script_mut_t script = NULL;
+    kth_error_code_t ec = kth_chain_script_construct_from_data(
+        one_push, sizeof(one_push), 0, &script);
+    REQUIRE(ec == kth_ec_success);
+    kth_program_mut_t prog = kth_vm_program_construct_from_script(script);
+    REQUIRE(prog != NULL);
+
+    // `get_metrics` returns a borrowed view; copy it into an owned
+    // handle so the caller can release `prog` + `script` here.
+    kth_metrics_const_t borrowed = kth_vm_program_get_metrics(prog);
+    REQUIRE(borrowed != NULL);
+    kth_metrics_mut_t owned = kth_vm_metrics_copy(borrowed);
+    REQUIRE(owned != NULL);
+
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+    return owned;
+}
+
+// ---------------------------------------------------------------------------
+// Default construction
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - default metrics: all counters zero, no script limits",
+          "[C-API Metrics][lifecycle]") {
+    kth_metrics_mut_t m = fresh_metrics();
+    REQUIRE(kth_vm_metrics_sig_checks(m) == 0);
+    REQUIRE(kth_vm_metrics_op_cost(m) == 0);
+    REQUIRE(kth_vm_metrics_hash_digest_iterations(m) == 0);
+    REQUIRE(kth_vm_metrics_has_valid_script_limits(m) == 0);
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - without script_limits, every is_over_*_limit is false",
+          "[C-API Metrics][limits]") {
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_op_cost(m, 1000000000);
+    kth_vm_metrics_add_hash_iterations(m, 1 << 20, 1);
+    REQUIRE(kth_vm_metrics_is_over_op_cost_limit_simple(m) == 0);
+    REQUIRE(kth_vm_metrics_is_over_op_cost_limit(m, 0) == 0);
+    REQUIRE(kth_vm_metrics_is_over_hash_iters_limit(m) == 0);
+    kth_vm_metrics_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// destruct(NULL) is a no-op
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - destruct(NULL) is a no-op",
+          "[C-API Metrics][lifecycle]") {
+    kth_vm_metrics_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// copy produces an independent metrics
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - copy produces an independent metrics",
+          "[C-API Metrics][lifecycle]") {
+    kth_metrics_mut_t a = fresh_metrics();
+    kth_vm_metrics_add_op_cost(a, 500);
+
+    kth_metrics_mut_t b = kth_vm_metrics_copy(a);
+    REQUIRE(b != NULL);
+    REQUIRE(kth_vm_metrics_op_cost(b) == 500);
+
+    // Mutating the copy must not bleed back into the original.
+    kth_vm_metrics_add_op_cost(b, 100);
+    REQUIRE(kth_vm_metrics_op_cost(a) == 500);
+    REQUIRE(kth_vm_metrics_op_cost(b) == 600);
+
+    kth_vm_metrics_destruct(b);
+    kth_vm_metrics_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// add_op_cost / add_push_op
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - add_op_cost accumulates",
+          "[C-API Metrics][counters]") {
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_op_cost(m, 10);
+    kth_vm_metrics_add_op_cost(m, 20);
+    kth_vm_metrics_add_op_cost(m, 100);
+    REQUIRE(kth_vm_metrics_op_cost(m) == 130);
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - add_push_op is an alias of add_op_cost",
+          "[C-API Metrics][counters]") {
+    // `add_push_op` is the BCHN-TallyPushOp-shaped alias. It must be
+    // byte-for-byte equivalent to `add_op_cost`.
+    kth_metrics_mut_t via_push = fresh_metrics();
+    kth_vm_metrics_add_push_op(via_push, 5);
+    kth_vm_metrics_add_push_op(via_push, 17);
+
+    kth_metrics_mut_t via_op_cost = fresh_metrics();
+    kth_vm_metrics_add_op_cost(via_op_cost, 5);
+    kth_vm_metrics_add_op_cost(via_op_cost, 17);
+
+    REQUIRE(kth_vm_metrics_op_cost(via_push) == kth_vm_metrics_op_cost(via_op_cost));
+    REQUIRE(kth_vm_metrics_op_cost(via_push) == 22);
+
+    kth_vm_metrics_destruct(via_op_cost);
+    kth_vm_metrics_destruct(via_push);
+}
+
+// ---------------------------------------------------------------------------
+// add_hash_iterations
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - add_hash_iterations: one-round on short message",
+          "[C-API Metrics][hash]") {
+    // iters = is_two_round + 1 + ((msg_len + 8) / 64)
+    // msg_len = 0, one-round: 0 + 1 + 0 = 1
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_hash_iterations(m, 0, 0);
+    REQUIRE(kth_vm_metrics_hash_digest_iterations(m) == 1);
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - add_hash_iterations: two-round on short message",
+          "[C-API Metrics][hash]") {
+    // msg_len = 0, two-round: 1 + 1 + 0 = 2
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_hash_iterations(m, 0, 1);
+    REQUIRE(kth_vm_metrics_hash_digest_iterations(m) == 2);
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - add_hash_iterations: one-round on one block",
+          "[C-API Metrics][hash]") {
+    // msg_len = 56, one-round: 0 + 1 + ((56 + 8) / 64) = 2
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_hash_iterations(m, 56, 0);
+    REQUIRE(kth_vm_metrics_hash_digest_iterations(m) == 2);
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - add_hash_iterations accumulates across calls",
+          "[C-API Metrics][hash]") {
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_hash_iterations(m, 0, 0);    // 1
+    kth_vm_metrics_add_hash_iterations(m, 0, 1);    // 2
+    kth_vm_metrics_add_hash_iterations(m, 56, 0);   // 2
+    REQUIRE(kth_vm_metrics_hash_digest_iterations(m) == 5);
+    kth_vm_metrics_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// add_sig_checks
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - add_sig_checks accumulates",
+          "[C-API Metrics][counters]") {
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_sig_checks(m, 1);
+    kth_vm_metrics_add_sig_checks(m, 1);
+    kth_vm_metrics_add_sig_checks(m, 15);    // e.g. 15-key multisig
+    REQUIRE(kth_vm_metrics_sig_checks(m) == 17);
+    kth_vm_metrics_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// composite_op_cost — bool overload (native interpreter path)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - composite_op_cost on zero metrics is zero",
+          "[C-API Metrics][composite]") {
+    kth_metrics_mut_t m = fresh_metrics();
+    REQUIRE(kth_vm_metrics_composite_op_cost_bool(m, 0) == 0);
+    REQUIRE(kth_vm_metrics_composite_op_cost_bool(m, 1) == 0);
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - composite_op_cost: sig_checks contribution only",
+          "[C-API Metrics][composite]") {
+    // 3 sig checks alone → 3 * 26'000 = 78'000. Standard/non-standard
+    // bit is moot because hash_digest_iterations_ is 0.
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_sig_checks(m, 3);
+    REQUIRE(kth_vm_metrics_composite_op_cost_bool(m, 0) == 3 * kSigCheckCostFactor);
+    REQUIRE(kth_vm_metrics_composite_op_cost_bool(m, 1) == 3 * kSigCheckCostFactor);
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - composite_op_cost: hash iters weighted by 'standard'",
+          "[C-API Metrics][composite]") {
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_hash_iterations(m, 0, 0);  // +1 iter
+    REQUIRE(kth_vm_metrics_composite_op_cost_bool(m, 0) == 1 * kHashIterFactorConsensus); // 64
+    REQUIRE(kth_vm_metrics_composite_op_cost_bool(m, 1) == 1 * kHashIterFactorStandard);  // 192
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - composite_op_cost composes op_cost + hash_iters + sig_checks",
+          "[C-API Metrics][composite]") {
+    // Consensus (standard==false) factor is 64, so:
+    //   500 (op_cost) + 2 * 64 (hash iters) + 1 * 26'000 (sig_checks)
+    //   = 500 + 128 + 26'000 = 26'628.
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_op_cost(m, 500);
+    kth_vm_metrics_add_hash_iterations(m, 0, 1);   // +2 (two-round on empty msg)
+    kth_vm_metrics_add_sig_checks(m, 1);
+    REQUIRE(kth_vm_metrics_composite_op_cost_bool(m, 0)
+            == 500 + 2 * kHashIterFactorConsensus + 1 * kSigCheckCostFactor);
+    kth_vm_metrics_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// composite_op_cost — script_flags_t overload
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - composite_op_cost(flags) routes through is_vm_limits_standard",
+          "[C-API Metrics][composite][flags]") {
+    // With `bch_vm_limits_standard` in the flag set, the
+    // script_flags_t-taking overload agrees with composite_op_cost(true).
+    // Without the flag, it agrees with composite_op_cost(false).
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_add_hash_iterations(m, 0, 0);
+
+    REQUIRE(kth_vm_metrics_composite_op_cost_script_flags(
+                m, kth_script_flags_bch_vm_limits_standard)
+            == kth_vm_metrics_composite_op_cost_bool(m, 1));
+    REQUIRE(kth_vm_metrics_composite_op_cost_script_flags(m, 0)
+            == kth_vm_metrics_composite_op_cost_bool(m, 0));
+    kth_vm_metrics_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// set_script_limits / set_native_script_limits
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - set_script_limits activates has_valid_script_limits",
+          "[C-API Metrics][limits]") {
+    kth_metrics_mut_t m = fresh_metrics();
+    REQUIRE(kth_vm_metrics_has_valid_script_limits(m) == 0);
+
+    kth_vm_metrics_set_script_limits(m, 0, kScriptSigSize);
+    REQUIRE(kth_vm_metrics_has_valid_script_limits(m) != 0);
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - set_native_script_limits picks the hash_iters ceiling from 'standard'",
+          "[C-API Metrics][limits]") {
+    // hash_iters_limit = ((n + 41) * factor) / 2, with factor = 1 for
+    // standard and factor = 7 for non-standard (consensus). At n=100:
+    //   standard     → (141 * 1) / 2 = 70
+    //   non-standard → (141 * 7) / 2 = 493
+    // A single `add_hash_iterations(msg_len=0, two_round=true)` adds 2
+    // iters, below both ceilings. To cross only the standard ceiling we
+    // pump the iters to a value between 70 and 493: msg_len=5000,
+    // one-round → 1 + (5008/64) = 79, crossing 70 but not 493.
+    kth_metrics_mut_t consensus = fresh_metrics();
+    kth_vm_metrics_set_native_script_limits(consensus, 0, kScriptSigSize);
+
+    kth_metrics_mut_t standard = fresh_metrics();
+    kth_vm_metrics_set_native_script_limits(standard, 1, kScriptSigSize);
+
+    kth_vm_metrics_add_hash_iterations(consensus, 5000, 0);  // +79 iters
+    kth_vm_metrics_add_hash_iterations(standard, 5000, 0);   // +79 iters
+
+    // Same counter value, different stored ceiling: only the `standard`
+    // fixture crosses, proving `set_native_script_limits` persists the
+    // 'standard' bit into the stored limits.
+    REQUIRE(kth_vm_metrics_is_over_hash_iters_limit(consensus) == 0);
+    REQUIRE(kth_vm_metrics_is_over_hash_iters_limit(standard)  != 0);
+
+    kth_vm_metrics_destruct(standard);
+    kth_vm_metrics_destruct(consensus);
+}
+
+// ---------------------------------------------------------------------------
+// is_over_*_limit crossing tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - is_over_op_cost_limit crosses when composite > ceiling",
+          "[C-API Metrics][limits]") {
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_set_native_script_limits(m, 0, kScriptSigSize);
+    // op_cost_limit here is 112'800. Push op_cost right below it via
+    // `add_op_cost` only (no iters, no sig checks → composite == op_cost_).
+    kth_vm_metrics_add_op_cost(m, 112800);
+    REQUIRE(kth_vm_metrics_is_over_op_cost_limit_simple(m) == 0);
+
+    // One more unit tips us over.
+    kth_vm_metrics_add_op_cost(m, 1);
+    REQUIRE(kth_vm_metrics_is_over_op_cost_limit_simple(m) != 0);
+    kth_vm_metrics_destruct(m);
+}
+
+TEST_CASE("C-API Metrics - is_over_hash_iters_limit crosses when iters > ceiling",
+          "[C-API Metrics][limits]") {
+    // hash_iters_limit on non-standard 100-byte scriptSig: 493.
+    // For msg_len = 30'000, one-round: 0 + 1 + (30'008 / 64) = 469.
+    // Two calls → 938, crossing 493.
+    kth_metrics_mut_t m = fresh_metrics();
+    kth_vm_metrics_set_native_script_limits(m, 0, kScriptSigSize);
+    kth_vm_metrics_add_hash_iterations(m, 30000, 0);   // +469
+    REQUIRE(kth_vm_metrics_is_over_hash_iters_limit(m) == 0);
+    kth_vm_metrics_add_hash_iterations(m, 30000, 0);   // +469 → 938 total
+    REQUIRE(kth_vm_metrics_is_over_hash_iters_limit(m) != 0);
+    kth_vm_metrics_destruct(m);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions — const getters abort on NULL
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Metrics - sig_checks null aborts",
+          "[C-API Metrics][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_metrics_sig_checks(NULL));
+}
+
+TEST_CASE("C-API Metrics - op_cost null aborts",
+          "[C-API Metrics][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_metrics_op_cost(NULL));
+}
+
+TEST_CASE("C-API Metrics - hash_digest_iterations null aborts",
+          "[C-API Metrics][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_metrics_hash_digest_iterations(NULL));
+}
+
+TEST_CASE("C-API Metrics - copy null aborts",
+          "[C-API Metrics][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_metrics_copy(NULL));
+}


### PR DESCRIPTION
## Summary
- Exposes `kth::domain::machine::metrics` via the C-API (`kth_vm_metrics_*`): getters for the three counters, incremental adders, composite cost, script-limit setters, and the `is_over_*_limit` predicates.
- Surfaces the new `bch_vm_limits_standard` policy flag (bit 57) in `script_flags.h`; the `composite_op_cost(script_flags_t)` overload routes through `is_vm_limits_standard(flags)` to pick the 192x vs 64x hash-iter cost factor.
- Adds a C-API test suite mirroring the domain-level metrics invariants (counter accumulation, hash-iter formula, composite cost with and without the standard bit, script-limit activation, limit crossings) plus NULL-precondition abort checks.

## Test plan
- [ ] `cmake --build build --target kth-capi-tests && ctest --test-dir build -R "C-API Metrics"`
- [ ] Existing VM test suites (`program`, `interpreter`, `debug_snapshot`, `function_table`) still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public C-API surface for VM execution-cost accounting and introduces a new BCH policy flag that affects how composite VM cost may be computed; consumers could mis-handle the new flag or rely on updated policy-mask semantics.
> 
> **Overview**
> Exposes `kth::domain::machine::metrics` through a new C-API (`kth_vm_metrics_*`) for reading counters (sigchecks/op-cost/hash iters), incrementing them, computing composite cost, configuring script limits, and checking whether limits are exceeded.
> 
> Adds the BCH policy flag `kth_script_flags_bch_vm_limits_standard` (bit 57) and updates `kth_script_flags_all_policy_flags` accordingly, then wires the new metrics binding into the build and umbrella header (`capi.h`). A new Catch2 test suite validates metrics lifecycle, counter accumulation, composite-cost behavior (including the standard-vs-consensus hash-iter weighting), script-limit activation, and NULL-precondition aborts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db03fef8019730600ffa4dea5fb959c4953dff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive VM metrics API to query and manage virtual machine performance metrics.
  * Added functions to track operation costs, signature checks, and hash digest iterations.
  * New validation capabilities to enforce script execution limit thresholds.
  * Added script flag constant for VM standard limit enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->