### PR TITLE
feat(c-api): expose BIP137 wallet::message module + tests

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -184,6 +184,7 @@ set(kth_sources
   src/wallet/hd_private.cpp
 
   src/wallet/cashtoken_minting.cpp
+  src/wallet/message.cpp
   src/wallet/payment_address.cpp
   src/wallet/payment_address_list.cpp
   src/wallet/wallet.cpp
@@ -315,6 +316,7 @@ set(kth_headers
 
   include/kth/capi/wallet/cashtoken_minting.h
   include/kth/capi/wallet/ec_public.h
+  include/kth/capi/wallet/message.h
   include/kth/capi/wallet/payment_address.h
   include/kth/capi/wallet/payment_address_list.h
   include/kth/capi/wallet/wallet.h
@@ -538,6 +540,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/wallet/cashtoken_minting.cpp
         test/wallet/hd_public.cpp
         test/wallet/hd_private.cpp
+        test/wallet/message.cpp
         test/wallet/wallet_data.cpp
         test/vm/big_number.cpp
         test/vm/program.cpp

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -101,6 +101,7 @@
 #include <kth/capi/wallet/hd_lineage.h>
 #include <kth/capi/wallet/hd_private.h>
 #include <kth/capi/wallet/hd_public.h>
+#include <kth/capi/wallet/message.h>
 #include <kth/capi/wallet/payment_address.h>
 #include <kth/capi/wallet/payment_address_list.h>
 #include <kth/capi/wallet/primitives.h>

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -21,6 +21,7 @@
 #include <kth/domain/config/network.hpp>
 #include <kth/domain/machine/opcode.hpp>
 #include <kth/domain/wallet/hd_public.hpp>
+#include <kth/domain/wallet/message.hpp>
 #include <kth/domain/wallet/wallet_manager.hpp>
 
 #include <kth/infrastructure/math/hash.hpp>
@@ -342,6 +343,21 @@ inline kth_ec_uncompressed_t to_ec_uncompressed_t(kth::ec_uncompressed const& x)
 }
 inline kth::ec_uncompressed ec_uncompressed_to_cpp(uint8_t const* x) {
     return to_array_cpp<kth::ec_uncompressed_size>(x);
+}
+
+// message_signature (65 bytes: BIP137 magic byte + ECDSA r,s). Same
+// underlying layout as `ec_uncompressed` (both are byte_array<65>),
+// but exposed as a distinct helper so call sites carry the right
+// intent — a signature, not a public key point.
+inline kth_message_signature_t to_message_signature_t(
+        kth::domain::wallet::message_signature const& x) {
+    kth_message_signature_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::domain::wallet::message_signature message_signature_to_cpp(
+        uint8_t const* x) {
+    return to_array_cpp<kth::domain::wallet::message_signature_size>(x);
 }
 
 // wif_compressed (38 bytes)

--- a/src/c-api/include/kth/capi/wallet/message.h
+++ b/src/c-api/include/kth/capi/wallet/message.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_MESSAGE_H_
+#define KTH_CAPI_WALLET_MESSAGE_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Static utilities
+
+KTH_EXPORT
+kth_hash_t kth_wallet_message_hash_message(uint8_t const* message, kth_size_t n);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_message_sign_message_ec_private(kth_message_signature_t* out_signature, uint8_t const* message, kth_size_t n, kth_ec_private_const_t secret);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_message_sign_message_string(kth_message_signature_t* out_signature, uint8_t const* message, kth_size_t n, char const* wif);
+
+/** @param secret Borrowed input; must be non-null. Read during the call; ownership of `secret` stays with the caller. */
+KTH_EXPORT
+kth_bool_t kth_wallet_message_sign_message_hash(kth_message_signature_t* out_signature, uint8_t const* message, kth_size_t n, kth_hash_t const* secret, kth_bool_t compressed);
+
+/** @warning `secret` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
+KTH_EXPORT
+kth_bool_t kth_wallet_message_sign_message_hash_unsafe(kth_message_signature_t* out_signature, uint8_t const* message, kth_size_t n, uint8_t const* secret, kth_bool_t compressed);
+
+/** @param signature Borrowed input; must be non-null. Read during the call; ownership of `signature` stays with the caller. */
+KTH_EXPORT
+kth_bool_t kth_wallet_message_verify_message(uint8_t const* message, kth_size_t n, kth_payment_address_const_t address, kth_message_signature_t const* signature);
+
+/** @warning `signature` MUST point to a buffer of at least 65 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_message_signature_t`. */
+KTH_EXPORT
+kth_bool_t kth_wallet_message_verify_message_unsafe(uint8_t const* message, kth_size_t n, kth_payment_address_const_t address, uint8_t const* signature);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_message_recovery_id_to_magic(uint8_t* out_magic, uint8_t recovery_id, kth_bool_t compressed);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_message_magic_to_recovery_id(uint8_t* out_recovery_id, kth_bool_t* out_compressed, uint8_t magic);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_MESSAGE_H_

--- a/src/c-api/include/kth/capi/wallet/primitives.h
+++ b/src/c-api/include/kth/capi/wallet/primitives.h
@@ -57,6 +57,12 @@ typedef struct {
     uint8_t data[KTH_EC_SIGNATURE_SIZE];
 } kth_ec_signature_t;
 
+// BIP137 signed-message envelope: 1 recovery-magic byte + 64-byte ECDSA sig.
+#define KTH_MESSAGE_SIGNATURE_SIZE 65
+typedef struct kth_message_signature_t {
+    uint8_t data[KTH_MESSAGE_SIGNATURE_SIZE];
+} kth_message_signature_t;
+
 #define KTH_BITCOIN_PAYMENT_SIZE 25
 typedef struct kth_payment_t {
     uint8_t hash[KTH_BITCOIN_PAYMENT_SIZE];

--- a/src/c-api/src/wallet/message.cpp
+++ b/src/c-api/src/wallet/message.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <cstring>
+
+#include <kth/capi/wallet/message.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/message.hpp>
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Static utilities
+
+kth_hash_t kth_wallet_message_hash_message(uint8_t const* message, kth_size_t n) {
+    KTH_PRECONDITION(message != nullptr || n == 0);
+    auto const message_cpp = kth::byte_span(message, kth::sz(n));
+    return kth::to_hash_t(kth::domain::wallet::hash_message(message_cpp));
+}
+
+kth_bool_t kth_wallet_message_sign_message_ec_private(kth_message_signature_t* out_signature, uint8_t const* message, kth_size_t n, kth_ec_private_const_t secret) {
+    KTH_PRECONDITION(out_signature != nullptr);
+    KTH_PRECONDITION(message != nullptr || n == 0);
+    KTH_PRECONDITION(secret != nullptr);
+    std::array<uint8_t, 65> out_signature_cpp;
+    auto const message_cpp = kth::byte_span(message, kth::sz(n));
+    auto const& secret_cpp = kth::cpp_ref<kth::domain::wallet::ec_private>(secret);
+    auto const cpp_result = kth::domain::wallet::sign_message(out_signature_cpp, message_cpp, secret_cpp);
+    if (cpp_result) {
+        std::memcpy(out_signature->data, out_signature_cpp.data(), out_signature_cpp.size());
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+kth_bool_t kth_wallet_message_sign_message_string(kth_message_signature_t* out_signature, uint8_t const* message, kth_size_t n, char const* wif) {
+    KTH_PRECONDITION(out_signature != nullptr);
+    KTH_PRECONDITION(message != nullptr || n == 0);
+    KTH_PRECONDITION(wif != nullptr);
+    std::array<uint8_t, 65> out_signature_cpp;
+    auto const message_cpp = kth::byte_span(message, kth::sz(n));
+    auto const wif_cpp = std::string(wif);
+    auto const cpp_result = kth::domain::wallet::sign_message(out_signature_cpp, message_cpp, wif_cpp);
+    if (cpp_result) {
+        std::memcpy(out_signature->data, out_signature_cpp.data(), out_signature_cpp.size());
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+kth_bool_t kth_wallet_message_sign_message_hash(kth_message_signature_t* out_signature, uint8_t const* message, kth_size_t n, kth_hash_t const* secret, kth_bool_t compressed) {
+    KTH_PRECONDITION(out_signature != nullptr);
+    KTH_PRECONDITION(message != nullptr || n == 0);
+    KTH_PRECONDITION(secret != nullptr);
+    std::array<uint8_t, 65> out_signature_cpp;
+    auto const message_cpp = kth::byte_span(message, kth::sz(n));
+    auto secret_cpp = kth::hash_to_cpp(secret->hash);
+    kth::secure_scrub secret_cpp_scrub{&secret_cpp, sizeof(secret_cpp)};
+    auto const compressed_cpp = kth::int_to_bool(compressed);
+    auto const cpp_result = kth::domain::wallet::sign_message(out_signature_cpp, message_cpp, secret_cpp, compressed_cpp);
+    if (cpp_result) {
+        std::memcpy(out_signature->data, out_signature_cpp.data(), out_signature_cpp.size());
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+kth_bool_t kth_wallet_message_sign_message_hash_unsafe(kth_message_signature_t* out_signature, uint8_t const* message, kth_size_t n, uint8_t const* secret, kth_bool_t compressed) {
+    KTH_PRECONDITION(out_signature != nullptr);
+    KTH_PRECONDITION(message != nullptr || n == 0);
+    KTH_PRECONDITION(secret != nullptr);
+    std::array<uint8_t, 65> out_signature_cpp;
+    auto const message_cpp = kth::byte_span(message, kth::sz(n));
+    auto secret_cpp = kth::hash_to_cpp(secret);
+    kth::secure_scrub secret_cpp_scrub{&secret_cpp, sizeof(secret_cpp)};
+    auto const compressed_cpp = kth::int_to_bool(compressed);
+    auto const cpp_result = kth::domain::wallet::sign_message(out_signature_cpp, message_cpp, secret_cpp, compressed_cpp);
+    if (cpp_result) {
+        std::memcpy(out_signature->data, out_signature_cpp.data(), out_signature_cpp.size());
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+kth_bool_t kth_wallet_message_verify_message(uint8_t const* message, kth_size_t n, kth_payment_address_const_t address, kth_message_signature_t const* signature) {
+    KTH_PRECONDITION(message != nullptr || n == 0);
+    KTH_PRECONDITION(address != nullptr);
+    KTH_PRECONDITION(signature != nullptr);
+    auto const message_cpp = kth::byte_span(message, kth::sz(n));
+    auto const& address_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(address);
+    auto const signature_cpp = kth::message_signature_to_cpp(signature->data);
+    return kth::bool_to_int(kth::domain::wallet::verify_message(message_cpp, address_cpp, signature_cpp));
+}
+
+kth_bool_t kth_wallet_message_verify_message_unsafe(uint8_t const* message, kth_size_t n, kth_payment_address_const_t address, uint8_t const* signature) {
+    KTH_PRECONDITION(message != nullptr || n == 0);
+    KTH_PRECONDITION(address != nullptr);
+    KTH_PRECONDITION(signature != nullptr);
+    auto const message_cpp = kth::byte_span(message, kth::sz(n));
+    auto const& address_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(address);
+    auto const signature_cpp = kth::message_signature_to_cpp(signature);
+    return kth::bool_to_int(kth::domain::wallet::verify_message(message_cpp, address_cpp, signature_cpp));
+}
+
+kth_bool_t kth_wallet_message_recovery_id_to_magic(uint8_t* out_magic, uint8_t recovery_id, kth_bool_t compressed) {
+    KTH_PRECONDITION(out_magic != nullptr);
+    uint8_t out_magic_cpp = 0;
+    auto const compressed_cpp = kth::int_to_bool(compressed);
+    auto const cpp_result = kth::domain::wallet::recovery_id_to_magic(out_magic_cpp, recovery_id, compressed_cpp);
+    if (cpp_result) {
+        *out_magic = static_cast<uint8_t>(out_magic_cpp);
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+kth_bool_t kth_wallet_message_magic_to_recovery_id(uint8_t* out_recovery_id, kth_bool_t* out_compressed, uint8_t magic) {
+    KTH_PRECONDITION(out_recovery_id != nullptr);
+    KTH_PRECONDITION(out_compressed != nullptr);
+    uint8_t out_recovery_id_cpp = 0;
+    bool out_compressed_cpp = false;
+    auto const cpp_result = kth::domain::wallet::magic_to_recovery_id(out_recovery_id_cpp, out_compressed_cpp, magic);
+    if (cpp_result) {
+        *out_recovery_id = static_cast<uint8_t>(out_recovery_id_cpp);
+        *out_compressed = kth::bool_to_int(out_compressed_cpp);
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+} // extern "C"

--- a/src/c-api/test/wallet/message.cpp
+++ b/src/c-api/test/wallet/message.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/ec_private.h>
+#include <kth/capi/wallet/message.h>
+#include <kth/capi/wallet/payment_address.h>
+#include <kth/capi/wallet/primitives.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures — a fully-deterministic 32-byte secret keeps the signature
+// stable across runs, so we don't need to re-sign for every assertion.
+// ---------------------------------------------------------------------------
+
+static kth_hash_t const kSecret = {{
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20
+}};
+
+static uint8_t const kMessage[] = "hello Knuth";
+static kth_size_t const kMessageLen = sizeof(kMessage) - 1; // drop '\0'
+
+// ---------------------------------------------------------------------------
+// hash_message — deterministic, well-defined for empty input
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::message - hash_message yields a stable 32-byte digest",
+          "[C-API WalletMessage][hash]") {
+    kth_hash_t a = kth_wallet_message_hash_message(kMessage, kMessageLen);
+    kth_hash_t b = kth_wallet_message_hash_message(kMessage, kMessageLen);
+    // Same input → same digest (deterministic BIP137 preamble + SHA256²).
+    REQUIRE(kth_hash_equal(a, b) != 0);
+    REQUIRE(kth_hash_is_null(a) == 0);  // non-null digest
+}
+
+TEST_CASE("C-API wallet::message - hash_message accepts empty input",
+          "[C-API WalletMessage][hash]") {
+    kth_hash_t h = kth_wallet_message_hash_message(NULL, 0);
+    // Empty message still hashes cleanly (the preamble alone seeds the digest).
+    REQUIRE(kth_hash_is_null(h) == 0);
+}
+
+// ---------------------------------------------------------------------------
+// Recovery-id ↔ magic byte round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::message - recovery_id ↔ magic round-trip",
+          "[C-API WalletMessage][recovery]") {
+    // BIP137 recovery ids range 0..3 for each (compressed, uncompressed)
+    // flavour. Round-trip every value through magic-byte encoding to
+    // confirm the two helpers are proper inverses.
+    for (uint8_t rid = 0; rid <= 3; ++rid) {
+        for (int compressed = 0; compressed <= 1; ++compressed) {
+            uint8_t magic = 0;
+            REQUIRE(kth_wallet_message_recovery_id_to_magic(
+                &magic, rid, (kth_bool_t)compressed) != 0);
+
+            uint8_t back_rid = 0xff;
+            kth_bool_t back_compressed = compressed ? 0 : 1;
+            REQUIRE(kth_wallet_message_magic_to_recovery_id(
+                &back_rid, &back_compressed, magic) != 0);
+
+            REQUIRE(back_rid == rid);
+            REQUIRE((back_compressed != 0) == (compressed != 0));
+        }
+    }
+}
+
+TEST_CASE("C-API wallet::message - recovery_id_to_magic rejects out-of-range ids",
+          "[C-API WalletMessage][recovery]") {
+    uint8_t magic = 0xaa;
+    // BIP137 only defines 0..3; a larger id must fail and leave the
+    // output untouched.
+    REQUIRE(kth_wallet_message_recovery_id_to_magic(&magic, 4, 1) == 0);
+    REQUIRE(magic == 0xaa);
+}
+
+// ---------------------------------------------------------------------------
+// Sign / verify round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::message - sign(ec_private) + verify round-trip",
+          "[C-API WalletMessage][sign][verify]") {
+    // Build a private key from the fixture secret, derive its payment
+    // address, sign a message under the key, and verify the signature
+    // resolves back to the same address.
+    kth_ec_private_mut_t secret = kth_wallet_ec_private_construct_from_secret_version_compress(
+        &kSecret, /*version=*/0x8000u, /*compress=*/1);
+    REQUIRE(secret != NULL);
+
+    kth_payment_address_mut_t address = kth_wallet_ec_private_to_payment_address(secret);
+    REQUIRE(address != NULL);
+
+    kth_message_signature_t sig;
+    memset(&sig, 0, sizeof(sig));
+    REQUIRE(kth_wallet_message_sign_message_ec_private(
+        &sig, kMessage, kMessageLen, secret) != 0);
+
+    // The signature's magic byte encodes (recovery_id, compressed).
+    // Compressed keys use magic 31..34 — assert we landed there so a
+    // future regression that picks the wrong magic would surface.
+    REQUIRE(sig.data[0] >= 31);
+    REQUIRE(sig.data[0] <= 34);
+
+    // verify must succeed against the signer's address.
+    REQUIRE(kth_wallet_message_verify_message(
+        kMessage, kMessageLen, address, &sig) != 0);
+
+    kth_wallet_payment_address_destruct(address);
+    kth_wallet_ec_private_destruct(secret);
+}
+
+TEST_CASE("C-API wallet::message - verify rejects a tampered message",
+          "[C-API WalletMessage][verify]") {
+    kth_ec_private_mut_t secret = kth_wallet_ec_private_construct_from_secret_version_compress(
+        &kSecret, 0x8000u, 1);
+    kth_payment_address_mut_t address = kth_wallet_ec_private_to_payment_address(secret);
+
+    kth_message_signature_t sig;
+    memset(&sig, 0, sizeof(sig));
+    REQUIRE(kth_wallet_message_sign_message_ec_private(
+        &sig, kMessage, kMessageLen, secret) != 0);
+
+    // Flip one byte of the message payload; verify must report failure.
+    uint8_t tampered[sizeof(kMessage)];
+    memcpy(tampered, kMessage, sizeof(kMessage));
+    tampered[0] ^= 0x01;
+    REQUIRE(kth_wallet_message_verify_message(
+        tampered, kMessageLen, address, &sig) == 0);
+
+    kth_wallet_payment_address_destruct(address);
+    kth_wallet_ec_private_destruct(secret);
+}
+
+TEST_CASE("C-API wallet::message - sign_hash (raw secret) produces the same result",
+          "[C-API WalletMessage][sign]") {
+    // Signing with the raw 32-byte secret + `compressed=true` must
+    // yield the same signature as signing via the `ec_private` handle
+    // (both go through the same underlying ECDSA path).
+    kth_ec_private_mut_t secret_handle = kth_wallet_ec_private_construct_from_secret_version_compress(
+        &kSecret, 0x8000u, 1);
+    kth_message_signature_t via_handle;
+    memset(&via_handle, 0, sizeof(via_handle));
+    REQUIRE(kth_wallet_message_sign_message_ec_private(
+        &via_handle, kMessage, kMessageLen, secret_handle) != 0);
+
+    kth_message_signature_t via_raw;
+    memset(&via_raw, 0, sizeof(via_raw));
+    REQUIRE(kth_wallet_message_sign_message_hash(
+        &via_raw, kMessage, kMessageLen, &kSecret, /*compressed=*/1) != 0);
+
+    REQUIRE(memcmp(via_handle.data, via_raw.data, KTH_MESSAGE_SIGNATURE_SIZE) == 0);
+
+    kth_wallet_ec_private_destruct(secret_handle);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::message - hash null with non-zero size aborts",
+          "[C-API WalletMessage][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_message_hash_message(NULL, 1));
+}
+
+TEST_CASE("C-API wallet::message - recovery_id_to_magic null out aborts",
+          "[C-API WalletMessage][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_message_recovery_id_to_magic(NULL, 0, 1));
+}
+
+TEST_CASE("C-API wallet::message - magic_to_recovery_id null outs abort",
+          "[C-API WalletMessage][precondition]") {
+    kth_bool_t compressed = 0;
+    KTH_EXPECT_ABORT(kth_wallet_message_magic_to_recovery_id(NULL, &compressed, 31));
+    uint8_t rid = 0;
+    KTH_EXPECT_ABORT(kth_wallet_message_magic_to_recovery_id(&rid, NULL, 31));
+}


### PR DESCRIPTION
## Summary
First namespace-module binding for the C-API. The generator now supports \`is_namespace_module=True\` on \`ClassConfig\`: bind every free function in the target namespace(s) without needing an anchor class. This PR exercises the new mode on BIP137's \`kth::domain::wallet::message\` helpers and ships the resulting bindings.

**Surface emitted:**
- \`kth_wallet_message_hash_message(msg, n)\` → 32-byte digest
- \`kth_wallet_message_sign_message_ec_private\` / \`_string\` / \`_hash\` / \`_hash_unsafe\` — 65-byte \`kth_message_signature_t\` out-param
- \`kth_wallet_message_verify_message\` / \`_unsafe\` — round-trip check
- \`kth_wallet_message_recovery_id_to_magic\` / \`_magic_to_recovery_id\` — BIP137 magic byte ↔ (recovery_id, compressed) helpers

**Generator changes (in kth-tools):**
- \`ClassConfig.is_namespace_module\` — bypasses the anchor-class heuristic in the free-function scanner; pinned to the module's own header so neighbouring wallet free functions don't get swept in.
- Value-struct registry is now matched by source-level spelling first, so a typedef like \`message_signature = byte_array<65>\` wins over the same-size \`ec_uncompressed\` fallback.
- Non-const lvalue reference out-params: value_structs land as typed \`kth_<type>_t*\` (previously raw \`uint8_t*\`); scalars + \`bool\` gain pointer out-params with proper default-init / writeback.
- Body emitter skips the \`cpp_t\` alias substitution in namespace-module mode so \`kth::domain::wallet::sign_message\` keeps its qualified spelling.

## Test plan
- [ ] \`cmake --build build --target kth-capi-tests && ctest --test-dir build -R "C-API WalletMessage"\`
- [ ] Existing wallet / ec_private / payment_address suites still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new C-API surface for message hashing/signing/verification (including `_unsafe` raw-pointer variants) and introduces a new 65-byte signature value type, which could impact FFI consumers and requires careful buffer sizing/secret handling.
> 
> **Overview**
> Exposes **BIP137 signed-message** support in the C-API via a new `wallet/message` module: message hashing, signing (from `ec_private`, WIF string, or raw 32-byte secret), verification against a `payment_address`, and recovery-id/magic-byte conversion helpers.
> 
> Introduces `kth_message_signature_t` (65-byte envelope) plus conversion helpers, wires the new module into the build/umbrella `capi.h`, and adds a focused Catch2 suite covering determinism, sign/verify round-trips, error cases, and precondition aborts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8206372e21d3ad510c32519604a9c3434788de13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->