### PR TITLE
feat(c-api): expose script_execution_context + program::context()

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -200,6 +200,7 @@ set(kth_sources
   src/vm/interpreter.cpp
   src/vm/metrics.cpp
   src/vm/program.cpp
+  src/vm/script_execution_context.cpp
 
 
 )
@@ -349,6 +350,7 @@ set(kth_headers
   include/kth/capi/vm/interpreter.h
   include/kth/capi/vm/metrics.h
   include/kth/capi/vm/program.h
+  include/kth/capi/vm/script_execution_context.h
 
   include/kth/capi.h
 
@@ -531,6 +533,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/vm/debug_snapshot.cpp
         test/vm/function_table.cpp
         test/vm/metrics.cpp
+        test/vm/script_execution_context.cpp
     )
 
     target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -79,6 +79,7 @@
 #include <kth/capi/vm/interpreter.h>
 #include <kth/capi/vm/metrics.h>
 #include <kth/capi/vm/program.h>
+#include <kth/capi/vm/script_execution_context.h>
 
 #include <kth/capi/bool_list.h>
 #include <kth/capi/double_list.h>

--- a/src/c-api/include/kth/capi/handles.h
+++ b/src/c-api/include/kth/capi/handles.h
@@ -207,6 +207,8 @@ typedef void* kth_debug_snapshot_list_mut_t;
 typedef void const* kth_debug_snapshot_list_const_t;
 typedef void* kth_function_table_mut_t;
 typedef void const* kth_function_table_const_t;
+typedef void* kth_script_execution_context_mut_t;
+typedef void const* kth_script_execution_context_const_t;
 
 
 // Hash structs

--- a/src/c-api/include/kth/capi/vm/program.h
+++ b/src/c-api/include/kth/capi/vm/program.h
@@ -104,6 +104,10 @@ uint64_t kth_vm_program_value(kth_program_const_t self);
 KTH_EXPORT
 kth_transaction_const_t kth_vm_program_transaction(kth_program_const_t self);
 
+/** @return Borrowed `kth_script_execution_context_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_script_execution_context_const_t kth_vm_program_context(kth_program_const_t self);
+
 /** @return Borrowed `kth_script_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
 KTH_EXPORT
 kth_script_const_t kth_vm_program_get_script(kth_program_const_t self);

--- a/src/c-api/include/kth/capi/vm/script_execution_context.h
+++ b/src/c-api/include/kth/capi/vm/script_execution_context.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_VM_SCRIPT_EXECUTION_CONTEXT_H_
+#define KTH_CAPI_VM_SCRIPT_EXECUTION_CONTEXT_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/**
+ * @return Owned `kth_script_execution_context_mut_t`. Caller must release with `kth_vm_script_execution_context_destruct`.
+ * @param transaction Borrowed input. Copied by value into the resulting object; ownership of `transaction` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_script_execution_context_mut_t kth_vm_script_execution_context_construct(uint32_t input_index, kth_transaction_const_t transaction);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_vm_script_execution_context_destruct(kth_script_execution_context_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_script_execution_context_mut_t`. Caller must release with `kth_vm_script_execution_context_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_script_execution_context_mut_t kth_vm_script_execution_context_copy(kth_script_execution_context_const_t self);
+
+
+// Getters
+
+KTH_EXPORT
+uint32_t kth_vm_script_execution_context_input_index(kth_script_execution_context_const_t self);
+
+/** @return Borrowed `kth_transaction_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_transaction_const_t kth_vm_script_execution_context_transaction(kth_script_execution_context_const_t self);
+
+KTH_EXPORT
+uint32_t kth_vm_script_execution_context_input_count(kth_script_execution_context_const_t self);
+
+KTH_EXPORT
+uint32_t kth_vm_script_execution_context_output_count(kth_script_execution_context_const_t self);
+
+KTH_EXPORT
+uint32_t kth_vm_script_execution_context_tx_version(kth_script_execution_context_const_t self);
+
+KTH_EXPORT
+uint32_t kth_vm_script_execution_context_tx_locktime(kth_script_execution_context_const_t self);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_VM_SCRIPT_EXECUTION_CONTEXT_H_

--- a/src/c-api/src/vm/program.cpp
+++ b/src/c-api/src/vm/program.cpp
@@ -122,6 +122,12 @@ kth_transaction_const_t kth_vm_program_transaction(kth_program_const_t self) {
     return &(kth::cpp_ref<cpp_t>(self).transaction());
 }
 
+kth_script_execution_context_const_t kth_vm_program_context(kth_program_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const& opt = kth::cpp_ref<cpp_t>(self).context();
+    return opt.has_value() ? &(*opt) : nullptr;
+}
+
 kth_script_const_t kth_vm_program_get_script(kth_program_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return &(kth::cpp_ref<cpp_t>(self).get_script());

--- a/src/c-api/src/vm/script_execution_context.cpp
+++ b/src/c-api/src/vm/script_execution_context.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/vm/script_execution_context.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/machine/script_execution_context.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::machine::script_execution_context;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_script_execution_context_mut_t kth_vm_script_execution_context_construct(uint32_t input_index, kth_transaction_const_t transaction) {
+    KTH_PRECONDITION(transaction != nullptr);
+    auto const& transaction_cpp = kth::cpp_ref<kth::domain::chain::transaction>(transaction);
+    return kth::leak<cpp_t>(input_index, transaction_cpp);
+}
+
+
+// Destructor
+
+void kth_vm_script_execution_context_destruct(kth_script_execution_context_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_script_execution_context_mut_t kth_vm_script_execution_context_copy(kth_script_execution_context_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Getters
+
+uint32_t kth_vm_script_execution_context_input_index(kth_script_execution_context_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).input_index();
+}
+
+kth_transaction_const_t kth_vm_script_execution_context_transaction(kth_script_execution_context_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<cpp_t>(self).transaction());
+}
+
+uint32_t kth_vm_script_execution_context_input_count(kth_script_execution_context_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).input_count();
+}
+
+uint32_t kth_vm_script_execution_context_output_count(kth_script_execution_context_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).output_count();
+}
+
+uint32_t kth_vm_script_execution_context_tx_version(kth_script_execution_context_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).tx_version();
+}
+
+uint32_t kth_vm_script_execution_context_tx_locktime(kth_script_execution_context_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).tx_locktime();
+}
+
+} // extern "C"

--- a/src/c-api/test/vm/script_execution_context.cpp
+++ b/src/c-api/test/vm/script_execution_context.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+
+#include <kth/capi/chain/input.h>
+#include <kth/capi/chain/input_list.h>
+#include <kth/capi/chain/output.h>
+#include <kth/capi/chain/output_list.h>
+#include <kth/capi/chain/output_point.h>
+#include <kth/capi/chain/script.h>
+#include <kth/capi/chain/transaction.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+#include <kth/capi/vm/program.h>
+#include <kth/capi/vm/script_execution_context.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures — minimal one-in/one-out transaction so the context's
+// getters have something non-trivial to return.
+// ---------------------------------------------------------------------------
+
+static uint32_t const kVersion  = 2u;
+static uint32_t const kLocktime = 42u;
+
+static kth_hash_t const kPrevHash = {{
+    0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+    0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+    0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7,
+    0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf
+}};
+
+static uint8_t const kScriptBody[20] = {
+    0xec, 0xe4, 0x24, 0xa6, 0xbb, 0x6d, 0xdf, 0x4d,
+    0xb5, 0x92, 0xc0, 0xfa, 0xed, 0x60, 0x68, 0x50,
+    0x47, 0xa3, 0x61, 0xb1
+};
+
+static kth_script_mut_t make_script(void) {
+    kth_script_mut_t s = NULL;
+    kth_error_code_t ec = kth_chain_script_construct_from_data(
+        kScriptBody, sizeof(kScriptBody), 0, &s);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(s != NULL);
+    return s;
+}
+
+static kth_input_list_mut_t make_inputs(void) {
+    kth_input_list_mut_t list = kth_chain_input_list_construct_default();
+    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kPrevHash, 0);
+    kth_script_mut_t script = make_script();
+    kth_input_mut_t in = kth_chain_input_construct(op, script, 0xffffffffu);
+    kth_chain_input_list_push_back(list, in);
+    kth_chain_input_destruct(in);
+    kth_chain_script_destruct(script);
+    kth_chain_output_point_destruct(op);
+    return list;
+}
+
+static kth_output_list_mut_t make_outputs(void) {
+    kth_output_list_mut_t list = kth_chain_output_list_construct_default();
+    kth_script_mut_t script = make_script();
+    kth_output_mut_t out = kth_chain_output_construct(50000ull, script, NULL);
+    kth_chain_output_list_push_back(list, out);
+    kth_chain_output_destruct(out);
+    kth_chain_script_destruct(script);
+    return list;
+}
+
+static kth_transaction_mut_t make_tx(void) {
+    kth_input_list_mut_t ins = make_inputs();
+    kth_output_list_mut_t outs = make_outputs();
+    kth_transaction_mut_t tx = kth_chain_transaction_construct_from_version_locktime_inputs_outputs(
+        kVersion, kLocktime, ins, outs);
+    REQUIRE(tx != NULL);
+    kth_chain_input_list_destruct(ins);
+    kth_chain_output_list_destruct(outs);
+    return tx;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API ScriptExecutionContext - construct surfaces the input index and tx getters",
+          "[C-API ScriptExecutionContext][lifecycle]") {
+    kth_transaction_mut_t tx = make_tx();
+
+    kth_script_execution_context_mut_t ctx =
+        kth_vm_script_execution_context_construct(0u, tx);
+    REQUIRE(ctx != NULL);
+
+    REQUIRE(kth_vm_script_execution_context_input_index(ctx) == 0u);
+    REQUIRE(kth_vm_script_execution_context_input_count(ctx) == 1u);
+    REQUIRE(kth_vm_script_execution_context_output_count(ctx) == 1u);
+    REQUIRE(kth_vm_script_execution_context_tx_version(ctx) == kVersion);
+    REQUIRE(kth_vm_script_execution_context_tx_locktime(ctx) == kLocktime);
+
+    kth_vm_script_execution_context_destruct(ctx);
+    kth_chain_transaction_destruct(tx);
+}
+
+TEST_CASE("C-API ScriptExecutionContext - destruct(NULL) is a no-op",
+          "[C-API ScriptExecutionContext][lifecycle]") {
+    kth_vm_script_execution_context_destruct(NULL);
+}
+
+TEST_CASE("C-API ScriptExecutionContext - copy is an independent handle",
+          "[C-API ScriptExecutionContext][lifecycle]") {
+    kth_transaction_mut_t tx = make_tx();
+
+    kth_script_execution_context_mut_t orig =
+        kth_vm_script_execution_context_construct(0u, tx);
+    kth_script_execution_context_mut_t cp =
+        kth_vm_script_execution_context_copy(orig);
+    REQUIRE(cp != NULL);
+    REQUIRE(cp != orig);
+
+    // Destroying the copy must not disturb the source.
+    kth_vm_script_execution_context_destruct(cp);
+    REQUIRE(kth_vm_script_execution_context_input_index(orig) == 0u);
+
+    kth_vm_script_execution_context_destruct(orig);
+    kth_chain_transaction_destruct(tx);
+}
+
+// ---------------------------------------------------------------------------
+// Borrowed transaction view
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API ScriptExecutionContext - transaction() returns a queryable borrowed view",
+          "[C-API ScriptExecutionContext][getter]") {
+    kth_transaction_mut_t tx = make_tx();
+    kth_script_execution_context_mut_t ctx =
+        kth_vm_script_execution_context_construct(0u, tx);
+
+    // The borrowed view must expose the same version/locktime as the
+    // owning transaction handle — proving the context's `transaction()`
+    // accessor hands back the actual object, not a detached copy.
+    kth_transaction_const_t borrowed = kth_vm_script_execution_context_transaction(ctx);
+    REQUIRE(borrowed != NULL);
+    REQUIRE(kth_chain_transaction_version(borrowed) == kVersion);
+    REQUIRE(kth_chain_transaction_locktime(borrowed) == kLocktime);
+
+    // Do NOT destruct `borrowed` — it's a non-owning view into the tx.
+    kth_vm_script_execution_context_destruct(ctx);
+    kth_chain_transaction_destruct(tx);
+}
+
+// ---------------------------------------------------------------------------
+// program::context() — empty by default
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API ScriptExecutionContext - program without ctx reports no context",
+          "[C-API ScriptExecutionContext][program]") {
+    // A program constructed from script alone has no execution
+    // context — `context()` must return NULL. A non-NULL handle here
+    // would mean the generator emitted a phantom optional.
+    kth_script_mut_t script = make_script();
+    kth_program_mut_t prog = kth_vm_program_construct_from_script(script);
+
+    kth_script_execution_context_const_t ctx = kth_vm_program_context(prog);
+    REQUIRE(ctx == NULL);
+
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions — const getters abort on NULL
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API ScriptExecutionContext - input_index null aborts",
+          "[C-API ScriptExecutionContext][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_script_execution_context_input_index(NULL));
+}
+
+TEST_CASE("C-API ScriptExecutionContext - input_count null aborts",
+          "[C-API ScriptExecutionContext][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_script_execution_context_input_count(NULL));
+}
+
+TEST_CASE("C-API ScriptExecutionContext - output_count null aborts",
+          "[C-API ScriptExecutionContext][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_script_execution_context_output_count(NULL));
+}
+
+TEST_CASE("C-API ScriptExecutionContext - tx_version null aborts",
+          "[C-API ScriptExecutionContext][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_script_execution_context_tx_version(NULL));
+}
+
+TEST_CASE("C-API ScriptExecutionContext - tx_locktime null aborts",
+          "[C-API ScriptExecutionContext][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_script_execution_context_tx_locktime(NULL));
+}
+
+TEST_CASE("C-API ScriptExecutionContext - transaction null aborts",
+          "[C-API ScriptExecutionContext][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_script_execution_context_transaction(NULL));
+}
+
+TEST_CASE("C-API ScriptExecutionContext - copy null aborts",
+          "[C-API ScriptExecutionContext][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_script_execution_context_copy(NULL));
+}


### PR DESCRIPTION
## Summary
- Exposes \`kth::domain::machine::script_execution_context\` via the C-API: ctor that takes an input index + a borrowed transaction view, destruct/copy, and getters for \`input_index\`, \`input_count\`, \`output_count\`, \`tx_version\`, \`tx_locktime\`, plus the borrowed \`transaction()\` view.
- Wires \`kth_vm_program_context\`: returns a borrowed \`kth_script_execution_context_const_t\` view into the program's stored optional, or NULL when the program was built without one. This previously showed up as a skipped method in the generator output.
- Adds a C-API test battery mirroring the lifecycle / borrowed-view / precondition shape of the existing vm bindings.

## Test plan
- [ ] \`cmake --build build --target kth-capi-tests && ctest --test-dir build -R "C-API ScriptExecutionContext"\`
- [ ] Existing VM test suites (program / interpreter / debug_snapshot / metrics) still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new public C-API type and borrowed-pointer accessor (`program::context()`), so misuse could lead to lifetime/NULL-handling bugs for downstream consumers despite minimal impact on existing logic.
> 
> **Overview**
> Adds a new C-API surface for VM `script_execution_context`, including handle types plus `construct`/`destruct`/`copy` and getters for input index/counts and transaction version/locktime, along with a borrowed `transaction()` view.
> 
> Extends the VM `program` C-API with `kth_vm_program_context()` to expose the program’s optional execution context (returning `NULL` when absent), wires the new header into the umbrella `capi.h`, and updates CMake/test targets with a dedicated Catch2 test suite covering lifecycle, borrowed-view semantics, and NULL precondition aborts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e76bab89eab60c61bb3aa41b81a293214d708be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended C-API with script execution context operations for creating, cloning, and managing execution contexts with access to transaction details, input indices, and transaction metadata.

* **Tests**
  * Added comprehensive test coverage for script execution context operations including lifecycle management, data retrieval, and null-safety validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->