### PR TITLE
feat(c-api): expose stealth_address (BIP63) + bitcoin_uri (BIP21) + tests

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -183,10 +183,12 @@ set(kth_sources
   src/wallet/hd_public.cpp
   src/wallet/hd_private.cpp
 
+  src/wallet/bitcoin_uri.cpp
   src/wallet/cashtoken_minting.cpp
   src/wallet/message.cpp
   src/wallet/payment_address.cpp
   src/wallet/payment_address_list.cpp
+  src/wallet/stealth_address.cpp
   src/wallet/wallet.cpp
   src/wallet/ec_compressed_list.cpp
   src/wallet/wallet_data.cpp
@@ -314,11 +316,13 @@ set(kth_headers
 
   include/kth/capi/vm/program.h
 
+  include/kth/capi/wallet/bitcoin_uri.h
   include/kth/capi/wallet/cashtoken_minting.h
   include/kth/capi/wallet/ec_public.h
   include/kth/capi/wallet/message.h
   include/kth/capi/wallet/payment_address.h
   include/kth/capi/wallet/payment_address_list.h
+  include/kth/capi/wallet/stealth_address.h
   include/kth/capi/wallet/wallet.h
   include/kth/capi/wallet/ec_compressed_list.h
   include/kth/capi/wallet/wallet_data.h
@@ -537,10 +541,12 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/double_spend_proof.cpp
         test/chain/token_data.cpp
         test/chain/utxo.cpp
+        test/wallet/bitcoin_uri.cpp
         test/wallet/cashtoken_minting.cpp
         test/wallet/hd_public.cpp
         test/wallet/hd_private.cpp
         test/wallet/message.cpp
+        test/wallet/stealth_address.cpp
         test/wallet/wallet_data.cpp
         test/vm/big_number.cpp
         test/vm/program.cpp

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -100,9 +100,11 @@
 #include <kth/capi/wallet/cashtoken_minting.h>
 #include <kth/capi/wallet/hd_lineage.h>
 #include <kth/capi/wallet/hd_private.h>
+#include <kth/capi/wallet/bitcoin_uri.h>
 #include <kth/capi/wallet/hd_public.h>
 #include <kth/capi/wallet/message.h>
 #include <kth/capi/wallet/payment_address.h>
+#include <kth/capi/wallet/stealth_address.h>
 #include <kth/capi/wallet/payment_address_list.h>
 #include <kth/capi/wallet/primitives.h>
 #include <kth/capi/wallet/wallet.h>

--- a/src/c-api/include/kth/capi/handles.h
+++ b/src/c-api/include/kth/capi/handles.h
@@ -185,6 +185,11 @@ typedef void const* kth_bool_list_const_t;
 typedef void* kth_wallet_data_mut_t;
 typedef void const* kth_wallet_data_const_t;
 
+typedef void* kth_stealth_address_mut_t;
+typedef void const* kth_stealth_address_const_t;
+typedef void* kth_bitcoin_uri_mut_t;
+typedef void const* kth_bitcoin_uri_const_t;
+
 typedef void* kth_ec_compressed_list_t;
 typedef void* kth_ec_compressed_list_mut_t;
 typedef void const* kth_ec_compressed_list_const_t;

--- a/src/c-api/include/kth/capi/wallet/bitcoin_uri.h
+++ b/src/c-api/include/kth/capi/wallet/bitcoin_uri.h
@@ -1,0 +1,144 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_BITCOIN_URI_H_
+#define KTH_CAPI_WALLET_BITCOIN_URI_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/** @return Owned `kth_bitcoin_uri_mut_t`. Caller must release with `kth_wallet_bitcoin_uri_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_bitcoin_uri_mut_t kth_wallet_bitcoin_uri_construct_default(void);
+
+/** @return Owned `kth_bitcoin_uri_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_bitcoin_uri_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_bitcoin_uri_mut_t kth_wallet_bitcoin_uri_construct(char const* uri, kth_bool_t strict);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_wallet_bitcoin_uri_destruct(kth_bitcoin_uri_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_bitcoin_uri_mut_t`. Caller must release with `kth_wallet_bitcoin_uri_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_bitcoin_uri_mut_t kth_wallet_bitcoin_uri_copy(kth_bitcoin_uri_const_t self);
+
+
+// Equality
+
+KTH_EXPORT
+kth_bool_t kth_wallet_bitcoin_uri_equals(kth_bitcoin_uri_const_t self, kth_bitcoin_uri_const_t other);
+
+
+// Getters
+
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
+KTH_EXPORT
+kth_bool_t kth_wallet_bitcoin_uri_valid(kth_bitcoin_uri_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_bitcoin_uri_encoded(kth_bitcoin_uri_const_t self);
+
+KTH_EXPORT
+uint64_t kth_wallet_bitcoin_uri_amount(kth_bitcoin_uri_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_bitcoin_uri_label(kth_bitcoin_uri_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_bitcoin_uri_message(kth_bitcoin_uri_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_bitcoin_uri_r(kth_bitcoin_uri_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_bitcoin_uri_address(kth_bitcoin_uri_const_t self);
+
+/** @return Owned `kth_payment_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_payment_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_payment_address_mut_t kth_wallet_bitcoin_uri_payment(kth_bitcoin_uri_const_t self);
+
+/** @return Owned `kth_stealth_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_stealth_address_mut_t kth_wallet_bitcoin_uri_stealth(kth_bitcoin_uri_const_t self);
+
+
+// Setters
+
+KTH_EXPORT
+void kth_wallet_bitcoin_uri_set_amount(kth_bitcoin_uri_mut_t self, uint64_t satoshis);
+
+KTH_EXPORT
+void kth_wallet_bitcoin_uri_set_label(kth_bitcoin_uri_mut_t self, char const* label);
+
+KTH_EXPORT
+void kth_wallet_bitcoin_uri_set_message(kth_bitcoin_uri_mut_t self, char const* message);
+
+KTH_EXPORT
+void kth_wallet_bitcoin_uri_set_r(kth_bitcoin_uri_mut_t self, char const* r);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_bitcoin_uri_set_address_string(kth_bitcoin_uri_mut_t self, char const* address);
+
+/** @param payment Borrowed input. Copied by value into the resulting object; ownership of `payment` stays with the caller. */
+KTH_EXPORT
+void kth_wallet_bitcoin_uri_set_address_payment_address(kth_bitcoin_uri_mut_t self, kth_payment_address_const_t payment);
+
+/** @param stealth Borrowed input. Copied by value into the resulting object; ownership of `stealth` stays with the caller. */
+KTH_EXPORT
+void kth_wallet_bitcoin_uri_set_address_stealth_address(kth_bitcoin_uri_mut_t self, kth_stealth_address_const_t stealth);
+
+KTH_EXPORT
+void kth_wallet_bitcoin_uri_set_strict(kth_bitcoin_uri_mut_t self, kth_bool_t strict);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_bitcoin_uri_set_scheme(kth_bitcoin_uri_mut_t self, char const* scheme);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_bitcoin_uri_set_authority(kth_bitcoin_uri_mut_t self, char const* authority);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_bitcoin_uri_set_path(kth_bitcoin_uri_mut_t self, char const* path);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_bitcoin_uri_set_fragment(kth_bitcoin_uri_mut_t self, char const* fragment);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_bitcoin_uri_set_parameter(kth_bitcoin_uri_mut_t self, char const* key, char const* value);
+
+
+// Operations
+
+KTH_EXPORT
+kth_bool_t kth_wallet_bitcoin_uri_less(kth_bitcoin_uri_const_t self, kth_bitcoin_uri_const_t x);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_bitcoin_uri_parameter(kth_bitcoin_uri_const_t self, char const* key);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_BITCOIN_URI_H_

--- a/src/c-api/include/kth/capi/wallet/stealth_address.h
+++ b/src/c-api/include/kth/capi/wallet/stealth_address.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_STEALTH_ADDRESS_H_
+#define KTH_CAPI_WALLET_STEALTH_ADDRESS_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/** @return Owned `kth_stealth_address_mut_t`. Caller must release with `kth_wallet_stealth_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_default(void);
+
+/** @return Owned `kth_stealth_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_decoded(uint8_t const* decoded, kth_size_t n);
+
+/** @return Owned `kth_stealth_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_encoded(char const* encoded);
+
+/**
+ * @return Owned `kth_stealth_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_address_destruct`.
+ * @param filter Borrowed input. Copied by value into the resulting object; ownership of `filter` stays with the caller.
+ * @param spend_keys Borrowed input. Copied by value into the resulting object; ownership of `spend_keys` stays with the caller.
+ * @param scan_key Borrowed input; must be non-null. Copied into the resulting object; ownership of `scan_key` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_binary_scan_key_spend_keys_signatures_version(kth_binary_const_t filter, kth_ec_compressed_t const* scan_key, kth_ec_compressed_list_const_t spend_keys, uint8_t signatures, uint8_t version);
+
+/**
+ * @return Owned `kth_stealth_address_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_address_destruct`.
+ * @param filter Borrowed input. Copied by value into the resulting object; ownership of `filter` stays with the caller.
+ * @param spend_keys Borrowed input. Copied by value into the resulting object; ownership of `spend_keys` stays with the caller.
+ * @warning `scan_key` MUST point to a buffer of at least 33 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ec_compressed_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_binary_scan_key_spend_keys_signatures_version_unsafe(kth_binary_const_t filter, uint8_t const* scan_key, kth_ec_compressed_list_const_t spend_keys, uint8_t signatures, uint8_t version);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_wallet_stealth_address_destruct(kth_stealth_address_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_stealth_address_mut_t`. Caller must release with `kth_wallet_stealth_address_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_stealth_address_mut_t kth_wallet_stealth_address_copy(kth_stealth_address_const_t self);
+
+
+// Equality
+
+KTH_EXPORT
+kth_bool_t kth_wallet_stealth_address_equals(kth_stealth_address_const_t self, kth_stealth_address_const_t other);
+
+
+// Getters
+
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
+KTH_EXPORT
+kth_bool_t kth_wallet_stealth_address_valid(kth_stealth_address_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_stealth_address_encoded(kth_stealth_address_const_t self);
+
+KTH_EXPORT
+uint8_t kth_wallet_stealth_address_version(kth_stealth_address_const_t self);
+
+KTH_EXPORT
+kth_ec_compressed_t kth_wallet_stealth_address_scan_key(kth_stealth_address_const_t self);
+
+/** @return Borrowed `kth_ec_compressed_list_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_ec_compressed_list_const_t kth_wallet_stealth_address_spend_keys(kth_stealth_address_const_t self);
+
+KTH_EXPORT
+uint8_t kth_wallet_stealth_address_signatures(kth_stealth_address_const_t self);
+
+/** @return Borrowed `kth_binary_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_binary_const_t kth_wallet_stealth_address_filter(kth_stealth_address_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_wallet_stealth_address_to_chunk(kth_stealth_address_const_t self, kth_size_t* out_size);
+
+
+// Operations
+
+KTH_EXPORT
+kth_bool_t kth_wallet_stealth_address_less(kth_stealth_address_const_t self, kth_stealth_address_const_t x);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_STEALTH_ADDRESS_H_

--- a/src/c-api/src/chain/script.cpp
+++ b/src/c-api/src/chain/script.cpp
@@ -479,7 +479,7 @@ kth_operation_list_mut_t kth_chain_script_to_pay_script_hash_32_pattern_unsafe(u
 
 kth_operation_list_mut_t kth_chain_script_to_pay_multisig_pattern_ec_compressed_list(uint8_t signatures, kth_ec_compressed_list_const_t points) {
     KTH_PRECONDITION(points != nullptr);
-    auto const& points_cpp = kth::cpp_ref<std::vector<std::array<unsigned char, 33>>>(points);
+    auto const& points_cpp = kth::cpp_ref<kth::point_list>(points);
     return kth::leak_list<kth::domain::machine::operation>(cpp_t::to_pay_multisig_pattern(signatures, points_cpp));
 }
 

--- a/src/c-api/src/wallet/bitcoin_uri.cpp
+++ b/src/c-api/src/wallet/bitcoin_uri.cpp
@@ -1,0 +1,220 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/bitcoin_uri.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/bitcoin_uri.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::wallet::bitcoin_uri;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_bitcoin_uri_mut_t kth_wallet_bitcoin_uri_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_bitcoin_uri_mut_t kth_wallet_bitcoin_uri_construct(char const* uri, kth_bool_t strict) {
+    KTH_PRECONDITION(uri != nullptr);
+    auto const uri_cpp = std::string(uri);
+    auto const strict_cpp = kth::int_to_bool(strict);
+    return kth::leak_if_valid(cpp_t(uri_cpp, strict_cpp));
+}
+
+
+// Destructor
+
+void kth_wallet_bitcoin_uri_destruct(kth_bitcoin_uri_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_bitcoin_uri_mut_t kth_wallet_bitcoin_uri_copy(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Equality
+
+kth_bool_t kth_wallet_bitcoin_uri_equals(kth_bitcoin_uri_const_t self, kth_bitcoin_uri_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::eq<cpp_t>(self, other);
+}
+
+
+// Getters
+
+kth_bool_t kth_wallet_bitcoin_uri_valid(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(static_cast<bool>(kth::cpp_ref<cpp_t>(self)));
+}
+
+char* kth_wallet_bitcoin_uri_encoded(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).encoded();
+    return kth::create_c_str(s);
+}
+
+uint64_t kth_wallet_bitcoin_uri_amount(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).amount();
+}
+
+char* kth_wallet_bitcoin_uri_label(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).label();
+    return kth::create_c_str(s);
+}
+
+char* kth_wallet_bitcoin_uri_message(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).message();
+    return kth::create_c_str(s);
+}
+
+char* kth_wallet_bitcoin_uri_r(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).r();
+    return kth::create_c_str(s);
+}
+
+char* kth_wallet_bitcoin_uri_address(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).address();
+    return kth::create_c_str(s);
+}
+
+kth_payment_address_mut_t kth_wallet_bitcoin_uri_payment(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).payment());
+}
+
+kth_stealth_address_mut_t kth_wallet_bitcoin_uri_stealth(kth_bitcoin_uri_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::leak_if_valid(kth::cpp_ref<cpp_t>(self).stealth());
+}
+
+
+// Setters
+
+void kth_wallet_bitcoin_uri_set_amount(kth_bitcoin_uri_mut_t self, uint64_t satoshis) {
+    KTH_PRECONDITION(self != nullptr);
+    kth::cpp_ref<cpp_t>(self).set_amount(satoshis);
+}
+
+void kth_wallet_bitcoin_uri_set_label(kth_bitcoin_uri_mut_t self, char const* label) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(label != nullptr);
+    auto const label_cpp = std::string(label);
+    kth::cpp_ref<cpp_t>(self).set_label(label_cpp);
+}
+
+void kth_wallet_bitcoin_uri_set_message(kth_bitcoin_uri_mut_t self, char const* message) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(message != nullptr);
+    auto const message_cpp = std::string(message);
+    kth::cpp_ref<cpp_t>(self).set_message(message_cpp);
+}
+
+void kth_wallet_bitcoin_uri_set_r(kth_bitcoin_uri_mut_t self, char const* r) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(r != nullptr);
+    auto const r_cpp = std::string(r);
+    kth::cpp_ref<cpp_t>(self).set_r(r_cpp);
+}
+
+kth_bool_t kth_wallet_bitcoin_uri_set_address_string(kth_bitcoin_uri_mut_t self, char const* address) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(address != nullptr);
+    auto const address_cpp = std::string(address);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).set_address(address_cpp));
+}
+
+void kth_wallet_bitcoin_uri_set_address_payment_address(kth_bitcoin_uri_mut_t self, kth_payment_address_const_t payment) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(payment != nullptr);
+    auto const& payment_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(payment);
+    kth::cpp_ref<cpp_t>(self).set_address(payment_cpp);
+}
+
+void kth_wallet_bitcoin_uri_set_address_stealth_address(kth_bitcoin_uri_mut_t self, kth_stealth_address_const_t stealth) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(stealth != nullptr);
+    auto const& stealth_cpp = kth::cpp_ref<kth::domain::wallet::stealth_address>(stealth);
+    kth::cpp_ref<cpp_t>(self).set_address(stealth_cpp);
+}
+
+void kth_wallet_bitcoin_uri_set_strict(kth_bitcoin_uri_mut_t self, kth_bool_t strict) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const strict_cpp = kth::int_to_bool(strict);
+    kth::cpp_ref<cpp_t>(self).set_strict(strict_cpp);
+}
+
+kth_bool_t kth_wallet_bitcoin_uri_set_scheme(kth_bitcoin_uri_mut_t self, char const* scheme) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(scheme != nullptr);
+    auto const scheme_cpp = std::string(scheme);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).set_scheme(scheme_cpp));
+}
+
+kth_bool_t kth_wallet_bitcoin_uri_set_authority(kth_bitcoin_uri_mut_t self, char const* authority) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(authority != nullptr);
+    auto const authority_cpp = std::string(authority);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).set_authority(authority_cpp));
+}
+
+kth_bool_t kth_wallet_bitcoin_uri_set_path(kth_bitcoin_uri_mut_t self, char const* path) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(path != nullptr);
+    auto const path_cpp = std::string(path);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).set_path(path_cpp));
+}
+
+kth_bool_t kth_wallet_bitcoin_uri_set_fragment(kth_bitcoin_uri_mut_t self, char const* fragment) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(fragment != nullptr);
+    auto const fragment_cpp = std::string(fragment);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).set_fragment(fragment_cpp));
+}
+
+kth_bool_t kth_wallet_bitcoin_uri_set_parameter(kth_bitcoin_uri_mut_t self, char const* key, char const* value) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(key != nullptr);
+    KTH_PRECONDITION(value != nullptr);
+    auto const key_cpp = std::string(key);
+    auto const value_cpp = std::string(value);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).set_parameter(key_cpp, value_cpp));
+}
+
+
+// Operations
+
+kth_bool_t kth_wallet_bitcoin_uri_less(kth_bitcoin_uri_const_t self, kth_bitcoin_uri_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::lt<cpp_t>(self, x);
+}
+
+char* kth_wallet_bitcoin_uri_parameter(kth_bitcoin_uri_const_t self, char const* key) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(key != nullptr);
+    auto const key_cpp = std::string(key);
+    auto const s = kth::cpp_ref<cpp_t>(self).parameter(key_cpp);
+    return kth::create_c_str(s);
+}
+
+} // extern "C"

--- a/src/c-api/src/wallet/stealth_address.cpp
+++ b/src/c-api/src/wallet/stealth_address.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/stealth_address.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/stealth_address.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::wallet::stealth_address;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_decoded(uint8_t const* decoded, kth_size_t n) {
+    KTH_PRECONDITION(decoded != nullptr || n == 0);
+    auto const decoded_cpp = n != 0 ? kth::data_chunk(decoded, decoded + n) : kth::data_chunk{};
+    return kth::leak_if_valid(cpp_t(decoded_cpp));
+}
+
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_encoded(char const* encoded) {
+    KTH_PRECONDITION(encoded != nullptr);
+    auto const encoded_cpp = std::string(encoded);
+    return kth::leak_if_valid(cpp_t(encoded_cpp));
+}
+
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_binary_scan_key_spend_keys_signatures_version(kth_binary_const_t filter, kth_ec_compressed_t const* scan_key, kth_ec_compressed_list_const_t spend_keys, uint8_t signatures, uint8_t version) {
+    KTH_PRECONDITION(filter != nullptr);
+    KTH_PRECONDITION(scan_key != nullptr);
+    KTH_PRECONDITION(spend_keys != nullptr);
+    auto const& filter_cpp = kth::cpp_ref<kth::binary>(filter);
+    auto const scan_key_cpp = kth::ec_compressed_to_cpp(scan_key->data);
+    auto const& spend_keys_cpp = kth::cpp_ref<kth::point_list>(spend_keys);
+    return kth::leak_if_valid(cpp_t(filter_cpp, scan_key_cpp, spend_keys_cpp, signatures, version));
+}
+
+kth_stealth_address_mut_t kth_wallet_stealth_address_construct_from_binary_scan_key_spend_keys_signatures_version_unsafe(kth_binary_const_t filter, uint8_t const* scan_key, kth_ec_compressed_list_const_t spend_keys, uint8_t signatures, uint8_t version) {
+    KTH_PRECONDITION(filter != nullptr);
+    KTH_PRECONDITION(scan_key != nullptr);
+    KTH_PRECONDITION(spend_keys != nullptr);
+    auto const& filter_cpp = kth::cpp_ref<kth::binary>(filter);
+    auto const scan_key_cpp = kth::ec_compressed_to_cpp(scan_key);
+    auto const& spend_keys_cpp = kth::cpp_ref<kth::point_list>(spend_keys);
+    return kth::leak_if_valid(cpp_t(filter_cpp, scan_key_cpp, spend_keys_cpp, signatures, version));
+}
+
+
+// Destructor
+
+void kth_wallet_stealth_address_destruct(kth_stealth_address_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_stealth_address_mut_t kth_wallet_stealth_address_copy(kth_stealth_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Equality
+
+kth_bool_t kth_wallet_stealth_address_equals(kth_stealth_address_const_t self, kth_stealth_address_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::eq<cpp_t>(self, other);
+}
+
+
+// Getters
+
+kth_bool_t kth_wallet_stealth_address_valid(kth_stealth_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(static_cast<bool>(kth::cpp_ref<cpp_t>(self)));
+}
+
+char* kth_wallet_stealth_address_encoded(kth_stealth_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).encoded();
+    return kth::create_c_str(s);
+}
+
+uint8_t kth_wallet_stealth_address_version(kth_stealth_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).version();
+}
+
+kth_ec_compressed_t kth_wallet_stealth_address_scan_key(kth_stealth_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::to_ec_compressed_t(kth::cpp_ref<cpp_t>(self).scan_key());
+}
+
+kth_ec_compressed_list_const_t kth_wallet_stealth_address_spend_keys(kth_stealth_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<cpp_t>(self).spend_keys());
+}
+
+uint8_t kth_wallet_stealth_address_signatures(kth_stealth_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).signatures();
+}
+
+kth_binary_const_t kth_wallet_stealth_address_filter(kth_stealth_address_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<cpp_t>(self).filter());
+}
+
+uint8_t* kth_wallet_stealth_address_to_chunk(kth_stealth_address_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    auto const data = kth::cpp_ref<cpp_t>(self).to_chunk();
+    return kth::create_c_array(data, *out_size);
+}
+
+
+// Operations
+
+kth_bool_t kth_wallet_stealth_address_less(kth_stealth_address_const_t self, kth_stealth_address_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::lt<cpp_t>(self, x);
+}
+
+} // extern "C"

--- a/src/c-api/test/wallet/bitcoin_uri.cpp
+++ b/src/c-api/test/wallet/bitcoin_uri.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/bitcoin_uri.h>
+#include <kth/capi/wallet/payment_address.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures — a canonical BIP21 URI with every standard query key set
+// so each getter has something non-default to verify.
+// ---------------------------------------------------------------------------
+
+static char const* const kFullUri =
+    "bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD"
+    "?amount=0.001"
+    "&label=Donation"
+    "&message=Thanks"
+    "&r=https%3A%2F%2Fmerchant.example.com%2Fbip70";
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BitcoinURI - default construct is invalid-but-queryable",
+          "[C-API BitcoinURI][lifecycle]") {
+    // A default URI carries no scheme / address / parameters — its
+    // `operator bool` (surfaced as `valid`) reports false until a
+    // scheme is set.
+    kth_bitcoin_uri_mut_t u = kth_wallet_bitcoin_uri_construct_default();
+    REQUIRE(u != NULL);
+    REQUIRE(kth_wallet_bitcoin_uri_valid(u) == 0);
+    REQUIRE(kth_wallet_bitcoin_uri_amount(u) == 0u);
+    kth_wallet_bitcoin_uri_destruct(u);
+}
+
+TEST_CASE("C-API BitcoinURI - destruct(NULL) is a no-op",
+          "[C-API BitcoinURI][lifecycle]") {
+    kth_wallet_bitcoin_uri_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Parsing — every BIP21 query key round-trips
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BitcoinURI - parses amount / label / message / r",
+          "[C-API BitcoinURI][parse]") {
+    // `strict=1` rejects anything that doesn't conform to the BIP21
+    // grammar; the fixture is well-formed so parsing succeeds.
+    kth_bitcoin_uri_mut_t u = kth_wallet_bitcoin_uri_construct(kFullUri, 1);
+    REQUIRE(u != NULL);
+    REQUIRE(kth_wallet_bitcoin_uri_valid(u) != 0);
+
+    // amount=0.001 BTC → 100_000 satoshis. BIP21 fixed-point parsing
+    // lives in the URI layer, so a regression there surfaces here.
+    REQUIRE(kth_wallet_bitcoin_uri_amount(u) == 100000ull);
+
+    char* label = kth_wallet_bitcoin_uri_label(u);
+    REQUIRE(label != NULL);
+    REQUIRE(strcmp(label, "Donation") == 0);
+    kth_core_destruct_string(label);
+
+    char* msg = kth_wallet_bitcoin_uri_message(u);
+    REQUIRE(msg != NULL);
+    REQUIRE(strcmp(msg, "Thanks") == 0);
+    kth_core_destruct_string(msg);
+
+    char* r = kth_wallet_bitcoin_uri_r(u);
+    REQUIRE(r != NULL);
+    REQUIRE(strcmp(r, "https://merchant.example.com/bip70") == 0);
+    kth_core_destruct_string(r);
+
+    char* addr = kth_wallet_bitcoin_uri_address(u);
+    REQUIRE(addr != NULL);
+    REQUIRE(strcmp(addr, "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD") == 0);
+    kth_core_destruct_string(addr);
+
+    kth_wallet_bitcoin_uri_destruct(u);
+}
+
+TEST_CASE("C-API BitcoinURI - strict mode rejects a malformed scheme",
+          "[C-API BitcoinURI][parse]") {
+    // BIP21 requires the `bitcoin:` scheme. In strict mode, anything
+    // else is rejected and the constructor hands back NULL (the
+    // `leak_if_valid` gate on the string-taking factory collapses an
+    // `operator bool == false` instance to a null handle) so the
+    // caller can distinguish a parse failure from a successful parse
+    // of a blank URI.
+    kth_bitcoin_uri_mut_t u = kth_wallet_bitcoin_uri_construct("http://example.com", 1);
+    REQUIRE(u == NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Encoded round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BitcoinURI - encoded round-trips through construct",
+          "[C-API BitcoinURI][encode]") {
+    // Parse → encode → parse again yields an equal URI. The exact byte
+    // spelling can vary (query-param ordering isn't canonicalised), so
+    // compare via equals on the re-parsed handles rather than strcmp.
+    // Guard every handle / owned string explicitly — the getters abort
+    // on NULL, and we'd rather a parse regression surface as a REQUIRE
+    // failure than a SIGABRT during the test run.
+    kth_bitcoin_uri_mut_t u = kth_wallet_bitcoin_uri_construct(kFullUri, 1);
+    REQUIRE(u != NULL);
+    char* encoded = kth_wallet_bitcoin_uri_encoded(u);
+    REQUIRE(encoded != NULL);
+
+    kth_bitcoin_uri_mut_t reparsed = kth_wallet_bitcoin_uri_construct(encoded, 1);
+    REQUIRE(reparsed != NULL);
+    REQUIRE(kth_wallet_bitcoin_uri_valid(reparsed) != 0);
+    REQUIRE(kth_wallet_bitcoin_uri_amount(reparsed)
+            == kth_wallet_bitcoin_uri_amount(u));
+
+    kth_wallet_bitcoin_uri_destruct(reparsed);
+    kth_core_destruct_string(encoded);
+    kth_wallet_bitcoin_uri_destruct(u);
+}
+
+// ---------------------------------------------------------------------------
+// Setters — build a URI from scratch
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BitcoinURI - setters compose a fresh URI",
+          "[C-API BitcoinURI][build]") {
+    kth_bitcoin_uri_mut_t u = kth_wallet_bitcoin_uri_construct_default();
+    REQUIRE(u != NULL);
+    REQUIRE(kth_wallet_bitcoin_uri_set_scheme(u, "bitcoin") != 0);
+    REQUIRE(kth_wallet_bitcoin_uri_set_address_string(
+        u, "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD") != 0);
+    kth_wallet_bitcoin_uri_set_amount(u, 250000ull);   // 0.0025 BTC
+    kth_wallet_bitcoin_uri_set_label(u, "Coffee");
+    kth_wallet_bitcoin_uri_set_message(u, "thx");
+
+    REQUIRE(kth_wallet_bitcoin_uri_valid(u) != 0);
+    REQUIRE(kth_wallet_bitcoin_uri_amount(u) == 250000ull);
+
+    char* encoded = kth_wallet_bitcoin_uri_encoded(u);
+    REQUIRE(encoded != NULL);
+    // The address-and-query portion is present; exact parameter order
+    // isn't pinned, so only assert on substrings that MUST appear in
+    // the output. `0.0025` pins the BIP21 fixed-point amount encoding
+    // (250000 sats ÷ 10⁸), catching any regression in the satoshi →
+    // decimal path independent of the `amount()` getter's model-level
+    // round-trip.
+    REQUIRE(strstr(encoded, "bitcoin:") == encoded);
+    REQUIRE(strstr(encoded, "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD") != NULL);
+    REQUIRE(strstr(encoded, "0.0025") != NULL);
+    kth_core_destruct_string(encoded);
+
+    kth_wallet_bitcoin_uri_destruct(u);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API BitcoinURI - copy null aborts",
+          "[C-API BitcoinURI][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_bitcoin_uri_copy(NULL));
+}
+
+TEST_CASE("C-API BitcoinURI - valid null aborts",
+          "[C-API BitcoinURI][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_bitcoin_uri_valid(NULL));
+}

--- a/src/c-api/test/wallet/stealth_address.cpp
+++ b/src/c-api/test/wallet/stealth_address.cpp
@@ -1,0 +1,149 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/stealth_address.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Known-good fixtures (lifted from the domain suite) — both cover
+// scan-only and scan+spend variants on mainnet / testnet.
+// ---------------------------------------------------------------------------
+
+static char const* const kScanMainnet =
+    "vJmzLu29obZcUGXXgotapfQLUpz7dfnZpbr4xg1R75qctf8xaXAteRdi3ZUk3T2ZMSad5KyPbve7uyH6eswYAxLHRVSbWgNUeoGuXp";
+
+static char const* const kScanTestnet =
+    "waPXhQwQE9tDugfgLkvpDs3dnkPx1RsfDjFt4zBq7EeWeATRHpyQpYrFZR8T4BQy91Vpvshm2TDER8b9ZryuZ8VSzz8ywzNzX8NqF4";
+
+static char const* const kScanPubOnlyMainnet =
+    "hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i";
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API StealthAddress - default construct is invalid",
+          "[C-API StealthAddress][lifecycle]") {
+    kth_stealth_address_mut_t a = kth_wallet_stealth_address_construct_default();
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_stealth_address_valid(a) == 0);
+    kth_wallet_stealth_address_destruct(a);
+}
+
+TEST_CASE("C-API StealthAddress - destruct(NULL) is a no-op",
+          "[C-API StealthAddress][lifecycle]") {
+    kth_wallet_stealth_address_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Encoded string round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API StealthAddress - encoded round-trips through construct_from_encoded (mainnet)",
+          "[C-API StealthAddress][encode]") {
+    kth_stealth_address_mut_t a = kth_wallet_stealth_address_construct_from_encoded(kScanMainnet);
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_stealth_address_valid(a) != 0);
+    REQUIRE(kth_wallet_stealth_address_version(a) == 42u);
+
+    char* back = kth_wallet_stealth_address_encoded(a);
+    REQUIRE(back != NULL);
+    REQUIRE(strcmp(back, kScanMainnet) == 0);
+    kth_core_destruct_string(back);
+
+    kth_wallet_stealth_address_destruct(a);
+}
+
+TEST_CASE("C-API StealthAddress - encoded round-trips through construct_from_encoded (testnet)",
+          "[C-API StealthAddress][encode]") {
+    // Testnet addresses carry version 43, separating them from the 42
+    // of mainnet — exercise both so a future regression that hardcodes
+    // a version byte anywhere in the codepath trips here.
+    kth_stealth_address_mut_t a = kth_wallet_stealth_address_construct_from_encoded(kScanTestnet);
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_stealth_address_valid(a) != 0);
+    REQUIRE(kth_wallet_stealth_address_version(a) == 43u);
+    kth_wallet_stealth_address_destruct(a);
+}
+
+TEST_CASE("C-API StealthAddress - scan-only variant preserves version",
+          "[C-API StealthAddress][encode]") {
+    // Short variant (no spend keys) also hits the same parser path.
+    kth_stealth_address_mut_t a = kth_wallet_stealth_address_construct_from_encoded(kScanPubOnlyMainnet);
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_stealth_address_valid(a) != 0);
+    REQUIRE(kth_wallet_stealth_address_version(a) == 42u);
+    kth_wallet_stealth_address_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// Chunk round-trip (decoded bytes)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API StealthAddress - to_chunk / construct_from_decoded round-trips",
+          "[C-API StealthAddress][encode]") {
+    kth_stealth_address_mut_t orig = kth_wallet_stealth_address_construct_from_encoded(kScanMainnet);
+    REQUIRE(orig != NULL);
+    REQUIRE(kth_wallet_stealth_address_valid(orig) != 0);
+
+    kth_size_t size = 0;
+    uint8_t* chunk = kth_wallet_stealth_address_to_chunk(orig, &size);
+    REQUIRE(chunk != NULL);
+    REQUIRE(size > 0);
+
+    kth_stealth_address_mut_t parsed = kth_wallet_stealth_address_construct_from_decoded(chunk, size);
+    REQUIRE(parsed != NULL);
+    REQUIRE(kth_wallet_stealth_address_valid(parsed) != 0);
+    REQUIRE(kth_wallet_stealth_address_equals(orig, parsed) != 0);
+
+    kth_wallet_stealth_address_destruct(parsed);
+    kth_core_destruct_array(chunk);
+    kth_wallet_stealth_address_destruct(orig);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equals
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API StealthAddress - copy produces an equal-but-independent handle",
+          "[C-API StealthAddress][lifecycle]") {
+    kth_stealth_address_mut_t a = kth_wallet_stealth_address_construct_from_encoded(kScanMainnet);
+    REQUIRE(a != NULL);
+    kth_stealth_address_mut_t b = kth_wallet_stealth_address_copy(a);
+    REQUIRE(b != NULL);
+    REQUIRE(b != a);
+    REQUIRE(kth_wallet_stealth_address_equals(a, b) != 0);
+
+    kth_wallet_stealth_address_destruct(b);
+    REQUIRE(kth_wallet_stealth_address_valid(a) != 0);  // source survives copy destruct
+
+    kth_wallet_stealth_address_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API StealthAddress - copy null aborts",
+          "[C-API StealthAddress][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_stealth_address_copy(NULL));
+}
+
+TEST_CASE("C-API StealthAddress - version null aborts",
+          "[C-API StealthAddress][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_stealth_address_version(NULL));
+}


### PR DESCRIPTION
## Summary
Two wallet classes that round out the BIP21 / BIP63 surface at the C boundary. Both generate straight from the existing ClassConfig path — the new machinery from the previous namespace-module PR wasn't needed, just two opaque-handle typedefs and the \`_OPAQUE_REGISTRY\` entries.

- \`stealth_address\` — BIP63 coinbase/sender address. Scan-only + scan+spend variants round-trip through both \`construct_from_encoded\` / \`encoded\` and \`to_chunk\` / \`construct_from_decoded\`.
- \`bitcoin_uri\` — BIP21 payment URI parser. Amount / label / message / r parse cleanly; setters compose a fresh URI from scratch; \`encoded\` round-trips back through \`construct\`.

Shipped together because \`bitcoin_uri::stealth()\` and one of its \`set_address\` overloads take a \`stealth_address\`. Splitting into two PRs would either have stranded those methods behind a \`skip_methods\` on \`bitcoin_uri\` (lossy) or required a cross-PR dependency.

## Test plan
- [ ] \`cmake --build build --target kth-capi-tests && ctest --test-dir build -R "C-API (StealthAddress|BitcoinURI)"\`
- [ ] Existing wallet suites still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new exported C-API surface area (new opaque handles, constructors, getters/setters) and adjusts multisig script pattern input casting, which could impact ABI/FFI consumers and script-building call sites if type expectations were relied upon.
> 
> **Overview**
> Exposes two additional wallet primitives at the C boundary: `bitcoin_uri` (BIP21) for parsing/encoding payment URIs and `stealth_address` (BIP63) for constructing/serializing/inspecting stealth addresses, including URI integration points that return/accept stealth addresses.
> 
> Wires the new modules into the build (`CMakeLists.txt`), umbrella header (`capi.h`), and handle typedefs (`handles.h`), and adds Catch2 tests covering lifecycle, round-trips, setters, and precondition abort behavior.
> 
> Also updates `kth_chain_script_to_pay_multisig_pattern_ec_compressed_list` to treat the incoming handle as a `kth::point_list` rather than a raw `std::vector<std::array<unsigned char, 33>>` reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1bb43f626418991fe3e28d460b2d0cdeda1406. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bitcoin URI support: construct, parse, encode, validate, inspect and modify URI fields (amount, address, label, message, parameters), and compare URIs.
  * Stealth Address support: construct from encoded/decoded/binary formats, serialize/deserialize, validate, inspect components, and compare addresses.

* **Tests**
  * New test suites covering lifecycle, parsing/encoding round-trips, setters/getters, validity, and API precondition enforcement for both Bitcoin URI and Stealth Address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->