### PR TITLE
feat(c-api): expose operator+ / - / * on number and big_number

### DIFF
--- a/src/c-api/include/kth/capi/vm/big_number.h
+++ b/src/c-api/include/kth/capi/vm/big_number.h
@@ -123,6 +123,18 @@ kth_bool_t kth_vm_big_number_deserialize(kth_big_number_mut_t self, uint8_t cons
 KTH_EXPORT
 int kth_vm_big_number_compare(kth_big_number_const_t self, kth_big_number_const_t other);
 
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_add(kth_big_number_const_t self, kth_big_number_const_t other);
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_subtract(kth_big_number_const_t self, kth_big_number_const_t other);
+
+/** @return Owned `kth_big_number_mut_t`. Caller must release with `kth_vm_big_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_big_number_mut_t kth_vm_big_number_multiply(kth_big_number_const_t self, kth_big_number_const_t other);
+
 KTH_EXPORT
 void kth_vm_big_number_negate(kth_big_number_mut_t self);
 

--- a/src/c-api/include/kth/capi/vm/number.h
+++ b/src/c-api/include/kth/capi/vm/number.h
@@ -89,6 +89,26 @@ kth_bool_t kth_vm_number_greater_or_equal(kth_number_const_t self, int64_t value
 KTH_EXPORT
 kth_bool_t kth_vm_number_less_or_equal(kth_number_const_t self, int64_t value);
 
+/** @return Owned `kth_number_mut_t`. Caller must release with `kth_vm_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_number_mut_t kth_vm_number_add_int64(kth_number_const_t self, int64_t value);
+
+/** @return Owned `kth_number_mut_t`. Caller must release with `kth_vm_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_number_mut_t kth_vm_number_subtract_int64(kth_number_const_t self, int64_t value);
+
+/** @return Owned `kth_number_mut_t`. Caller must release with `kth_vm_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_number_mut_t kth_vm_number_add_number(kth_number_const_t self, kth_number_const_t x);
+
+/** @return Owned `kth_number_mut_t`. Caller must release with `kth_vm_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_number_mut_t kth_vm_number_subtract_number(kth_number_const_t self, kth_number_const_t x);
+
+/** @return Owned `kth_number_mut_t`. Caller must release with `kth_vm_number_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_number_mut_t kth_vm_number_multiply(kth_number_const_t self, kth_number_const_t x);
+
 KTH_EXPORT
 kth_bool_t kth_vm_number_safe_add_number(kth_number_mut_t self, kth_number_const_t x);
 

--- a/src/c-api/src/vm/big_number.cpp
+++ b/src/c-api/src/vm/big_number.cpp
@@ -180,6 +180,27 @@ int kth_vm_big_number_compare(kth_big_number_const_t self, kth_big_number_const_
     return kth::cpp_ref<cpp_t>(self).compare(other_cpp);
 }
 
+kth_big_number_mut_t kth_vm_big_number_add(kth_big_number_const_t self, kth_big_number_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    auto const& other_cpp = kth::cpp_ref<cpp_t>(other);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).operator+(other_cpp));
+}
+
+kth_big_number_mut_t kth_vm_big_number_subtract(kth_big_number_const_t self, kth_big_number_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    auto const& other_cpp = kth::cpp_ref<cpp_t>(other);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).operator-(other_cpp));
+}
+
+kth_big_number_mut_t kth_vm_big_number_multiply(kth_big_number_const_t self, kth_big_number_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    auto const& other_cpp = kth::cpp_ref<cpp_t>(other);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).operator*(other_cpp));
+}
+
 void kth_vm_big_number_negate(kth_big_number_mut_t self) {
     KTH_PRECONDITION(self != nullptr);
     kth::cpp_ref<cpp_t>(self).negate();

--- a/src/c-api/src/vm/number.cpp
+++ b/src/c-api/src/vm/number.cpp
@@ -130,6 +130,37 @@ kth_bool_t kth_vm_number_less_or_equal(kth_number_const_t self, int64_t value) {
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).operator<=(value));
 }
 
+kth_number_mut_t kth_vm_number_add_int64(kth_number_const_t self, int64_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).operator+(value));
+}
+
+kth_number_mut_t kth_vm_number_subtract_int64(kth_number_const_t self, int64_t value) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).operator-(value));
+}
+
+kth_number_mut_t kth_vm_number_add_number(kth_number_const_t self, kth_number_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).operator+(x_cpp));
+}
+
+kth_number_mut_t kth_vm_number_subtract_number(kth_number_const_t self, kth_number_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).operator-(x_cpp));
+}
+
+kth_number_mut_t kth_vm_number_multiply(kth_number_const_t self, kth_number_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    auto const& x_cpp = kth::cpp_ref<cpp_t>(x);
+    return kth::leak(kth::cpp_ref<cpp_t>(self).operator*(x_cpp));
+}
+
 kth_bool_t kth_vm_number_safe_add_number(kth_number_mut_t self, kth_number_const_t x) {
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(x != nullptr);

--- a/src/c-api/test/vm/big_number.cpp
+++ b/src/c-api/test/vm/big_number.cpp
@@ -143,6 +143,35 @@ TEST_CASE("C-API BigNumber - pow produces a new handle with correct value",
     kth_vm_big_number_destruct(base);
 }
 
+TEST_CASE("C-API BigNumber - add / subtract / multiply operators produce new handles",
+          "[C-API BigNumber][arithmetic]") {
+    // `operator+ - *` surface is emitted as `add` / `subtract` /
+    // `multiply` — functional semantics, inputs untouched. One
+    // battery covers all three so the precondition / ownership
+    // shape exercises together.
+    kth_big_number_mut_t a = kth_vm_big_number_construct_from_value(12345);
+    kth_big_number_mut_t b = kth_vm_big_number_construct_from_value(67);
+
+    kth_big_number_mut_t sum = kth_vm_big_number_add(a, b);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(sum) == 12345 + 67);
+
+    kth_big_number_mut_t diff = kth_vm_big_number_subtract(a, b);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(diff) == 12345 - 67);
+
+    kth_big_number_mut_t product = kth_vm_big_number_multiply(a, b);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(product) == 12345 * 67);
+
+    // `a` and `b` still hold their original values.
+    REQUIRE(kth_vm_big_number_to_int32_saturating(a) == 12345);
+    REQUIRE(kth_vm_big_number_to_int32_saturating(b) == 67);
+
+    kth_vm_big_number_destruct(product);
+    kth_vm_big_number_destruct(diff);
+    kth_vm_big_number_destruct(sum);
+    kth_vm_big_number_destruct(b);
+    kth_vm_big_number_destruct(a);
+}
+
 // ---------------------------------------------------------------------------
 // Serialization
 // ---------------------------------------------------------------------------

--- a/src/c-api/test/vm/number.cpp
+++ b/src/c-api/test/vm/number.cpp
@@ -144,6 +144,90 @@ TEST_CASE("C-API Number - safe_sub_number subtracts by handle",
 }
 
 // ---------------------------------------------------------------------------
+// Arithmetic operators — `operator+/-/*` renamed to `add`/`subtract`/`multiply`
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API Number - add_number produces a new handle without mutating inputs",
+          "[C-API Number][arithmetic]") {
+    // `operator+(number const&)` → `add_number`. Returns an owned
+    // handle; inputs stay intact. Compare against the mutating
+    // `safe_add_*` family: this is the functional path.
+    kth_number_mut_t a = NULL;
+    kth_number_mut_t b = NULL;
+    REQUIRE(kth_vm_number_from_int(3, &a) == kth_ec_success);
+    REQUIRE(kth_vm_number_from_int(4, &b) == kth_ec_success);
+
+    kth_number_mut_t sum = kth_vm_number_add_number(a, b);
+    REQUIRE(sum != NULL);
+    REQUIRE(kth_vm_number_int64(sum) == 7);
+
+    REQUIRE(kth_vm_number_int64(a) == 3);
+    REQUIRE(kth_vm_number_int64(b) == 4);
+
+    kth_vm_number_destruct(sum);
+    kth_vm_number_destruct(b);
+    kth_vm_number_destruct(a);
+}
+
+TEST_CASE("C-API Number - add_int64 uses the int64 overload of operator+",
+          "[C-API Number][arithmetic]") {
+    kth_number_mut_t a = NULL;
+    REQUIRE(kth_vm_number_from_int(10, &a) == kth_ec_success);
+
+    kth_number_mut_t sum = kth_vm_number_add_int64(a, 5);
+    REQUIRE(kth_vm_number_int64(sum) == 15);
+    REQUIRE(kth_vm_number_int64(a) == 10);     // source unchanged
+
+    kth_vm_number_destruct(sum);
+    kth_vm_number_destruct(a);
+}
+
+TEST_CASE("C-API Number - subtract_number returns a new difference",
+          "[C-API Number][arithmetic]") {
+    kth_number_mut_t a = NULL;
+    kth_number_mut_t b = NULL;
+    REQUIRE(kth_vm_number_from_int(100, &a) == kth_ec_success);
+    REQUIRE(kth_vm_number_from_int(30, &b) == kth_ec_success);
+
+    kth_number_mut_t diff = kth_vm_number_subtract_number(a, b);
+    REQUIRE(kth_vm_number_int64(diff) == 70);
+    REQUIRE(kth_vm_number_int64(a) == 100);
+    REQUIRE(kth_vm_number_int64(b) == 30);
+
+    kth_vm_number_destruct(diff);
+    kth_vm_number_destruct(b);
+    kth_vm_number_destruct(a);
+}
+
+TEST_CASE("C-API Number - subtract_int64 uses the int64 overload of operator-",
+          "[C-API Number][arithmetic]") {
+    kth_number_mut_t a = NULL;
+    REQUIRE(kth_vm_number_from_int(20, &a) == kth_ec_success);
+
+    kth_number_mut_t diff = kth_vm_number_subtract_int64(a, 7);
+    REQUIRE(kth_vm_number_int64(diff) == 13);
+    REQUIRE(kth_vm_number_int64(a) == 20);     // source unchanged
+
+    kth_vm_number_destruct(diff);
+    kth_vm_number_destruct(a);
+}
+
+TEST_CASE("C-API Number - multiply returns the product as a new handle",
+          "[C-API Number][arithmetic]") {
+    kth_number_mut_t a = NULL;
+    kth_number_mut_t b = NULL;
+    REQUIRE(kth_vm_number_from_int(6, &a) == kth_ec_success);
+    REQUIRE(kth_vm_number_from_int(7, &b) == kth_ec_success);
+
+    kth_number_mut_t product = kth_vm_number_multiply(a, b);
+    REQUIRE(kth_vm_number_int64(product) == 42);
+
+    kth_vm_number_destruct(product);
+    kth_vm_number_destruct(b);
+    kth_vm_number_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
 // safe_add_number2 / safe_sub_number2 / safe_mul_number2 — static variants
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
The C-API was skipping every arithmetic operator because the generator had no rename for them. This PR teaches the generator to rename \`operator+\` / \`operator-\` / \`operator*\` as \`add\` / \`subtract\` / \`multiply\` and routes the renames through the regular method path so the overload disambiguator handles multiple variants (e.g. \`number::operator+(int64_t)\` vs \`number::operator+(number)\` both land as \`add_int64\` / \`add_number\`).

**Surface lit up:**
- \`number::add_int64\` / \`add_number\` / \`subtract_int64\` / \`subtract_number\` / \`multiply\` — functional semantics, inputs untouched.
- \`big_number::add\` / \`subtract\` / \`multiply\` — same shape, single overload.

**Out of scope (still skipped):**
- Unary \`operator-()\` (negation) — binary and unary would alias into the same name; "negate" is the better verb and we haven't wired it.
- Compound assignment (\`operator+=\` etc.) — the mutating path on \`number\` is already covered by the \`safe_add\` / \`safe_sub\` / \`safe_mul\` family, and \`big_number\` doesn't need it.

## Test plan
- [ ] \`cmake --build build --target kth-capi-tests && ctest --test-dir build -R "C-API (Number|BigNumber).*arithmetic"\`
- [ ] Existing number / big_number suites still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the public C API with new owned-return arithmetic functions, which can impact ABI/API consumers and introduces new ownership expectations to get right.
> 
> **Overview**
> Exposes C-API wrappers for binary arithmetic on `number` and `big_number` by adding `add`/`subtract`/`multiply` functions (including `number` overloads for `int64_t` vs `number`) that **return new owned handles** and leave inputs unchanged.
> 
> Adds unit tests covering these new operators for both types, asserting correct results, non-mutation of inputs, and proper handle lifecycle cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff86cda3184cca25b497a18aa72b84ba9861a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->