### PR TITLE
feat(c-api): add cashtoken_minting bindings

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -183,6 +183,7 @@ set(kth_sources
   src/wallet/hd_public.cpp
   src/wallet/hd_private.cpp
 
+  src/wallet/cashtoken_minting.cpp
   src/wallet/payment_address.cpp
   src/wallet/payment_address_list.cpp
   src/wallet/wallet.cpp
@@ -265,6 +266,7 @@ set(kth_sources
         src/wallet/hd_public.cpp
         src/wallet/hd_private.cpp
 
+        src/wallet/cashtoken_minting.cpp
         src/wallet/payment_address.cpp
         src/wallet/payment_address_list.cpp
         src/wallet/wallet.cpp
@@ -305,6 +307,7 @@ set(kth_headers
 
   include/kth/capi/vm/program.h
 
+  include/kth/capi/wallet/cashtoken_minting.h
   include/kth/capi/wallet/ec_public.h
   include/kth/capi/wallet/payment_address.h
   include/kth/capi/wallet/payment_address_list.h
@@ -521,6 +524,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/double_spend_proof.cpp
         test/chain/token_data.cpp
         test/chain/utxo.cpp
+        test/wallet/cashtoken_minting.cpp
         test/wallet/hd_public.cpp
         test/wallet/hd_private.cpp
         test/wallet/wallet_data.cpp

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -92,6 +92,7 @@
 #include <kth/capi/wallet/ec_private.h>
 #include <kth/capi/wallet/ec_public.h>
 #include <kth/capi/wallet/elliptic_curve.h>
+#include <kth/capi/wallet/cashtoken_minting.h>
 #include <kth/capi/wallet/hd_lineage.h>
 #include <kth/capi/wallet/hd_private.h>
 #include <kth/capi/wallet/hd_public.h>

--- a/src/c-api/include/kth/capi/wallet/cashtoken_minting.h
+++ b/src/c-api/include/kth/capi/wallet/cashtoken_minting.h
@@ -1,0 +1,690 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_CASHTOKEN_MINTING_H_
+#define KTH_CAPI_WALLET_CASHTOKEN_MINTING_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/chain/token_capability.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ---------------------------------------------------------------------------
+// Opaque handles — one per C++ params/result struct.
+// ---------------------------------------------------------------------------
+//
+// C mirrors the `kth::domain::wallet::cashtoken` C++ API. Each C++ struct
+// maps to an opaque handle (`kth_cashtoken_<type>_mut_t`) with
+// `construct_default` / `destruct` lifecycle functions plus per-field
+// setters/getters. Builders take a params handle and return either a
+// result handle via out-parameter or an error code.
+//
+// Type aliases (all `void*` at the ABI level, see helpers.hpp):
+typedef void*       kth_cashtoken_prepare_genesis_params_mut_t;
+typedef void const* kth_cashtoken_prepare_genesis_params_const_t;
+typedef void*       kth_cashtoken_prepare_genesis_result_mut_t;
+typedef void const* kth_cashtoken_prepare_genesis_result_const_t;
+
+typedef void*       kth_cashtoken_nft_spec_mut_t;
+typedef void const* kth_cashtoken_nft_spec_const_t;
+typedef void*       kth_cashtoken_nft_mint_request_mut_t;
+typedef void const* kth_cashtoken_nft_mint_request_const_t;
+typedef void*       kth_cashtoken_nft_mint_request_list_mut_t;
+typedef void const* kth_cashtoken_nft_mint_request_list_const_t;
+typedef void*       kth_cashtoken_nft_collection_item_mut_t;
+typedef void const* kth_cashtoken_nft_collection_item_const_t;
+typedef void*       kth_cashtoken_nft_collection_item_list_mut_t;
+typedef void const* kth_cashtoken_nft_collection_item_list_const_t;
+
+typedef void*       kth_cashtoken_token_genesis_params_mut_t;
+typedef void const* kth_cashtoken_token_genesis_params_const_t;
+typedef void*       kth_cashtoken_token_genesis_result_mut_t;
+typedef void const* kth_cashtoken_token_genesis_result_const_t;
+
+typedef void*       kth_cashtoken_token_mint_params_mut_t;
+typedef void const* kth_cashtoken_token_mint_params_const_t;
+typedef void*       kth_cashtoken_token_mint_result_mut_t;
+typedef void const* kth_cashtoken_token_mint_result_const_t;
+
+typedef void*       kth_cashtoken_token_transfer_params_mut_t;
+typedef void const* kth_cashtoken_token_transfer_params_const_t;
+typedef void*       kth_cashtoken_token_burn_params_mut_t;
+typedef void const* kth_cashtoken_token_burn_params_const_t;
+typedef void*       kth_cashtoken_token_tx_result_mut_t;
+typedef void const* kth_cashtoken_token_tx_result_const_t;
+
+typedef void*       kth_cashtoken_ft_params_mut_t;
+typedef void const* kth_cashtoken_ft_params_const_t;
+
+typedef void*       kth_cashtoken_nft_collection_params_mut_t;
+typedef void const* kth_cashtoken_nft_collection_params_const_t;
+typedef void*       kth_cashtoken_nft_collection_result_mut_t;
+typedef void const* kth_cashtoken_nft_collection_result_const_t;
+
+
+// ---------------------------------------------------------------------------
+// encode_nft_number
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode an integer as a minimally-serialised Bitcoin Script number
+ * (VM-number) suitable for use as an NFT commitment.
+ *
+ * @param value      Integer to encode.
+ * @param out_data   Receives an owned byte array (caller must release with
+ *                   `kth_core_destruct_array`). Untouched on error.
+ * @param out_size   Receives the size of `*out_data`. Zero is a valid
+ *                   encoding (the empty byte string for `value == 0`).
+ * @return `kth_ec_success` on success, otherwise a VM-number range error
+ *         (notably when `value == INT64_MIN`, whose negation is UB).
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_cashtoken_encode_nft_number(
+    int64_t value,
+    uint8_t** out_data,
+    kth_size_t* out_size);
+
+
+// ---------------------------------------------------------------------------
+// Output factories
+// ---------------------------------------------------------------------------
+
+/** @return Owned `kth_output_mut_t`. Caller must release with `kth_chain_output_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_mut_t kth_wallet_cashtoken_create_ft_output(
+    kth_payment_address_const_t destination,
+    uint8_t const* category_id,
+    uint64_t ft_amount,
+    uint64_t satoshis);
+
+/** @return Owned `kth_output_mut_t`. Caller must release with `kth_chain_output_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_mut_t kth_wallet_cashtoken_create_nft_output(
+    kth_payment_address_const_t destination,
+    uint8_t const* category_id,
+    kth_token_capability_t capability,
+    uint8_t const* commitment,
+    kth_size_t commitment_n,
+    uint64_t satoshis);
+
+/** @return Owned `kth_output_mut_t`. Caller must release with `kth_chain_output_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_mut_t kth_wallet_cashtoken_create_combined_token_output(
+    kth_payment_address_const_t destination,
+    uint8_t const* category_id,
+    uint64_t ft_amount,
+    kth_token_capability_t capability,
+    uint8_t const* commitment,
+    kth_size_t commitment_n,
+    uint64_t satoshis);
+
+
+// ---------------------------------------------------------------------------
+// nft_spec
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_nft_spec_mut_t kth_wallet_cashtoken_nft_spec_construct(
+    kth_token_capability_t capability,
+    uint8_t const* commitment,
+    kth_size_t commitment_n);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_spec_destruct(kth_cashtoken_nft_spec_mut_t self);
+
+
+// ---------------------------------------------------------------------------
+// nft_mint_request
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_nft_mint_request_mut_t kth_wallet_cashtoken_nft_mint_request_construct(
+    kth_payment_address_const_t destination,
+    uint8_t const* commitment,
+    kth_size_t commitment_n,
+    kth_token_capability_t capability,
+    uint64_t satoshis);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_mint_request_destruct(
+    kth_cashtoken_nft_mint_request_mut_t self);
+
+// --- list ---
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_nft_mint_request_list_mut_t kth_wallet_cashtoken_nft_mint_request_list_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_mint_request_list_push_back(
+    kth_cashtoken_nft_mint_request_list_mut_t list,
+    kth_cashtoken_nft_mint_request_const_t elem);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_mint_request_list_destruct(
+    kth_cashtoken_nft_mint_request_list_mut_t list);
+
+KTH_EXPORT
+kth_size_t kth_wallet_cashtoken_nft_mint_request_list_count(
+    kth_cashtoken_nft_mint_request_list_const_t list);
+
+KTH_EXPORT
+kth_cashtoken_nft_mint_request_const_t kth_wallet_cashtoken_nft_mint_request_list_nth(
+    kth_cashtoken_nft_mint_request_list_const_t list, kth_size_t index);
+
+
+// ---------------------------------------------------------------------------
+// nft_collection_item
+// ---------------------------------------------------------------------------
+
+/**
+ * @param destination Optional — pass NULL to default to
+ *                    `nft_collection_params::creator_address`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_nft_collection_item_mut_t kth_wallet_cashtoken_nft_collection_item_construct(
+    uint8_t const* commitment,
+    kth_size_t commitment_n,
+    kth_payment_address_const_t destination);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_item_destruct(
+    kth_cashtoken_nft_collection_item_mut_t self);
+
+// --- list ---
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_nft_collection_item_list_mut_t kth_wallet_cashtoken_nft_collection_item_list_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_item_list_push_back(
+    kth_cashtoken_nft_collection_item_list_mut_t list,
+    kth_cashtoken_nft_collection_item_const_t elem);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_item_list_destruct(
+    kth_cashtoken_nft_collection_item_list_mut_t list);
+
+KTH_EXPORT
+kth_size_t kth_wallet_cashtoken_nft_collection_item_list_count(
+    kth_cashtoken_nft_collection_item_list_const_t list);
+
+/** @return Borrowed `kth_cashtoken_nft_collection_item_const_t` view into `list`. Do not destruct. */
+KTH_EXPORT
+kth_cashtoken_nft_collection_item_const_t kth_wallet_cashtoken_nft_collection_item_list_nth(
+    kth_cashtoken_nft_collection_item_list_const_t list, kth_size_t index);
+
+
+// ---------------------------------------------------------------------------
+// prepare_genesis_params / prepare_genesis_result / prepare_genesis_utxo
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_prepare_genesis_params_mut_t kth_wallet_cashtoken_prepare_genesis_params_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_prepare_genesis_params_destruct(
+    kth_cashtoken_prepare_genesis_params_mut_t self);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_prepare_genesis_params_set_utxo(
+    kth_cashtoken_prepare_genesis_params_mut_t self, kth_utxo_const_t utxo);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_prepare_genesis_params_set_destination(
+    kth_cashtoken_prepare_genesis_params_mut_t self, kth_payment_address_const_t destination);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_prepare_genesis_params_set_satoshis(
+    kth_cashtoken_prepare_genesis_params_mut_t self, uint64_t satoshis);
+
+/** @param change_address Optional — pass NULL for "no explicit change address". */
+KTH_EXPORT
+void kth_wallet_cashtoken_prepare_genesis_params_set_change_address(
+    kth_cashtoken_prepare_genesis_params_mut_t self, kth_payment_address_const_t change_address);
+
+/** @param[out] out Must point to a null `kth_cashtoken_prepare_genesis_result_mut_t` slot. */
+KTH_EXPORT
+kth_error_code_t kth_wallet_cashtoken_prepare_genesis_utxo(
+    kth_cashtoken_prepare_genesis_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_prepare_genesis_result_mut_t* out);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_prepare_genesis_result_destruct(
+    kth_cashtoken_prepare_genesis_result_mut_t self);
+
+/** @return Borrowed `kth_transaction_const_t` view; do not destruct. */
+KTH_EXPORT
+kth_transaction_const_t kth_wallet_cashtoken_prepare_genesis_result_transaction(
+    kth_cashtoken_prepare_genesis_result_const_t self);
+
+/** @return Number of signing indices. */
+KTH_EXPORT
+kth_size_t kth_wallet_cashtoken_prepare_genesis_result_signing_indices_count(
+    kth_cashtoken_prepare_genesis_result_const_t self);
+
+KTH_EXPORT
+uint32_t kth_wallet_cashtoken_prepare_genesis_result_signing_index_nth(
+    kth_cashtoken_prepare_genesis_result_const_t self, kth_size_t index);
+
+
+// ---------------------------------------------------------------------------
+// token_genesis_params / token_genesis_result / create_token_genesis
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_token_genesis_params_mut_t kth_wallet_cashtoken_token_genesis_params_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_params_destruct(
+    kth_cashtoken_token_genesis_params_mut_t self);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_params_set_genesis_utxo(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_utxo_const_t genesis_utxo);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_params_set_destination(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_payment_address_const_t destination);
+
+/** Sets the optional FT supply. `has_value == 0` clears the optional. */
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_params_set_ft_amount(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount);
+
+/** @param nft Optional — pass NULL to clear the NFT spec. */
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_params_set_nft(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_cashtoken_nft_spec_const_t nft);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_params_set_satoshis(
+    kth_cashtoken_token_genesis_params_mut_t self, uint64_t satoshis);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_params_set_fee_utxos(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_utxo_list_const_t fee_utxos);
+
+/** @param change_address Optional — pass NULL for no explicit change address. */
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_params_set_change_address(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_payment_address_const_t change_address);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_params_set_script_flags(
+    kth_cashtoken_token_genesis_params_mut_t self, uint64_t script_flags);
+
+KTH_EXPORT
+kth_error_code_t kth_wallet_cashtoken_create_token_genesis(
+    kth_cashtoken_token_genesis_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_genesis_result_mut_t* out);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_result_destruct(
+    kth_cashtoken_token_genesis_result_mut_t self);
+
+KTH_EXPORT
+kth_transaction_const_t kth_wallet_cashtoken_token_genesis_result_transaction(
+    kth_cashtoken_token_genesis_result_const_t self);
+
+/** Writes the 32-byte category id into `out_hash`. */
+KTH_EXPORT
+void kth_wallet_cashtoken_token_genesis_result_category_id(
+    kth_cashtoken_token_genesis_result_const_t self, uint8_t* out_hash);
+
+KTH_EXPORT
+kth_size_t kth_wallet_cashtoken_token_genesis_result_signing_indices_count(
+    kth_cashtoken_token_genesis_result_const_t self);
+
+KTH_EXPORT
+uint32_t kth_wallet_cashtoken_token_genesis_result_signing_index_nth(
+    kth_cashtoken_token_genesis_result_const_t self, kth_size_t index);
+
+
+// ---------------------------------------------------------------------------
+// token_mint_params / token_mint_result / create_token_mint
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_token_mint_params_mut_t kth_wallet_cashtoken_token_mint_params_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_mint_params_destruct(
+    kth_cashtoken_token_mint_params_mut_t self);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_mint_params_set_minting_utxo(
+    kth_cashtoken_token_mint_params_mut_t self, kth_utxo_const_t minting_utxo);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_mint_params_set_nfts(
+    kth_cashtoken_token_mint_params_mut_t self,
+    kth_cashtoken_nft_mint_request_list_const_t nfts);
+
+/**
+ * Sets the optional preserved-minting commitment. `commitment == NULL`
+ * clears the optional.
+ */
+KTH_EXPORT
+void kth_wallet_cashtoken_token_mint_params_set_new_minting_commitment(
+    kth_cashtoken_token_mint_params_mut_t self,
+    uint8_t const* commitment, kth_size_t commitment_n);
+
+/** Required — pass the address explicitly; no fallback to change_address. */
+KTH_EXPORT
+void kth_wallet_cashtoken_token_mint_params_set_minting_destination(
+    kth_cashtoken_token_mint_params_mut_t self,
+    kth_payment_address_const_t minting_destination);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_mint_params_set_fee_utxos(
+    kth_cashtoken_token_mint_params_mut_t self, kth_utxo_list_const_t fee_utxos);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_mint_params_set_change_address(
+    kth_cashtoken_token_mint_params_mut_t self,
+    kth_payment_address_const_t change_address);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_mint_params_set_script_flags(
+    kth_cashtoken_token_mint_params_mut_t self, uint64_t script_flags);
+
+KTH_EXPORT
+kth_error_code_t kth_wallet_cashtoken_create_token_mint(
+    kth_cashtoken_token_mint_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_mint_result_mut_t* out);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_mint_result_destruct(
+    kth_cashtoken_token_mint_result_mut_t self);
+
+KTH_EXPORT
+kth_transaction_const_t kth_wallet_cashtoken_token_mint_result_transaction(
+    kth_cashtoken_token_mint_result_const_t self);
+
+KTH_EXPORT
+kth_size_t kth_wallet_cashtoken_token_mint_result_signing_indices_count(
+    kth_cashtoken_token_mint_result_const_t self);
+
+KTH_EXPORT
+uint32_t kth_wallet_cashtoken_token_mint_result_signing_index_nth(
+    kth_cashtoken_token_mint_result_const_t self, kth_size_t index);
+
+KTH_EXPORT
+kth_size_t kth_wallet_cashtoken_token_mint_result_minted_output_indices_count(
+    kth_cashtoken_token_mint_result_const_t self);
+
+KTH_EXPORT
+uint32_t kth_wallet_cashtoken_token_mint_result_minted_output_index_nth(
+    kth_cashtoken_token_mint_result_const_t self, kth_size_t index);
+
+
+// ---------------------------------------------------------------------------
+// token_transfer_params / create_token_transfer
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_token_transfer_params_mut_t kth_wallet_cashtoken_token_transfer_params_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_transfer_params_destruct(
+    kth_cashtoken_token_transfer_params_mut_t self);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_transfer_params_set_token_utxos(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_utxo_list_const_t token_utxos);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_transfer_params_set_destination(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t destination);
+
+/** `has_value == 0` clears the optional. */
+KTH_EXPORT
+void kth_wallet_cashtoken_token_transfer_params_set_ft_amount(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount);
+
+/** @param nft Optional — pass NULL to clear. */
+KTH_EXPORT
+void kth_wallet_cashtoken_token_transfer_params_set_nft(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_cashtoken_nft_spec_const_t nft);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_transfer_params_set_fee_utxos(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_utxo_list_const_t fee_utxos);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_transfer_params_set_token_change_address(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t addr);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_transfer_params_set_bch_change_address(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t addr);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_transfer_params_set_satoshis(
+    kth_cashtoken_token_transfer_params_mut_t self, uint64_t satoshis);
+
+KTH_EXPORT
+kth_error_code_t kth_wallet_cashtoken_create_token_transfer(
+    kth_cashtoken_token_transfer_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_tx_result_mut_t* out);
+
+
+// ---------------------------------------------------------------------------
+// token_burn_params / create_token_burn
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_token_burn_params_mut_t kth_wallet_cashtoken_token_burn_params_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_burn_params_destruct(
+    kth_cashtoken_token_burn_params_mut_t self);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_burn_params_set_token_utxo(
+    kth_cashtoken_token_burn_params_mut_t self, kth_utxo_const_t token_utxo);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_burn_params_set_burn_ft_amount(
+    kth_cashtoken_token_burn_params_mut_t self, kth_bool_t has_value, uint64_t burn_ft_amount);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_burn_params_set_burn_nft(
+    kth_cashtoken_token_burn_params_mut_t self, kth_bool_t burn_nft);
+
+/** @param message Optional UTF-8 null-terminated string; NULL clears. */
+KTH_EXPORT
+void kth_wallet_cashtoken_token_burn_params_set_message(
+    kth_cashtoken_token_burn_params_mut_t self, char const* message);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_burn_params_set_destination(
+    kth_cashtoken_token_burn_params_mut_t self, kth_payment_address_const_t destination);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_burn_params_set_fee_utxos(
+    kth_cashtoken_token_burn_params_mut_t self, kth_utxo_list_const_t fee_utxos);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_burn_params_set_change_address(
+    kth_cashtoken_token_burn_params_mut_t self, kth_payment_address_const_t change_address);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_burn_params_set_satoshis(
+    kth_cashtoken_token_burn_params_mut_t self, uint64_t satoshis);
+
+KTH_EXPORT
+kth_error_code_t kth_wallet_cashtoken_create_token_burn(
+    kth_cashtoken_token_burn_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_tx_result_mut_t* out);
+
+
+// ---------------------------------------------------------------------------
+// token_tx_result — shared between transfer and burn
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT
+void kth_wallet_cashtoken_token_tx_result_destruct(
+    kth_cashtoken_token_tx_result_mut_t self);
+
+KTH_EXPORT
+kth_transaction_const_t kth_wallet_cashtoken_token_tx_result_transaction(
+    kth_cashtoken_token_tx_result_const_t self);
+
+KTH_EXPORT
+kth_size_t kth_wallet_cashtoken_token_tx_result_signing_indices_count(
+    kth_cashtoken_token_tx_result_const_t self);
+
+KTH_EXPORT
+uint32_t kth_wallet_cashtoken_token_tx_result_signing_index_nth(
+    kth_cashtoken_token_tx_result_const_t self, kth_size_t index);
+
+
+// ---------------------------------------------------------------------------
+// ft_params / create_ft — high-level fungible token genesis
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_ft_params_mut_t kth_wallet_cashtoken_ft_params_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_ft_params_destruct(
+    kth_cashtoken_ft_params_mut_t self);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_ft_params_set_genesis_utxo(
+    kth_cashtoken_ft_params_mut_t self, kth_utxo_const_t genesis_utxo);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_ft_params_set_destination(
+    kth_cashtoken_ft_params_mut_t self, kth_payment_address_const_t destination);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_ft_params_set_total_supply(
+    kth_cashtoken_ft_params_mut_t self, uint64_t total_supply);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_ft_params_set_with_minting_nft(
+    kth_cashtoken_ft_params_mut_t self, kth_bool_t with_minting_nft);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_ft_params_set_fee_utxos(
+    kth_cashtoken_ft_params_mut_t self, kth_utxo_list_const_t fee_utxos);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_ft_params_set_change_address(
+    kth_cashtoken_ft_params_mut_t self, kth_payment_address_const_t change_address);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_ft_params_set_script_flags(
+    kth_cashtoken_ft_params_mut_t self, uint64_t script_flags);
+
+KTH_EXPORT
+kth_error_code_t kth_wallet_cashtoken_create_ft(
+    kth_cashtoken_ft_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_genesis_result_mut_t* out);
+
+
+// ---------------------------------------------------------------------------
+// nft_collection_params / nft_collection_result / create_nft_collection
+// ---------------------------------------------------------------------------
+
+KTH_EXPORT KTH_OWNED
+kth_cashtoken_nft_collection_params_mut_t kth_wallet_cashtoken_nft_collection_params_construct_default(void);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_destruct(
+    kth_cashtoken_nft_collection_params_mut_t self);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_set_genesis_utxo(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_utxo_const_t genesis_utxo);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_set_nfts(
+    kth_cashtoken_nft_collection_params_mut_t self,
+    kth_cashtoken_nft_collection_item_list_const_t nfts);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_set_creator_address(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_payment_address_const_t creator_address);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_set_keep_minting_token(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_bool_t keep_minting_token);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_set_ft_amount(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_set_fee_utxos(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_utxo_list_const_t fee_utxos);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_set_change_address(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_payment_address_const_t change_address);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_set_batch_size(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_size_t batch_size);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_params_set_script_flags(
+    kth_cashtoken_nft_collection_params_mut_t self, uint64_t script_flags);
+
+KTH_EXPORT
+kth_error_code_t kth_wallet_cashtoken_create_nft_collection(
+    kth_cashtoken_nft_collection_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_nft_collection_result_mut_t* out);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_result_destruct(
+    kth_cashtoken_nft_collection_result_mut_t self);
+
+KTH_EXPORT
+kth_transaction_const_t kth_wallet_cashtoken_nft_collection_result_genesis_transaction(
+    kth_cashtoken_nft_collection_result_const_t self);
+
+KTH_EXPORT
+kth_size_t kth_wallet_cashtoken_nft_collection_result_genesis_signing_indices_count(
+    kth_cashtoken_nft_collection_result_const_t self);
+
+KTH_EXPORT
+uint32_t kth_wallet_cashtoken_nft_collection_result_genesis_signing_index_nth(
+    kth_cashtoken_nft_collection_result_const_t self, kth_size_t index);
+
+KTH_EXPORT
+void kth_wallet_cashtoken_nft_collection_result_category_id(
+    kth_cashtoken_nft_collection_result_const_t self, uint8_t* out_hash);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_cashtoken_nft_collection_result_final_burn(
+    kth_cashtoken_nft_collection_result_const_t self);
+
+/** Number of mint batches. */
+KTH_EXPORT
+kth_size_t kth_wallet_cashtoken_nft_collection_result_batches_count(
+    kth_cashtoken_nft_collection_result_const_t self);
+
+/**
+ * Returns a borrowed view of a batch's mint-requests list. Caller must
+ * NOT destruct this list — it's owned by the parent result handle and
+ * invalidated when the result is destructed.
+ */
+KTH_EXPORT
+kth_cashtoken_nft_mint_request_list_const_t kth_wallet_cashtoken_nft_collection_result_batch_mint_requests(
+    kth_cashtoken_nft_collection_result_const_t self, kth_size_t batch_index);
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_CASHTOKEN_MINTING_H_

--- a/src/c-api/src/wallet/cashtoken_minting.cpp
+++ b/src/c-api/src/wallet/cashtoken_minting.cpp
@@ -1,0 +1,1086 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/cashtoken_minting.h>
+
+#include <cstring>
+#include <utility>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/chain/token_data.hpp>
+#include <kth/domain/chain/transaction.hpp>
+#include <kth/domain/chain/utxo.hpp>
+#include <kth/domain/wallet/cashtoken_minting.hpp>
+#include <kth/domain/wallet/payment_address.hpp>
+#include <kth/infrastructure/error.hpp>
+
+namespace ct = kth::domain::wallet::cashtoken;
+
+extern "C" {
+
+// ---------------------------------------------------------------------------
+// encode_nft_number
+// ---------------------------------------------------------------------------
+
+kth_error_code_t kth_wallet_cashtoken_encode_nft_number(
+    int64_t value,
+    uint8_t** out_data,
+    kth_size_t* out_size
+) {
+    KTH_PRECONDITION(out_data != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto r = ct::encode_nft_number(value);
+    if ( ! r.has_value()) return kth::to_c_err(r.error());
+    *out_data = kth::create_c_array(*r, *out_size);
+    return kth_ec_success;
+}
+
+// ---------------------------------------------------------------------------
+// Output factories
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Shared helper to turn a (ptr, size) commitment pair into data_chunk.
+//
+// `(data == nullptr, n == 0)` is valid and means "empty commitment".
+// `(data == nullptr, n >  0)` is a caller bug — silently folding it to
+// an empty commitment would produce a valid-looking TX with the wrong
+// NFT commitment, so we trip the precondition instead of dropping the
+// bytes.
+kth::data_chunk commitment_from(uint8_t const* data, kth_size_t n) {
+    if (n == 0) return kth::data_chunk{};
+    KTH_PRECONDITION(data != nullptr);
+    return kth::data_chunk(data, data + kth::sz(n));
+}
+
+// Copies a kth_utxo_list_const_t handle into a fresh C++ vector. NULL
+// list is interpreted as "empty vector" — the only way the C caller
+// can express "no fee UTXOs" at this ABI.
+std::vector<kth::domain::chain::utxo>
+copy_utxo_list(kth_utxo_list_const_t list) {
+    if (list == nullptr) return {};
+    return kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(list);
+}
+
+// Wraps a nullable address handle in std::optional. NULL → nullopt.
+std::optional<kth::domain::wallet::payment_address>
+optional_addr(kth_payment_address_const_t addr) {
+    if (addr == nullptr) return std::nullopt;
+    return kth::cpp_ref<kth::domain::wallet::payment_address>(addr);
+}
+
+} // namespace
+
+kth_output_mut_t kth_wallet_cashtoken_create_ft_output(
+    kth_payment_address_const_t destination,
+    uint8_t const* category_id,
+    uint64_t ft_amount,
+    uint64_t satoshis
+) {
+    KTH_PRECONDITION(destination != nullptr);
+    KTH_PRECONDITION(category_id != nullptr);
+    auto const& dest_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+    auto const cat_cpp = kth::hash_to_cpp(category_id);
+    return kth::leak(ct::create_ft_output(dest_cpp, cat_cpp, ft_amount, satoshis));
+}
+
+kth_output_mut_t kth_wallet_cashtoken_create_nft_output(
+    kth_payment_address_const_t destination,
+    uint8_t const* category_id,
+    kth_token_capability_t capability,
+    uint8_t const* commitment,
+    kth_size_t commitment_n,
+    uint64_t satoshis
+) {
+    KTH_PRECONDITION(destination != nullptr);
+    KTH_PRECONDITION(category_id != nullptr);
+    auto const& dest_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+    auto const cat_cpp = kth::hash_to_cpp(category_id);
+    auto const cap_cpp = static_cast<kth::domain::chain::capability_t>(capability);
+    return kth::leak(ct::create_nft_output(
+        dest_cpp, cat_cpp, cap_cpp,
+        commitment_from(commitment, commitment_n),
+        satoshis));
+}
+
+kth_output_mut_t kth_wallet_cashtoken_create_combined_token_output(
+    kth_payment_address_const_t destination,
+    uint8_t const* category_id,
+    uint64_t ft_amount,
+    kth_token_capability_t capability,
+    uint8_t const* commitment,
+    kth_size_t commitment_n,
+    uint64_t satoshis
+) {
+    KTH_PRECONDITION(destination != nullptr);
+    KTH_PRECONDITION(category_id != nullptr);
+    auto const& dest_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+    auto const cat_cpp = kth::hash_to_cpp(category_id);
+    auto const cap_cpp = static_cast<kth::domain::chain::capability_t>(capability);
+    return kth::leak(ct::create_combined_token_output(
+        dest_cpp, cat_cpp, ft_amount, cap_cpp,
+        commitment_from(commitment, commitment_n),
+        satoshis));
+}
+
+// ---------------------------------------------------------------------------
+// nft_spec
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_nft_spec_mut_t kth_wallet_cashtoken_nft_spec_construct(
+    kth_token_capability_t capability,
+    uint8_t const* commitment,
+    kth_size_t commitment_n
+) {
+    ct::nft_spec s;
+    s.capability = static_cast<kth::domain::chain::capability_t>(capability);
+    s.commitment = commitment_from(commitment, commitment_n);
+    return kth::leak(std::move(s));
+}
+
+void kth_wallet_cashtoken_nft_spec_destruct(kth_cashtoken_nft_spec_mut_t self) {
+    kth::del<ct::nft_spec>(self);
+}
+
+// ---------------------------------------------------------------------------
+// nft_mint_request
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_nft_mint_request_mut_t kth_wallet_cashtoken_nft_mint_request_construct(
+    kth_payment_address_const_t destination,
+    uint8_t const* commitment,
+    kth_size_t commitment_n,
+    kth_token_capability_t capability,
+    uint64_t satoshis
+) {
+    KTH_PRECONDITION(destination != nullptr);
+    ct::nft_mint_request r;
+    r.destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+    r.commitment = commitment_from(commitment, commitment_n);
+    r.capability = static_cast<kth::domain::chain::capability_t>(capability);
+    r.satoshis = satoshis;
+    return kth::leak(std::move(r));
+}
+
+void kth_wallet_cashtoken_nft_mint_request_destruct(
+    kth_cashtoken_nft_mint_request_mut_t self
+) {
+    kth::del<ct::nft_mint_request>(self);
+}
+
+// --- list ---
+
+kth_cashtoken_nft_mint_request_list_mut_t
+kth_wallet_cashtoken_nft_mint_request_list_construct_default(void) {
+    return kth::leak<std::vector<ct::nft_mint_request>>();
+}
+
+void kth_wallet_cashtoken_nft_mint_request_list_push_back(
+    kth_cashtoken_nft_mint_request_list_mut_t list,
+    kth_cashtoken_nft_mint_request_const_t elem
+) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    auto& l = kth::cpp_ref<std::vector<ct::nft_mint_request>>(list);
+    l.push_back(kth::cpp_ref<ct::nft_mint_request>(elem));
+}
+
+void kth_wallet_cashtoken_nft_mint_request_list_destruct(
+    kth_cashtoken_nft_mint_request_list_mut_t list
+) {
+    kth::del<std::vector<ct::nft_mint_request>>(list);
+}
+
+kth_size_t kth_wallet_cashtoken_nft_mint_request_list_count(
+    kth_cashtoken_nft_mint_request_list_const_t list
+) {
+    if (list == nullptr) return 0;
+    return kth::cpp_ref<std::vector<ct::nft_mint_request>>(list).size();
+}
+
+kth_cashtoken_nft_mint_request_const_t kth_wallet_cashtoken_nft_mint_request_list_nth(
+    kth_cashtoken_nft_mint_request_list_const_t list, kth_size_t index
+) {
+    KTH_PRECONDITION(list != nullptr);
+    auto const& l = kth::cpp_ref<std::vector<ct::nft_mint_request>>(list);
+    KTH_PRECONDITION(kth::sz(index) < l.size());
+    return &l[kth::sz(index)];
+}
+
+// ---------------------------------------------------------------------------
+// nft_collection_item
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_nft_collection_item_mut_t kth_wallet_cashtoken_nft_collection_item_construct(
+    uint8_t const* commitment,
+    kth_size_t commitment_n,
+    kth_payment_address_const_t destination
+) {
+    ct::nft_collection_item item;
+    item.commitment = commitment_from(commitment, commitment_n);
+    if (destination != nullptr) {
+        item.destination = kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+    }
+    return kth::leak(std::move(item));
+}
+
+void kth_wallet_cashtoken_nft_collection_item_destruct(
+    kth_cashtoken_nft_collection_item_mut_t self
+) {
+    kth::del<ct::nft_collection_item>(self);
+}
+
+// --- list ---
+
+kth_cashtoken_nft_collection_item_list_mut_t
+kth_wallet_cashtoken_nft_collection_item_list_construct_default(void) {
+    return kth::leak<std::vector<ct::nft_collection_item>>();
+}
+
+void kth_wallet_cashtoken_nft_collection_item_list_push_back(
+    kth_cashtoken_nft_collection_item_list_mut_t list,
+    kth_cashtoken_nft_collection_item_const_t elem
+) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(elem != nullptr);
+    auto& l = kth::cpp_ref<std::vector<ct::nft_collection_item>>(list);
+    l.push_back(kth::cpp_ref<ct::nft_collection_item>(elem));
+}
+
+void kth_wallet_cashtoken_nft_collection_item_list_destruct(
+    kth_cashtoken_nft_collection_item_list_mut_t list
+) {
+    kth::del<std::vector<ct::nft_collection_item>>(list);
+}
+
+kth_size_t kth_wallet_cashtoken_nft_collection_item_list_count(
+    kth_cashtoken_nft_collection_item_list_const_t list
+) {
+    if (list == nullptr) return 0;
+    return kth::cpp_ref<std::vector<ct::nft_collection_item>>(list).size();
+}
+
+kth_cashtoken_nft_collection_item_const_t kth_wallet_cashtoken_nft_collection_item_list_nth(
+    kth_cashtoken_nft_collection_item_list_const_t list, kth_size_t index
+) {
+    KTH_PRECONDITION(list != nullptr);
+    auto const& l = kth::cpp_ref<std::vector<ct::nft_collection_item>>(list);
+    KTH_PRECONDITION(kth::sz(index) < l.size());
+    return &l[kth::sz(index)];
+}
+
+// ---------------------------------------------------------------------------
+// prepare_genesis_params / prepare_genesis_result
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_prepare_genesis_params_mut_t
+kth_wallet_cashtoken_prepare_genesis_params_construct_default(void) {
+    return kth::leak<ct::prepare_genesis_params>();
+}
+
+void kth_wallet_cashtoken_prepare_genesis_params_destruct(
+    kth_cashtoken_prepare_genesis_params_mut_t self
+) {
+    kth::del<ct::prepare_genesis_params>(self);
+}
+
+void kth_wallet_cashtoken_prepare_genesis_params_set_utxo(
+    kth_cashtoken_prepare_genesis_params_mut_t self, kth_utxo_const_t utxo
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(utxo != nullptr);
+    kth::cpp_ref<ct::prepare_genesis_params>(self).utxo =
+        kth::cpp_ref<kth::domain::chain::utxo>(utxo);
+}
+
+void kth_wallet_cashtoken_prepare_genesis_params_set_destination(
+    kth_cashtoken_prepare_genesis_params_mut_t self, kth_payment_address_const_t destination
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
+    kth::cpp_ref<ct::prepare_genesis_params>(self).destination =
+        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+}
+
+void kth_wallet_cashtoken_prepare_genesis_params_set_satoshis(
+    kth_cashtoken_prepare_genesis_params_mut_t self, uint64_t satoshis
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::prepare_genesis_params>(self).satoshis = satoshis;
+}
+
+void kth_wallet_cashtoken_prepare_genesis_params_set_change_address(
+    kth_cashtoken_prepare_genesis_params_mut_t self, kth_payment_address_const_t change_address
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::prepare_genesis_params>(self).change_address = optional_addr(change_address);
+}
+
+kth_error_code_t kth_wallet_cashtoken_prepare_genesis_utxo(
+    kth_cashtoken_prepare_genesis_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_prepare_genesis_result_mut_t* out
+) {
+    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto r = ct::prepare_genesis_utxo(kth::cpp_ref<ct::prepare_genesis_params>(params));
+    if ( ! r.has_value()) return kth::to_c_err(r.error());
+    *out = kth::leak(std::move(*r));
+    return kth_ec_success;
+}
+
+void kth_wallet_cashtoken_prepare_genesis_result_destruct(
+    kth_cashtoken_prepare_genesis_result_mut_t self
+) {
+    kth::del<ct::prepare_genesis_result>(self);
+}
+
+kth_transaction_const_t kth_wallet_cashtoken_prepare_genesis_result_transaction(
+    kth_cashtoken_prepare_genesis_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return &kth::cpp_ref<ct::prepare_genesis_result>(self).transaction;
+}
+
+kth_size_t kth_wallet_cashtoken_prepare_genesis_result_signing_indices_count(
+    kth_cashtoken_prepare_genesis_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<ct::prepare_genesis_result>(self).signing_indices.size();
+}
+
+uint32_t kth_wallet_cashtoken_prepare_genesis_result_signing_index_nth(
+    kth_cashtoken_prepare_genesis_result_const_t self, kth_size_t index
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const& v = kth::cpp_ref<ct::prepare_genesis_result>(self).signing_indices;
+    KTH_PRECONDITION(kth::sz(index) < v.size());
+    return v[kth::sz(index)];
+}
+
+// ---------------------------------------------------------------------------
+// token_genesis_params / token_genesis_result / create_token_genesis
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_token_genesis_params_mut_t
+kth_wallet_cashtoken_token_genesis_params_construct_default(void) {
+    return kth::leak<ct::token_genesis_params>();
+}
+
+void kth_wallet_cashtoken_token_genesis_params_destruct(
+    kth_cashtoken_token_genesis_params_mut_t self
+) {
+    kth::del<ct::token_genesis_params>(self);
+}
+
+void kth_wallet_cashtoken_token_genesis_params_set_genesis_utxo(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_utxo_const_t genesis_utxo
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(genesis_utxo != nullptr);
+    kth::cpp_ref<ct::token_genesis_params>(self).genesis_utxo =
+        kth::cpp_ref<kth::domain::chain::utxo>(genesis_utxo);
+}
+
+void kth_wallet_cashtoken_token_genesis_params_set_destination(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_payment_address_const_t destination
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
+    kth::cpp_ref<ct::token_genesis_params>(self).destination =
+        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+}
+
+void kth_wallet_cashtoken_token_genesis_params_set_ft_amount(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::token_genesis_params>(self);
+    p.ft_amount = kth::int_to_bool(has_value) ? std::optional<uint64_t>(ft_amount) : std::nullopt;
+}
+
+void kth_wallet_cashtoken_token_genesis_params_set_nft(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_cashtoken_nft_spec_const_t nft
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::token_genesis_params>(self);
+    p.nft = nft == nullptr
+        ? std::nullopt
+        : std::optional<ct::nft_spec>(kth::cpp_ref<ct::nft_spec>(nft));
+}
+
+void kth_wallet_cashtoken_token_genesis_params_set_satoshis(
+    kth_cashtoken_token_genesis_params_mut_t self, uint64_t satoshis
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_genesis_params>(self).satoshis = satoshis;
+}
+
+void kth_wallet_cashtoken_token_genesis_params_set_fee_utxos(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_utxo_list_const_t fee_utxos
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_genesis_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
+}
+
+void kth_wallet_cashtoken_token_genesis_params_set_change_address(
+    kth_cashtoken_token_genesis_params_mut_t self, kth_payment_address_const_t change_address
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_genesis_params>(self).change_address = optional_addr(change_address);
+}
+
+void kth_wallet_cashtoken_token_genesis_params_set_script_flags(
+    kth_cashtoken_token_genesis_params_mut_t self, uint64_t script_flags
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_genesis_params>(self).script_flags = script_flags;
+}
+
+kth_error_code_t kth_wallet_cashtoken_create_token_genesis(
+    kth_cashtoken_token_genesis_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_genesis_result_mut_t* out
+) {
+    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto r = ct::create_token_genesis(kth::cpp_ref<ct::token_genesis_params>(params));
+    if ( ! r.has_value()) return kth::to_c_err(r.error());
+    *out = kth::leak(std::move(*r));
+    return kth_ec_success;
+}
+
+void kth_wallet_cashtoken_token_genesis_result_destruct(
+    kth_cashtoken_token_genesis_result_mut_t self
+) {
+    kth::del<ct::token_genesis_result>(self);
+}
+
+kth_transaction_const_t kth_wallet_cashtoken_token_genesis_result_transaction(
+    kth_cashtoken_token_genesis_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return &kth::cpp_ref<ct::token_genesis_result>(self).transaction;
+}
+
+void kth_wallet_cashtoken_token_genesis_result_category_id(
+    kth_cashtoken_token_genesis_result_const_t self, uint8_t* out_hash
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_hash != nullptr);
+    auto const& id = kth::cpp_ref<ct::token_genesis_result>(self).category_id;
+    std::memcpy(out_hash, id.data(), id.size());
+}
+
+kth_size_t kth_wallet_cashtoken_token_genesis_result_signing_indices_count(
+    kth_cashtoken_token_genesis_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<ct::token_genesis_result>(self).signing_indices.size();
+}
+
+uint32_t kth_wallet_cashtoken_token_genesis_result_signing_index_nth(
+    kth_cashtoken_token_genesis_result_const_t self, kth_size_t index
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const& v = kth::cpp_ref<ct::token_genesis_result>(self).signing_indices;
+    KTH_PRECONDITION(kth::sz(index) < v.size());
+    return v[kth::sz(index)];
+}
+
+// ---------------------------------------------------------------------------
+// token_mint_params / token_mint_result / create_token_mint
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_token_mint_params_mut_t
+kth_wallet_cashtoken_token_mint_params_construct_default(void) {
+    return kth::leak<ct::token_mint_params>();
+}
+
+void kth_wallet_cashtoken_token_mint_params_destruct(
+    kth_cashtoken_token_mint_params_mut_t self
+) {
+    kth::del<ct::token_mint_params>(self);
+}
+
+void kth_wallet_cashtoken_token_mint_params_set_minting_utxo(
+    kth_cashtoken_token_mint_params_mut_t self, kth_utxo_const_t minting_utxo
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(minting_utxo != nullptr);
+    kth::cpp_ref<ct::token_mint_params>(self).minting_utxo =
+        kth::cpp_ref<kth::domain::chain::utxo>(minting_utxo);
+}
+
+void kth_wallet_cashtoken_token_mint_params_set_nfts(
+    kth_cashtoken_token_mint_params_mut_t self,
+    kth_cashtoken_nft_mint_request_list_const_t nfts
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::token_mint_params>(self);
+    p.nfts = nfts == nullptr
+        ? std::vector<ct::nft_mint_request>{}
+        : kth::cpp_ref<std::vector<ct::nft_mint_request>>(nfts);
+}
+
+void kth_wallet_cashtoken_token_mint_params_set_new_minting_commitment(
+    kth_cashtoken_token_mint_params_mut_t self,
+    uint8_t const* commitment, kth_size_t commitment_n
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::token_mint_params>(self);
+    p.new_minting_commitment = commitment == nullptr
+        ? std::nullopt
+        : std::optional<kth::data_chunk>(commitment_from(commitment, commitment_n));
+}
+
+void kth_wallet_cashtoken_token_mint_params_set_minting_destination(
+    kth_cashtoken_token_mint_params_mut_t self,
+    kth_payment_address_const_t minting_destination
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(minting_destination != nullptr);
+    kth::cpp_ref<ct::token_mint_params>(self).minting_destination =
+        kth::cpp_ref<kth::domain::wallet::payment_address>(minting_destination);
+}
+
+void kth_wallet_cashtoken_token_mint_params_set_fee_utxos(
+    kth_cashtoken_token_mint_params_mut_t self, kth_utxo_list_const_t fee_utxos
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_mint_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
+}
+
+void kth_wallet_cashtoken_token_mint_params_set_change_address(
+    kth_cashtoken_token_mint_params_mut_t self,
+    kth_payment_address_const_t change_address
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_mint_params>(self).change_address = optional_addr(change_address);
+}
+
+void kth_wallet_cashtoken_token_mint_params_set_script_flags(
+    kth_cashtoken_token_mint_params_mut_t self, uint64_t script_flags
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_mint_params>(self).script_flags = script_flags;
+}
+
+kth_error_code_t kth_wallet_cashtoken_create_token_mint(
+    kth_cashtoken_token_mint_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_mint_result_mut_t* out
+) {
+    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto r = ct::create_token_mint(kth::cpp_ref<ct::token_mint_params>(params));
+    if ( ! r.has_value()) return kth::to_c_err(r.error());
+    *out = kth::leak(std::move(*r));
+    return kth_ec_success;
+}
+
+void kth_wallet_cashtoken_token_mint_result_destruct(
+    kth_cashtoken_token_mint_result_mut_t self
+) {
+    kth::del<ct::token_mint_result>(self);
+}
+
+kth_transaction_const_t kth_wallet_cashtoken_token_mint_result_transaction(
+    kth_cashtoken_token_mint_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return &kth::cpp_ref<ct::token_mint_result>(self).transaction;
+}
+
+kth_size_t kth_wallet_cashtoken_token_mint_result_signing_indices_count(
+    kth_cashtoken_token_mint_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<ct::token_mint_result>(self).signing_indices.size();
+}
+
+uint32_t kth_wallet_cashtoken_token_mint_result_signing_index_nth(
+    kth_cashtoken_token_mint_result_const_t self, kth_size_t index
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const& v = kth::cpp_ref<ct::token_mint_result>(self).signing_indices;
+    KTH_PRECONDITION(kth::sz(index) < v.size());
+    return v[kth::sz(index)];
+}
+
+kth_size_t kth_wallet_cashtoken_token_mint_result_minted_output_indices_count(
+    kth_cashtoken_token_mint_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<ct::token_mint_result>(self).minted_output_indices.size();
+}
+
+uint32_t kth_wallet_cashtoken_token_mint_result_minted_output_index_nth(
+    kth_cashtoken_token_mint_result_const_t self, kth_size_t index
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const& v = kth::cpp_ref<ct::token_mint_result>(self).minted_output_indices;
+    KTH_PRECONDITION(kth::sz(index) < v.size());
+    return v[kth::sz(index)];
+}
+
+// ---------------------------------------------------------------------------
+// token_transfer_params / create_token_transfer
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_token_transfer_params_mut_t
+kth_wallet_cashtoken_token_transfer_params_construct_default(void) {
+    return kth::leak<ct::token_transfer_params>();
+}
+
+void kth_wallet_cashtoken_token_transfer_params_destruct(
+    kth_cashtoken_token_transfer_params_mut_t self
+) {
+    kth::del<ct::token_transfer_params>(self);
+}
+
+void kth_wallet_cashtoken_token_transfer_params_set_token_utxos(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_utxo_list_const_t token_utxos
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_transfer_params>(self).token_utxos = copy_utxo_list(token_utxos);
+}
+
+void kth_wallet_cashtoken_token_transfer_params_set_destination(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t destination
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
+    kth::cpp_ref<ct::token_transfer_params>(self).destination =
+        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+}
+
+void kth_wallet_cashtoken_token_transfer_params_set_ft_amount(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::token_transfer_params>(self);
+    p.ft_amount = kth::int_to_bool(has_value) ? std::optional<uint64_t>(ft_amount) : std::nullopt;
+}
+
+void kth_wallet_cashtoken_token_transfer_params_set_nft(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_cashtoken_nft_spec_const_t nft
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::token_transfer_params>(self);
+    p.nft = nft == nullptr
+        ? std::nullopt
+        : std::optional<ct::nft_spec>(kth::cpp_ref<ct::nft_spec>(nft));
+}
+
+void kth_wallet_cashtoken_token_transfer_params_set_fee_utxos(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_utxo_list_const_t fee_utxos
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_transfer_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
+}
+
+void kth_wallet_cashtoken_token_transfer_params_set_token_change_address(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t addr
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_transfer_params>(self).token_change_address = optional_addr(addr);
+}
+
+void kth_wallet_cashtoken_token_transfer_params_set_bch_change_address(
+    kth_cashtoken_token_transfer_params_mut_t self, kth_payment_address_const_t addr
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_transfer_params>(self).bch_change_address = optional_addr(addr);
+}
+
+void kth_wallet_cashtoken_token_transfer_params_set_satoshis(
+    kth_cashtoken_token_transfer_params_mut_t self, uint64_t satoshis
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_transfer_params>(self).satoshis = satoshis;
+}
+
+kth_error_code_t kth_wallet_cashtoken_create_token_transfer(
+    kth_cashtoken_token_transfer_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_tx_result_mut_t* out
+) {
+    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto r = ct::create_token_transfer(kth::cpp_ref<ct::token_transfer_params>(params));
+    if ( ! r.has_value()) return kth::to_c_err(r.error());
+    *out = kth::leak(std::move(*r));
+    return kth_ec_success;
+}
+
+// ---------------------------------------------------------------------------
+// token_burn_params / create_token_burn
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_token_burn_params_mut_t
+kth_wallet_cashtoken_token_burn_params_construct_default(void) {
+    return kth::leak<ct::token_burn_params>();
+}
+
+void kth_wallet_cashtoken_token_burn_params_destruct(
+    kth_cashtoken_token_burn_params_mut_t self
+) {
+    kth::del<ct::token_burn_params>(self);
+}
+
+void kth_wallet_cashtoken_token_burn_params_set_token_utxo(
+    kth_cashtoken_token_burn_params_mut_t self, kth_utxo_const_t token_utxo
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(token_utxo != nullptr);
+    kth::cpp_ref<ct::token_burn_params>(self).token_utxo =
+        kth::cpp_ref<kth::domain::chain::utxo>(token_utxo);
+}
+
+void kth_wallet_cashtoken_token_burn_params_set_burn_ft_amount(
+    kth_cashtoken_token_burn_params_mut_t self, kth_bool_t has_value, uint64_t burn_ft_amount
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::token_burn_params>(self);
+    p.burn_ft_amount = kth::int_to_bool(has_value)
+        ? std::optional<uint64_t>(burn_ft_amount)
+        : std::nullopt;
+}
+
+void kth_wallet_cashtoken_token_burn_params_set_burn_nft(
+    kth_cashtoken_token_burn_params_mut_t self, kth_bool_t burn_nft
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_burn_params>(self).burn_nft = kth::int_to_bool(burn_nft);
+}
+
+void kth_wallet_cashtoken_token_burn_params_set_message(
+    kth_cashtoken_token_burn_params_mut_t self, char const* message
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::token_burn_params>(self);
+    p.message = message == nullptr ? std::nullopt : std::optional<std::string>(message);
+}
+
+void kth_wallet_cashtoken_token_burn_params_set_destination(
+    kth_cashtoken_token_burn_params_mut_t self, kth_payment_address_const_t destination
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
+    kth::cpp_ref<ct::token_burn_params>(self).destination =
+        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+}
+
+void kth_wallet_cashtoken_token_burn_params_set_fee_utxos(
+    kth_cashtoken_token_burn_params_mut_t self, kth_utxo_list_const_t fee_utxos
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_burn_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
+}
+
+void kth_wallet_cashtoken_token_burn_params_set_change_address(
+    kth_cashtoken_token_burn_params_mut_t self, kth_payment_address_const_t change_address
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_burn_params>(self).change_address = optional_addr(change_address);
+}
+
+void kth_wallet_cashtoken_token_burn_params_set_satoshis(
+    kth_cashtoken_token_burn_params_mut_t self, uint64_t satoshis
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::token_burn_params>(self).satoshis = satoshis;
+}
+
+kth_error_code_t kth_wallet_cashtoken_create_token_burn(
+    kth_cashtoken_token_burn_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_tx_result_mut_t* out
+) {
+    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto r = ct::create_token_burn(kth::cpp_ref<ct::token_burn_params>(params));
+    if ( ! r.has_value()) return kth::to_c_err(r.error());
+    *out = kth::leak(std::move(*r));
+    return kth_ec_success;
+}
+
+// ---------------------------------------------------------------------------
+// token_tx_result (shared by transfer / burn)
+// ---------------------------------------------------------------------------
+
+void kth_wallet_cashtoken_token_tx_result_destruct(
+    kth_cashtoken_token_tx_result_mut_t self
+) {
+    kth::del<ct::token_tx_result>(self);
+}
+
+kth_transaction_const_t kth_wallet_cashtoken_token_tx_result_transaction(
+    kth_cashtoken_token_tx_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return &kth::cpp_ref<ct::token_tx_result>(self).transaction;
+}
+
+kth_size_t kth_wallet_cashtoken_token_tx_result_signing_indices_count(
+    kth_cashtoken_token_tx_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<ct::token_tx_result>(self).signing_indices.size();
+}
+
+uint32_t kth_wallet_cashtoken_token_tx_result_signing_index_nth(
+    kth_cashtoken_token_tx_result_const_t self, kth_size_t index
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const& v = kth::cpp_ref<ct::token_tx_result>(self).signing_indices;
+    KTH_PRECONDITION(kth::sz(index) < v.size());
+    return v[kth::sz(index)];
+}
+
+// ---------------------------------------------------------------------------
+// ft_params / create_ft
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_ft_params_mut_t kth_wallet_cashtoken_ft_params_construct_default(void) {
+    return kth::leak<ct::ft_params>();
+}
+
+void kth_wallet_cashtoken_ft_params_destruct(kth_cashtoken_ft_params_mut_t self) {
+    kth::del<ct::ft_params>(self);
+}
+
+void kth_wallet_cashtoken_ft_params_set_genesis_utxo(
+    kth_cashtoken_ft_params_mut_t self, kth_utxo_const_t genesis_utxo
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(genesis_utxo != nullptr);
+    kth::cpp_ref<ct::ft_params>(self).genesis_utxo =
+        kth::cpp_ref<kth::domain::chain::utxo>(genesis_utxo);
+}
+
+void kth_wallet_cashtoken_ft_params_set_destination(
+    kth_cashtoken_ft_params_mut_t self, kth_payment_address_const_t destination
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(destination != nullptr);
+    kth::cpp_ref<ct::ft_params>(self).destination =
+        kth::cpp_ref<kth::domain::wallet::payment_address>(destination);
+}
+
+void kth_wallet_cashtoken_ft_params_set_total_supply(
+    kth_cashtoken_ft_params_mut_t self, uint64_t total_supply
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::ft_params>(self).total_supply = total_supply;
+}
+
+void kth_wallet_cashtoken_ft_params_set_with_minting_nft(
+    kth_cashtoken_ft_params_mut_t self, kth_bool_t with_minting_nft
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::ft_params>(self).with_minting_nft = kth::int_to_bool(with_minting_nft);
+}
+
+void kth_wallet_cashtoken_ft_params_set_fee_utxos(
+    kth_cashtoken_ft_params_mut_t self, kth_utxo_list_const_t fee_utxos
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::ft_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
+}
+
+void kth_wallet_cashtoken_ft_params_set_change_address(
+    kth_cashtoken_ft_params_mut_t self, kth_payment_address_const_t change_address
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::ft_params>(self).change_address = optional_addr(change_address);
+}
+
+void kth_wallet_cashtoken_ft_params_set_script_flags(
+    kth_cashtoken_ft_params_mut_t self, uint64_t script_flags
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::ft_params>(self).script_flags = script_flags;
+}
+
+kth_error_code_t kth_wallet_cashtoken_create_ft(
+    kth_cashtoken_ft_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_token_genesis_result_mut_t* out
+) {
+    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto r = ct::create_ft(kth::cpp_ref<ct::ft_params>(params));
+    if ( ! r.has_value()) return kth::to_c_err(r.error());
+    *out = kth::leak(std::move(*r));
+    return kth_ec_success;
+}
+
+// ---------------------------------------------------------------------------
+// nft_collection_params / nft_collection_result / create_nft_collection
+// ---------------------------------------------------------------------------
+
+kth_cashtoken_nft_collection_params_mut_t
+kth_wallet_cashtoken_nft_collection_params_construct_default(void) {
+    return kth::leak<ct::nft_collection_params>();
+}
+
+void kth_wallet_cashtoken_nft_collection_params_destruct(
+    kth_cashtoken_nft_collection_params_mut_t self
+) {
+    kth::del<ct::nft_collection_params>(self);
+}
+
+void kth_wallet_cashtoken_nft_collection_params_set_genesis_utxo(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_utxo_const_t genesis_utxo
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(genesis_utxo != nullptr);
+    kth::cpp_ref<ct::nft_collection_params>(self).genesis_utxo =
+        kth::cpp_ref<kth::domain::chain::utxo>(genesis_utxo);
+}
+
+void kth_wallet_cashtoken_nft_collection_params_set_nfts(
+    kth_cashtoken_nft_collection_params_mut_t self,
+    kth_cashtoken_nft_collection_item_list_const_t nfts
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::nft_collection_params>(self);
+    p.nfts = nfts == nullptr
+        ? std::vector<ct::nft_collection_item>{}
+        : kth::cpp_ref<std::vector<ct::nft_collection_item>>(nfts);
+}
+
+void kth_wallet_cashtoken_nft_collection_params_set_creator_address(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_payment_address_const_t creator_address
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(creator_address != nullptr);
+    kth::cpp_ref<ct::nft_collection_params>(self).creator_address =
+        kth::cpp_ref<kth::domain::wallet::payment_address>(creator_address);
+}
+
+void kth_wallet_cashtoken_nft_collection_params_set_keep_minting_token(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_bool_t keep_minting_token
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::nft_collection_params>(self).keep_minting_token =
+        kth::int_to_bool(keep_minting_token);
+}
+
+void kth_wallet_cashtoken_nft_collection_params_set_ft_amount(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_bool_t has_value, uint64_t ft_amount
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& p = kth::cpp_ref<ct::nft_collection_params>(self);
+    p.ft_amount = kth::int_to_bool(has_value) ? std::optional<uint64_t>(ft_amount) : std::nullopt;
+}
+
+void kth_wallet_cashtoken_nft_collection_params_set_fee_utxos(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_utxo_list_const_t fee_utxos
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::nft_collection_params>(self).fee_utxos = copy_utxo_list(fee_utxos);
+}
+
+void kth_wallet_cashtoken_nft_collection_params_set_change_address(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_payment_address_const_t change_address
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::nft_collection_params>(self).change_address = optional_addr(change_address);
+}
+
+void kth_wallet_cashtoken_nft_collection_params_set_batch_size(
+    kth_cashtoken_nft_collection_params_mut_t self, kth_size_t batch_size
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::nft_collection_params>(self).batch_size = kth::sz(batch_size);
+}
+
+void kth_wallet_cashtoken_nft_collection_params_set_script_flags(
+    kth_cashtoken_nft_collection_params_mut_t self, uint64_t script_flags
+) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<ct::nft_collection_params>(self).script_flags = script_flags;
+}
+
+kth_error_code_t kth_wallet_cashtoken_create_nft_collection(
+    kth_cashtoken_nft_collection_params_const_t params,
+    KTH_OUT_OWNED kth_cashtoken_nft_collection_result_mut_t* out
+) {
+    KTH_PRECONDITION(params != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto r = ct::create_nft_collection(kth::cpp_ref<ct::nft_collection_params>(params));
+    if ( ! r.has_value()) return kth::to_c_err(r.error());
+    *out = kth::leak(std::move(*r));
+    return kth_ec_success;
+}
+
+void kth_wallet_cashtoken_nft_collection_result_destruct(
+    kth_cashtoken_nft_collection_result_mut_t self
+) {
+    kth::del<ct::nft_collection_result>(self);
+}
+
+kth_transaction_const_t kth_wallet_cashtoken_nft_collection_result_genesis_transaction(
+    kth_cashtoken_nft_collection_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return &kth::cpp_ref<ct::nft_collection_result>(self).genesis_transaction;
+}
+
+kth_size_t kth_wallet_cashtoken_nft_collection_result_genesis_signing_indices_count(
+    kth_cashtoken_nft_collection_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<ct::nft_collection_result>(self).genesis_signing_indices.size();
+}
+
+uint32_t kth_wallet_cashtoken_nft_collection_result_genesis_signing_index_nth(
+    kth_cashtoken_nft_collection_result_const_t self, kth_size_t index
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const& v = kth::cpp_ref<ct::nft_collection_result>(self).genesis_signing_indices;
+    KTH_PRECONDITION(kth::sz(index) < v.size());
+    return v[kth::sz(index)];
+}
+
+void kth_wallet_cashtoken_nft_collection_result_category_id(
+    kth_cashtoken_nft_collection_result_const_t self, uint8_t* out_hash
+) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_hash != nullptr);
+    auto const& id = kth::cpp_ref<ct::nft_collection_result>(self).category_id;
+    std::memcpy(out_hash, id.data(), id.size());
+}
+
+kth_bool_t kth_wallet_cashtoken_nft_collection_result_final_burn(
+    kth_cashtoken_nft_collection_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<ct::nft_collection_result>(self).final_burn);
+}
+
+kth_size_t kth_wallet_cashtoken_nft_collection_result_batches_count(
+    kth_cashtoken_nft_collection_result_const_t self
+) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<ct::nft_collection_result>(self).batches.size();
+}
+
+kth_cashtoken_nft_mint_request_list_const_t
+kth_wallet_cashtoken_nft_collection_result_batch_mint_requests(
+    kth_cashtoken_nft_collection_result_const_t self, kth_size_t batch_index
+) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const& r = kth::cpp_ref<ct::nft_collection_result>(self);
+    KTH_PRECONDITION(kth::sz(batch_index) < r.batches.size());
+    return &r.batches[kth::sz(batch_index)].mint_requests;
+}
+
+} // extern "C"

--- a/src/c-api/test/wallet/cashtoken_minting.cpp
+++ b/src/c-api/test/wallet/cashtoken_minting.cpp
@@ -1,0 +1,315 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/chain/output.h>
+#include <kth/capi/chain/output_point.h>
+#include <kth/capi/chain/token_capability.h>
+#include <kth/capi/chain/utxo.h>
+#include <kth/capi/chain/utxo_list.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/cashtoken_minting.h>
+#include <kth/capi/wallet/payment_address.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+static uint8_t const kParentTxA[32] = {
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
+};
+
+static uint8_t const kCategoryA[32] = {
+    0xAA, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01
+};
+
+// A valid mainnet P2PKH CashAddr for use across tests. Using a real,
+// parse-able address keeps us clear of any internal preconditions in
+// the downstream builders (which reject default-constructed addresses).
+static char const* const kAddr1 =
+    "bitcoincash:qpzz8n7jp6847yyx8t33matrgcsdx6c0cvmtevrfgz";
+
+static kth_payment_address_mut_t make_addr(void) {
+    return kth_wallet_payment_address_construct_from_address(kAddr1);
+}
+
+// Build a plain BCH UTXO.
+static kth_utxo_mut_t make_bch_utxo(uint8_t const* parent, uint32_t index, uint64_t amount) {
+    kth_hash_t h;
+    memcpy(h.hash, parent, 32);
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&h, index);
+    kth_utxo_mut_t u = kth_chain_utxo_construct(op, amount, NULL);
+    kth_chain_output_point_destruct(op);
+    return u;
+}
+
+// ---------------------------------------------------------------------------
+// encode_nft_number
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API encode_nft_number - zero encodes to empty chunk",
+          "[C-API cashtoken_minting]") {
+    uint8_t* data = NULL;
+    kth_size_t n = 0;
+    kth_error_code_t ec = kth_wallet_cashtoken_encode_nft_number(0, &data, &n);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(n == 0u);
+    kth_core_destruct_array(data);
+}
+
+TEST_CASE("C-API encode_nft_number - BCHN reference vectors",
+          "[C-API cashtoken_minting]") {
+    uint8_t* data = NULL;
+    kth_size_t n = 0;
+
+    // 1 -> {0x01}
+    REQUIRE(kth_wallet_cashtoken_encode_nft_number(1, &data, &n) == kth_ec_success);
+    REQUIRE(n == 1u);
+    REQUIRE(data[0] == 0x01);
+    kth_core_destruct_array(data);
+
+    // 128 -> {0x80, 0x00}
+    data = NULL;
+    n = 0;
+    REQUIRE(kth_wallet_cashtoken_encode_nft_number(128, &data, &n) == kth_ec_success);
+    REQUIRE(n == 2u);
+    REQUIRE(data[0] == 0x80);
+    REQUIRE(data[1] == 0x00);
+    kth_core_destruct_array(data);
+
+    // 256 -> {0x00, 0x01}
+    data = NULL;
+    n = 0;
+    REQUIRE(kth_wallet_cashtoken_encode_nft_number(256, &data, &n) == kth_ec_success);
+    REQUIRE(n == 2u);
+    REQUIRE(data[0] == 0x00);
+    REQUIRE(data[1] == 0x01);
+    kth_core_destruct_array(data);
+}
+
+TEST_CASE("C-API encode_nft_number - INT64_MIN rejected distinctly from zero",
+          "[C-API cashtoken_minting]") {
+    uint8_t* data = NULL;
+    kth_size_t n = 0;
+    kth_error_code_t ec = kth_wallet_cashtoken_encode_nft_number(INT64_MIN, &data, &n);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(data == NULL);
+    REQUIRE(n == 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Output factories
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API create_ft_output - returns a valid owned output",
+          "[C-API cashtoken_minting]") {
+    kth_payment_address_mut_t addr = make_addr();
+    kth_output_mut_t out = kth_wallet_cashtoken_create_ft_output(addr, kCategoryA, 1000u, 1500u);
+    REQUIRE(out != NULL);
+    REQUIRE(kth_chain_output_value(out) == 1500u);
+    kth_chain_output_destruct(out);
+    kth_wallet_payment_address_destruct(addr);
+}
+
+TEST_CASE("C-API create_nft_output - returns a valid owned output",
+          "[C-API cashtoken_minting]") {
+    kth_payment_address_mut_t addr = make_addr();
+    uint8_t const commitment[4] = {0xDE, 0xAD, 0xBE, 0xEF};
+    kth_output_mut_t out = kth_wallet_cashtoken_create_nft_output(
+        addr, kCategoryA, kth_token_capability_mut, commitment, 4u, 1000u);
+    REQUIRE(out != NULL);
+    REQUIRE(kth_chain_output_value(out) == 1000u);
+    kth_chain_output_destruct(out);
+    kth_wallet_payment_address_destruct(addr);
+}
+
+TEST_CASE("C-API create_combined_token_output - returns a valid owned output",
+          "[C-API cashtoken_minting]") {
+    kth_payment_address_mut_t addr = make_addr();
+    uint8_t const commitment[1] = {0x01};
+    kth_output_mut_t out = kth_wallet_cashtoken_create_combined_token_output(
+        addr, kCategoryA, 5000u, kth_token_capability_minting, commitment, 1u, 1000u);
+    REQUIRE(out != NULL);
+    kth_chain_output_destruct(out);
+    kth_wallet_payment_address_destruct(addr);
+}
+
+// ---------------------------------------------------------------------------
+// prepare_genesis_utxo
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API prepare_genesis_utxo - happy path produces a result",
+          "[C-API cashtoken_minting]") {
+    kth_payment_address_mut_t dest = make_addr();
+    kth_utxo_mut_t u = make_bch_utxo(kParentTxA, 3u, 50000u);
+
+    kth_cashtoken_prepare_genesis_params_mut_t p =
+        kth_wallet_cashtoken_prepare_genesis_params_construct_default();
+    kth_wallet_cashtoken_prepare_genesis_params_set_utxo(p, u);
+    kth_wallet_cashtoken_prepare_genesis_params_set_destination(p, dest);
+    kth_wallet_cashtoken_prepare_genesis_params_set_satoshis(p, 10000u);
+
+    kth_cashtoken_prepare_genesis_result_mut_t res = NULL;
+    kth_error_code_t ec = kth_wallet_cashtoken_prepare_genesis_utxo(p, &res);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(res != NULL);
+
+    REQUIRE(kth_wallet_cashtoken_prepare_genesis_result_signing_indices_count(res) == 1u);
+    REQUIRE(kth_wallet_cashtoken_prepare_genesis_result_signing_index_nth(res, 0) == 0u);
+
+    kth_wallet_cashtoken_prepare_genesis_result_destruct(res);
+    kth_wallet_cashtoken_prepare_genesis_params_destruct(p);
+    kth_chain_utxo_destruct(u);
+    kth_wallet_payment_address_destruct(dest);
+}
+
+TEST_CASE("C-API prepare_genesis_utxo - rejects dust-level satoshis",
+          "[C-API cashtoken_minting]") {
+    kth_payment_address_mut_t dest = make_addr();
+    kth_utxo_mut_t u = make_bch_utxo(kParentTxA, 0u, 50000u);
+
+    kth_cashtoken_prepare_genesis_params_mut_t p =
+        kth_wallet_cashtoken_prepare_genesis_params_construct_default();
+    kth_wallet_cashtoken_prepare_genesis_params_set_utxo(p, u);
+    kth_wallet_cashtoken_prepare_genesis_params_set_destination(p, dest);
+    kth_wallet_cashtoken_prepare_genesis_params_set_satoshis(p, 100u); // below dust
+
+    kth_cashtoken_prepare_genesis_result_mut_t res = NULL;
+    kth_error_code_t ec = kth_wallet_cashtoken_prepare_genesis_utxo(p, &res);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(res == NULL);
+
+    kth_wallet_cashtoken_prepare_genesis_params_destruct(p);
+    kth_chain_utxo_destruct(u);
+    kth_wallet_payment_address_destruct(dest);
+}
+
+// ---------------------------------------------------------------------------
+// create_token_genesis — pure FT
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API create_token_genesis - FT-only returns category_id = parent txid",
+          "[C-API cashtoken_minting]") {
+    kth_payment_address_mut_t dest = make_addr();
+    kth_utxo_mut_t u = make_bch_utxo(kParentTxA, 0u, 50000u);
+
+    kth_cashtoken_token_genesis_params_mut_t p =
+        kth_wallet_cashtoken_token_genesis_params_construct_default();
+    kth_wallet_cashtoken_token_genesis_params_set_genesis_utxo(p, u);
+    kth_wallet_cashtoken_token_genesis_params_set_destination(p, dest);
+    kth_wallet_cashtoken_token_genesis_params_set_ft_amount(p, 1, 1000000u);
+    kth_wallet_cashtoken_token_genesis_params_set_script_flags(p, 0u);
+
+    kth_cashtoken_token_genesis_result_mut_t res = NULL;
+    kth_error_code_t ec = kth_wallet_cashtoken_create_token_genesis(p, &res);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(res != NULL);
+
+    uint8_t cat[32];
+    kth_wallet_cashtoken_token_genesis_result_category_id(res, cat);
+    REQUIRE(memcmp(cat, kParentTxA, 32) == 0);
+
+    kth_wallet_cashtoken_token_genesis_result_destruct(res);
+    kth_wallet_cashtoken_token_genesis_params_destruct(p);
+    kth_chain_utxo_destruct(u);
+    kth_wallet_payment_address_destruct(dest);
+}
+
+TEST_CASE("C-API create_token_genesis - rejects outpoint.index != 0",
+          "[C-API cashtoken_minting]") {
+    kth_payment_address_mut_t dest = make_addr();
+    kth_utxo_mut_t u = make_bch_utxo(kParentTxA, 3u, 50000u); // index != 0
+
+    kth_cashtoken_token_genesis_params_mut_t p =
+        kth_wallet_cashtoken_token_genesis_params_construct_default();
+    kth_wallet_cashtoken_token_genesis_params_set_genesis_utxo(p, u);
+    kth_wallet_cashtoken_token_genesis_params_set_destination(p, dest);
+    kth_wallet_cashtoken_token_genesis_params_set_ft_amount(p, 1, 1000u);
+    kth_wallet_cashtoken_token_genesis_params_set_script_flags(p, 0u);
+
+    kth_cashtoken_token_genesis_result_mut_t res = NULL;
+    kth_error_code_t ec = kth_wallet_cashtoken_create_token_genesis(p, &res);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(res == NULL);
+
+    kth_wallet_cashtoken_token_genesis_params_destruct(p);
+    kth_chain_utxo_destruct(u);
+    kth_wallet_payment_address_destruct(dest);
+}
+
+// ---------------------------------------------------------------------------
+// create_nft_collection — high-level planner
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API create_nft_collection - partitions into batches",
+          "[C-API cashtoken_minting]") {
+    kth_payment_address_mut_t creator = make_addr();
+    kth_utxo_mut_t u = make_bch_utxo(kParentTxA, 0u, 1000000u);
+
+    // Build a list of 12 NFT items (each with a 1-byte commitment).
+    kth_cashtoken_nft_collection_item_list_mut_t items =
+        kth_wallet_cashtoken_nft_collection_item_list_construct_default();
+    for (uint8_t i = 0; i < 12; ++i) {
+        uint8_t const commitment[1] = {(uint8_t)(i + 1)};
+        kth_cashtoken_nft_collection_item_mut_t item =
+            kth_wallet_cashtoken_nft_collection_item_construct(commitment, 1u, NULL);
+        kth_wallet_cashtoken_nft_collection_item_list_push_back(items, item);
+        kth_wallet_cashtoken_nft_collection_item_destruct(item);
+    }
+
+    kth_cashtoken_nft_collection_params_mut_t p =
+        kth_wallet_cashtoken_nft_collection_params_construct_default();
+    kth_wallet_cashtoken_nft_collection_params_set_genesis_utxo(p, u);
+    kth_wallet_cashtoken_nft_collection_params_set_nfts(p, items);
+    kth_wallet_cashtoken_nft_collection_params_set_creator_address(p, creator);
+    kth_wallet_cashtoken_nft_collection_params_set_batch_size(p, 5u);
+    kth_wallet_cashtoken_nft_collection_params_set_script_flags(p, 0u);
+
+    kth_cashtoken_nft_collection_result_mut_t res = NULL;
+    kth_error_code_t ec = kth_wallet_cashtoken_create_nft_collection(p, &res);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(res != NULL);
+
+    // 12 / batch_size=5 -> 3 batches (5 + 5 + 2)
+    REQUIRE(kth_wallet_cashtoken_nft_collection_result_batches_count(res) == 3u);
+
+    // `final_burn` defaults to true (keep_minting_token == false).
+    REQUIRE(kth_wallet_cashtoken_nft_collection_result_final_burn(res) != 0);
+
+    // The category id equals `kParentTxA`.
+    uint8_t cat[32];
+    kth_wallet_cashtoken_nft_collection_result_category_id(res, cat);
+    REQUIRE(memcmp(cat, kParentTxA, 32) == 0);
+
+    // Batch 0 must have 5 requests, batch 2 must have 2.
+    kth_cashtoken_nft_mint_request_list_const_t b0 =
+        kth_wallet_cashtoken_nft_collection_result_batch_mint_requests(res, 0);
+    REQUIRE(kth_wallet_cashtoken_nft_mint_request_list_count(b0) == 5u);
+
+    kth_cashtoken_nft_mint_request_list_const_t b2 =
+        kth_wallet_cashtoken_nft_collection_result_batch_mint_requests(res, 2);
+    REQUIRE(kth_wallet_cashtoken_nft_mint_request_list_count(b2) == 2u);
+
+    kth_wallet_cashtoken_nft_collection_result_destruct(res);
+    kth_wallet_cashtoken_nft_collection_params_destruct(p);
+    kth_wallet_cashtoken_nft_collection_item_list_destruct(items);
+    kth_chain_utxo_destruct(u);
+    kth_wallet_payment_address_destruct(creator);
+}


### PR DESCRIPTION
C-API wrapper for the wallet-level CashTokens minting API introduced in #288 and hardened in #296.

## Contents

- \`include/kth/capi/wallet/cashtoken_minting.h\` — full declaration of the binding surface.
- \`src/wallet/cashtoken_minting.cpp\` — implementation.
- \`test/wallet/cashtoken_minting.cpp\` — Catch2 tests written in pure-C style, same convention as \`test/chain/utxo.cpp\`.
- \`include/kth/capi/capi.h\` — aggregator \`#include\` for the new header.
- \`CMakeLists.txt\` — source/header/test registration.

## Binding shape

The C++ API uses param structs with many optional fields. The C surface mirrors that with an opaque-handle-per-struct pattern:

- One handle per C++ params struct (\`kth_cashtoken_<name>_params_mut_t\`) with \`construct_default\` / \`destruct\` + per-field setters.
- One handle per C++ result struct with \`destruct\` + per-field getters (transaction, signing indices, category id, minted output indices, batches, final_burn).
- Builder functions take the params handle, return \`kth_error_code_t\`, and populate a \`KTH_OUT_OWNED\` result handle on success — same shape as \`kth_chain_transaction_construct_from_data\`.
- \`std::optional<payment_address>\` fields: pass NULL to the setter to clear.
- \`std::optional<uint64_t>\` fields: two-arg setters taking \`(has_value, value)\`.
- \`std::expected<T, std::error_code>\` returns: error propagated via \`kth::to_c_err(result.error())\`.

## Exported functions

- \`encode_nft_number(value, out_data, out_size)\` — mirrors the expected-returning C++ helper; error path distinct from the empty-chunk encoding of \`0\`.
- \`create_ft_output\` / \`create_nft_output\` / \`create_combined_token_output\` — direct single-output factories.
- \`prepare_genesis_utxo\`
- \`create_token_genesis\`
- \`create_token_mint\`
- \`create_token_transfer\`
- \`create_token_burn\`
- \`create_ft\`
- \`create_nft_collection\`

Plus supporting list types for \`nft_mint_request\` and \`nft_collection_item\`.

## Tests

Catch2 \`TEST_CASE\` blocks, pure-C inside the bodies. Covered:

- \`encode_nft_number\`: zero, BCHN reference vectors, INT64_MIN distinct-from-success.
- Output factories: each returns a valid owned \`kth_output_mut_t\`.
- \`prepare_genesis_utxo\`: happy path + dust rejection.
- \`create_token_genesis\`: FT-only success + \`outpoint.index() != 0\` rejection.
- \`create_nft_collection\`: 12 NFTs / \`batch_size == 5\` produces 3 batches, category id matches parent txid, \`final_burn\` true by default, per-batch \`mint_requests\` count.

## Test plan

- [ ] \`cmake --build . --target domain\` succeeds
- [ ] \`cmake --build . --target kth_capi_test && ./src/c-api/kth_capi_test "[C-API cashtoken_minting]"\` — all pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large new C ABI surface for constructing CashTokens-related transactions; risk is mainly API/ABI correctness and memory/ownership handling rather than changes to existing logic.
> 
> **Overview**
> Adds a new `cashtoken_minting` C-API module that exposes wallet-level CashTokens transaction builders and helpers via opaque handles (params/results + setters/getters), including `encode_nft_number`, tokenized output factories, genesis preparation, token genesis/mint/transfer/burn flows, and high-level FT/NFT-collection creation.
> 
> Integrates the new header/implementation into the CMake build and the umbrella `capi.h`, and adds Catch2 tests validating success/error paths, ownership semantics, and NFT collection batching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 505b936f614ecaf3b559b37733f60704baaa97ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded C API to fully support cashtoken minting workflows: FT/NFT outputs, token genesis, minting, transfer, burn, and collection creation.
  * Added constructors, builders, list and accessor APIs for minting-related objects and result views.
* **Tests**
  * Added C-API tests covering encoding, output factories, genesis/minting flows, batching, and error cases for cashtoken minting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->