### PR TITLE
feat(c-api): expose number, big_number, data_stack handles + tests

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -195,13 +195,17 @@ set(kth_sources
 
   src/node/settings.cpp
 
+  src/vm/big_number.cpp
   src/vm/debug_snapshot.cpp
   src/vm/debug_snapshot_list.cpp
   src/vm/function_table.cpp
   src/vm/interpreter.cpp
   src/vm/metrics.cpp
+  src/vm/number.cpp
   src/vm/program.cpp
   src/vm/script_execution_context.cpp
+
+  src/data_stack.cpp
 
 
 )
@@ -321,6 +325,7 @@ set(kth_headers
   include/kth/capi/primitives.h
   include/kth/capi/handles.h
   include/kth/capi/callbacks.h
+  include/kth/capi/data_stack.h
   include/kth/capi/hash_list.h
   include/kth/capi/error.h
   include/kth/capi/hash.h
@@ -350,8 +355,10 @@ set(kth_headers
 
   include/kth/capi/libconfig/libconfig.h
 
+  include/kth/capi/vm/big_number.h
   include/kth/capi/vm/interpreter.h
   include/kth/capi/vm/metrics.h
+  include/kth/capi/vm/number.h
   include/kth/capi/vm/program.h
   include/kth/capi/vm/script_execution_context.h
 
@@ -532,12 +539,15 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/wallet/hd_public.cpp
         test/wallet/hd_private.cpp
         test/wallet/wallet_data.cpp
+        test/vm/big_number.cpp
         test/vm/program.cpp
         test/vm/interpreter.cpp
         test/vm/debug_snapshot.cpp
         test/vm/function_table.cpp
         test/vm/metrics.cpp
+        test/vm/number.cpp
         test/vm/script_execution_context.cpp
+        test/data_stack.cpp
     )
 
     target_link_libraries(kth_capi_test PUBLIC ${PROJECT_NAME})

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -73,15 +73,18 @@
 
 #include <kth/capi/p2p/p2p.h>
 
+#include <kth/capi/vm/big_number.h>
 #include <kth/capi/vm/debug_snapshot.h>
 #include <kth/capi/vm/debug_snapshot_list.h>
 #include <kth/capi/vm/function_table.h>
 #include <kth/capi/vm/interpreter.h>
 #include <kth/capi/vm/metrics.h>
+#include <kth/capi/vm/number.h>
 #include <kth/capi/vm/program.h>
 #include <kth/capi/vm/script_execution_context.h>
 
 #include <kth/capi/bool_list.h>
+#include <kth/capi/data_stack.h>
 #include <kth/capi/double_list.h>
 #include <kth/capi/hash.h>
 #include <kth/capi/hash_list.h>

--- a/src/c-api/include/kth/capi/data_stack.h
+++ b/src/c-api/include/kth/capi/data_stack.h
@@ -1,0 +1,81 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_DATA_STACK_H_
+#define KTH_CAPI_DATA_STACK_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// `data_stack` is the Bitcoin script runtime stack: a list of
+// variable-length byte buffers. Each element is an owned `data_chunk`
+// (kept inside the list). Hand-written — the generator only emits
+// list modules for fixed-size or opaque-handle elements today; a
+// list of raw byte buffers needs a bespoke `push_back(ptr, len)` /
+// `nth(index, *out_size)` surface.
+
+/** @return Owned `kth_data_stack_mut_t`. Caller must release with `kth_core_data_stack_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_data_stack_mut_t kth_core_data_stack_construct_default(void);
+
+/** No-op if `list` is null. */
+KTH_EXPORT
+void kth_core_data_stack_destruct(kth_data_stack_mut_t list);
+
+/** @return Owned `kth_data_stack_mut_t`. Caller must release with `kth_core_data_stack_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_data_stack_mut_t kth_core_data_stack_copy(kth_data_stack_const_t list);
+
+KTH_EXPORT
+kth_size_t kth_core_data_stack_count(kth_data_stack_const_t list);
+
+/**
+ * Append a new byte buffer to the list. The buffer is copied by value
+ * into the list — the caller retains ownership of `data`.
+ * `data == NULL` is allowed only when `n == 0` (produces an empty
+ * element).
+ */
+KTH_EXPORT
+void kth_core_data_stack_push_back(kth_data_stack_mut_t list, uint8_t const* data, kth_size_t n);
+
+/**
+ * Borrowed view into the n-th element. The returned pointer refers
+ * to memory owned by `list` and is invalidated by any mutation of
+ * the list. `*out_size` is always set to the element's byte count
+ * — use that to decide whether to dereference the pointer, since
+ * `std::vector::data()` on an empty element may legally return
+ * `NULL` on some platforms (e.g. MSVC).
+ *
+ * @param list Must be non-null.
+ * @param n    Must be strictly less than `count(list)`.
+ * @param out_size Must be non-null; receives the element length.
+ * @return Borrowed pointer into the element's bytes, or `NULL` when
+ *         the element is empty. Do not free.
+ */
+KTH_EXPORT
+uint8_t const* kth_core_data_stack_nth(kth_data_stack_const_t list, kth_size_t n, kth_size_t* out_size);
+
+/**
+ * Owned copy of the n-th element. Caller releases with
+ * `kth_core_destruct_array`. `*out_size` is set to the element's
+ * byte count regardless of whether the copy was needed.
+ */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_core_data_stack_nth_copy(kth_data_stack_const_t list, kth_size_t n, kth_size_t* out_size);
+
+/** Remove the n-th element. `n` must be strictly less than `count(list)`. */
+KTH_EXPORT
+void kth_core_data_stack_erase(kth_data_stack_mut_t list, kth_size_t n);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_DATA_STACK_H_ */

--- a/src/c-api/include/kth/capi/handles.h
+++ b/src/c-api/include/kth/capi/handles.h
@@ -190,8 +190,9 @@ typedef void* kth_ec_compressed_list_mut_t;
 typedef void const* kth_ec_compressed_list_const_t;
 
 // Vector of byte buffers — used by Bitcoin script's runtime stack and by
-// `to_pay_multisig_pattern` for the signature variant. The owning C-API
-// type is opaque; element accessors are not exposed yet.
+// `to_pay_multisig_pattern` for the signature variant. Variable-length
+// elements (`kth_byte_buffer_t` in spirit) are exposed through the
+// `kth_core_data_stack_*` module.
 typedef void* kth_data_stack_mut_t;
 typedef void const* kth_data_stack_const_t;
 
@@ -201,6 +202,12 @@ typedef void* kth_metrics_mut_t;
 typedef void const* kth_metrics_const_t;
 typedef void* kth_program_mut_t;
 typedef void const* kth_program_const_t;
+// Bounded 4-byte script integer (`kth::infrastructure::machine::number`).
+typedef void* kth_number_mut_t;
+typedef void const* kth_number_const_t;
+// Unbounded big-integer for BCH 2025 (`kth::infrastructure::machine::big_number`).
+typedef void* kth_big_number_mut_t;
+typedef void const* kth_big_number_const_t;
 typedef void* kth_debug_snapshot_mut_t;
 typedef void const* kth_debug_snapshot_const_t;
 typedef void* kth_debug_snapshot_list_mut_t;

--- a/src/c-api/include/kth/capi/vm/big_number.h
+++ b/src/c-api/include/kth/capi/vm/big_number.h
@@ -1,0 +1,145 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_VM_BIG_NUMBER_H_
+#define KTH_CAPI_VM_BIG_NUMBER_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_construct_default(void);
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_construct_from_value(int64_t value);
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_construct_from_decimal_str(char const* decimal_str);
+
+
+// Static factories
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_from_hex(char const* hex_str);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_vm_big_number_destruct(kth_big_number_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_copy(kth_big_number_const_t self);
+
+
+// Equality
+
+KTH_EXPORT
+kth_bool_t kth_vm_big_number_equals(kth_big_number_const_t self, kth_big_number_const_t other);
+
+
+// Getters
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_vm_big_number_serialize(kth_big_number_const_t self, kth_size_t* out_size);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_vm_big_number_to_string(kth_big_number_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_vm_big_number_to_hex(kth_big_number_const_t self);
+
+KTH_EXPORT
+int kth_vm_big_number_sign(kth_big_number_const_t self);
+
+KTH_EXPORT
+int32_t kth_vm_big_number_to_int32_saturating(kth_big_number_const_t self);
+
+KTH_EXPORT
+kth_size_t kth_vm_big_number_byte_count(kth_big_number_const_t self);
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_abs(kth_big_number_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_vm_big_number_data(kth_big_number_const_t self, kth_size_t* out_size);
+
+
+// Setters
+
+KTH_EXPORT
+kth_bool_t kth_vm_big_number_set_data(kth_big_number_mut_t self, uint8_t const* d, kth_size_t n, kth_size_t max_size);
+
+
+// Predicates
+
+KTH_EXPORT
+kth_bool_t kth_vm_big_number_is_zero(kth_big_number_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_big_number_is_nonzero(kth_big_number_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_big_number_is_negative(kth_big_number_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_big_number_is_true(kth_big_number_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_big_number_is_false(kth_big_number_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_big_number_is_minimally_encoded(uint8_t const* data, kth_size_t n, kth_size_t max_size);
+
+
+// Operations
+
+KTH_EXPORT
+kth_bool_t kth_vm_big_number_deserialize(kth_big_number_mut_t self, uint8_t const* data, kth_size_t n);
+
+KTH_EXPORT
+int kth_vm_big_number_compare(kth_big_number_const_t self, kth_big_number_const_t other);
+
+KTH_EXPORT
+void kth_vm_big_number_negate(kth_big_number_mut_t self);
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_pow(kth_big_number_const_t self, kth_big_number_const_t exp);
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_pow_mod(kth_big_number_const_t self, kth_big_number_const_t exp, kth_big_number_const_t mod);
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_math_modulo(kth_big_number_const_t self, kth_big_number_const_t mod);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_VM_BIG_NUMBER_H_

--- a/src/c-api/include/kth/capi/vm/number.h
+++ b/src/c-api/include/kth/capi/vm/number.h
@@ -1,0 +1,136 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_VM_NUMBER_H_
+#define KTH_CAPI_VM_NUMBER_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/** @return Owned `kth_number_mut_t`. Caller must release with `kth_vm_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_number_mut_t kth_vm_number_construct_default(void);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_vm_number_destruct(kth_number_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_number_mut_t`. Caller must release with `kth_vm_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_number_mut_t kth_vm_number_copy(kth_number_const_t self);
+
+
+// Equality
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_equals(kth_number_const_t self, kth_number_const_t other);
+
+
+// Getters
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_vm_number_data(kth_number_const_t self, kth_size_t* out_size);
+
+KTH_EXPORT
+int32_t kth_vm_number_int32(kth_number_const_t self);
+
+KTH_EXPORT
+int64_t kth_vm_number_int64(kth_number_const_t self);
+
+
+// Setters
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_set_data(kth_number_mut_t self, uint8_t const* data, kth_size_t n, kth_size_t max_size);
+
+
+// Predicates
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_is_true(kth_number_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_is_false(kth_number_const_t self);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_is_minimally_encoded(uint8_t const* data, kth_size_t n, kth_size_t max_integer_size);
+
+
+// Operations
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_valid(kth_number_mut_t self, kth_size_t max_size);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_greater(kth_number_const_t self, int64_t value);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_less(kth_number_const_t self, int64_t value);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_greater_or_equal(kth_number_const_t self, int64_t value);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_less_or_equal(kth_number_const_t self, int64_t value);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_safe_add_number(kth_number_mut_t self, kth_number_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_safe_add_int64(kth_number_mut_t self, int64_t x);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_safe_sub_number(kth_number_mut_t self, kth_number_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_safe_sub_int64(kth_number_mut_t self, int64_t x);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_safe_mul_number(kth_number_mut_t self, kth_number_const_t x);
+
+KTH_EXPORT
+kth_bool_t kth_vm_number_safe_mul_int64(kth_number_mut_t self, int64_t x);
+
+
+// Static utilities
+
+/** @param[out] out Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_vm_number_from_int(int64_t value, KTH_OUT_OWNED kth_number_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_vm_number_safe_add_number2(kth_number_const_t x, kth_number_const_t y, KTH_OUT_OWNED kth_number_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_vm_number_safe_sub_number2(kth_number_const_t x, kth_number_const_t y, KTH_OUT_OWNED kth_number_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_vm_number_safe_mul_number2(kth_number_const_t x, kth_number_const_t y, KTH_OUT_OWNED kth_number_mut_t* out);
+
+KTH_EXPORT
+kth_size_t kth_vm_number_minimally_encode(uint8_t* data, kth_size_t n);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_VM_NUMBER_H_

--- a/src/c-api/src/data_stack.cpp
+++ b/src/c-api/src/data_stack.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <cstdlib>
+#include <cstring>
+
+#include <kth/capi/data_stack.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/infrastructure/utility/data.hpp>
+
+namespace {
+using cpp_t = kth::data_stack;
+} // namespace
+
+extern "C" {
+
+kth_data_stack_mut_t kth_core_data_stack_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+void kth_core_data_stack_destruct(kth_data_stack_mut_t list) {
+    kth::del<cpp_t>(list);
+}
+
+kth_data_stack_mut_t kth_core_data_stack_copy(kth_data_stack_const_t list) {
+    KTH_PRECONDITION(list != nullptr);
+    return kth::clone<cpp_t>(list);
+}
+
+kth_size_t kth_core_data_stack_count(kth_data_stack_const_t list) {
+    KTH_PRECONDITION(list != nullptr);
+    return static_cast<kth_size_t>(kth::cpp_ref<cpp_t>(list).size());
+}
+
+void kth_core_data_stack_push_back(kth_data_stack_mut_t list, uint8_t const* data, kth_size_t n) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    auto& vec = kth::cpp_ref<cpp_t>(list);
+    if (n == 0) {
+        vec.emplace_back();
+    } else {
+        vec.emplace_back(data, data + n);
+    }
+}
+
+uint8_t const* kth_core_data_stack_nth(kth_data_stack_const_t list, kth_size_t n, kth_size_t* out_size) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const& vec = kth::cpp_ref<cpp_t>(list);
+    KTH_PRECONDITION(kth::sz(n) < vec.size());
+    auto const& elem = vec[kth::sz(n)];
+    *out_size = static_cast<kth_size_t>(elem.size());
+    return elem.data();
+}
+
+uint8_t* kth_core_data_stack_nth_copy(kth_data_stack_const_t list, kth_size_t n, kth_size_t* out_size) {
+    KTH_PRECONDITION(list != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const& vec = kth::cpp_ref<cpp_t>(list);
+    KTH_PRECONDITION(kth::sz(n) < vec.size());
+    auto const& elem = vec[kth::sz(n)];
+    auto const elem_size = elem.size();
+    *out_size = static_cast<kth_size_t>(elem_size);
+    // Match the rest of the C-API's ownership contract: owned buffers
+    // are released with `kth_core_destruct_array`, which is a thin
+    // wrapper over `free()`. Allocate with `malloc` so the two pair up.
+    auto* buf = static_cast<uint8_t*>(std::malloc(elem_size == 0 ? 1 : elem_size));
+    if (buf == nullptr) return nullptr;
+    if (elem_size != 0) {
+        std::memcpy(buf, elem.data(), elem_size);
+    }
+    return buf;
+}
+
+void kth_core_data_stack_erase(kth_data_stack_mut_t list, kth_size_t n) {
+    KTH_PRECONDITION(list != nullptr);
+    auto& vec = kth::cpp_ref<cpp_t>(list);
+    KTH_PRECONDITION(kth::sz(n) < vec.size());
+    vec.erase(vec.begin() + kth::sz(n));
+}
+
+} // extern "C"

--- a/src/c-api/src/vm/big_number.cpp
+++ b/src/c-api/src/vm/big_number.cpp
@@ -1,0 +1,211 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <string_view>
+
+#include <kth/capi/vm/big_number.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/infrastructure/machine/big_number.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::infrastructure::machine::big_number;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_big_number_mut_t kth_vm_big_number_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_big_number_mut_t kth_vm_big_number_construct_from_value(int64_t value) {
+    return kth::leak<cpp_t>(value);
+}
+
+kth_big_number_mut_t kth_vm_big_number_construct_from_decimal_str(char const* decimal_str) {
+    KTH_PRECONDITION(decimal_str != nullptr);
+    auto const decimal_str_cpp = std::string_view(decimal_str);
+    return kth::leak<cpp_t>(decimal_str_cpp);
+}
+
+
+// Static factories
+
+kth_big_number_mut_t kth_vm_big_number_from_hex(char const* hex_str) {
+    KTH_PRECONDITION(hex_str != nullptr);
+    auto const hex_str_cpp = std::string_view(hex_str);
+    return kth::leak(cpp_t::from_hex(hex_str_cpp));
+}
+
+
+// Destructor
+
+void kth_vm_big_number_destruct(kth_big_number_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_big_number_mut_t kth_vm_big_number_copy(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Equality
+
+kth_bool_t kth_vm_big_number_equals(kth_big_number_const_t self, kth_big_number_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::eq<cpp_t>(self, other);
+}
+
+
+// Getters
+
+uint8_t* kth_vm_big_number_serialize(kth_big_number_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth::cpp_ref<cpp_t>(self).serialize();
+    return kth::create_c_array(data, *out_size);
+}
+
+char* kth_vm_big_number_to_string(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).to_string();
+    return kth::create_c_str(s);
+}
+
+char* kth_vm_big_number_to_hex(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).to_hex();
+    return kth::create_c_str(s);
+}
+
+int kth_vm_big_number_sign(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).sign();
+}
+
+int32_t kth_vm_big_number_to_int32_saturating(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).to_int32_saturating();
+}
+
+kth_size_t kth_vm_big_number_byte_count(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).byte_count();
+}
+
+kth_big_number_mut_t kth_vm_big_number_abs(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).abs());
+}
+
+uint8_t* kth_vm_big_number_data(kth_big_number_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth::cpp_ref<cpp_t>(self).data();
+    return kth::create_c_array(data, *out_size);
+}
+
+
+// Setters
+
+kth_bool_t kth_vm_big_number_set_data(kth_big_number_mut_t self, uint8_t const* d, kth_size_t n, kth_size_t max_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(d != nullptr || n == 0);
+    auto const d_cpp = n != 0 ? kth::data_chunk(d, d + n) : kth::data_chunk{};
+    auto const max_size_cpp = kth::sz(max_size);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).set_data(d_cpp, max_size_cpp));
+}
+
+
+// Predicates
+
+kth_bool_t kth_vm_big_number_is_zero(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_zero());
+}
+
+kth_bool_t kth_vm_big_number_is_nonzero(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_nonzero());
+}
+
+kth_bool_t kth_vm_big_number_is_negative(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_negative());
+}
+
+kth_bool_t kth_vm_big_number_is_true(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_true());
+}
+
+kth_bool_t kth_vm_big_number_is_false(kth_big_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_false());
+}
+
+kth_bool_t kth_vm_big_number_is_minimally_encoded(uint8_t const* data, kth_size_t n, kth_size_t max_size) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    auto const data_cpp = n != 0 ? kth::data_chunk(data, data + n) : kth::data_chunk{};
+    auto const max_size_cpp = kth::sz(max_size);
+    return kth::bool_to_int(cpp_t::is_minimally_encoded(data_cpp, max_size_cpp));
+}
+
+
+// Operations
+
+kth_bool_t kth_vm_big_number_deserialize(kth_big_number_mut_t self, uint8_t const* data, kth_size_t n) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    auto const data_cpp = n != 0 ? kth::data_chunk(data, data + n) : kth::data_chunk{};
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).deserialize(data_cpp));
+}
+
+int kth_vm_big_number_compare(kth_big_number_const_t self, kth_big_number_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    auto const& other_cpp = kth::cpp_ref<cpp_t>(other);
+    return kth::cpp_ref<cpp_t>(self).compare(other_cpp);
+}
+
+void kth_vm_big_number_negate(kth_big_number_mut_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<cpp_t>(self).negate();
+}
+
+kth_big_number_mut_t kth_vm_big_number_pow(kth_big_number_const_t self, kth_big_number_const_t exp) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(exp != nullptr);
+    auto const& exp_cpp = kth::cpp_ref<cpp_t>(exp);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).pow(exp_cpp));
+}
+
+kth_big_number_mut_t kth_vm_big_number_pow_mod(kth_big_number_const_t self, kth_big_number_const_t exp, kth_big_number_const_t mod) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(exp != nullptr);
+    KTH_PRECONDITION(mod != nullptr);
+    auto const& exp_cpp = kth::cpp_ref<cpp_t>(exp);
+    auto const& mod_cpp = kth::cpp_ref<cpp_t>(mod);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).pow_mod(exp_cpp, mod_cpp));
+}
+
+kth_big_number_mut_t kth_vm_big_number_math_modulo(kth_big_number_const_t self, kth_big_number_const_t mod) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(mod != nullptr);
+    auto const& mod_cpp = kth::cpp_ref<cpp_t>(mod);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).math_modulo(mod_cpp));
+}
+
+} // extern "C"

--- a/src/c-api/src/vm/number.cpp
+++ b/src/c-api/src/vm/number.cpp
@@ -1,0 +1,229 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <cstring>
+#include <utility>
+
+#include <kth/capi/vm/number.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/infrastructure/machine/number.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::infrastructure::machine::number;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_number_mut_t kth_vm_number_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+
+// Destructor
+
+void kth_vm_number_destruct(kth_number_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_number_mut_t kth_vm_number_copy(kth_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Equality
+
+kth_bool_t kth_vm_number_equals(kth_number_const_t self, kth_number_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::eq<cpp_t>(self, other);
+}
+
+
+// Getters
+
+uint8_t* kth_vm_number_data(kth_number_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth::cpp_ref<cpp_t>(self).data();
+    return kth::create_c_array(data, *out_size);
+}
+
+int32_t kth_vm_number_int32(kth_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).int32();
+}
+
+int64_t kth_vm_number_int64(kth_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).int64();
+}
+
+
+// Setters
+
+kth_bool_t kth_vm_number_set_data(kth_number_mut_t self, uint8_t const* data, kth_size_t n, kth_size_t max_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    auto const data_cpp = n != 0 ? kth::data_chunk(data, data + n) : kth::data_chunk{};
+    auto const max_size_cpp = kth::sz(max_size);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).set_data(data_cpp, max_size_cpp));
+}
+
+
+// Predicates
+
+kth_bool_t kth_vm_number_is_true(kth_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_true());
+}
+
+kth_bool_t kth_vm_number_is_false(kth_number_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_false());
+}
+
+kth_bool_t kth_vm_number_is_minimally_encoded(uint8_t const* data, kth_size_t n, kth_size_t max_integer_size) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    auto const data_cpp = n != 0 ? kth::data_chunk(data, data + n) : kth::data_chunk{};
+    auto const max_integer_size_cpp = kth::sz(max_integer_size);
+    return kth::bool_to_int(cpp_t::is_minimally_encoded(data_cpp, max_integer_size_cpp));
+}
+
+
+// Operations
+
+kth_bool_t kth_vm_number_valid(kth_number_mut_t self, kth_size_t max_size) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const max_size_cpp = kth::sz(max_size);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).valid(max_size_cpp));
+}
+
+kth_bool_t kth_vm_number_greater(kth_number_const_t self, int64_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).operator>(value));
+}
+
+kth_bool_t kth_vm_number_less(kth_number_const_t self, int64_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).operator<(value));
+}
+
+kth_bool_t kth_vm_number_greater_or_equal(kth_number_const_t self, int64_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).operator>=(value));
+}
+
+kth_bool_t kth_vm_number_less_or_equal(kth_number_const_t self, int64_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).operator<=(value));
+}
+
+kth_bool_t kth_vm_number_safe_add_number(kth_number_mut_t self, kth_number_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).safe_add(x_cpp));
+}
+
+kth_bool_t kth_vm_number_safe_add_int64(kth_number_mut_t self, int64_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).safe_add(x));
+}
+
+kth_bool_t kth_vm_number_safe_sub_number(kth_number_mut_t self, kth_number_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).safe_sub(x_cpp));
+}
+
+kth_bool_t kth_vm_number_safe_sub_int64(kth_number_mut_t self, int64_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).safe_sub(x));
+}
+
+kth_bool_t kth_vm_number_safe_mul_number(kth_number_mut_t self, kth_number_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).safe_mul(x_cpp));
+}
+
+kth_bool_t kth_vm_number_safe_mul_int64(kth_number_mut_t self, int64_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).safe_mul(x));
+}
+
+
+// Static utilities
+
+kth_error_code_t kth_vm_number_from_int(int64_t value, KTH_OUT_OWNED kth_number_mut_t* out) {
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto result = cpp_t::from_int(value);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_vm_number_safe_add_number2(kth_number_const_t x, kth_number_const_t y, KTH_OUT_OWNED kth_number_mut_t* out) {
+    KTH_PRECONDITION(x != nullptr);
+    KTH_PRECONDITION(y != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
+    auto const& y_cpp = kth::cpp_ref<cpp_t>(y);
+    auto result = cpp_t::safe_add(x_cpp, y_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_vm_number_safe_sub_number2(kth_number_const_t x, kth_number_const_t y, KTH_OUT_OWNED kth_number_mut_t* out) {
+    KTH_PRECONDITION(x != nullptr);
+    KTH_PRECONDITION(y != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
+    auto const& y_cpp = kth::cpp_ref<cpp_t>(y);
+    auto result = cpp_t::safe_sub(x_cpp, y_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_vm_number_safe_mul_number2(kth_number_const_t x, kth_number_const_t y, KTH_OUT_OWNED kth_number_mut_t* out) {
+    KTH_PRECONDITION(x != nullptr);
+    KTH_PRECONDITION(y != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
+    auto const& y_cpp = kth::cpp_ref<cpp_t>(y);
+    auto result = cpp_t::safe_mul(x_cpp, y_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_size_t kth_vm_number_minimally_encode(uint8_t* data, kth_size_t n) {
+    KTH_PRECONDITION(data != nullptr || n == 0);
+    kth::data_chunk data_cpp = n != 0 ? kth::data_chunk(data, data + n) : kth::data_chunk{};
+    (void)cpp_t::minimally_encode(data_cpp);
+    auto const required = data_cpp.size();
+    if (kth::sz(n) >= required && required > 0) std::memcpy(data, data_cpp.data(), required);
+    return static_cast<kth_size_t>(required);
+}
+
+} // extern "C"

--- a/src/c-api/test/data_stack.cpp
+++ b/src/c-api/test/data_stack.cpp
@@ -1,0 +1,170 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/data_stack.h>
+#include <kth/capi/primitives.h>
+
+#include "test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DataStack - default construct yields empty list",
+          "[C-API DataStack][lifecycle]") {
+    kth_data_stack_mut_t list = kth_core_data_stack_construct_default();
+    REQUIRE(list != NULL);
+    REQUIRE(kth_core_data_stack_count(list) == 0);
+    kth_core_data_stack_destruct(list);
+}
+
+TEST_CASE("C-API DataStack - destruct(NULL) is a no-op",
+          "[C-API DataStack][lifecycle]") {
+    kth_core_data_stack_destruct(NULL);
+}
+
+TEST_CASE("C-API DataStack - copy is independent of source",
+          "[C-API DataStack][lifecycle]") {
+    kth_data_stack_mut_t src = kth_core_data_stack_construct_default();
+    uint8_t const a[] = { 0x01, 0x02, 0x03 };
+    uint8_t const b[] = { 0xff };
+    kth_core_data_stack_push_back(src, a, sizeof(a));
+    kth_core_data_stack_push_back(src, b, sizeof(b));
+
+    kth_data_stack_mut_t cp = kth_core_data_stack_copy(src);
+    REQUIRE(cp != NULL);
+    REQUIRE(kth_core_data_stack_count(cp) == 2);
+
+    // Mutating the copy must not bleed back into the source.
+    kth_core_data_stack_erase(cp, 0);
+    REQUIRE(kth_core_data_stack_count(cp) == 1);
+    REQUIRE(kth_core_data_stack_count(src) == 2);
+
+    kth_core_data_stack_destruct(cp);
+    kth_core_data_stack_destruct(src);
+}
+
+// ---------------------------------------------------------------------------
+// push_back / count / nth (borrowed view)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DataStack - push_back appends variable-length buffers",
+          "[C-API DataStack][push]") {
+    kth_data_stack_mut_t list = kth_core_data_stack_construct_default();
+    uint8_t const b0[] = { 0xde, 0xad, 0xbe, 0xef };
+    uint8_t const b1[] = { 0x42 };
+    kth_core_data_stack_push_back(list, b0, sizeof(b0));
+    kth_core_data_stack_push_back(list, b1, sizeof(b1));
+    REQUIRE(kth_core_data_stack_count(list) == 2);
+
+    kth_size_t size = 0;
+    uint8_t const* p0 = kth_core_data_stack_nth(list, 0, &size);
+    REQUIRE(size == sizeof(b0));
+    REQUIRE(memcmp(p0, b0, sizeof(b0)) == 0);
+
+    uint8_t const* p1 = kth_core_data_stack_nth(list, 1, &size);
+    REQUIRE(size == sizeof(b1));
+    REQUIRE(p1[0] == 0x42);
+
+    kth_core_data_stack_destruct(list);
+}
+
+TEST_CASE("C-API DataStack - push_back handles empty elements (NULL + n=0)",
+          "[C-API DataStack][push]") {
+    kth_data_stack_mut_t list = kth_core_data_stack_construct_default();
+    kth_core_data_stack_push_back(list, NULL, 0);
+    REQUIRE(kth_core_data_stack_count(list) == 1);
+
+    // `nth` may return NULL for an empty element (implementation-defined
+    // on some platforms for `std::vector::data()`). Callers must check
+    // `*out_size`, not the pointer, before dereferencing.
+    kth_size_t size = 0xdead;
+    uint8_t const* p = kth_core_data_stack_nth(list, 0, &size);
+    (void)p;
+    REQUIRE(size == 0);
+
+    kth_core_data_stack_destruct(list);
+}
+
+// ---------------------------------------------------------------------------
+// nth_copy — owned bytes the caller must free
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DataStack - nth_copy hands back an owned buffer",
+          "[C-API DataStack][copy]") {
+    kth_data_stack_mut_t list = kth_core_data_stack_construct_default();
+    uint8_t const bytes[] = { 0x10, 0x20, 0x30 };
+    kth_core_data_stack_push_back(list, bytes, sizeof(bytes));
+
+    kth_size_t size = 0;
+    uint8_t* owned = kth_core_data_stack_nth_copy(list, 0, &size);
+    REQUIRE(owned != NULL);
+    REQUIRE(size == sizeof(bytes));
+    REQUIRE(memcmp(owned, bytes, sizeof(bytes)) == 0);
+
+    // The owned buffer survives list destruction.
+    kth_core_data_stack_destruct(list);
+    REQUIRE(owned[0] == 0x10);
+    kth_core_destruct_array(owned);
+}
+
+// ---------------------------------------------------------------------------
+// erase
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DataStack - erase removes the selected element",
+          "[C-API DataStack][erase]") {
+    kth_data_stack_mut_t list = kth_core_data_stack_construct_default();
+    uint8_t const b0[] = { 0xaa };
+    uint8_t const b1[] = { 0xbb };
+    uint8_t const b2[] = { 0xcc };
+    kth_core_data_stack_push_back(list, b0, 1);
+    kth_core_data_stack_push_back(list, b1, 1);
+    kth_core_data_stack_push_back(list, b2, 1);
+
+    kth_core_data_stack_erase(list, 1);
+    REQUIRE(kth_core_data_stack_count(list) == 2);
+
+    kth_size_t size = 0;
+    uint8_t const* p0 = kth_core_data_stack_nth(list, 0, &size);
+    REQUIRE(p0[0] == 0xaa);
+    uint8_t const* p1 = kth_core_data_stack_nth(list, 1, &size);
+    REQUIRE(p1[0] == 0xcc);
+
+    kth_core_data_stack_destruct(list);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API DataStack - count null aborts",
+          "[C-API DataStack][precondition]") {
+    KTH_EXPECT_ABORT(kth_core_data_stack_count(NULL));
+}
+
+TEST_CASE("C-API DataStack - push_back null aborts",
+          "[C-API DataStack][precondition]") {
+    uint8_t const buf[] = { 0x01 };
+    KTH_EXPECT_ABORT(kth_core_data_stack_push_back(NULL, buf, 1));
+}
+
+TEST_CASE("C-API DataStack - nth out-of-range aborts",
+          "[C-API DataStack][precondition]") {
+    kth_data_stack_mut_t list = kth_core_data_stack_construct_default();
+    kth_size_t size = 0;
+    KTH_EXPECT_ABORT(kth_core_data_stack_nth(list, 5, &size));
+    kth_core_data_stack_destruct(list);
+}

--- a/src/c-api/test/vm/big_number.cpp
+++ b/src/c-api/test/vm/big_number.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/vm/big_number.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BigNumber - default construct yields zero",
+          "[C-API BigNumber][lifecycle]") {
+    kth_big_number_mut_t n = kth_vm_big_number_construct_default();
+    REQUIRE(n != NULL);
+    REQUIRE(kth_vm_big_number_is_zero(n) != 0);
+    REQUIRE(kth_vm_big_number_is_nonzero(n) == 0);
+    REQUIRE(kth_vm_big_number_sign(n) == 0);
+    kth_vm_big_number_destruct(n);
+}
+
+TEST_CASE("C-API BigNumber - destruct(NULL) is a no-op",
+          "[C-API BigNumber][lifecycle]") {
+    kth_vm_big_number_destruct(NULL);
+}
+
+TEST_CASE("C-API BigNumber - construct_from_value carries a signed int64",
+          "[C-API BigNumber][lifecycle]") {
+    kth_big_number_mut_t n = kth_vm_big_number_construct_from_value(-12345);
+    REQUIRE(kth_vm_big_number_sign(n) < 0);
+    REQUIRE(kth_vm_big_number_is_negative(n) != 0);
+    REQUIRE(kth_vm_big_number_is_nonzero(n) != 0);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(n) == -12345);
+    kth_vm_big_number_destruct(n);
+}
+
+TEST_CASE("C-API BigNumber - construct_from_decimal_str parses base-10",
+          "[C-API BigNumber][lifecycle]") {
+    kth_big_number_mut_t n = kth_vm_big_number_construct_from_decimal_str("99999999999999999999");
+    REQUIRE(n != NULL);
+    // Verify via to_string (round-trip through the canonical decimal form).
+    char* s = kth_vm_big_number_to_string(n);
+    REQUIRE(s != NULL);
+    REQUIRE(strcmp(s, "99999999999999999999") == 0);
+    kth_core_destruct_string(s);
+    kth_vm_big_number_destruct(n);
+}
+
+TEST_CASE("C-API BigNumber - copy is independent of source",
+          "[C-API BigNumber][lifecycle]") {
+    kth_big_number_mut_t a = kth_vm_big_number_construct_from_value(1000);
+    kth_big_number_mut_t b = kth_vm_big_number_copy(a);
+    REQUIRE(b != NULL);
+
+    // Mutating the copy (via negate) must not bleed back.
+    kth_vm_big_number_negate(b);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(a) == 1000);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(b) == -1000);
+
+    kth_vm_big_number_destruct(b);
+    kth_vm_big_number_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// String / hex accessors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BigNumber - to_string round-trips through decimal",
+          "[C-API BigNumber][encode]") {
+    kth_big_number_mut_t n = kth_vm_big_number_construct_from_value(42);
+    char* s = kth_vm_big_number_to_string(n);
+    REQUIRE(strcmp(s, "42") == 0);
+    kth_core_destruct_string(s);
+    kth_vm_big_number_destruct(n);
+}
+
+TEST_CASE("C-API BigNumber - from_hex / to_hex round-trip",
+          "[C-API BigNumber][encode]") {
+    kth_big_number_mut_t n = kth_vm_big_number_from_hex("ff00");
+    REQUIRE(n != NULL);
+    char* s = kth_vm_big_number_to_hex(n);
+    REQUIRE(s != NULL);
+    // Hex formatter returns canonical form (no leading zeros, no prefix).
+    REQUIRE(strcmp(s, "ff00") == 0);
+    kth_core_destruct_string(s);
+    kth_vm_big_number_destruct(n);
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BigNumber - compare orders two handles",
+          "[C-API BigNumber][compare]") {
+    kth_big_number_mut_t a = kth_vm_big_number_construct_from_value(5);
+    kth_big_number_mut_t b = kth_vm_big_number_construct_from_value(5);
+    kth_big_number_mut_t c = kth_vm_big_number_construct_from_value(10);
+
+    REQUIRE(kth_vm_big_number_equals(a, b) != 0);
+    REQUIRE(kth_vm_big_number_equals(a, c) == 0);
+    REQUIRE(kth_vm_big_number_compare(a, c) < 0);
+    REQUIRE(kth_vm_big_number_compare(c, a) > 0);
+    REQUIRE(kth_vm_big_number_compare(a, b) == 0);
+
+    kth_vm_big_number_destruct(c);
+    kth_vm_big_number_destruct(b);
+    kth_vm_big_number_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// Arithmetic producing new handles
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BigNumber - pow produces a new handle with correct value",
+          "[C-API BigNumber][arithmetic]") {
+    // 2^10 = 1024. `pow` returns an owned new handle; inputs untouched.
+    kth_big_number_mut_t base = kth_vm_big_number_construct_from_value(2);
+    kth_big_number_mut_t exp = kth_vm_big_number_construct_from_value(10);
+    kth_big_number_mut_t result = kth_vm_big_number_pow(base, exp);
+    REQUIRE(result != NULL);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(result) == 1024);
+
+    // Inputs unchanged.
+    REQUIRE(kth_vm_big_number_to_int32_saturating(base) == 2);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(exp) == 10);
+
+    kth_vm_big_number_destruct(result);
+    kth_vm_big_number_destruct(exp);
+    kth_vm_big_number_destruct(base);
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BigNumber - serialize → deserialize round-trip",
+          "[C-API BigNumber][encode]") {
+    kth_big_number_mut_t src = kth_vm_big_number_construct_from_value(123456);
+    kth_size_t size = 0;
+    uint8_t* buf = kth_vm_big_number_serialize(src, &size);
+    REQUIRE(buf != NULL);
+    REQUIRE(size > 0);
+
+    kth_big_number_mut_t dst = kth_vm_big_number_construct_default();
+    REQUIRE(kth_vm_big_number_deserialize(dst, buf, size) != 0);
+    REQUIRE(kth_vm_big_number_equals(src, dst) != 0);
+
+    kth_vm_big_number_destruct(dst);
+    kth_core_destruct_array(buf);
+    kth_vm_big_number_destruct(src);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BigNumber - sign null aborts",
+          "[C-API BigNumber][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_big_number_sign(NULL));
+}
+
+TEST_CASE("C-API BigNumber - copy null aborts",
+          "[C-API BigNumber][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_big_number_copy(NULL));
+}

--- a/src/c-api/test/vm/number.cpp
+++ b/src/c-api/test/vm/number.cpp
@@ -1,0 +1,253 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/vm/number.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Number - default construct yields a zero value",
+          "[C-API Number][lifecycle]") {
+    kth_number_mut_t n = kth_vm_number_construct_default();
+    REQUIRE(n != NULL);
+    REQUIRE(kth_vm_number_int64(n) == 0);
+    REQUIRE(kth_vm_number_int32(n) == 0);
+    REQUIRE(kth_vm_number_is_false(n) != 0);
+    REQUIRE(kth_vm_number_is_true(n) == 0);
+    kth_vm_number_destruct(n);
+}
+
+TEST_CASE("C-API Number - destruct(NULL) is a no-op",
+          "[C-API Number][lifecycle]") {
+    kth_vm_number_destruct(NULL);
+}
+
+TEST_CASE("C-API Number - copy is independent of source",
+          "[C-API Number][lifecycle]") {
+    kth_number_mut_t a = NULL;
+    REQUIRE(kth_vm_number_from_int(7, &a) == kth_ec_success);
+    kth_number_mut_t b = kth_vm_number_copy(a);
+    REQUIRE(b != NULL);
+    REQUIRE(kth_vm_number_int64(b) == 7);
+
+    // Mutating the copy must not bleed back into the source.
+    kth_vm_number_safe_add_int64(b, 10);
+    REQUIRE(kth_vm_number_int64(b) == 17);
+    REQUIRE(kth_vm_number_int64(a) == 7);
+
+    kth_vm_number_destruct(b);
+    kth_vm_number_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// from_int / getters
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Number - from_int preserves the signed 64-bit value",
+          "[C-API Number][getter]") {
+    kth_number_mut_t n = NULL;
+    REQUIRE(kth_vm_number_from_int(-42, &n) == kth_ec_success);
+    REQUIRE(n != NULL);
+    REQUIRE(kth_vm_number_int64(n) == -42);
+    REQUIRE(kth_vm_number_int32(n) == -42);
+    REQUIRE(kth_vm_number_is_true(n) != 0);
+    REQUIRE(kth_vm_number_is_false(n) == 0);
+    kth_vm_number_destruct(n);
+}
+
+TEST_CASE("C-API Number - int32 saturates at int32 boundary",
+          "[C-API Number][getter]") {
+    // from_int enforces the [-2^31 + 1, 2^31 - 1] consensus range;
+    // above-range values fail construction. Anything inside that range
+    // round-trips exactly through int32().
+    kth_number_mut_t n = NULL;
+    REQUIRE(kth_vm_number_from_int(2147483647, &n) == kth_ec_success);
+    REQUIRE(kth_vm_number_int32(n) == 2147483647);
+    REQUIRE(kth_vm_number_int64(n) == 2147483647);
+    kth_vm_number_destruct(n);
+}
+
+// ---------------------------------------------------------------------------
+// Comparison predicates
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Number - comparison against int64",
+          "[C-API Number][compare]") {
+    kth_number_mut_t n = NULL;
+    REQUIRE(kth_vm_number_from_int(10, &n) == kth_ec_success);
+
+    REQUIRE(kth_vm_number_greater(n, 5) != 0);
+    REQUIRE(kth_vm_number_greater(n, 10) == 0);
+    REQUIRE(kth_vm_number_less(n, 20) != 0);
+    REQUIRE(kth_vm_number_less_or_equal(n, 10) != 0);
+    REQUIRE(kth_vm_number_greater_or_equal(n, 10) != 0);
+
+    kth_vm_number_destruct(n);
+}
+
+TEST_CASE("C-API Number - equals compares two handles",
+          "[C-API Number][compare]") {
+    kth_number_mut_t a = NULL;
+    kth_number_mut_t b = NULL;
+    REQUIRE(kth_vm_number_from_int(3, &a) == kth_ec_success);
+    REQUIRE(kth_vm_number_from_int(3, &b) == kth_ec_success);
+    REQUIRE(kth_vm_number_equals(a, b) != 0);
+
+    kth_number_mut_t c = NULL;
+    REQUIRE(kth_vm_number_from_int(4, &c) == kth_ec_success);
+    REQUIRE(kth_vm_number_equals(a, c) == 0);
+
+    kth_vm_number_destruct(c);
+    kth_vm_number_destruct(b);
+    kth_vm_number_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// safe_add / safe_sub / safe_mul — in-place (member) variants
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Number - safe_add_int64 accumulates on the receiver",
+          "[C-API Number][arithmetic]") {
+    kth_number_mut_t n = NULL;
+    REQUIRE(kth_vm_number_from_int(10, &n) == kth_ec_success);
+    REQUIRE(kth_vm_number_safe_add_int64(n, 20) != 0);
+    REQUIRE(kth_vm_number_int64(n) == 30);
+    kth_vm_number_destruct(n);
+}
+
+TEST_CASE("C-API Number - safe_sub_number subtracts by handle",
+          "[C-API Number][arithmetic]") {
+    kth_number_mut_t a = NULL;
+    kth_number_mut_t b = NULL;
+    REQUIRE(kth_vm_number_from_int(100, &a) == kth_ec_success);
+    REQUIRE(kth_vm_number_from_int(30, &b) == kth_ec_success);
+    REQUIRE(kth_vm_number_safe_sub_number(a, b) != 0);
+    REQUIRE(kth_vm_number_int64(a) == 70);
+    kth_vm_number_destruct(b);
+    kth_vm_number_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// safe_add_number2 / safe_sub_number2 / safe_mul_number2 — static variants
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Number - safe_add_number2 produces a new handle",
+          "[C-API Number][arithmetic]") {
+    // The `_number2` suffix is the arity-disambiguated name for the
+    // static two-argument overload. It never mutates the inputs —
+    // returns an owned handle via `out`.
+    kth_number_mut_t a = NULL;
+    kth_number_mut_t b = NULL;
+    kth_number_mut_t sum = NULL;
+    REQUIRE(kth_vm_number_from_int(3, &a) == kth_ec_success);
+    REQUIRE(kth_vm_number_from_int(4, &b) == kth_ec_success);
+    REQUIRE(kth_vm_number_safe_add_number2(a, b, &sum) == kth_ec_success);
+    REQUIRE(sum != NULL);
+    REQUIRE(kth_vm_number_int64(sum) == 7);
+
+    // Inputs untouched.
+    REQUIRE(kth_vm_number_int64(a) == 3);
+    REQUIRE(kth_vm_number_int64(b) == 4);
+
+    kth_vm_number_destruct(sum);
+    kth_vm_number_destruct(b);
+    kth_vm_number_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// data round-trip (LSB-first byte encoding)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Number - data() encodes the int64 as script bytes",
+          "[C-API Number][data]") {
+    kth_number_mut_t n = NULL;
+    REQUIRE(kth_vm_number_from_int(1, &n) == kth_ec_success);
+
+    kth_size_t size = 0;
+    uint8_t* bytes = kth_vm_number_data(n, &size);
+    REQUIRE(bytes != NULL);
+    REQUIRE(size == 1);
+    REQUIRE(bytes[0] == 0x01);
+    kth_core_destruct_array(bytes);
+
+    kth_vm_number_destruct(n);
+}
+
+TEST_CASE("C-API Number - set_data parses a script-encoded byte string",
+          "[C-API Number][data]") {
+    kth_number_mut_t n = kth_vm_number_construct_default();
+    uint8_t const encoded[] = { 0x0a };
+    REQUIRE(kth_vm_number_set_data(n, encoded, sizeof(encoded), 4) != 0);
+    REQUIRE(kth_vm_number_int64(n) == 10);
+    kth_vm_number_destruct(n);
+}
+
+// ---------------------------------------------------------------------------
+// minimally_encode — in-place byte-buffer transform
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Number - minimally_encode trims an over-padded encoding",
+          "[C-API Number][data]") {
+    // `[0x05, 0x00]` is a non-minimal encoding for the integer 5
+    // (the trailing zero byte is redundant). `minimally_encode` must
+    // strip it and report the trimmed length. The probe-size pattern
+    // lets callers allocate exactly: first call with n=0 (NULL) to
+    // learn the required size, then again with a fitted buffer.
+    uint8_t src[2] = { 0x05, 0x00 };
+    // Probe — the input is read-only semantically (the buffer is not
+    // touched when n is below required).
+    kth_size_t required = kth_vm_number_minimally_encode(src, sizeof(src));
+    REQUIRE(required == 1);
+
+    // `src[0]` is overwritten in place with the trimmed encoding; the
+    // trailing byte past `required` is left as-is (it's stale).
+    REQUIRE(src[0] == 0x05);
+}
+
+TEST_CASE("C-API Number - minimally_encode leaves already-minimal input intact",
+          "[C-API Number][data]") {
+    // [0x05] is already minimal — the function must return 1 and
+    // leave the byte untouched.
+    uint8_t buf[1] = { 0x05 };
+    kth_size_t required = kth_vm_number_minimally_encode(buf, sizeof(buf));
+    REQUIRE(required == 1);
+    REQUIRE(buf[0] == 0x05);
+}
+
+TEST_CASE("C-API Number - minimally_encode on empty input returns 0",
+          "[C-API Number][data]") {
+    // The empty encoding represents the stack value 0; it is already
+    // minimal, so nothing to strip.
+    kth_size_t required = kth_vm_number_minimally_encode(NULL, 0);
+    REQUIRE(required == 0);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Number - int64 null aborts",
+          "[C-API Number][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_number_int64(NULL));
+}
+
+TEST_CASE("C-API Number - copy null aborts",
+          "[C-API Number][precondition]") {
+    KTH_EXPECT_ABORT(kth_vm_number_copy(NULL));
+}


### PR DESCRIPTION
## Summary
- Adds opaque handles for the three numeric / stack types the VM interpreter uses internally but never exposed to C consumers: \`number\` (bounded 4-byte script integer with checked arithmetic), \`big_number\` (BCH 2025 unbounded big-int), and \`data_stack\` (list of variable-length byte buffers).
- \`big_number\` is backend-agnostic: parsing targets \`big_number_gmp\` (what libclang sees by default) but the generated cpp binds through the \`kth::big_number\` alias so the compiled binary follows whichever backend the project is built with.
- \`data_stack\` is a hand-written \`kth_core_data_stack_*\` module — the existing list generator doesn't cover lists whose element is a buffer with its own length. Exposes \`construct_default\`, \`destruct\`, \`copy\`, \`count\`, \`push_back(ptr, len)\`, \`nth\` (borrowed view), \`nth_copy\` (owned copy), \`erase\`.
- Test suites mirror the lifecycle / value / arithmetic / encode / precondition shape used by the other VM bindings.

These are the three handles the remaining \`program\` skipped methods (\`pop_number\`, \`top_number\`, \`pop_big_number\`, \`top_big_number\`, \`pop(size_t)\`) need before the generator can emit them. The \`program\` regen itself is deferred to a follow-up so this PR lands cleanly independent of other in-flight work.

## Test plan
- [ ] \`cmake --build build --target kth-capi-tests && ctest --test-dir build -R "C-API (Number|BigNumber|DataStack)"\`
- [ ] Existing VM test suites still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new C-API surface area with manual memory-ownership contracts (owned buffers/handles) and thin wrappers over VM numeric types; risk is mainly ABI/API correctness and potential leaks/misuse, not changes to consensus logic.
> 
> **Overview**
> Exposes previously-internal VM primitives to C consumers by adding new opaque handles and C wrappers for `number` (bounded script integer) and `big_number` (unbounded integer), including construction/copy/destruction, encoding/decoding, comparisons, and safe arithmetic helpers.
> 
> Adds a new hand-written `kth_core_data_stack_*` module to manipulate `data_stack` (variable-length byte-buffer stack) with `push_back`, `nth`/`nth_copy`, `count`, and `erase`, and wires all new headers/sources plus Catch2 tests into the build via `CMakeLists.txt` and the umbrella `capi.h` include.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52a64ce298d6527001f62cad92b669962c335f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->