### PR TITLE
feat(c-api): expose wallet::coin_selection (BCH CashTokens UTXO picker)

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -204,6 +204,8 @@ set(kth_sources
 
   src/wallet/bitcoin_uri.cpp
   src/wallet/cashtoken_minting.cpp
+  src/wallet/coin_selection.cpp
+  src/wallet/coin_selection_result.cpp
   src/wallet/ek_private.cpp
   src/wallet/ek_public.cpp
   src/wallet/ek_token.cpp
@@ -342,6 +344,9 @@ set(kth_headers
 
   include/kth/capi/wallet/bitcoin_uri.h
   include/kth/capi/wallet/cashtoken_minting.h
+  include/kth/capi/wallet/coin_selection.h
+  include/kth/capi/wallet/coin_selection_result.h
+  include/kth/capi/wallet/coin_selection_strategy.h
   include/kth/capi/wallet/ec_public.h
   include/kth/capi/wallet/ek_private.h
   include/kth/capi/wallet/ek_public.h
@@ -572,6 +577,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/chain/utxo.cpp
         test/wallet/bitcoin_uri.cpp
         test/wallet/cashtoken_minting.cpp
+        test/wallet/coin_selection.cpp
         test/wallet/ek_private.cpp
         test/wallet/ek_public.cpp
         test/wallet/ek_token.cpp

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -98,6 +98,9 @@
 #include <kth/capi/wallet/ec_public.h>
 #include <kth/capi/wallet/elliptic_curve.h>
 #include <kth/capi/wallet/cashtoken_minting.h>
+#include <kth/capi/wallet/coin_selection.h>
+#include <kth/capi/wallet/coin_selection_result.h>
+#include <kth/capi/wallet/coin_selection_strategy.h>
 #include <kth/capi/wallet/ek_private.h>
 #include <kth/capi/wallet/ek_public.h>
 #include <kth/capi/wallet/ek_token.h>

--- a/src/c-api/include/kth/capi/handles.h
+++ b/src/c-api/include/kth/capi/handles.h
@@ -200,6 +200,12 @@ typedef void const* kth_ek_public_const_t;
 typedef void* kth_ek_token_mut_t;
 typedef void const* kth_ek_token_const_t;
 
+// BCH CashTokens coin-selection result. Returned by the
+// `kth_wallet_coin_selection_select_utxos*` family; carries the
+// selected-amount totals plus the container metadata fields.
+typedef void* kth_coin_selection_result_mut_t;
+typedef void const* kth_coin_selection_result_const_t;
+
 // BIP39 wordlist handles. `dictionary` is `std::array<char const*, 2048>`
 // and `dictionary_list` is `std::vector<dictionary const*>`; callers
 // obtain handles through the `kth_wallet_language_*` factories

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -30,6 +30,7 @@
 #include <kth/infrastructure/machine/script_version.hpp>
 
 #include <kth/capi/chain/coin_selection_algorithm.h>
+#include <kth/capi/wallet/coin_selection_strategy.h>
 #include <kth/domain/wallet/coin_selection.hpp>
 #include <kth/capi/chain/opcode.h>
 #include <kth/capi/chain/script_flags.h>
@@ -713,6 +714,16 @@ kth::domain::wallet::coin_selection_algorithm coin_selection_algorithm_to_cpp(kt
 inline
 kth_coin_selection_algorithm_t coin_selection_algorithm_to_c(kth::domain::wallet::coin_selection_algorithm algo) {
     return static_cast<kth_coin_selection_algorithm_t>(algo);
+}
+
+inline
+kth::domain::wallet::coin_selection_strategy coin_selection_strategy_to_cpp(kth_coin_selection_strategy_t strategy) {
+    return static_cast<kth::domain::wallet::coin_selection_strategy>(strategy);
+}
+
+inline
+kth_coin_selection_strategy_t coin_selection_strategy_to_c(kth::domain::wallet::coin_selection_strategy strategy) {
+    return static_cast<kth_coin_selection_strategy_t>(strategy);
 }
 
 // Cash Tokens -----------------------------------------------------

--- a/src/c-api/include/kth/capi/wallet/coin_selection.h
+++ b/src/c-api/include/kth/capi/wallet/coin_selection.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_COIN_SELECTION_H_
+#define KTH_CAPI_WALLET_COIN_SELECTION_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+#include <kth/capi/wallet/coin_selection_strategy.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Static utilities
+
+/**
+ * @param category Borrowed input; must be non-null. Read during the call; ownership of `category` stays with the caller.
+ * @param[out] out Must point to a null `kth_coin_selection_result_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_coin_selection_result_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_coin_selection_select_utxos(kth_utxo_list_const_t available_utxos, uint64_t amount, kth_size_t outputs_size, kth_hash_t const* category, kth_coin_selection_strategy_t strategy, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out);
+
+/**
+ * @warning `category` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ * @param[out] out Must point to a null `kth_coin_selection_result_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_coin_selection_result_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_coin_selection_select_utxos_unsafe(kth_utxo_list_const_t available_utxos, uint64_t amount, kth_size_t outputs_size, uint8_t const* category, kth_coin_selection_strategy_t strategy, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out);
+
+/**
+ * @param category Borrowed input; must be non-null. Read during the call; ownership of `category` stays with the caller.
+ * @param[out] out Must point to a null `kth_coin_selection_result_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_coin_selection_result_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_coin_selection_select_utxos_send_all(kth_utxo_list_const_t available_utxos, kth_size_t outputs_size, kth_hash_t const* category, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out);
+
+/**
+ * @warning `category` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ * @param[out] out Must point to a null `kth_coin_selection_result_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_coin_selection_result_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_coin_selection_select_utxos_send_all_unsafe(kth_utxo_list_const_t available_utxos, kth_size_t outputs_size, uint8_t const* category, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out);
+
+/**
+ * @param token_category Borrowed input; must be non-null. Read during the call; ownership of `token_category` stays with the caller.
+ * @param[out] out Must point to a null `kth_coin_selection_result_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_coin_selection_result_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_coin_selection_select_utxos_both(kth_utxo_list_const_t available_utxos, uint64_t bch_amount, kth_hash_t const* token_category, uint64_t token_amount, kth_size_t outputs_size, kth_coin_selection_strategy_t strategy, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out);
+
+/**
+ * @warning `token_category` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ * @param[out] out Must point to a null `kth_coin_selection_result_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_wallet_coin_selection_result_destruct`. Untouched on error.
+ */
+KTH_EXPORT
+kth_error_code_t kth_wallet_coin_selection_select_utxos_both_unsafe(kth_utxo_list_const_t available_utxos, uint64_t bch_amount, uint8_t const* token_category, uint64_t token_amount, kth_size_t outputs_size, kth_coin_selection_strategy_t strategy, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out);
+
+/** @return Owned `kth_double_list_mut_t`. Caller must release with `kth_core_double_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_double_list_mut_t kth_wallet_coin_selection_make_change_ratios(kth_size_t change_count);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_COIN_SELECTION_H_

--- a/src/c-api/include/kth/capi/wallet/coin_selection_result.h
+++ b/src/c-api/include/kth/capi/wallet/coin_selection_result.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_COIN_SELECTION_RESULT_H_
+#define KTH_CAPI_WALLET_COIN_SELECTION_RESULT_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_wallet_coin_selection_result_destruct(kth_coin_selection_result_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_coin_selection_result_mut_t`. Caller must release with `kth_wallet_coin_selection_result_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_coin_selection_result_mut_t kth_wallet_coin_selection_result_copy(kth_coin_selection_result_const_t self);
+
+
+// Getters
+
+KTH_EXPORT
+uint64_t kth_wallet_coin_selection_result_total_selected_bch(kth_coin_selection_result_const_t self);
+
+KTH_EXPORT
+uint64_t kth_wallet_coin_selection_result_total_selected_token(kth_coin_selection_result_const_t self);
+
+KTH_EXPORT
+uint64_t kth_wallet_coin_selection_result_estimated_size(kth_coin_selection_result_const_t self);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_COIN_SELECTION_RESULT_H_

--- a/src/c-api/include/kth/capi/wallet/coin_selection_strategy.h
+++ b/src/c-api/include/kth/capi/wallet/coin_selection_strategy.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is auto-generated. Do not edit manually.
+
+#ifndef KTH_CAPI_WALLET_COIN_SELECTION_STRATEGY_H_
+#define KTH_CAPI_WALLET_COIN_SELECTION_STRATEGY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    // Only selects "clean" UTXOs:
+    //   - For BCH needs: selects UTXOs that carry no tokens.
+    //   - For token needs: selects UTXOs that carry only the target token.
+    //     All UTXOs carry some BCH (the protocol requires it), but token
+    //     UTXOs typically carry only the dust minimum (800 sats). Wallets
+    //     treat a token output with dust BCH as "BCH = 0" for display
+    //     purposes. An output is considered "clean" when it is either pure
+    //     BCH (no tokens) or token + dust (no excess BCH).
+    // This is the wallet-friendly default. Mixed outputs (tokens + excess
+    // BCH, or multiple token categories in one output) confuse wallet
+    // balance displays and make spending harder.
+    kth_coin_selection_strategy_clean,
+
+    // Allows selecting any UTXO regardless of what it carries.
+    // When a selected UTXO carries unrelated tokens, those tokens are reported
+    // in collateral_fts (fungible tokens) / collateral_nfts (non-fungible tokens)
+    // so the caller can create proper change outputs to preserve them.
+    //
+    // NOTE: This mode is experimental. Most BCH wallets do not handle mixed
+    // outputs correctly. Use only if you understand the implications and your
+    // application properly handles collateral token change.
+    // Discussion with wallet developers and BCH protocol (CHIP) developers
+    // did not reach a conclusive answer on whether mixed mode is ever
+    // preferable to clean mode for general wallet use cases.
+    // The clean mode exists specifically because
+    // mixed outputs created by earlier implementations caused tokens to become
+    // "stuck" in outputs that wallets couldn't spend properly. The split
+    // template (create_token_split_tx_template) was created to recover
+    // tokens from such dirty outputs.
+    kth_coin_selection_strategy_mixed,
+} kth_coin_selection_strategy_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* KTH_CAPI_WALLET_COIN_SELECTION_STRATEGY_H_ */

--- a/src/c-api/src/wallet/coin_selection.cpp
+++ b/src/c-api/src/wallet/coin_selection.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <utility>
+
+#include <kth/capi/wallet/coin_selection.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/coin_selection.hpp>
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Static utilities
+
+kth_error_code_t kth_wallet_coin_selection_select_utxos(kth_utxo_list_const_t available_utxos, uint64_t amount, kth_size_t outputs_size, kth_hash_t const* category, kth_coin_selection_strategy_t strategy, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out) {
+    KTH_PRECONDITION(available_utxos != nullptr);
+    KTH_PRECONDITION(category != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& available_utxos_cpp = kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(available_utxos);
+    auto const outputs_size_cpp = kth::sz(outputs_size);
+    auto const category_cpp = kth::hash_to_cpp(category->hash);
+    auto const strategy_cpp = kth::coin_selection_strategy_to_cpp(strategy);
+    auto result = kth::domain::wallet::select_utxos(available_utxos_cpp, amount, outputs_size_cpp, category_cpp, strategy_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_coin_selection_select_utxos_unsafe(kth_utxo_list_const_t available_utxos, uint64_t amount, kth_size_t outputs_size, uint8_t const* category, kth_coin_selection_strategy_t strategy, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out) {
+    KTH_PRECONDITION(available_utxos != nullptr);
+    KTH_PRECONDITION(category != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& available_utxos_cpp = kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(available_utxos);
+    auto const outputs_size_cpp = kth::sz(outputs_size);
+    auto const category_cpp = kth::hash_to_cpp(category);
+    auto const strategy_cpp = kth::coin_selection_strategy_to_cpp(strategy);
+    auto result = kth::domain::wallet::select_utxos(available_utxos_cpp, amount, outputs_size_cpp, category_cpp, strategy_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_coin_selection_select_utxos_send_all(kth_utxo_list_const_t available_utxos, kth_size_t outputs_size, kth_hash_t const* category, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out) {
+    KTH_PRECONDITION(available_utxos != nullptr);
+    KTH_PRECONDITION(category != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& available_utxos_cpp = kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(available_utxos);
+    auto const outputs_size_cpp = kth::sz(outputs_size);
+    auto const category_cpp = kth::hash_to_cpp(category->hash);
+    auto result = kth::domain::wallet::select_utxos_send_all(available_utxos_cpp, outputs_size_cpp, category_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_coin_selection_select_utxos_send_all_unsafe(kth_utxo_list_const_t available_utxos, kth_size_t outputs_size, uint8_t const* category, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out) {
+    KTH_PRECONDITION(available_utxos != nullptr);
+    KTH_PRECONDITION(category != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& available_utxos_cpp = kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(available_utxos);
+    auto const outputs_size_cpp = kth::sz(outputs_size);
+    auto const category_cpp = kth::hash_to_cpp(category);
+    auto result = kth::domain::wallet::select_utxos_send_all(available_utxos_cpp, outputs_size_cpp, category_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_coin_selection_select_utxos_both(kth_utxo_list_const_t available_utxos, uint64_t bch_amount, kth_hash_t const* token_category, uint64_t token_amount, kth_size_t outputs_size, kth_coin_selection_strategy_t strategy, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out) {
+    KTH_PRECONDITION(available_utxos != nullptr);
+    KTH_PRECONDITION(token_category != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& available_utxos_cpp = kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(available_utxos);
+    auto const token_category_cpp = kth::hash_to_cpp(token_category->hash);
+    auto const outputs_size_cpp = kth::sz(outputs_size);
+    auto const strategy_cpp = kth::coin_selection_strategy_to_cpp(strategy);
+    auto result = kth::domain::wallet::select_utxos_both(available_utxos_cpp, bch_amount, token_category_cpp, token_amount, outputs_size_cpp, strategy_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_wallet_coin_selection_select_utxos_both_unsafe(kth_utxo_list_const_t available_utxos, uint64_t bch_amount, uint8_t const* token_category, uint64_t token_amount, kth_size_t outputs_size, kth_coin_selection_strategy_t strategy, KTH_OUT_OWNED kth_coin_selection_result_mut_t* out) {
+    KTH_PRECONDITION(available_utxos != nullptr);
+    KTH_PRECONDITION(token_category != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
+    auto const& available_utxos_cpp = kth::cpp_ref<std::vector<kth::domain::chain::utxo>>(available_utxos);
+    auto const token_category_cpp = kth::hash_to_cpp(token_category);
+    auto const outputs_size_cpp = kth::sz(outputs_size);
+    auto const strategy_cpp = kth::coin_selection_strategy_to_cpp(strategy);
+    auto result = kth::domain::wallet::select_utxos_both(available_utxos_cpp, bch_amount, token_category_cpp, token_amount, outputs_size_cpp, strategy_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
+}
+
+kth_double_list_mut_t kth_wallet_coin_selection_make_change_ratios(kth_size_t change_count) {
+    auto const change_count_cpp = kth::sz(change_count);
+    return kth::leak_list<double>(kth::domain::wallet::make_change_ratios(change_count_cpp));
+}
+
+} // extern "C"

--- a/src/c-api/src/wallet/coin_selection_result.cpp
+++ b/src/c-api/src/wallet/coin_selection_result.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/coin_selection_result.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/coin_selection.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::wallet::coin_selection_result;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Destructor
+
+void kth_wallet_coin_selection_result_destruct(kth_coin_selection_result_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_coin_selection_result_mut_t kth_wallet_coin_selection_result_copy(kth_coin_selection_result_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Getters
+
+uint64_t kth_wallet_coin_selection_result_total_selected_bch(kth_coin_selection_result_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).total_selected_bch;
+}
+
+uint64_t kth_wallet_coin_selection_result_total_selected_token(kth_coin_selection_result_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).total_selected_token;
+}
+
+uint64_t kth_wallet_coin_selection_result_estimated_size(kth_coin_selection_result_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::cpp_ref<cpp_t>(self).estimated_size;
+}
+
+} // extern "C"

--- a/src/c-api/test/wallet/coin_selection.cpp
+++ b/src/c-api/test/wallet/coin_selection.cpp
@@ -1,0 +1,231 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+
+#include <kth/capi/chain/output_point.h>
+#include <kth/capi/chain/token_data.h>
+#include <kth/capi/chain/utxo.h>
+#include <kth/capi/chain/utxo_list.h>
+#include <kth/capi/double_list.h>
+#include <kth/capi/hash.h>
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/coin_selection.h>
+#include <kth/capi/wallet/coin_selection_result.h>
+#include <kth/capi/wallet/coin_selection_strategy.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// BCH selection uses the canonical all-zero hash (null_hash) as the
+// "this is BCH, not a token" sentinel — matches the C++ `bch_id`
+// constant in coin_selection.hpp.
+static kth_hash_t const kBchCategory = {{ 0 }};
+
+static kth_hash_t const kTokenCategory = {{
+    0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+    0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+    0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+    0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb
+}};
+
+static kth_hash_t const kPrevTxid = {{
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
+}};
+
+// Build a UTXO list of pure-BCH outputs. Caller owns the returned
+// list and must release with kth_chain_utxo_list_destruct.
+static kth_utxo_list_mut_t make_bch_utxos(uint64_t const* amounts, int count) {
+    kth_utxo_list_mut_t list = kth_chain_utxo_list_construct_default();
+    for (int i = 0; i < count; ++i) {
+        kth_output_point_mut_t op =
+            kth_chain_output_point_construct_from_hash_index(&kPrevTxid, (uint32_t)i);
+        kth_utxo_mut_t u = kth_chain_utxo_construct(op, amounts[i], NULL);
+        kth_chain_utxo_list_push_back(list, u);
+        kth_chain_utxo_destruct(u);
+        kth_chain_output_point_destruct(op);
+    }
+    return list;
+}
+
+// ---------------------------------------------------------------------------
+// result — lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::coin_selection_result - destruct(NULL) is a no-op",
+          "[C-API WalletCoinSelection][result]") {
+    kth_wallet_coin_selection_result_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// select_utxos — BCH, clean strategy
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::coin_selection - select_utxos picks enough BCH to cover amount",
+          "[C-API WalletCoinSelection][select]") {
+    // Ask for 1500 sats from a set of {1000, 2000, 3000} sats. The
+    // picker must select at least enough to cover the amount plus the
+    // per-input fee estimate; the exact choice depends on strategy,
+    // but total_selected_bch must be >= amount.
+    uint64_t amounts[] = { 1000u, 2000u, 3000u };
+    kth_utxo_list_mut_t utxos = make_bch_utxos(amounts, 3);
+
+    kth_coin_selection_result_mut_t out = NULL;
+    kth_error_code_t rc = kth_wallet_coin_selection_select_utxos(
+        utxos, 1500u, 1u, &kBchCategory,
+        kth_coin_selection_strategy_clean, &out);
+    REQUIRE(rc == kth_ec_success);
+    REQUIRE(out != NULL);
+
+    REQUIRE(kth_wallet_coin_selection_result_total_selected_bch(out) >= 1500u);
+    REQUIRE(kth_wallet_coin_selection_result_total_selected_token(out) == 0u);
+    REQUIRE(kth_wallet_coin_selection_result_estimated_size(out) > 0u);
+
+    kth_wallet_coin_selection_result_destruct(out);
+    kth_chain_utxo_list_destruct(utxos);
+}
+
+TEST_CASE("C-API wallet::coin_selection - select_utxos fails when funds are insufficient",
+          "[C-API WalletCoinSelection][select]") {
+    // Only 100 sats available; asking for 1000 must fail cleanly with
+    // a non-success error code and leave `out` untouched (NULL).
+    uint64_t amounts[] = { 100u };
+    kth_utxo_list_mut_t utxos = make_bch_utxos(amounts, 1);
+
+    kth_coin_selection_result_mut_t out = NULL;
+    kth_error_code_t rc = kth_wallet_coin_selection_select_utxos(
+        utxos, 1000u, 1u, &kBchCategory,
+        kth_coin_selection_strategy_clean, &out);
+    REQUIRE(rc != kth_ec_success);
+    REQUIRE(out == NULL);
+
+    kth_chain_utxo_list_destruct(utxos);
+}
+
+// ---------------------------------------------------------------------------
+// select_utxos_send_all
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::coin_selection - send_all sums every matching UTXO",
+          "[C-API WalletCoinSelection][select]") {
+    // In "send all BCH" mode the picker takes every pure-BCH UTXO;
+    // total_selected_bch is the sum of the inputs minus the fee the
+    // tx would need, but must match the raw input total here since
+    // send_all doesn't carve out a fee from the `total_selected`
+    // reporting (that is handled at tx-template time).
+    uint64_t amounts[] = { 1000u, 2000u, 3000u };
+    kth_utxo_list_mut_t utxos = make_bch_utxos(amounts, 3);
+
+    kth_coin_selection_result_mut_t out = NULL;
+    kth_error_code_t rc = kth_wallet_coin_selection_select_utxos_send_all(
+        utxos, 1u, &kBchCategory, &out);
+    REQUIRE(rc == kth_ec_success);
+    REQUIRE(out != NULL);
+    REQUIRE(kth_wallet_coin_selection_result_total_selected_bch(out) == 6000u);
+
+    kth_wallet_coin_selection_result_destruct(out);
+    kth_chain_utxo_list_destruct(utxos);
+}
+
+// ---------------------------------------------------------------------------
+// select_utxos_both — asking for a token when none exists must fail
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::coin_selection - select_utxos_both fails when token absent",
+          "[C-API WalletCoinSelection][select]") {
+    // With only pure-BCH UTXOs available, asking for any amount of a
+    // specific token must fail — there is nothing to select from for
+    // the token half of the request.
+    uint64_t amounts[] = { 10000u };
+    kth_utxo_list_mut_t utxos = make_bch_utxos(amounts, 1);
+
+    kth_coin_selection_result_mut_t out = NULL;
+    kth_error_code_t rc = kth_wallet_coin_selection_select_utxos_both(
+        utxos, 1000u, &kTokenCategory, 500u, 2u,
+        kth_coin_selection_strategy_clean, &out);
+    REQUIRE(rc != kth_ec_success);
+    REQUIRE(out == NULL);
+
+    kth_chain_utxo_list_destruct(utxos);
+}
+
+// ---------------------------------------------------------------------------
+// make_change_ratios — returns a list of `count` doubles summing to ~1.0
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::coin_selection - make_change_ratios produces a list of the requested size",
+          "[C-API WalletCoinSelection][ratios]") {
+    // make_change_ratios is a deterministic utility: for `count = N`
+    // it returns N doubles that sum to 1.0 (within floating-point
+    // tolerance). The randomisation is inside the distribution, not
+    // the element count — so the count check is stable.
+    kth_double_list_mut_t ratios = kth_wallet_coin_selection_make_change_ratios(5u);
+    REQUIRE(ratios != NULL);
+    REQUIRE(kth_core_double_list_count(ratios) == 5u);
+
+    double sum = 0.0;
+    for (kth_size_t i = 0; i < 5u; ++i) {
+        sum += kth_core_double_list_nth(ratios, i);
+    }
+    // Allow a little FP slack; the domain is not guaranteed to hit
+    // exactly 1.0 for every seed, but it is normalised to the unit
+    // interval and the sum is expected to be very close.
+    REQUIRE(sum > 0.999);
+    REQUIRE(sum < 1.001);
+
+    kth_core_double_list_destruct(ratios);
+}
+
+TEST_CASE("C-API wallet::coin_selection - make_change_ratios(0) returns empty list",
+          "[C-API WalletCoinSelection][ratios]") {
+    kth_double_list_mut_t ratios = kth_wallet_coin_selection_make_change_ratios(0u);
+    REQUIRE(ratios != NULL);
+    REQUIRE(kth_core_double_list_count(ratios) == 0u);
+    kth_core_double_list_destruct(ratios);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::coin_selection - select_utxos(NULL utxos) aborts",
+          "[C-API WalletCoinSelection][precondition]") {
+    kth_coin_selection_result_mut_t out = NULL;
+    KTH_EXPECT_ABORT(kth_wallet_coin_selection_select_utxos(
+        NULL, 1u, 1u, &kBchCategory,
+        kth_coin_selection_strategy_clean, &out));
+}
+
+TEST_CASE("C-API wallet::coin_selection - select_utxos(NULL category) aborts",
+          "[C-API WalletCoinSelection][precondition]") {
+    kth_utxo_list_mut_t utxos = kth_chain_utxo_list_construct_default();
+    kth_coin_selection_result_mut_t out = NULL;
+    KTH_EXPECT_ABORT(kth_wallet_coin_selection_select_utxos(
+        utxos, 1u, 1u, NULL,
+        kth_coin_selection_strategy_clean, &out));
+    kth_chain_utxo_list_destruct(utxos);
+}
+
+TEST_CASE("C-API wallet::coin_selection - select_utxos(NULL out) aborts",
+          "[C-API WalletCoinSelection][precondition]") {
+    kth_utxo_list_mut_t utxos = kth_chain_utxo_list_construct_default();
+    KTH_EXPECT_ABORT(kth_wallet_coin_selection_select_utxos(
+        utxos, 1u, 1u, &kBchCategory,
+        kth_coin_selection_strategy_clean, NULL));
+    kth_chain_utxo_list_destruct(utxos);
+}


### PR DESCRIPTION
## Summary
Closes the first half of #205: the `kth::domain::wallet::coin_selection` free-function surface is now exposed through a proper C-API namespace module, replacing the older `chain::transaction::create_template*` detour with direct bindings on the wallet side.

### Exposed
- `kth_wallet_coin_selection_select_utxos(utxos, amount, outputs_size, category, strategy, &out)` — pick UTXOs for a single asset (BCH or a token category).
- `kth_wallet_coin_selection_select_utxos_send_all(utxos, outputs_size, category, &out)` — "spend everything matching this asset" variant.
- `kth_wallet_coin_selection_select_utxos_both(utxos, bch_amount, token_category, token_amount, outputs_size, strategy, &out)` — joint BCH + token selection.
- `kth_wallet_coin_selection_make_change_ratios(n)` — random ratios summing to ~1.0 for distributing change.
- `kth_coin_selection_result` opaque handle, with scalar getters `total_selected_bch`, `total_selected_token`, `estimated_size`.
- `kth_coin_selection_strategy_t` enum (`clean` / `mixed`).

### Not in this PR (scheduled follow-ups)
- `create_tx_template` / `create_token_split_tx_template` — return `std::expected<std::tuple<transaction, address_list, amount_vector>>` whose non-opaque tuple components the generator doesn't model yet.
- `coin_selection_result` container accessors (`selected_indices`, `collateral_fts`, `collateral_nfts`) — need list-of-size_t + map-hash-to-u64 aliases that don't exist today; skipped via `field_skips`.
- Relocating `kth_coin_selection_algorithm_t` from `capi/chain/` to `capi/wallet/` — blocked on migrating every caller at once.

## Test plan
- [ ] `kth_capi_test "[C-API WalletCoinSelection]"` — 10 cases, 30 assertions.
- [ ] Full suite still green (2582 assertions, 722 cases locally).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new wallet-facing C-API entry points for UTXO picking and introduces a new opaque result type, which may affect downstream FFI consumers and memory/ownership handling despite being additive.
> 
> **Overview**
> Exposes wallet-side coin selection through a new C-API module, adding functions to select UTXOs for *single-asset*, *send-all*, and *joint BCH+token* scenarios (plus safe/`_unsafe` category-pointer variants) and a `make_change_ratios` helper.
> 
> Introduces `kth_coin_selection_result` as an opaque handle with lifecycle (`copy`/`destruct`) and scalar getters, plus a new `kth_coin_selection_strategy_t` enum (`clean`/`mixed`) and C++↔C conversion helpers; wires everything into the build and adds Catch2 coverage for success/failure and precondition aborts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba0e18e71a51a424394fc9bad0578972c591e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wallet coin selection API enabling selection of unspent transaction outputs for various use cases: targeting specific amounts, spending all available funds, or handling combined BCH and token transactions.
  * Introduced coin selection strategies (clean and mixed modes) for different wallet scenarios.
  * Added result querying functions to retrieve selected asset totals and estimated transaction sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->