### PR TITLE
feat(c-api): expose BIP38 ek_private / ek_public / ek_token + tests

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -204,6 +204,9 @@ set(kth_sources
 
   src/wallet/bitcoin_uri.cpp
   src/wallet/cashtoken_minting.cpp
+  src/wallet/ek_private.cpp
+  src/wallet/ek_public.cpp
+  src/wallet/ek_token.cpp
   src/wallet/language.cpp
   src/wallet/message.cpp
   src/wallet/mnemonic.cpp
@@ -340,6 +343,9 @@ set(kth_headers
   include/kth/capi/wallet/bitcoin_uri.h
   include/kth/capi/wallet/cashtoken_minting.h
   include/kth/capi/wallet/ec_public.h
+  include/kth/capi/wallet/ek_private.h
+  include/kth/capi/wallet/ek_public.h
+  include/kth/capi/wallet/ek_token.h
   include/kth/capi/wallet/language.h
   include/kth/capi/wallet/message.h
   include/kth/capi/wallet/mnemonic.h
@@ -566,6 +572,9 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/utxo.cpp
         test/wallet/bitcoin_uri.cpp
         test/wallet/cashtoken_minting.cpp
+        test/wallet/ek_private.cpp
+        test/wallet/ek_public.cpp
+        test/wallet/ek_token.cpp
         test/wallet/hd_public.cpp
         test/wallet/hd_private.cpp
         test/wallet/message.cpp

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -98,6 +98,9 @@
 #include <kth/capi/wallet/ec_public.h>
 #include <kth/capi/wallet/elliptic_curve.h>
 #include <kth/capi/wallet/cashtoken_minting.h>
+#include <kth/capi/wallet/ek_private.h>
+#include <kth/capi/wallet/ek_public.h>
+#include <kth/capi/wallet/ek_token.h>
 #include <kth/capi/wallet/hd_lineage.h>
 #include <kth/capi/wallet/hd_private.h>
 #include <kth/capi/wallet/bitcoin_uri.h>

--- a/src/c-api/include/kth/capi/handles.h
+++ b/src/c-api/include/kth/capi/handles.h
@@ -190,6 +190,16 @@ typedef void const* kth_stealth_address_const_t;
 typedef void* kth_bitcoin_uri_mut_t;
 typedef void const* kth_bitcoin_uri_const_t;
 
+// BIP38 encrypted key wrappers. Each is a thin opaque handle around
+// a base58-checked `encrypted_{private,public,token}` byte_array
+// with string I/O and a typed accessor.
+typedef void* kth_ek_private_mut_t;
+typedef void const* kth_ek_private_const_t;
+typedef void* kth_ek_public_mut_t;
+typedef void const* kth_ek_public_const_t;
+typedef void* kth_ek_token_mut_t;
+typedef void const* kth_ek_token_const_t;
+
 // BIP39 wordlist handles. `dictionary` is `std::array<char const*, 2048>`
 // and `dictionary_list` is `std::vector<dictionary const*>`; callers
 // obtain handles through the `kth_wallet_language_*` factories

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -20,6 +20,7 @@
 #include <kth/domain/chain/token_data.hpp>
 #include <kth/domain/config/network.hpp>
 #include <kth/domain/machine/opcode.hpp>
+#include <kth/domain/wallet/encrypted_keys.hpp>
 #include <kth/domain/wallet/hd_public.hpp>
 #include <kth/domain/wallet/message.hpp>
 #include <kth/domain/wallet/wallet_manager.hpp>
@@ -393,6 +394,36 @@ inline kth::domain::wallet::hd_key hd_key_to_cpp(uint8_t const* x) {
 // encrypted_seed (96 bytes)
 inline kth::domain::wallet::encrypted_seed_t encrypted_seed_to_cpp(uint8_t const* x) {
     return to_array_cpp<std::tuple_size_v<kth::domain::wallet::encrypted_seed_t>>(x);
+}
+
+// BIP38 encrypted_private (43 bytes)
+inline kth_encrypted_private_t to_encrypted_private_t(kth::domain::wallet::encrypted_private const& x) {
+    kth_encrypted_private_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::domain::wallet::encrypted_private encrypted_private_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::domain::wallet::ek_private_decoded_size>(x);
+}
+
+// BIP38 encrypted_public (55 bytes)
+inline kth_encrypted_public_t to_encrypted_public_t(kth::domain::wallet::encrypted_public const& x) {
+    kth_encrypted_public_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::domain::wallet::encrypted_public encrypted_public_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::domain::wallet::encrypted_public_decoded_size>(x);
+}
+
+// BIP38 encrypted_token (53 bytes)
+inline kth_encrypted_token_t to_encrypted_token_t(kth::domain::wallet::encrypted_token const& x) {
+    kth_encrypted_token_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::domain::wallet::encrypted_token encrypted_token_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::domain::wallet::encrypted_token_decoded_size>(x);
 }
 
 template <typename T>

--- a/src/c-api/include/kth/capi/wallet/ek_private.h
+++ b/src/c-api/include/kth/capi/wallet/ek_private.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_EK_PRIVATE_H_
+#define KTH_CAPI_WALLET_EK_PRIVATE_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/** @return Owned `kth_ek_private_mut_t`. Caller must release with `kth_wallet_ek_private_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ek_private_mut_t kth_wallet_ek_private_construct_default(void);
+
+/** @return Owned `kth_ek_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_private_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ek_private_mut_t kth_wallet_ek_private_construct_from_encoded(char const* encoded);
+
+/**
+ * @return Owned `kth_ek_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_private_destruct`.
+ * @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ek_private_mut_t kth_wallet_ek_private_construct_from_value(kth_encrypted_private_t const* value);
+
+/**
+ * @return Owned `kth_ek_private_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_private_destruct`.
+ * @warning `value` MUST point to a buffer of at least 43 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_encrypted_private_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ek_private_mut_t kth_wallet_ek_private_construct_from_value_unsafe(uint8_t const* value);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_wallet_ek_private_destruct(kth_ek_private_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_ek_private_mut_t`. Caller must release with `kth_wallet_ek_private_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ek_private_mut_t kth_wallet_ek_private_copy(kth_ek_private_const_t self);
+
+
+// Equality
+
+KTH_EXPORT
+kth_bool_t kth_wallet_ek_private_equals(kth_ek_private_const_t self, kth_ek_private_const_t other);
+
+
+// Getters
+
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
+KTH_EXPORT
+kth_bool_t kth_wallet_ek_private_valid(kth_ek_private_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_ek_private_encoded(kth_ek_private_const_t self);
+
+KTH_EXPORT
+kth_encrypted_private_t kth_wallet_ek_private_private_key(kth_ek_private_const_t self);
+
+
+// Operations
+
+KTH_EXPORT
+kth_bool_t kth_wallet_ek_private_less(kth_ek_private_const_t self, kth_ek_private_const_t x);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_EK_PRIVATE_H_

--- a/src/c-api/include/kth/capi/wallet/ek_public.h
+++ b/src/c-api/include/kth/capi/wallet/ek_public.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_EK_PUBLIC_H_
+#define KTH_CAPI_WALLET_EK_PUBLIC_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/** @return Owned `kth_ek_public_mut_t`. Caller must release with `kth_wallet_ek_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ek_public_mut_t kth_wallet_ek_public_construct_default(void);
+
+/** @return Owned `kth_ek_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ek_public_mut_t kth_wallet_ek_public_construct_from_encoded(char const* encoded);
+
+/**
+ * @return Owned `kth_ek_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_public_destruct`.
+ * @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ek_public_mut_t kth_wallet_ek_public_construct_from_value(kth_encrypted_public_t const* value);
+
+/**
+ * @return Owned `kth_ek_public_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_public_destruct`.
+ * @warning `value` MUST point to a buffer of at least 55 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_encrypted_public_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ek_public_mut_t kth_wallet_ek_public_construct_from_value_unsafe(uint8_t const* value);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_wallet_ek_public_destruct(kth_ek_public_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_ek_public_mut_t`. Caller must release with `kth_wallet_ek_public_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ek_public_mut_t kth_wallet_ek_public_copy(kth_ek_public_const_t self);
+
+
+// Equality
+
+KTH_EXPORT
+kth_bool_t kth_wallet_ek_public_equals(kth_ek_public_const_t self, kth_ek_public_const_t other);
+
+
+// Getters
+
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
+KTH_EXPORT
+kth_bool_t kth_wallet_ek_public_valid(kth_ek_public_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_ek_public_encoded(kth_ek_public_const_t self);
+
+KTH_EXPORT
+kth_encrypted_public_t kth_wallet_ek_public_public_key(kth_ek_public_const_t self);
+
+
+// Operations
+
+KTH_EXPORT
+kth_bool_t kth_wallet_ek_public_less(kth_ek_public_const_t self, kth_ek_public_const_t x);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_EK_PUBLIC_H_

--- a/src/c-api/include/kth/capi/wallet/ek_token.h
+++ b/src/c-api/include/kth/capi/wallet/ek_token.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_EK_TOKEN_H_
+#define KTH_CAPI_WALLET_EK_TOKEN_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/** @return Owned `kth_ek_token_mut_t`. Caller must release with `kth_wallet_ek_token_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ek_token_mut_t kth_wallet_ek_token_construct_default(void);
+
+/** @return Owned `kth_ek_token_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_token_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ek_token_mut_t kth_wallet_ek_token_construct_from_encoded(char const* encoded);
+
+/**
+ * @return Owned `kth_ek_token_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_token_destruct`.
+ * @param value Borrowed input; must be non-null. Copied into the resulting object; ownership of `value` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ek_token_mut_t kth_wallet_ek_token_construct_from_value(kth_encrypted_token_t const* value);
+
+/**
+ * @return Owned `kth_ek_token_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_ek_token_destruct`.
+ * @warning `value` MUST point to a buffer of at least 53 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_encrypted_token_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_ek_token_mut_t kth_wallet_ek_token_construct_from_value_unsafe(uint8_t const* value);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_wallet_ek_token_destruct(kth_ek_token_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_ek_token_mut_t`. Caller must release with `kth_wallet_ek_token_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_ek_token_mut_t kth_wallet_ek_token_copy(kth_ek_token_const_t self);
+
+
+// Equality
+
+KTH_EXPORT
+kth_bool_t kth_wallet_ek_token_equals(kth_ek_token_const_t self, kth_ek_token_const_t other);
+
+
+// Getters
+
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
+KTH_EXPORT
+kth_bool_t kth_wallet_ek_token_valid(kth_ek_token_const_t self);
+
+/** @return Owned C string. Caller must release with `kth_core_destruct_string`. */
+KTH_EXPORT KTH_OWNED
+char* kth_wallet_ek_token_encoded(kth_ek_token_const_t self);
+
+KTH_EXPORT
+kth_encrypted_token_t kth_wallet_ek_token_token(kth_ek_token_const_t self);
+
+
+// Operations
+
+KTH_EXPORT
+kth_bool_t kth_wallet_ek_token_less(kth_ek_token_const_t self, kth_ek_token_const_t x);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_EK_TOKEN_H_

--- a/src/c-api/include/kth/capi/wallet/primitives.h
+++ b/src/c-api/include/kth/capi/wallet/primitives.h
@@ -68,6 +68,24 @@ typedef struct kth_payment_t {
     uint8_t hash[KTH_BITCOIN_PAYMENT_SIZE];
 } kth_payment_t;
 
+// BIP38 encrypted-key byte payloads. These are the base58-checked
+// wire forms that `ek_private` / `ek_public` / `ek_token` wrap, each
+// a fixed-size byte_array in the domain layer.
+#define KTH_EK_PRIVATE_DECODED_SIZE 43
+#define KTH_EK_PUBLIC_DECODED_SIZE 55
+#define KTH_EK_TOKEN_DECODED_SIZE 53
+typedef struct kth_encrypted_private_t {
+    uint8_t data[KTH_EK_PRIVATE_DECODED_SIZE];
+} kth_encrypted_private_t;
+
+typedef struct kth_encrypted_public_t {
+    uint8_t data[KTH_EK_PUBLIC_DECODED_SIZE];
+} kth_encrypted_public_t;
+
+typedef struct kth_encrypted_token_t {
+    uint8_t data[KTH_EK_TOKEN_DECODED_SIZE];
+} kth_encrypted_token_t;
+
 
 typedef void* kth_ec_private_t;
 typedef void* kth_ec_private_mut_t;

--- a/src/c-api/src/wallet/ek_private.cpp
+++ b/src/c-api/src/wallet/ek_private.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/ek_private.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/ek_private.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::wallet::ek_private;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_ek_private_mut_t kth_wallet_ek_private_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_ek_private_mut_t kth_wallet_ek_private_construct_from_encoded(char const* encoded) {
+    KTH_PRECONDITION(encoded != nullptr);
+    auto const encoded_cpp = std::string(encoded);
+    return kth::leak_if_valid(cpp_t(encoded_cpp));
+}
+
+kth_ek_private_mut_t kth_wallet_ek_private_construct_from_value(kth_encrypted_private_t const* value) {
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::encrypted_private_to_cpp(value->data);
+    return kth::leak_if_valid(cpp_t(value_cpp));
+}
+
+kth_ek_private_mut_t kth_wallet_ek_private_construct_from_value_unsafe(uint8_t const* value) {
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::to_array_cpp<43>(value);
+    return kth::leak_if_valid(cpp_t(value_cpp));
+}
+
+
+// Destructor
+
+void kth_wallet_ek_private_destruct(kth_ek_private_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_ek_private_mut_t kth_wallet_ek_private_copy(kth_ek_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Equality
+
+kth_bool_t kth_wallet_ek_private_equals(kth_ek_private_const_t self, kth_ek_private_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::eq<cpp_t>(self, other);
+}
+
+
+// Getters
+
+kth_bool_t kth_wallet_ek_private_valid(kth_ek_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(static_cast<bool>(kth::cpp_ref<cpp_t>(self)));
+}
+
+char* kth_wallet_ek_private_encoded(kth_ek_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).encoded();
+    return kth::create_c_str(s);
+}
+
+kth_encrypted_private_t kth_wallet_ek_private_private_key(kth_ek_private_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::to_encrypted_private_t(kth::cpp_ref<cpp_t>(self).private_key());
+}
+
+
+// Operations
+
+kth_bool_t kth_wallet_ek_private_less(kth_ek_private_const_t self, kth_ek_private_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::lt<cpp_t>(self, x);
+}
+
+} // extern "C"

--- a/src/c-api/src/wallet/ek_public.cpp
+++ b/src/c-api/src/wallet/ek_public.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/ek_public.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/ek_public.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::wallet::ek_public;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_ek_public_mut_t kth_wallet_ek_public_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_ek_public_mut_t kth_wallet_ek_public_construct_from_encoded(char const* encoded) {
+    KTH_PRECONDITION(encoded != nullptr);
+    auto const encoded_cpp = std::string(encoded);
+    return kth::leak_if_valid(cpp_t(encoded_cpp));
+}
+
+kth_ek_public_mut_t kth_wallet_ek_public_construct_from_value(kth_encrypted_public_t const* value) {
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::encrypted_public_to_cpp(value->data);
+    return kth::leak_if_valid(cpp_t(value_cpp));
+}
+
+kth_ek_public_mut_t kth_wallet_ek_public_construct_from_value_unsafe(uint8_t const* value) {
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::to_array_cpp<55>(value);
+    return kth::leak_if_valid(cpp_t(value_cpp));
+}
+
+
+// Destructor
+
+void kth_wallet_ek_public_destruct(kth_ek_public_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_ek_public_mut_t kth_wallet_ek_public_copy(kth_ek_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Equality
+
+kth_bool_t kth_wallet_ek_public_equals(kth_ek_public_const_t self, kth_ek_public_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::eq<cpp_t>(self, other);
+}
+
+
+// Getters
+
+kth_bool_t kth_wallet_ek_public_valid(kth_ek_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(static_cast<bool>(kth::cpp_ref<cpp_t>(self)));
+}
+
+char* kth_wallet_ek_public_encoded(kth_ek_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).encoded();
+    return kth::create_c_str(s);
+}
+
+kth_encrypted_public_t kth_wallet_ek_public_public_key(kth_ek_public_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::to_encrypted_public_t(kth::cpp_ref<cpp_t>(self).public_key());
+}
+
+
+// Operations
+
+kth_bool_t kth_wallet_ek_public_less(kth_ek_public_const_t self, kth_ek_public_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::lt<cpp_t>(self, x);
+}
+
+} // extern "C"

--- a/src/c-api/src/wallet/ek_token.cpp
+++ b/src/c-api/src/wallet/ek_token.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/ek_token.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/ek_token.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::wallet::ek_token;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_ek_token_mut_t kth_wallet_ek_token_construct_default(void) {
+    return kth::leak<cpp_t>();
+}
+
+kth_ek_token_mut_t kth_wallet_ek_token_construct_from_encoded(char const* encoded) {
+    KTH_PRECONDITION(encoded != nullptr);
+    auto const encoded_cpp = std::string(encoded);
+    return kth::leak_if_valid(cpp_t(encoded_cpp));
+}
+
+kth_ek_token_mut_t kth_wallet_ek_token_construct_from_value(kth_encrypted_token_t const* value) {
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::encrypted_token_to_cpp(value->data);
+    return kth::leak_if_valid(cpp_t(value_cpp));
+}
+
+kth_ek_token_mut_t kth_wallet_ek_token_construct_from_value_unsafe(uint8_t const* value) {
+    KTH_PRECONDITION(value != nullptr);
+    auto const value_cpp = kth::to_array_cpp<53>(value);
+    return kth::leak_if_valid(cpp_t(value_cpp));
+}
+
+
+// Destructor
+
+void kth_wallet_ek_token_destruct(kth_ek_token_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_ek_token_mut_t kth_wallet_ek_token_copy(kth_ek_token_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Equality
+
+kth_bool_t kth_wallet_ek_token_equals(kth_ek_token_const_t self, kth_ek_token_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::eq<cpp_t>(self, other);
+}
+
+
+// Getters
+
+kth_bool_t kth_wallet_ek_token_valid(kth_ek_token_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(static_cast<bool>(kth::cpp_ref<cpp_t>(self)));
+}
+
+char* kth_wallet_ek_token_encoded(kth_ek_token_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    auto const s = kth::cpp_ref<cpp_t>(self).encoded();
+    return kth::create_c_str(s);
+}
+
+kth_encrypted_token_t kth_wallet_ek_token_token(kth_ek_token_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::to_encrypted_token_t(kth::cpp_ref<cpp_t>(self).token());
+}
+
+
+// Operations
+
+kth_bool_t kth_wallet_ek_token_less(kth_ek_token_const_t self, kth_ek_token_const_t x) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(x != nullptr);
+    return kth::lt<cpp_t>(self, x);
+}
+
+} // extern "C"

--- a/src/c-api/test/wallet/ek_private.cpp
+++ b/src/c-api/test/wallet/ek_private.cpp
@@ -1,0 +1,173 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/ek_private.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures — BIP38 vectors lifted from the domain test suite. The
+// "6P..." prefix is the base58-checked signature for encrypted private
+// keys (ek_private is the wire-format wrapper used for display).
+// ---------------------------------------------------------------------------
+
+static char const* const kEncrypted =
+    "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg";
+
+static char const* const kEncryptedOther =
+    "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq";
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_private - default construct is invalid",
+          "[C-API WalletEkPrivate][lifecycle]") {
+    // Matches the domain default ctor: no payload, `valid_ == false`.
+    // The handle itself is non-null (the allocation succeeded), but
+    // `valid()` returns 0 so callers know not to trust the state.
+    kth_ek_private_mut_t a = kth_wallet_ek_private_construct_default();
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_ek_private_valid(a) == 0);
+    kth_wallet_ek_private_destruct(a);
+}
+
+TEST_CASE("C-API wallet::ek_private - destruct(NULL) is a no-op",
+          "[C-API WalletEkPrivate][lifecycle]") {
+    kth_wallet_ek_private_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Encoded string round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_private - encoded round-trips through construct_from_encoded",
+          "[C-API WalletEkPrivate][encode]") {
+    // Parse a known-good BIP38 vector and re-serialise; the result
+    // must match byte-for-byte. A regression in base58-check framing
+    // would diverge here.
+    kth_ek_private_mut_t a = kth_wallet_ek_private_construct_from_encoded(kEncrypted);
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_ek_private_valid(a) != 0);
+
+    char* back = kth_wallet_ek_private_encoded(a);
+    REQUIRE(back != NULL);
+    REQUIRE(strcmp(back, kEncrypted) == 0);
+    kth_core_destruct_string(back);
+
+    kth_wallet_ek_private_destruct(a);
+}
+
+TEST_CASE("C-API wallet::ek_private - invalid encoded string fails to construct",
+          "[C-API WalletEkPrivate][encode]") {
+    // Anything that isn't valid BIP38 base58-check fails the domain
+    // `from_string` factory and `leak_if_valid` maps that to NULL.
+    kth_ek_private_mut_t a = kth_wallet_ek_private_construct_from_encoded("not-a-key");
+    REQUIRE(a == NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Value (raw byte payload) round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_private - private_key byte payload round-trip",
+          "[C-API WalletEkPrivate][encode]") {
+    // encoded → ek_private → raw 43-byte payload → new ek_private →
+    // encoded. This exercises both directions of the value-struct
+    // bridge (`kth_encrypted_private_t` ↔ `encrypted_private`).
+    kth_ek_private_mut_t orig = kth_wallet_ek_private_construct_from_encoded(kEncrypted);
+    REQUIRE(orig != NULL);
+    kth_encrypted_private_t bytes = kth_wallet_ek_private_private_key(orig);
+
+    kth_ek_private_mut_t rebuilt = kth_wallet_ek_private_construct_from_value(&bytes);
+    REQUIRE(rebuilt != NULL);
+    REQUIRE(kth_wallet_ek_private_valid(rebuilt) != 0);
+
+    char* back = kth_wallet_ek_private_encoded(rebuilt);
+    REQUIRE(back != NULL);
+    REQUIRE(strcmp(back, kEncrypted) == 0);
+    kth_core_destruct_string(back);
+
+    kth_wallet_ek_private_destruct(rebuilt);
+    kth_wallet_ek_private_destruct(orig);
+}
+
+TEST_CASE("C-API wallet::ek_private - construct_from_value_unsafe matches safe variant",
+          "[C-API WalletEkPrivate][encode]") {
+    // Equivalent call path for callers that can't pass a struct by
+    // pointer (some FFIs can only hand over a raw `uint8_t*`). Both
+    // must produce equal wrappers over the same payload.
+    kth_ek_private_mut_t orig = kth_wallet_ek_private_construct_from_encoded(kEncrypted);
+    REQUIRE(orig != NULL);
+    kth_encrypted_private_t bytes = kth_wallet_ek_private_private_key(orig);
+
+    kth_ek_private_mut_t rebuilt =
+        kth_wallet_ek_private_construct_from_value_unsafe(bytes.data);
+    REQUIRE(rebuilt != NULL);
+    REQUIRE(kth_wallet_ek_private_equals(orig, rebuilt) != 0);
+
+    kth_wallet_ek_private_destruct(rebuilt);
+    kth_wallet_ek_private_destruct(orig);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equality / ordering
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_private - copy preserves value equality",
+          "[C-API WalletEkPrivate][value]") {
+    kth_ek_private_mut_t a = kth_wallet_ek_private_construct_from_encoded(kEncrypted);
+    kth_ek_private_mut_t b = kth_wallet_ek_private_copy(a);
+    REQUIRE(b != NULL);
+    REQUIRE(kth_wallet_ek_private_equals(a, b) != 0);
+    kth_wallet_ek_private_destruct(b);
+    kth_wallet_ek_private_destruct(a);
+}
+
+TEST_CASE("C-API wallet::ek_private - equals / less compare distinct keys",
+          "[C-API WalletEkPrivate][value]") {
+    // Two different BIP38 keys must not compare equal; `less` is a
+    // total ordering so exactly one of `a<b` / `b<a` is non-zero.
+    kth_ek_private_mut_t a = kth_wallet_ek_private_construct_from_encoded(kEncrypted);
+    kth_ek_private_mut_t b = kth_wallet_ek_private_construct_from_encoded(kEncryptedOther);
+    REQUIRE(kth_wallet_ek_private_equals(a, b) == 0);
+
+    int const a_less_b = kth_wallet_ek_private_less(a, b) != 0;
+    int const b_less_a = kth_wallet_ek_private_less(b, a) != 0;
+    REQUIRE(a_less_b != b_less_a);
+
+    kth_wallet_ek_private_destruct(b);
+    kth_wallet_ek_private_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_private - construct_from_encoded(NULL) aborts",
+          "[C-API WalletEkPrivate][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_ek_private_construct_from_encoded(NULL));
+}
+
+TEST_CASE("C-API wallet::ek_private - construct_from_value(NULL) aborts",
+          "[C-API WalletEkPrivate][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_ek_private_construct_from_value(NULL));
+}
+
+TEST_CASE("C-API wallet::ek_private - valid(NULL) aborts",
+          "[C-API WalletEkPrivate][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_ek_private_valid(NULL));
+}

--- a/src/c-api/test/wallet/ek_public.cpp
+++ b/src/c-api/test/wallet/ek_public.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/ek_public.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures — BIP38 vectors lifted from the domain test suite. The
+// "cfrm" prefix is the base58-checked signature for encrypted public
+// keys (BIP38 "confirmation code" format, deprecated but still
+// round-trippable).
+// ---------------------------------------------------------------------------
+
+static char const* const kEncrypted =
+    "cfrm38V8aXBn7JWA1ESmFMUn6erxeBGZGAxJPY4e36S9QWkzZKtaVqLNMgnifETYw7BPwWC9aPD";
+
+static char const* const kEncryptedOther =
+    "cfrm38V8G4qq2ywYEFfWLD5Cc6msj9UwsG2Mj4Z6QdGJAFQpdatZLavkgRd1i4iBMdRngDqDs51";
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_public - default construct is invalid",
+          "[C-API WalletEkPublic][lifecycle]") {
+    kth_ek_public_mut_t a = kth_wallet_ek_public_construct_default();
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_ek_public_valid(a) == 0);
+    kth_wallet_ek_public_destruct(a);
+}
+
+TEST_CASE("C-API wallet::ek_public - destruct(NULL) is a no-op",
+          "[C-API WalletEkPublic][lifecycle]") {
+    kth_wallet_ek_public_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Encoded string round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_public - encoded round-trips through construct_from_encoded",
+          "[C-API WalletEkPublic][encode]") {
+    kth_ek_public_mut_t a = kth_wallet_ek_public_construct_from_encoded(kEncrypted);
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_ek_public_valid(a) != 0);
+
+    char* back = kth_wallet_ek_public_encoded(a);
+    REQUIRE(back != NULL);
+    REQUIRE(strcmp(back, kEncrypted) == 0);
+    kth_core_destruct_string(back);
+
+    kth_wallet_ek_public_destruct(a);
+}
+
+TEST_CASE("C-API wallet::ek_public - invalid encoded string fails to construct",
+          "[C-API WalletEkPublic][encode]") {
+    kth_ek_public_mut_t a = kth_wallet_ek_public_construct_from_encoded("not-a-key");
+    REQUIRE(a == NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Value (raw byte payload) round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_public - public_key byte payload round-trip",
+          "[C-API WalletEkPublic][encode]") {
+    // Exercises both directions of the `kth_encrypted_public_t` ↔
+    // `encrypted_public` value-struct bridge (55-byte payload).
+    kth_ek_public_mut_t orig = kth_wallet_ek_public_construct_from_encoded(kEncrypted);
+    REQUIRE(orig != NULL);
+    kth_encrypted_public_t bytes = kth_wallet_ek_public_public_key(orig);
+
+    kth_ek_public_mut_t rebuilt = kth_wallet_ek_public_construct_from_value(&bytes);
+    REQUIRE(rebuilt != NULL);
+    REQUIRE(kth_wallet_ek_public_valid(rebuilt) != 0);
+
+    char* back = kth_wallet_ek_public_encoded(rebuilt);
+    REQUIRE(back != NULL);
+    REQUIRE(strcmp(back, kEncrypted) == 0);
+    kth_core_destruct_string(back);
+
+    kth_wallet_ek_public_destruct(rebuilt);
+    kth_wallet_ek_public_destruct(orig);
+}
+
+TEST_CASE("C-API wallet::ek_public - construct_from_value_unsafe matches safe variant",
+          "[C-API WalletEkPublic][encode]") {
+    kth_ek_public_mut_t orig = kth_wallet_ek_public_construct_from_encoded(kEncrypted);
+    REQUIRE(orig != NULL);
+    kth_encrypted_public_t bytes = kth_wallet_ek_public_public_key(orig);
+
+    kth_ek_public_mut_t rebuilt =
+        kth_wallet_ek_public_construct_from_value_unsafe(bytes.data);
+    REQUIRE(rebuilt != NULL);
+    REQUIRE(kth_wallet_ek_public_equals(orig, rebuilt) != 0);
+
+    kth_wallet_ek_public_destruct(rebuilt);
+    kth_wallet_ek_public_destruct(orig);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equality / ordering
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_public - copy preserves value equality",
+          "[C-API WalletEkPublic][value]") {
+    kth_ek_public_mut_t a = kth_wallet_ek_public_construct_from_encoded(kEncrypted);
+    kth_ek_public_mut_t b = kth_wallet_ek_public_copy(a);
+    REQUIRE(b != NULL);
+    REQUIRE(kth_wallet_ek_public_equals(a, b) != 0);
+    kth_wallet_ek_public_destruct(b);
+    kth_wallet_ek_public_destruct(a);
+}
+
+TEST_CASE("C-API wallet::ek_public - equals / less compare distinct keys",
+          "[C-API WalletEkPublic][value]") {
+    kth_ek_public_mut_t a = kth_wallet_ek_public_construct_from_encoded(kEncrypted);
+    kth_ek_public_mut_t b = kth_wallet_ek_public_construct_from_encoded(kEncryptedOther);
+    REQUIRE(kth_wallet_ek_public_equals(a, b) == 0);
+
+    int const a_less_b = kth_wallet_ek_public_less(a, b) != 0;
+    int const b_less_a = kth_wallet_ek_public_less(b, a) != 0;
+    REQUIRE(a_less_b != b_less_a);
+
+    kth_wallet_ek_public_destruct(b);
+    kth_wallet_ek_public_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_public - construct_from_encoded(NULL) aborts",
+          "[C-API WalletEkPublic][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_ek_public_construct_from_encoded(NULL));
+}
+
+TEST_CASE("C-API wallet::ek_public - construct_from_value(NULL) aborts",
+          "[C-API WalletEkPublic][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_ek_public_construct_from_value(NULL));
+}
+
+TEST_CASE("C-API wallet::ek_public - valid(NULL) aborts",
+          "[C-API WalletEkPublic][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_ek_public_valid(NULL));
+}

--- a/src/c-api/test/wallet/ek_token.cpp
+++ b/src/c-api/test/wallet/ek_token.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/ek_token.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures — BIP38 vectors lifted from the domain test suite. The
+// "passphrase" prefix is the base58-checked signature for BIP38
+// intermediate-passphrase tokens (create_key_pair accepts one of
+// these as the `token` input).
+// ---------------------------------------------------------------------------
+
+static char const* const kEncrypted =
+    "passphrasecpXbDpHuo8F7yQVcg1eQKPuX7rzGwBtEH1YSZnKbyk75x3rugZu1ci4RyF4rEn";
+
+static char const* const kEncryptedOther =
+    "passphrasecpXbDpHuo8F7x4pQXMhsJs2j7L8LTV8ujk9jGqgzUrafBeto9VrabP5SmvANvz";
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_token - default construct is invalid",
+          "[C-API WalletEkToken][lifecycle]") {
+    kth_ek_token_mut_t a = kth_wallet_ek_token_construct_default();
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_ek_token_valid(a) == 0);
+    kth_wallet_ek_token_destruct(a);
+}
+
+TEST_CASE("C-API wallet::ek_token - destruct(NULL) is a no-op",
+          "[C-API WalletEkToken][lifecycle]") {
+    kth_wallet_ek_token_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Encoded string round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_token - encoded round-trips through construct_from_encoded",
+          "[C-API WalletEkToken][encode]") {
+    kth_ek_token_mut_t a = kth_wallet_ek_token_construct_from_encoded(kEncrypted);
+    REQUIRE(a != NULL);
+    REQUIRE(kth_wallet_ek_token_valid(a) != 0);
+
+    char* back = kth_wallet_ek_token_encoded(a);
+    REQUIRE(back != NULL);
+    REQUIRE(strcmp(back, kEncrypted) == 0);
+    kth_core_destruct_string(back);
+
+    kth_wallet_ek_token_destruct(a);
+}
+
+TEST_CASE("C-API wallet::ek_token - invalid encoded string fails to construct",
+          "[C-API WalletEkToken][encode]") {
+    kth_ek_token_mut_t a = kth_wallet_ek_token_construct_from_encoded("not-a-token");
+    REQUIRE(a == NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Value (raw byte payload) round-trip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_token - token byte payload round-trip",
+          "[C-API WalletEkToken][encode]") {
+    // Exercises both directions of the `kth_encrypted_token_t` ↔
+    // `encrypted_token` value-struct bridge (53-byte payload).
+    kth_ek_token_mut_t orig = kth_wallet_ek_token_construct_from_encoded(kEncrypted);
+    REQUIRE(orig != NULL);
+    kth_encrypted_token_t bytes = kth_wallet_ek_token_token(orig);
+
+    kth_ek_token_mut_t rebuilt = kth_wallet_ek_token_construct_from_value(&bytes);
+    REQUIRE(rebuilt != NULL);
+    REQUIRE(kth_wallet_ek_token_valid(rebuilt) != 0);
+
+    char* back = kth_wallet_ek_token_encoded(rebuilt);
+    REQUIRE(back != NULL);
+    REQUIRE(strcmp(back, kEncrypted) == 0);
+    kth_core_destruct_string(back);
+
+    kth_wallet_ek_token_destruct(rebuilt);
+    kth_wallet_ek_token_destruct(orig);
+}
+
+TEST_CASE("C-API wallet::ek_token - construct_from_value_unsafe matches safe variant",
+          "[C-API WalletEkToken][encode]") {
+    kth_ek_token_mut_t orig = kth_wallet_ek_token_construct_from_encoded(kEncrypted);
+    REQUIRE(orig != NULL);
+    kth_encrypted_token_t bytes = kth_wallet_ek_token_token(orig);
+
+    kth_ek_token_mut_t rebuilt =
+        kth_wallet_ek_token_construct_from_value_unsafe(bytes.data);
+    REQUIRE(rebuilt != NULL);
+    REQUIRE(kth_wallet_ek_token_equals(orig, rebuilt) != 0);
+
+    kth_wallet_ek_token_destruct(rebuilt);
+    kth_wallet_ek_token_destruct(orig);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / equality / ordering
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_token - copy preserves value equality",
+          "[C-API WalletEkToken][value]") {
+    kth_ek_token_mut_t a = kth_wallet_ek_token_construct_from_encoded(kEncrypted);
+    kth_ek_token_mut_t b = kth_wallet_ek_token_copy(a);
+    REQUIRE(b != NULL);
+    REQUIRE(kth_wallet_ek_token_equals(a, b) != 0);
+    kth_wallet_ek_token_destruct(b);
+    kth_wallet_ek_token_destruct(a);
+}
+
+TEST_CASE("C-API wallet::ek_token - equals / less compare distinct tokens",
+          "[C-API WalletEkToken][value]") {
+    kth_ek_token_mut_t a = kth_wallet_ek_token_construct_from_encoded(kEncrypted);
+    kth_ek_token_mut_t b = kth_wallet_ek_token_construct_from_encoded(kEncryptedOther);
+    REQUIRE(kth_wallet_ek_token_equals(a, b) == 0);
+
+    int const a_less_b = kth_wallet_ek_token_less(a, b) != 0;
+    int const b_less_a = kth_wallet_ek_token_less(b, a) != 0;
+    REQUIRE(a_less_b != b_less_a);
+
+    kth_wallet_ek_token_destruct(b);
+    kth_wallet_ek_token_destruct(a);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::ek_token - construct_from_encoded(NULL) aborts",
+          "[C-API WalletEkToken][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_ek_token_construct_from_encoded(NULL));
+}
+
+TEST_CASE("C-API wallet::ek_token - construct_from_value(NULL) aborts",
+          "[C-API WalletEkToken][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_ek_token_construct_from_value(NULL));
+}
+
+TEST_CASE("C-API wallet::ek_token - valid(NULL) aborts",
+          "[C-API WalletEkToken][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_ek_token_valid(NULL));
+}


### PR DESCRIPTION
## Summary
BIP38 defines three base58-checked string formats that carry encrypted key material — encrypted private key (`6P...`), encrypted public key / confirmation code (`cfrm...`), and intermediate passphrase token (`passphrase...`). The domain layer wraps each in `ek_private` / `ek_public` / `ek_token`; this PR exposes all three through the C-API as opaque handles with string I/O and a typed byte accessor.

Each class gets:
- `construct_default()` / `construct_from_encoded(char const*)` / `construct_from_value(kth_encrypted_X_t const*)` / `construct_from_value_unsafe(uint8_t const*)`
- `destruct`, `copy`, `equals`, `less`, `valid`
- `encoded()` → owned C string
- `private_key()` / `public_key()` / `token()` → `kth_encrypted_{private,public,token}_t` (43 / 55 / 53 bytes)

New infrastructure for the byte payloads:
- 3 POD value-structs in `wallet/primitives.h`
- Paired `to_*_t` / `*_to_cpp` helpers in `helpers.hpp`
- 3 opaque handle typedefs in `handles.h`

## Not in this PR
- BIP38 free functions (`create_key_pair`, `create_token`, `encrypt`, `decrypt`) — take `byte_array<N>&` out-params which the generator doesn't bind yet, and the passphrase-driven half is gated behind `WITH_ICU` (OFF in this build). Scheduled for a follow-up.
- Cast operators `operator encrypted_X const&()` on each class — auto-skipped by the generator as unsupported; the `*_key()` / `token()` accessors expose the same byte view.

## Test plan
- [ ] `build/.../kth_capi_test "[C-API WalletEkPrivate],[C-API WalletEkPublic],[C-API WalletEkToken]"` → 33 cases, 93 assertions.
- [ ] Full suite still green (2552 assertions, 712 cases locally).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new C-API surface area for parsing/serializing BIP38 encrypted key formats and handling fixed-size encrypted-key payloads. Risk is mostly around FFI misuse (notably the `_unsafe` constructors) and correctness of encoded/value round-trips, but it doesn’t change existing wallet logic.
> 
> **Overview**
> **Adds C-API bindings for BIP38 encrypted key formats** by introducing opaque handle types for `ek_private`, `ek_public`, and `ek_token`, each with constructors (from encoded strings and raw payloads), lifecycle (`destruct`/`copy`), validation, comparison (`equals`/`less`), and `encoded()` accessors.
> 
> Extends wallet primitives and helper conversions with fixed-size `kth_encrypted_{private,public,token}_t` payload structs and C↔C++ bridges, wires the new modules into the build (`CMakeLists.txt`) and umbrella header (`capi.h`), and adds Catch2 tests covering parsing failures, round-trips, copy/equality/ordering, and precondition aborts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b780956018b23993ce071e8a9f6cf2574dc38027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->