### PR TITLE
feat(c-api): expose pop_binary / pop_ternary / pop(count)

### DIFF
--- a/src/c-api/include/kth/capi/vm/program.h
+++ b/src/c-api/include/kth/capi/vm/program.h
@@ -194,7 +194,7 @@ void kth_vm_program_drop(kth_program_mut_t self);
 
 /** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
 KTH_EXPORT KTH_OWNED
-uint8_t* kth_vm_program_pop(kth_program_mut_t self, kth_size_t* out_size);
+uint8_t* kth_vm_program_pop_simple(kth_program_mut_t self, kth_size_t* out_size);
 
 KTH_EXPORT
 kth_error_code_t kth_vm_program_pop_int32(kth_program_mut_t self, int32_t* out);
@@ -206,12 +206,46 @@ kth_error_code_t kth_vm_program_pop_int64(kth_program_mut_t self, int64_t* out);
 KTH_EXPORT
 kth_error_code_t kth_vm_program_pop_number(kth_program_mut_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_number_mut_t* out);
 
+/**
+ * @param[out] out_first Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error.
+ * @param[out] out_second Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_vm_program_pop_binary(kth_program_mut_t self, KTH_OUT_OWNED kth_number_mut_t* out_first, KTH_OUT_OWNED kth_number_mut_t* out_second);
+
+/**
+ * @param[out] out_0 Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error.
+ * @param[out] out_1 Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error.
+ * @param[out] out_2 Must point to a null `kth_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_number_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_vm_program_pop_ternary(kth_program_mut_t self, KTH_OUT_OWNED kth_number_mut_t* out_0, KTH_OUT_OWNED kth_number_mut_t* out_1, KTH_OUT_OWNED kth_number_mut_t* out_2);
+
 /** @param[out] out Must point to a null `kth_big_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_big_number_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_vm_program_pop_big_number(kth_program_mut_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_big_number_mut_t* out);
 
+/**
+ * @param[out] out_first Must point to a null `kth_big_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_big_number_destruct`. Untouched on error.
+ * @param[out] out_second Must point to a null `kth_big_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_big_number_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_vm_program_pop_big_binary(kth_program_mut_t self, KTH_OUT_OWNED kth_big_number_mut_t* out_first, KTH_OUT_OWNED kth_big_number_mut_t* out_second);
+
+/**
+ * @param[out] out_0 Must point to a null `kth_big_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_big_number_destruct`. Untouched on error.
+ * @param[out] out_1 Must point to a null `kth_big_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_big_number_destruct`. Untouched on error.
+ * @param[out] out_2 Must point to a null `kth_big_number_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_vm_big_number_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_vm_program_pop_big_ternary(kth_program_mut_t self, KTH_OUT_OWNED kth_big_number_mut_t* out_0, KTH_OUT_OWNED kth_big_number_mut_t* out_1, KTH_OUT_OWNED kth_big_number_mut_t* out_2);
+
 KTH_EXPORT
 kth_error_code_t kth_vm_program_pop_index(kth_program_mut_t self, uint32_t* out);
+
+/** @param[out] out Must point to a null `kth_data_stack_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_data_stack_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_vm_program_pop(kth_program_mut_t self, kth_size_t count, KTH_OUT_OWNED kth_data_stack_mut_t* out);
 
 KTH_EXPORT
 void kth_vm_program_duplicate(kth_program_mut_t self, kth_size_t index);

--- a/src/c-api/src/vm/program.cpp
+++ b/src/c-api/src/vm/program.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <tuple>
 #include <utility>
 
 #include <kth/capi/vm/program.h>
@@ -274,7 +275,7 @@ void kth_vm_program_drop(kth_program_mut_t self) {
     kth::cpp_ref<cpp_t>(self).drop();
 }
 
-uint8_t* kth_vm_program_pop(kth_program_mut_t self, kth_size_t* out_size) {
+uint8_t* kth_vm_program_pop_simple(kth_program_mut_t self, kth_size_t* out_size) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out_size != nullptr);
     auto const data = kth::cpp_ref<cpp_t>(self).pop();
@@ -310,6 +311,35 @@ kth_error_code_t kth_vm_program_pop_number(kth_program_mut_t self, kth_size_t ma
     return kth_ec_success;
 }
 
+kth_error_code_t kth_vm_program_pop_binary(kth_program_mut_t self, KTH_OUT_OWNED kth_number_mut_t* out_first, KTH_OUT_OWNED kth_number_mut_t* out_second) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_first != nullptr);
+    KTH_PRECONDITION(*out_first == nullptr);
+    KTH_PRECONDITION(out_second != nullptr);
+    KTH_PRECONDITION(*out_second == nullptr);
+    auto result = kth::cpp_ref<cpp_t>(self).pop_binary();
+    if ( ! result) return kth::to_c_err(result.error());
+    *out_first = kth::leak(std::move(result->first));
+    *out_second = kth::leak(std::move(result->second));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_vm_program_pop_ternary(kth_program_mut_t self, KTH_OUT_OWNED kth_number_mut_t* out_0, KTH_OUT_OWNED kth_number_mut_t* out_1, KTH_OUT_OWNED kth_number_mut_t* out_2) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_0 != nullptr);
+    KTH_PRECONDITION(*out_0 == nullptr);
+    KTH_PRECONDITION(out_1 != nullptr);
+    KTH_PRECONDITION(*out_1 == nullptr);
+    KTH_PRECONDITION(out_2 != nullptr);
+    KTH_PRECONDITION(*out_2 == nullptr);
+    auto result = kth::cpp_ref<cpp_t>(self).pop_ternary();
+    if ( ! result) return kth::to_c_err(result.error());
+    *out_0 = kth::leak(std::move(std::get<0>(*result)));
+    *out_1 = kth::leak(std::move(std::get<1>(*result)));
+    *out_2 = kth::leak(std::move(std::get<2>(*result)));
+    return kth_ec_success;
+}
+
 kth_error_code_t kth_vm_program_pop_big_number(kth_program_mut_t self, kth_size_t maximum_size, KTH_OUT_OWNED kth_big_number_mut_t* out) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out != nullptr);
@@ -321,12 +351,52 @@ kth_error_code_t kth_vm_program_pop_big_number(kth_program_mut_t self, kth_size_
     return kth_ec_success;
 }
 
+kth_error_code_t kth_vm_program_pop_big_binary(kth_program_mut_t self, KTH_OUT_OWNED kth_big_number_mut_t* out_first, KTH_OUT_OWNED kth_big_number_mut_t* out_second) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_first != nullptr);
+    KTH_PRECONDITION(*out_first == nullptr);
+    KTH_PRECONDITION(out_second != nullptr);
+    KTH_PRECONDITION(*out_second == nullptr);
+    auto result = kth::cpp_ref<cpp_t>(self).pop_big_binary();
+    if ( ! result) return kth::to_c_err(result.error());
+    *out_first = kth::leak(std::move(result->first));
+    *out_second = kth::leak(std::move(result->second));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_vm_program_pop_big_ternary(kth_program_mut_t self, KTH_OUT_OWNED kth_big_number_mut_t* out_0, KTH_OUT_OWNED kth_big_number_mut_t* out_1, KTH_OUT_OWNED kth_big_number_mut_t* out_2) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_0 != nullptr);
+    KTH_PRECONDITION(*out_0 == nullptr);
+    KTH_PRECONDITION(out_1 != nullptr);
+    KTH_PRECONDITION(*out_1 == nullptr);
+    KTH_PRECONDITION(out_2 != nullptr);
+    KTH_PRECONDITION(*out_2 == nullptr);
+    auto result = kth::cpp_ref<cpp_t>(self).pop_big_ternary();
+    if ( ! result) return kth::to_c_err(result.error());
+    *out_0 = kth::leak(std::move(std::get<0>(*result)));
+    *out_1 = kth::leak(std::move(std::get<1>(*result)));
+    *out_2 = kth::leak(std::move(std::get<2>(*result)));
+    return kth_ec_success;
+}
+
 kth_error_code_t kth_vm_program_pop_index(kth_program_mut_t self, uint32_t* out) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(out != nullptr);
     auto const result = kth::cpp_ref<cpp_t>(self).pop_index();
     if ( ! result) return kth::to_c_err(result.error());
     *out = static_cast<uint32_t>(*result);
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_vm_program_pop(kth_program_mut_t self, kth_size_t count, KTH_OUT_OWNED kth_data_stack_mut_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const count_cpp = kth::sz(count);
+    auto result = kth::cpp_ref<cpp_t>(self).pop(count_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak<kth::data_stack>(std::move(*result));
     return kth_ec_success;
 }
 

--- a/src/c-api/test/vm/program.cpp
+++ b/src/c-api/test/vm/program.cpp
@@ -13,6 +13,7 @@
 #include <stdint.h>
 
 #include <kth/capi/chain/script.h>
+#include <kth/capi/data_stack.h>
 #include <kth/capi/primitives.h>
 #include <kth/capi/vm/big_number.h>
 #include <kth/capi/vm/number.h>
@@ -182,6 +183,175 @@ TEST_CASE("C-API Program - pop_big_number consumes the stack top",
     REQUIRE(kth_vm_program_pop_big_number(prog, 4, &out) == kth_ec_success);
     REQUIRE(kth_vm_big_number_to_int32_saturating(out) == 1);
     kth_vm_big_number_destruct(out);
+
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// pop_binary / pop_ternary — multi-value stack reads (number)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Program - pop_binary pops two numbers from TOS",
+          "[C-API Program][number]") {
+    // Two `push(true)` calls leave two 1-byte `1` encodings on the
+    // main stack. `pop_binary` consumes both as `number` handles.
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+    kth_vm_program_push(prog, 1);
+
+    kth_number_mut_t a = NULL;
+    kth_number_mut_t b = NULL;
+    REQUIRE(kth_vm_program_pop_binary(prog, &a, &b) == kth_ec_success);
+    REQUIRE(a != NULL);
+    REQUIRE(b != NULL);
+    REQUIRE(kth_vm_number_int64(a) == 1);
+    REQUIRE(kth_vm_number_int64(b) == 1);
+
+    // Stack must be empty afterwards.
+    kth_number_mut_t c = NULL;
+    REQUIRE(kth_vm_program_pop_number(prog, 4, &c) != kth_ec_success);
+    REQUIRE(c == NULL);
+
+    kth_vm_number_destruct(b);
+    kth_vm_number_destruct(a);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Program - pop_ternary pops three numbers from TOS",
+          "[C-API Program][number]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+    kth_vm_program_push(prog, 1);
+    kth_vm_program_push(prog, 1);
+
+    kth_number_mut_t a = NULL;
+    kth_number_mut_t b = NULL;
+    kth_number_mut_t c = NULL;
+    REQUIRE(kth_vm_program_pop_ternary(prog, &a, &b, &c) == kth_ec_success);
+    REQUIRE(kth_vm_number_int64(a) == 1);
+    REQUIRE(kth_vm_number_int64(b) == 1);
+    REQUIRE(kth_vm_number_int64(c) == 1);
+
+    kth_vm_number_destruct(c);
+    kth_vm_number_destruct(b);
+    kth_vm_number_destruct(a);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Program - pop_binary on empty stack reports error",
+          "[C-API Program][number]") {
+    // No push first — the underlying `expected` returns an error and
+    // the wrapper must leave both out-slots untouched.
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+
+    kth_number_mut_t a = NULL;
+    kth_number_mut_t b = NULL;
+    REQUIRE(kth_vm_program_pop_binary(prog, &a, &b) != kth_ec_success);
+    REQUIRE(a == NULL);
+    REQUIRE(b == NULL);
+
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// pop_big_binary / pop_big_ternary — same shape for the big-int variant
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Program - pop_big_binary pops two big numbers from TOS",
+          "[C-API Program][big_number]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+    kth_vm_program_push(prog, 1);
+
+    kth_big_number_mut_t a = NULL;
+    kth_big_number_mut_t b = NULL;
+    REQUIRE(kth_vm_program_pop_big_binary(prog, &a, &b) == kth_ec_success);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(a) == 1);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(b) == 1);
+
+    kth_vm_big_number_destruct(b);
+    kth_vm_big_number_destruct(a);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Program - pop_big_ternary pops three big numbers from TOS",
+          "[C-API Program][big_number]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+    kth_vm_program_push(prog, 1);
+    kth_vm_program_push(prog, 1);
+
+    kth_big_number_mut_t a = NULL;
+    kth_big_number_mut_t b = NULL;
+    kth_big_number_mut_t c = NULL;
+    REQUIRE(kth_vm_program_pop_big_ternary(prog, &a, &b, &c) == kth_ec_success);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(a) == 1);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(b) == 1);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(c) == 1);
+
+    kth_vm_big_number_destruct(c);
+    kth_vm_big_number_destruct(b);
+    kth_vm_big_number_destruct(a);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+// ---------------------------------------------------------------------------
+// pop(count) — owned data_stack of the top `count` elements
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Program - pop(count) returns the top N stack elements",
+          "[C-API Program][stack]") {
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+    kth_vm_program_push(prog, 1);
+    kth_vm_program_push(prog, 1);
+
+    kth_data_stack_mut_t popped = NULL;
+    REQUIRE(kth_vm_program_pop(prog, 2, &popped) == kth_ec_success);
+    REQUIRE(popped != NULL);
+    REQUIRE(kth_core_data_stack_count(popped) == 2);
+
+    // Each popped element is the minimally-encoded `true` (1 byte = 0x01).
+    kth_size_t size = 0;
+    uint8_t const* elem = kth_core_data_stack_nth(popped, 0, &size);
+    REQUIRE(size == 1);
+    REQUIRE(elem[0] == 0x01);
+
+    kth_core_data_stack_destruct(popped);
+    kth_vm_program_destruct(prog);
+    kth_chain_script_destruct(script);
+}
+
+TEST_CASE("C-API Program - pop(count) fails when the stack is too short",
+          "[C-API Program][stack]") {
+    // One element on the stack, asking for two — the underlying
+    // `expected` signals an error and the wrapper leaves `out` NULL.
+    kth_program_mut_t prog = NULL;
+    kth_script_mut_t script = NULL;
+    build_program_for_two_op_script(&prog, &script);
+    kth_vm_program_push(prog, 1);
+
+    kth_data_stack_mut_t popped = NULL;
+    REQUIRE(kth_vm_program_pop(prog, 2, &popped) != kth_ec_success);
+    REQUIRE(popped == NULL);
 
     kth_vm_program_destruct(prog);
     kth_chain_script_destruct(script);


### PR DESCRIPTION
> **Depends on #303** — merge #303 first, then rebase this branch onto master:
> ```
> git fetch origin && git rebase origin/master
> git push --force-with-lease
> ```
> GitHub will re-target automatically once #303 is in master and the rebase drops the shared program.cpp regen lines.

## Summary
Closes the remaining \`program\` stack-read surface from TODO.md's "VM program — pending surface" section by teaching the generator three wrapper shapes that were previously unsupported:

- \`expected<pair<Handle, Handle>, E>\` → \`kth_error_code_t fn(self, Handle* out_first, Handle* out_second)\`. Drives \`pop_binary\` and \`pop_big_binary\`.
- \`expected<tuple<Handle, Handle, Handle>, E>\` → three positional out-params (\`out_0\`, \`out_1\`, \`out_2\`). Drives \`pop_ternary\` and \`pop_big_ternary\`.
- \`expected<list<T>, E>\` (when the vector is registered in the list alias registry) → a single \`kth_*_list_mut_t* out\`. Drives \`program::pop(size_t)\` returning an owned \`data_stack\`.

All five wrappers leave their out-slots untouched on error so callers can't inherit a dangling handle on a failed pop.

## Test plan
- [ ] \`cmake --build build --target kth-capi-tests && ctest --test-dir build -R "C-API Program.*(number|big_number|stack)"\`
- [ ] Existing program / number / big_number / data_stack suites still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new C-API entry points and repurposes `kth_vm_program_pop` (renamed to `kth_vm_program_pop_simple`), which is an API/ABI breaking change for existing consumers and touches stack/value ownership semantics.
> 
> **Overview**
> Extends the VM `program` C-API with **multi-value stack pop helpers**: `kth_vm_program_pop_binary`/`pop_ternary` and bigint equivalents, plus `kth_vm_program_pop(count, out_data_stack)` to return an owned `data_stack` of the top N elements.
> 
> Renames the prior raw-byte pop API from `kth_vm_program_pop` to `kth_vm_program_pop_simple` and adds Catch2 tests covering success/error paths and ensuring out-params remain untouched on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafc0fc3b553a5936729ec6d2ef9b34018760d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->