### PR TITLE
feat(c-api): expose output_point::null() coinbase sentinel

### DIFF
--- a/src/c-api/include/kth/capi/chain/output_point.h
+++ b/src/c-api/include/kth/capi/chain/output_point.h
@@ -46,6 +46,13 @@ KTH_EXPORT KTH_OWNED
 kth_output_point_mut_t kth_chain_output_point_construct_from_point(kth_point_const_t x);
 
 
+// Static factories
+
+/** @return Owned `kth_output_point_mut_t`. Caller must release with `kth_chain_output_point_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_output_point_mut_t kth_chain_output_point_null(void);
+
+
 // Destructor
 
 /** No-op if `self` is null. */

--- a/src/c-api/src/chain/output_point.cpp
+++ b/src/c-api/src/chain/output_point.cpp
@@ -57,6 +57,13 @@ kth_output_point_mut_t kth_chain_output_point_construct_from_point(kth_point_con
 }
 
 
+// Static factories
+
+kth_output_point_mut_t kth_chain_output_point_null(void) {
+    return kth::leak(cpp_t::null());
+}
+
+
 // Destructor
 
 void kth_chain_output_point_destruct(kth_output_point_mut_t self) {

--- a/src/c-api/test/chain/output_point.cpp
+++ b/src/c-api/test/chain/output_point.cpp
@@ -225,6 +225,22 @@ TEST_CASE("C-API OutputPoint - satoshi_fixed_size is 36", "[C-API OutputPoint]")
     REQUIRE(kth_chain_output_point_satoshi_fixed_size() == 36u);
 }
 
+TEST_CASE("C-API OutputPoint - null factory returns is_null",
+          "[C-API OutputPoint]") {
+    // `output_point::null()` shadows the inherited `point::null()` so
+    // the generated wrapper hands back an `output_point` handle, not
+    // a sliced `point`. The sentinel itself is the coinbase marker:
+    // a 32-byte null_hash paired with the null-index sentinel
+    // (`max_uint32`). Pin both halves so a future regression that
+    // preserves only one can't sneak through.
+    kth_output_point_mut_t op = kth_chain_output_point_null();
+    REQUIRE(op != NULL);
+    REQUIRE(kth_chain_output_point_is_null(op) != 0);
+    REQUIRE(kth_chain_output_point_index(op) == 0xffffffffu);
+    REQUIRE(kth_hash_is_null(kth_chain_output_point_hash(op)) != 0);
+    kth_chain_output_point_destruct(op);
+}
+
 // ---------------------------------------------------------------------------
 // Preconditions (death tests via fork)
 // ---------------------------------------------------------------------------

--- a/src/domain/include/kth/domain/chain/output_point.hpp
+++ b/src/domain/include/kth/domain/chain/output_point.hpp
@@ -58,6 +58,21 @@ public:
     output_point(point const& x);
     output_point& operator=(point const& /*x*/);
 
+    // Shadows the inherited `point::null()` so the return type is
+    // `output_point`. Without this, `output_point::null()` resolves
+    // to the base-class static and slices to `point` — callers (and
+    // generated bindings) that expected an `output_point` back end
+    // up with a `point`. Forwards to the base factory via the
+    // `point`-taking conversion constructor so the coinbase sentinel
+    // (`null_hash + null_index`) stays in one place. Not `constexpr`
+    // because the `validation_type` member brings in a non-constexpr
+    // `output` default, but `noexcept` mirrors `point::null()`.
+    [[nodiscard]]
+    static
+    output_point null() noexcept {
+        return output_point{point::null()};
+    }
+
     // Operators.
     //-------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
\`output_point\` used to inherit \`point::null()\` unchanged, so callers got back a sliced \`point\` instead of an \`output_point\` — the generator detected the type mismatch and skipped the method entirely. This PR shadows the static in \`output_point\` with a wrapper that forwards through the existing \`point\`-taking conversion constructor, keeping the coinbase sentinel (\`null_hash + null_index\`) in one place and letting the binding emit a proper \`kth_chain_output_point_null\`.

Mirrors what \`kth_chain_point_null\` already exposes, so C callers building coinbase inputs no longer have to roll the sentinel by hand.

## Test plan
- [ ] \`cmake --build build --target kth-capi-tests && ctest --test-dir build -R "C-API OutputPoint"\`
- [ ] Existing \`point\` / \`output_point\` suites still green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added null output point factory method to the C API for creating null-valued output points.
  * Added null output point factory method to the C++ domain library for consistent null-point handling.

* **Tests**
  * Added comprehensive tests for null output point factory behavior, including validation of null detection and proper resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive API change that introduces a new `output_point` null factory and associated test; behavior is localized to sentinel construction and should not affect non-null output point handling.
> 
> **Overview**
> Adds an `output_point`-typed `null()` static factory in the C++ domain layer to avoid base-class `point::null()` slicing, enabling bindings to surface the coinbase sentinel consistently.
> 
> Exposes this as a new C-API entrypoint `kth_chain_output_point_null()` and adds a test asserting it returns an `is_null` output point with `null_hash` and `0xffffffff` index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f77c83f5811858f23b9140e4cd3f4ef45f53cf7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->