### PR TITLE
feat(c-api): expose BIP39 mnemonic create / validate + language factories

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -204,7 +204,9 @@ set(kth_sources
 
   src/wallet/bitcoin_uri.cpp
   src/wallet/cashtoken_minting.cpp
+  src/wallet/language.cpp
   src/wallet/message.cpp
+  src/wallet/mnemonic.cpp
   src/wallet/payment_address.cpp
   src/wallet/payment_address_list.cpp
   src/wallet/stealth_address.cpp
@@ -338,7 +340,9 @@ set(kth_headers
   include/kth/capi/wallet/bitcoin_uri.h
   include/kth/capi/wallet/cashtoken_minting.h
   include/kth/capi/wallet/ec_public.h
+  include/kth/capi/wallet/language.h
   include/kth/capi/wallet/message.h
+  include/kth/capi/wallet/mnemonic.h
   include/kth/capi/wallet/payment_address.h
   include/kth/capi/wallet/payment_address_list.h
   include/kth/capi/wallet/stealth_address.h
@@ -565,6 +569,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/wallet/hd_public.cpp
         test/wallet/hd_private.cpp
         test/wallet/message.cpp
+        test/wallet/mnemonic.cpp
         test/wallet/stealth_address.cpp
         test/wallet/wallet_data.cpp
         test/vm/big_number.cpp

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -102,7 +102,9 @@
 #include <kth/capi/wallet/hd_private.h>
 #include <kth/capi/wallet/bitcoin_uri.h>
 #include <kth/capi/wallet/hd_public.h>
+#include <kth/capi/wallet/language.h>
 #include <kth/capi/wallet/message.h>
+#include <kth/capi/wallet/mnemonic.h>
 #include <kth/capi/wallet/payment_address.h>
 #include <kth/capi/wallet/stealth_address.h>
 #include <kth/capi/wallet/payment_address_list.h>

--- a/src/c-api/include/kth/capi/handles.h
+++ b/src/c-api/include/kth/capi/handles.h
@@ -190,6 +190,15 @@ typedef void const* kth_stealth_address_const_t;
 typedef void* kth_bitcoin_uri_mut_t;
 typedef void const* kth_bitcoin_uri_const_t;
 
+// BIP39 wordlist handles. `dictionary` is `std::array<char const*, 2048>`
+// and `dictionary_list` is `std::vector<dictionary const*>`; callers
+// obtain handles through the `kth_wallet_language_*` factories
+// (borrowed views into static storage — do not destruct).
+typedef void* kth_dictionary_mut_t;
+typedef void const* kth_dictionary_const_t;
+typedef void* kth_dictionary_list_mut_t;
+typedef void const* kth_dictionary_list_const_t;
+
 typedef void* kth_ec_compressed_list_t;
 typedef void* kth_ec_compressed_list_mut_t;
 typedef void const* kth_ec_compressed_list_const_t;

--- a/src/c-api/include/kth/capi/wallet/language.h
+++ b/src/c-api/include/kth/capi/wallet/language.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_LANGUAGE_H_
+#define KTH_CAPI_WALLET_LANGUAGE_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Static utilities
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_en(void);
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_es(void);
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_ja(void);
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_it(void);
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_fr(void);
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_cs(void);
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_ru(void);
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_uk(void);
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_zh_Hans(void);
+
+/** @return Borrowed `kth_dictionary_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_const_t kth_wallet_language_zh_Hant(void);
+
+/** @return Borrowed `kth_dictionary_list_const_t` into program-lifetime static storage. Do not destruct. */
+KTH_EXPORT
+kth_dictionary_list_const_t kth_wallet_language_all(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_LANGUAGE_H_

--- a/src/c-api/include/kth/capi/wallet/mnemonic.h
+++ b/src/c-api/include/kth/capi/wallet/mnemonic.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_MNEMONIC_H_
+#define KTH_CAPI_WALLET_MNEMONIC_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Static utilities
+
+/** @return Owned `kth_string_list_mut_t`. Caller must release with `kth_core_string_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_string_list_mut_t kth_wallet_mnemonic_create_mnemonic(uint8_t const* entropy, kth_size_t n, kth_dictionary_const_t lexicon);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_mnemonic_validate_mnemonic_dictionary(kth_string_list_const_t words, kth_dictionary_const_t lexicon);
+
+KTH_EXPORT
+kth_bool_t kth_wallet_mnemonic_validate_mnemonic_dictionary_list(kth_string_list_const_t mnemonic, kth_dictionary_list_const_t lexicons);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_MNEMONIC_H_

--- a/src/c-api/src/wallet/language.cpp
+++ b/src/c-api/src/wallet/language.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/language.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/dictionary.hpp>
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Static utilities
+
+kth_dictionary_const_t kth_wallet_language_en(void) {
+    return &(kth::domain::wallet::languages::en());
+}
+
+kth_dictionary_const_t kth_wallet_language_es(void) {
+    return &(kth::domain::wallet::languages::es());
+}
+
+kth_dictionary_const_t kth_wallet_language_ja(void) {
+    return &(kth::domain::wallet::languages::ja());
+}
+
+kth_dictionary_const_t kth_wallet_language_it(void) {
+    return &(kth::domain::wallet::languages::it());
+}
+
+kth_dictionary_const_t kth_wallet_language_fr(void) {
+    return &(kth::domain::wallet::languages::fr());
+}
+
+kth_dictionary_const_t kth_wallet_language_cs(void) {
+    return &(kth::domain::wallet::languages::cs());
+}
+
+kth_dictionary_const_t kth_wallet_language_ru(void) {
+    return &(kth::domain::wallet::languages::ru());
+}
+
+kth_dictionary_const_t kth_wallet_language_uk(void) {
+    return &(kth::domain::wallet::languages::uk());
+}
+
+kth_dictionary_const_t kth_wallet_language_zh_Hans(void) {
+    return &(kth::domain::wallet::languages::zh_Hans());
+}
+
+kth_dictionary_const_t kth_wallet_language_zh_Hant(void) {
+    return &(kth::domain::wallet::languages::zh_Hant());
+}
+
+kth_dictionary_list_const_t kth_wallet_language_all(void) {
+    return &(kth::domain::wallet::languages::all());
+}
+
+} // extern "C"

--- a/src/c-api/src/wallet/mnemonic.cpp
+++ b/src/c-api/src/wallet/mnemonic.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/mnemonic.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/mnemonic.hpp>
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Static utilities
+
+kth_string_list_mut_t kth_wallet_mnemonic_create_mnemonic(uint8_t const* entropy, kth_size_t n, kth_dictionary_const_t lexicon) {
+    KTH_PRECONDITION(entropy != nullptr || n == 0);
+    KTH_PRECONDITION(lexicon != nullptr);
+    auto const entropy_cpp = kth::byte_span(entropy, kth::sz(n));
+    auto const& lexicon_cpp = kth::cpp_ref<std::array<const char *, 2048>>(lexicon);
+    auto const cpp_result = kth::domain::wallet::create_mnemonic(entropy_cpp, lexicon_cpp);
+    return kth::leak_list<std::string>(cpp_result.begin(), cpp_result.end());
+}
+
+kth_bool_t kth_wallet_mnemonic_validate_mnemonic_dictionary(kth_string_list_const_t words, kth_dictionary_const_t lexicon) {
+    KTH_PRECONDITION(words != nullptr);
+    KTH_PRECONDITION(lexicon != nullptr);
+    auto const& words_cpp = kth::cpp_ref<kth::string_list>(words);
+    auto const& lexicon_cpp = kth::cpp_ref<std::array<const char *, 2048>>(lexicon);
+    return kth::bool_to_int(kth::domain::wallet::validate_mnemonic(words_cpp, lexicon_cpp));
+}
+
+kth_bool_t kth_wallet_mnemonic_validate_mnemonic_dictionary_list(kth_string_list_const_t mnemonic, kth_dictionary_list_const_t lexicons) {
+    KTH_PRECONDITION(mnemonic != nullptr);
+    KTH_PRECONDITION(lexicons != nullptr);
+    auto const& mnemonic_cpp = kth::cpp_ref<kth::string_list>(mnemonic);
+    auto const& lexicons_cpp = kth::cpp_ref<std::vector<const std::array<const char *, 2048> *>>(lexicons);
+    return kth::bool_to_int(kth::domain::wallet::validate_mnemonic(mnemonic_cpp, lexicons_cpp));
+}
+
+} // extern "C"

--- a/src/c-api/test/wallet/mnemonic.cpp
+++ b/src/c-api/test/wallet/mnemonic.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/string_list.h>
+#include <kth/capi/wallet/language.h>
+#include <kth/capi/wallet/mnemonic.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures — BIP39 test vector (English, 128-bit entropy).
+// ---------------------------------------------------------------------------
+
+// All-zero entropy → canonical first BIP39 vector:
+//   "abandon abandon abandon abandon abandon abandon
+//    abandon abandon abandon abandon abandon about"
+static uint8_t const kZeroEntropy128[16] = { 0 };
+
+// 160-bit zeros → 15-word mnemonic (BIP39 word count = entropy_bits / 32 * 3).
+static uint8_t const kZeroEntropy160[20] = { 0 };
+
+// ---------------------------------------------------------------------------
+// Language factories — borrowed views into static storage
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::language - built-in factories return non-null handles",
+          "[C-API WalletLanguage]") {
+    // All 10 language accessors must return borrowed views into the
+    // compiled-in `kth::domain::wallet::language::*` globals. NULL
+    // here would mean the domain linkage broke.
+    REQUIRE(kth_wallet_language_en() != NULL);
+    REQUIRE(kth_wallet_language_es() != NULL);
+    REQUIRE(kth_wallet_language_ja() != NULL);
+    REQUIRE(kth_wallet_language_it() != NULL);
+    REQUIRE(kth_wallet_language_fr() != NULL);
+    REQUIRE(kth_wallet_language_cs() != NULL);
+    REQUIRE(kth_wallet_language_ru() != NULL);
+    REQUIRE(kth_wallet_language_uk() != NULL);
+    REQUIRE(kth_wallet_language_zh_Hans() != NULL);
+    REQUIRE(kth_wallet_language_zh_Hant() != NULL);
+    REQUIRE(kth_wallet_language_all() != NULL);
+}
+
+TEST_CASE("C-API wallet::language - each factory returns a distinct dictionary",
+          "[C-API WalletLanguage]") {
+    // The handles borrow into 10 separate static `dictionary`
+    // globals — no two should alias. A regression that pointed them
+    // at the same wordlist (e.g. a copy-paste mistake in the domain
+    // factories) would collapse `validate` cross-language as well.
+    REQUIRE(kth_wallet_language_en() != kth_wallet_language_es());
+    REQUIRE(kth_wallet_language_en() != kth_wallet_language_ja());
+    REQUIRE(kth_wallet_language_zh_Hans() != kth_wallet_language_zh_Hant());
+}
+
+// ---------------------------------------------------------------------------
+// create_mnemonic
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::mnemonic - 128-bit entropy yields 12-word mnemonic",
+          "[C-API WalletMnemonic][create]") {
+    // BIP39: 128 bits of entropy → 12 words (11 from entropy + 1
+    // checksum word derived from the first 4 bits of SHA-256(entropy)).
+    kth_string_list_mut_t words = kth_wallet_mnemonic_create_mnemonic(
+        kZeroEntropy128, sizeof(kZeroEntropy128), kth_wallet_language_en());
+    REQUIRE(words != NULL);
+    REQUIRE(kth_core_string_list_count(words) == 12u);
+
+    // Canonical BIP39 all-zero-entropy checksum word is "about".
+    char const* last = kth_core_string_list_nth(words, 11u);
+    REQUIRE(last != NULL);
+    REQUIRE(strcmp(last, "about") == 0);
+
+    kth_core_string_list_destruct(words);
+}
+
+TEST_CASE("C-API wallet::mnemonic - 160-bit entropy yields 15-word mnemonic",
+          "[C-API WalletMnemonic][create]") {
+    kth_string_list_mut_t words = kth_wallet_mnemonic_create_mnemonic(
+        kZeroEntropy160, sizeof(kZeroEntropy160), kth_wallet_language_en());
+    REQUIRE(words != NULL);
+    REQUIRE(kth_core_string_list_count(words) == 15u);
+    kth_core_string_list_destruct(words);
+}
+
+// ---------------------------------------------------------------------------
+// validate_mnemonic — against a specific dictionary
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::mnemonic - validate accepts a freshly-created mnemonic",
+          "[C-API WalletMnemonic][validate]") {
+    // Round-trip: create → validate under the same language. Any
+    // drift in wordlist handling between create and validate would
+    // surface here.
+    kth_string_list_mut_t words = kth_wallet_mnemonic_create_mnemonic(
+        kZeroEntropy128, sizeof(kZeroEntropy128), kth_wallet_language_en());
+    REQUIRE(words != NULL);
+    REQUIRE(kth_wallet_mnemonic_validate_mnemonic_dictionary(
+        words, kth_wallet_language_en()) != 0);
+    kth_core_string_list_destruct(words);
+}
+
+TEST_CASE("C-API wallet::mnemonic - validate rejects under the wrong language",
+          "[C-API WalletMnemonic][validate]") {
+    // English words won't parse under the Spanish dictionary; the
+    // lookup fails before the checksum is even considered.
+    kth_string_list_mut_t words = kth_wallet_mnemonic_create_mnemonic(
+        kZeroEntropy128, sizeof(kZeroEntropy128), kth_wallet_language_en());
+    REQUIRE(words != NULL);
+    REQUIRE(kth_wallet_mnemonic_validate_mnemonic_dictionary(
+        words, kth_wallet_language_es()) == 0);
+    kth_core_string_list_destruct(words);
+}
+
+TEST_CASE("C-API wallet::mnemonic - validate rejects a bad checksum",
+          "[C-API WalletMnemonic][validate]") {
+    // Build a list where every word is a valid BIP39 English word but
+    // the checksum is wrong. `abandon` × 12 is only valid when the
+    // entropy is all zero; swapping the last word for any other valid
+    // English BIP39 word breaks the checksum.
+    kth_string_list_mut_t broken = kth_core_string_list_construct_default();
+    for (int i = 0; i < 12; ++i) {
+        kth_core_string_list_push_back(broken, "abandon");  // correct
+                                                            // checksum
+                                                            // word is
+                                                            // "about"
+    }
+
+    REQUIRE(kth_wallet_mnemonic_validate_mnemonic_dictionary(
+        broken, kth_wallet_language_en()) == 0);
+
+    kth_core_string_list_destruct(broken);
+}
+
+// ---------------------------------------------------------------------------
+// validate_mnemonic — against every built-in dictionary
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::mnemonic - validate_any accepts any built-in language",
+          "[C-API WalletMnemonic][validate]") {
+    // A valid Spanish-language mnemonic must be accepted by the
+    // dictionary_list overload without the caller specifying Spanish.
+    kth_string_list_mut_t words = kth_wallet_mnemonic_create_mnemonic(
+        kZeroEntropy128, sizeof(kZeroEntropy128), kth_wallet_language_es());
+    REQUIRE(words != NULL);
+    REQUIRE(kth_wallet_mnemonic_validate_mnemonic_dictionary_list(
+        words, kth_wallet_language_all()) != 0);
+    kth_core_string_list_destruct(words);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::mnemonic - create null entropy with non-zero size aborts",
+          "[C-API WalletMnemonic][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_mnemonic_create_mnemonic(
+        NULL, 16u, kth_wallet_language_en()));
+}
+
+TEST_CASE("C-API wallet::mnemonic - create null lexicon aborts",
+          "[C-API WalletMnemonic][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_mnemonic_create_mnemonic(
+        kZeroEntropy128, sizeof(kZeroEntropy128), NULL));
+}
+
+TEST_CASE("C-API wallet::mnemonic - validate null mnemonic aborts",
+          "[C-API WalletMnemonic][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_mnemonic_validate_mnemonic_dictionary(
+        NULL, kth_wallet_language_en()));
+}
+
+TEST_CASE("C-API wallet::mnemonic - validate_any null mnemonic aborts",
+          "[C-API WalletMnemonic][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_mnemonic_validate_mnemonic_dictionary_list(
+        NULL, kth_wallet_language_all()));
+}

--- a/src/domain/include/kth/domain/wallet/dictionary.hpp
+++ b/src/domain/include/kth/domain/wallet/dictionary.hpp
@@ -48,6 +48,32 @@ namespace language {
     extern const dictionary_list all;
 }
 
+// Function-shaped accessors over the `language::` globals above.
+// The existing `extern const` names are variables, not callables, so
+// a binding generator can't bind them directly; the factories below
+// give each built-in wordlist a function surface at the same
+// namespace level. They forward by reference and cost nothing at
+// runtime (every compiler inlines the return statement).
+namespace languages {
+
+inline dictionary const& en()      noexcept { return language::en; }
+inline dictionary const& es()      noexcept { return language::es; }
+inline dictionary const& ja()      noexcept { return language::ja; }
+inline dictionary const& it()      noexcept { return language::it; }
+inline dictionary const& fr()      noexcept { return language::fr; }
+inline dictionary const& cs()      noexcept { return language::cs; }
+inline dictionary const& ru()      noexcept { return language::ru; }
+inline dictionary const& uk()      noexcept { return language::uk; }
+inline dictionary const& zh_Hans() noexcept { return language::zh_Hans; }
+inline dictionary const& zh_Hant() noexcept { return language::zh_Hant; }
+
+// The union of every built-in BIP39 wordlist; the default lexicon for
+// `validate_mnemonic(word_list, dictionary_list)` when the caller
+// doesn't know which language produced the mnemonic.
+inline dictionary_list const& all() noexcept { return language::all; }
+
+} // namespace languages
+
 } // namespace kth::domain::wallet
 
 #endif // KTH_DOMAIN_WALLET_DICTIONARY_HPP_


### PR DESCRIPTION
## Summary
BIP39's decode-to-seed half was already covered by `wallet.cpp`'s `kth_wallet_mnemonics_to_seed*` helpers. What was still missing was the create / validate surface and, with it, some way to select one of the 10 built-in wordlists from C — the domain API takes `kth::domain::wallet::dictionary const&`, which is a plain `std::array<char const*, 2048>` type alias with no handle type.

Map `dictionary` and `dictionary_list` as opaque C handles and expose the 10 built-in BIP39 wordlists through a new `kth_wallet_language_*()` factory module that forwards to the `kth::domain::wallet::languages::` inline accessors. Callers thread those handles into the `kth_wallet_mnemonic_*` functions:

- `kth_wallet_mnemonic_create_mnemonic(entropy, n, lexicon)` — BIP39 words from entropy, one wordlist.
- `kth_wallet_mnemonic_validate_mnemonic_dictionary(words, lexicon)` — checksum + wordlist check under a specific language.
- `kth_wallet_mnemonic_validate_mnemonic_dictionary_list(words, lexicons)` — tries every wordlist in `lexicons`; use `kth_wallet_language_all()` for the built-in union.

## Test plan
- [ ] `cmake --build build --target kth_capi_test && build/.../kth_capi_test "[C-API WalletMnemonic],[C-API WalletLanguage]"`
- [ ] Existing wallet suites still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public C-API surface for BIP39 mnemonic generation/validation and introduces new opaque handle types with borrowed static lifetimes, which could affect downstream bindings/ABI expectations if misused.
> 
> **Overview**
> Exposes BIP39 *mnemonic generation and validation* through new C-API entry points (`kth_wallet_mnemonic_create_mnemonic`, `kth_wallet_mnemonic_validate_*`) and wires them into the umbrella `capi.h` header.
> 
> Introduces new opaque handles for BIP39 `dictionary`/`dictionary_list` plus `kth_wallet_language_*` factories that return borrowed views of the built-in wordlists (including `kth_wallet_language_all()`), and adds Catch2 coverage for round-trip creation/validation, cross-language failure cases, and precondition aborts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a6151eb203a727691f65977b88b618f77602e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BIP39 mnemonic generation from entropy input.
  * Added mnemonic validation against language-specific dictionaries.
  * Added support for 10 languages: English, Spanish, Japanese, Italian, French, Czech, Russian, Ukrainian, and Simplified/Traditional Chinese.

* **Tests**
  * Added comprehensive test suite for mnemonic creation and validation across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->