### PR TITLE
feat(c-api): expose program::pop_number / top_number (+big variants)

### DIFF
--- a/src/c-api/include/kth/capi/vm/program.h
+++ b/src/c-api/include/kth/capi/vm/program.h
@@ -202,6 +202,14 @@ kth_error_code_t kth_vm_program_pop_int32(kth_program_mut_t self, int32_t* out);
 KTH_EXPORT
 kth_error_code_t kth_vm_program_pop_int64(kth_program_mut_t self, int64_t* out);
 
+/** @param[out] out Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_vm_program_pop_number(kth_program_mut_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_number_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_big_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_big_number_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_vm_program_pop_big_number(kth_program_mut_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_big_number_mut_t* out);
+
 KTH_EXPORT
 kth_error_code_t kth_vm_program_pop_index(kth_program_mut_t self, uint32_t* out);
 
@@ -223,6 +231,14 @@ kth_bool_t kth_vm_program_if_(kth_program_const_t self, kth_operation_const_t op
 /** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
 KTH_EXPORT KTH_OWNED
 uint8_t* kth_vm_program_item(kth_program_const_t self, kth_size_t index, kth_size_t* out_size);
+
+/** @param[out] out Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_vm_program_top_number(kth_program_const_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_number_mut_t* out);
+
+/** @param[out] out Must point to a null `kth_big_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_big_number_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_vm_program_top_big_number(kth_program_const_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_big_number_mut_t* out);
 
 KTH_EXPORT
 void kth_vm_program_push_alternate(kth_program_mut_t self, uint8_t const* value, kth_size_t n);

--- a/src/c-api/src/vm/program.cpp
+++ b/src/c-api/src/vm/program.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <utility>
+
 #include <kth/capi/vm/program.h>
 
 #include <kth/capi/conversions.hpp>
@@ -297,6 +299,28 @@ kth_error_code_t kth_vm_program_pop_int64(kth_program_mut_t self, int64_t* out) 
     return kth_ec_success;
 }
 
+kth_error_code_t kth_vm_program_pop_number(kth_program_mut_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_number_mut_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const maximum_size_cpp = kth::sz(maximum_size);
+    auto result = kth::cpp_ref<cpp_t>(self).pop_number(maximum_size_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_vm_program_pop_big_number(kth_program_mut_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_big_number_mut_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const maximum_size_cpp = kth::sz(maximum_size);
+    auto result = kth::cpp_ref<cpp_t>(self).pop_big_number(maximum_size_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
 kth_error_code_t kth_vm_program_pop_index(kth_program_mut_t self, uint32_t* out) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out != nullptr);
@@ -344,6 +368,28 @@ uint8_t* kth_vm_program_item(kth_program_const_t self, kth_size_t index, kth_siz
     auto const index_cpp = kth::sz(index);
     auto const& data = kth::cpp_ref<cpp_t>(self).item(index_cpp);
     return kth::create_c_array(data, *out_size);
+}
+
+kth_error_code_t kth_vm_program_top_number(kth_program_const_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_number_mut_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const maximum_size_cpp = kth::sz(maximum_size);
+    auto result = kth::cpp_ref<cpp_t>(self).top_number(maximum_size_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_vm_program_top_big_number(kth_program_const_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_big_number_mut_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const maximum_size_cpp = kth::sz(maximum_size);
+    auto result = kth::cpp_ref<cpp_t>(self).top_big_number(maximum_size_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 void kth_vm_program_push_alternate(kth_program_mut_t self, uint8_t const* value, kth_size_t n) {

--- a/src/c-api/test/vm/program.cpp
+++ b/src/c-api/test/vm/program.cpp
@@ -14,6 +14,8 @@
 
 #include <kth/capi/chain/script.h>
 #include <kth/capi/primitives.h>
+#include <kth/capi/vm/big_number.h>
+#include <kth/capi/vm/number.h>
 #include <kth/capi/vm/program.h>
 
 #include "../test_helpers.hpp"
@@ -100,6 +102,86 @@ TEST_CASE("C-API Program - mark_code_separator rejects out-of-range PC",
 
     // Huge PC value must also be rejected without UB.
     REQUIRE(kth_vm_program_mark_code_separator(prog, (kth_size_t)(~(kth_size_t)0)) == 0);
+
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// top_number / pop_number — handle-returning wrappers over the stack top
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Program - top_number reads the script integer at TOS",
+          "[C-API Program][number]") {
+    // `push(true)` leaves the 1-byte encoding of 1 on the main stack.
+    // `top_number` wraps it into a `number` handle without popping.
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+
+    kth_number_mut_t out = NULL;
+    REQUIRE(kth_vm_program_top_number(prog, 4, &out) == kth_ec_success);
+    REQUIRE(out != NULL);
+    REQUIRE(kth_vm_number_int64(out) == 1);
+    kth_vm_number_destruct(out);
+
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Program - pop_number consumes the stack top",
+          "[C-API Program][number]") {
+    // Distinguish pop from top by reading size before and after.
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+
+    kth_number_mut_t out = NULL;
+    REQUIRE(kth_vm_program_pop_number(prog, 4, &out) == kth_ec_success);
+    REQUIRE(kth_vm_number_int64(out) == 1);
+    kth_vm_number_destruct(out);
+
+    // Subsequent pop must fail — the stack is empty.
+    kth_number_mut_t out2 = NULL;
+    REQUIRE(kth_vm_program_pop_number(prog, 4, &out2) != kth_ec_success);
+    REQUIRE(out2 == NULL);
+
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Program - top_big_number reads the stack top as big-int",
+          "[C-API Program][big_number]") {
+    // `push(true)` puts a minimally-encoded 1 on the stack; the
+    // big-int parse must see the same value as the `number` overload.
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+
+    kth_big_number_mut_t out = NULL;
+    REQUIRE(kth_vm_program_top_big_number(prog, 4, &out) == kth_ec_success);
+    REQUIRE(out != NULL);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(out) == 1);
+    kth_vm_big_number_destruct(out);
+
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Program - pop_big_number consumes the stack top",
+          "[C-API Program][big_number]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+
+    kth_big_number_mut_t out = NULL;
+    REQUIRE(kth_vm_program_pop_big_number(prog, 4, &out) == kth_ec_success);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(out) == 1);
+    kth_vm_big_number_destruct(out);
 
     kth_vm_program_destruct(prog);
     kth_chain_script_destruct(script);


### PR DESCRIPTION
## Summary
With \`number\` and \`big_number\` now registered as opaque handles (#302), the generator emits the four \`program\` stack-read methods that were previously skipped because their \`expected<Handle, error_code>\` returns had no type mapping:

- \`kth_vm_program_pop_number\` / \`kth_vm_program_top_number\` — the 4-byte-bounded script integer.
- \`kth_vm_program_pop_big_number\` / \`kth_vm_program_top_big_number\` — the BCH 2025 unbounded big-int.

All four use the \`kth_error_code_t fn(..., Handle* out)\` out-param shape that the rest of the C-API already uses for fallible constructors: \`out\` is populated with an owned handle on success and left untouched on error.

This closes the \`pop_number\` / \`top_number\` line from the "VM program — pending surface" section of TODO.md.

## Test plan
- [ ] \`cmake --build build --target kth-capi-tests && ctest --test-dir build -R "C-API Program.*(number|big_number)"\`
- [ ] Existing program / number / big_number suites still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new C-API wrapper functions and tests without changing VM semantics, but introduces new owned-handle out-parameter APIs that callers must manage correctly.
> 
> **Overview**
> Exposes four new C-API functions on `program` to read script integers from the main stack as opaque handles: `kth_vm_program_top_number`/`pop_number` and `kth_vm_program_top_big_number`/`pop_big_number`, each taking a `maximum_size` and returning results via an owned out-parameter.
> 
> Implements these wrappers in `program.cpp` using the existing `expected`-returning C++ methods (with preconditions that `out` is non-null and initially `NULL`), and adds Catch2 tests validating value decoding and that `pop_*` consumes the stack while `top_*` does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7573fb9e268498c45f04cc08fa5fdd3e94a0d197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->