### PR TITLE
feat(c-api): expose BIP38 create_key_pair free function

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -206,6 +206,7 @@ set(kth_sources
   src/wallet/cashtoken_minting.cpp
   src/wallet/coin_selection.cpp
   src/wallet/coin_selection_result.cpp
+  src/wallet/encrypted_keys.cpp
   src/wallet/ek_private.cpp
   src/wallet/ek_public.cpp
   src/wallet/ek_token.cpp
@@ -348,6 +349,7 @@ set(kth_headers
   include/kth/capi/wallet/coin_selection_result.h
   include/kth/capi/wallet/coin_selection_strategy.h
   include/kth/capi/wallet/ec_public.h
+  include/kth/capi/wallet/encrypted_keys.h
   include/kth/capi/wallet/ek_private.h
   include/kth/capi/wallet/ek_public.h
   include/kth/capi/wallet/ek_token.h
@@ -578,6 +580,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/wallet/bitcoin_uri.cpp
         test/wallet/cashtoken_minting.cpp
         test/wallet/coin_selection.cpp
+        test/wallet/encrypted_keys.cpp
         test/wallet/ek_private.cpp
         test/wallet/ek_public.cpp
         test/wallet/ek_token.cpp

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -101,6 +101,7 @@
 #include <kth/capi/wallet/coin_selection.h>
 #include <kth/capi/wallet/coin_selection_result.h>
 #include <kth/capi/wallet/coin_selection_strategy.h>
+#include <kth/capi/wallet/encrypted_keys.h>
 #include <kth/capi/wallet/ek_private.h>
 #include <kth/capi/wallet/ek_public.h>
 #include <kth/capi/wallet/ek_token.h>

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -427,6 +427,36 @@ inline kth::domain::wallet::encrypted_token encrypted_token_to_cpp(uint8_t const
     return to_array_cpp<kth::domain::wallet::encrypted_token_decoded_size>(x);
 }
 
+// BIP38 ek_seed (24 bytes) — caller-provided key-pair randomness.
+inline kth_ek_seed_t to_ek_seed_t(kth::domain::wallet::ek_seed const& x) {
+    kth_ek_seed_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::domain::wallet::ek_seed ek_seed_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::domain::wallet::ek_seed_size>(x);
+}
+
+// BIP38 ek_salt (4 bytes) — lot+sequence-mode salt input.
+inline kth_ek_salt_t to_ek_salt_t(kth::domain::wallet::ek_salt const& x) {
+    kth_ek_salt_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::domain::wallet::ek_salt ek_salt_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::domain::wallet::ek_salt_size>(x);
+}
+
+// BIP38 ek_entropy (8 bytes) — passphrase-mode token randomness.
+inline kth_ek_entropy_t to_ek_entropy_t(kth::domain::wallet::ek_entropy const& x) {
+    kth_ek_entropy_t ret;
+    std::copy_n(x.begin(), x.size(), ret.data);
+    return ret;
+}
+inline kth::domain::wallet::ek_entropy ek_entropy_to_cpp(uint8_t const* x) {
+    return to_array_cpp<kth::domain::wallet::ek_entropy_size>(x);
+}
+
 template <typename T>
 inline
 T* mnew(std::size_t n = 1) {

--- a/src/c-api/include/kth/capi/wallet/encrypted_keys.h
+++ b/src/c-api/include/kth/capi/wallet/encrypted_keys.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_ENCRYPTED_KEYS_H_
+#define KTH_CAPI_WALLET_ENCRYPTED_KEYS_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Static utilities
+
+/**
+ * @param token Borrowed input; must be non-null. Read during the call; ownership of `token` stays with the caller.
+ * @param seed Borrowed input; must be non-null. Read during the call; ownership of `seed` stays with the caller.
+ */
+KTH_EXPORT
+kth_bool_t kth_wallet_encrypted_keys_create_key_pair(kth_encrypted_private_t* out_private, kth_ec_compressed_t* out_point, kth_encrypted_token_t const* token, kth_ek_seed_t const* seed, uint8_t version, kth_bool_t compressed);
+
+/**
+ * @warning `token` MUST point to a buffer of at least 53 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_encrypted_token_t`.
+ * @warning `seed` MUST point to a buffer of at least 24 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ek_seed_t`.
+ */
+KTH_EXPORT
+kth_bool_t kth_wallet_encrypted_keys_create_key_pair_unsafe(kth_encrypted_private_t* out_private, kth_ec_compressed_t* out_point, uint8_t const* token, uint8_t const* seed, uint8_t version, kth_bool_t compressed);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_ENCRYPTED_KEYS_H_

--- a/src/c-api/include/kth/capi/wallet/primitives.h
+++ b/src/c-api/include/kth/capi/wallet/primitives.h
@@ -86,6 +86,24 @@ typedef struct kth_encrypted_token_t {
     uint8_t data[KTH_EK_TOKEN_DECODED_SIZE];
 } kth_encrypted_token_t;
 
+// BIP38 random-input byte_arrays. These are caller-provided entropy
+// sources consumed by `create_key_pair` / `create_token`; they never
+// base58-encode, just pass through as fixed-size buffers.
+#define KTH_EK_SEED_SIZE 24
+#define KTH_EK_SALT_SIZE 4
+#define KTH_EK_ENTROPY_SIZE 8
+typedef struct kth_ek_seed_t {
+    uint8_t data[KTH_EK_SEED_SIZE];
+} kth_ek_seed_t;
+
+typedef struct kth_ek_salt_t {
+    uint8_t data[KTH_EK_SALT_SIZE];
+} kth_ek_salt_t;
+
+typedef struct kth_ek_entropy_t {
+    uint8_t data[KTH_EK_ENTROPY_SIZE];
+} kth_ek_entropy_t;
+
 
 typedef void* kth_ec_private_t;
 typedef void* kth_ec_private_mut_t;

--- a/src/c-api/src/wallet/ek_private.cpp
+++ b/src/c-api/src/wallet/ek_private.cpp
@@ -37,7 +37,7 @@ kth_ek_private_mut_t kth_wallet_ek_private_construct_from_value(kth_encrypted_pr
 
 kth_ek_private_mut_t kth_wallet_ek_private_construct_from_value_unsafe(uint8_t const* value) {
     KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::to_array_cpp<43>(value);
+    auto const value_cpp = kth::encrypted_private_to_cpp(value);
     return kth::leak_if_valid(cpp_t(value_cpp));
 }
 

--- a/src/c-api/src/wallet/ek_public.cpp
+++ b/src/c-api/src/wallet/ek_public.cpp
@@ -37,7 +37,7 @@ kth_ek_public_mut_t kth_wallet_ek_public_construct_from_value(kth_encrypted_publ
 
 kth_ek_public_mut_t kth_wallet_ek_public_construct_from_value_unsafe(uint8_t const* value) {
     KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::to_array_cpp<55>(value);
+    auto const value_cpp = kth::encrypted_public_to_cpp(value);
     return kth::leak_if_valid(cpp_t(value_cpp));
 }
 

--- a/src/c-api/src/wallet/ek_token.cpp
+++ b/src/c-api/src/wallet/ek_token.cpp
@@ -37,7 +37,7 @@ kth_ek_token_mut_t kth_wallet_ek_token_construct_from_value(kth_encrypted_token_
 
 kth_ek_token_mut_t kth_wallet_ek_token_construct_from_value_unsafe(uint8_t const* value) {
     KTH_PRECONDITION(value != nullptr);
-    auto const value_cpp = kth::to_array_cpp<53>(value);
+    auto const value_cpp = kth::encrypted_token_to_cpp(value);
     return kth::leak_if_valid(cpp_t(value_cpp));
 }
 

--- a/src/c-api/src/wallet/encrypted_keys.cpp
+++ b/src/c-api/src/wallet/encrypted_keys.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <cstring>
+
+#include <kth/capi/wallet/encrypted_keys.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/encrypted_keys.hpp>
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Static utilities
+
+kth_bool_t kth_wallet_encrypted_keys_create_key_pair(kth_encrypted_private_t* out_private, kth_ec_compressed_t* out_point, kth_encrypted_token_t const* token, kth_ek_seed_t const* seed, uint8_t version, kth_bool_t compressed) {
+    KTH_PRECONDITION(out_private != nullptr);
+    KTH_PRECONDITION(out_point != nullptr);
+    KTH_PRECONDITION(token != nullptr);
+    KTH_PRECONDITION(seed != nullptr);
+    kth::domain::wallet::encrypted_private out_private_cpp;
+    kth::ec_compressed out_point_cpp;
+    auto const token_cpp = kth::encrypted_token_to_cpp(token->data);
+    auto const seed_cpp = kth::ek_seed_to_cpp(seed->data);
+    auto const compressed_cpp = kth::int_to_bool(compressed);
+    auto const cpp_result = kth::domain::wallet::create_key_pair(out_private_cpp, out_point_cpp, token_cpp, seed_cpp, version, compressed_cpp);
+    if (cpp_result) {
+        std::memcpy(out_private->data, out_private_cpp.data(), out_private_cpp.size());
+        std::memcpy(out_point->data, out_point_cpp.data(), out_point_cpp.size());
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+kth_bool_t kth_wallet_encrypted_keys_create_key_pair_unsafe(kth_encrypted_private_t* out_private, kth_ec_compressed_t* out_point, uint8_t const* token, uint8_t const* seed, uint8_t version, kth_bool_t compressed) {
+    KTH_PRECONDITION(out_private != nullptr);
+    KTH_PRECONDITION(out_point != nullptr);
+    KTH_PRECONDITION(token != nullptr);
+    KTH_PRECONDITION(seed != nullptr);
+    kth::domain::wallet::encrypted_private out_private_cpp;
+    kth::ec_compressed out_point_cpp;
+    auto const token_cpp = kth::encrypted_token_to_cpp(token);
+    auto const seed_cpp = kth::ek_seed_to_cpp(seed);
+    auto const compressed_cpp = kth::int_to_bool(compressed);
+    auto const cpp_result = kth::domain::wallet::create_key_pair(out_private_cpp, out_point_cpp, token_cpp, seed_cpp, version, compressed_cpp);
+    if (cpp_result) {
+        std::memcpy(out_private->data, out_private_cpp.data(), out_private_cpp.size());
+        std::memcpy(out_point->data, out_point_cpp.data(), out_point_cpp.size());
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+} // extern "C"

--- a/src/c-api/test/wallet/encrypted_keys.cpp
+++ b/src/c-api/test/wallet/encrypted_keys.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/ek_private.h>
+#include <kth/capi/wallet/ek_token.h>
+#include <kth/capi/wallet/encrypted_keys.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// BIP38 test vectors — lifted from the domain suite
+// (`src/domain/test/wallet/encrypted_keys.cpp`: "create key pair vector 8",
+// no lot/sequence, compressed=false, version=0x00). Originally generated
+// against bit2factor.com, so any drift in our AES / SCrypt wiring trips
+// the round-trip encoded-output check below.
+// ---------------------------------------------------------------------------
+
+static char const* const kToken =
+    "passphraseo59BauW85etaRsKpbbTrEa5RRYw6bq5K9yrDf4r4N5fcirPdtDKmfJw9oYNoGM";
+
+// 24-byte seed: hex "d36d8e703d8bd5445044178f69087657fba73d9f3ff211f7".
+static kth_ek_seed_t const kSeed = {{
+    0xd3, 0x6d, 0x8e, 0x70, 0x3d, 0x8b, 0xd5, 0x44,
+    0x50, 0x44, 0x17, 0x8f, 0x69, 0x08, 0x76, 0x57,
+    0xfb, 0xa7, 0x3d, 0x9f, 0x3f, 0xf2, 0x11, 0xf7,
+}};
+
+static uint8_t const kVersion = 0x00u;
+
+// Expected encoded private from vector 8.
+static char const* const kExpectedPrivate =
+    "6PfPAw5HErFdzMyBvGMwSfSWjKmzgm3jDg7RxQyVCSSBJFZLAZ6hVupmpn";
+
+// ---------------------------------------------------------------------------
+// create_key_pair — happy path
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::encrypted_keys - create_key_pair (vector 8, uncompressed) round-trips",
+          "[C-API WalletEncryptedKeys][create_key_pair]") {
+    // Build the token through the public ek_token C-API (parsing the
+    // base58-check string into the raw 53-byte payload the encryption
+    // function expects). This keeps the test honest: it exercises the
+    // same input path a real C consumer would use.
+    kth_ek_token_mut_t token_handle = kth_wallet_ek_token_construct_from_encoded(kToken);
+    REQUIRE(token_handle != NULL);
+    kth_encrypted_token_t const token = kth_wallet_ek_token_token(token_handle);
+    kth_wallet_ek_token_destruct(token_handle);
+
+    kth_encrypted_private_t out_private = {{ 0 }};
+    kth_ec_compressed_t out_point = {{ 0 }};
+    kth_bool_t const ok = kth_wallet_encrypted_keys_create_key_pair(
+        &out_private, &out_point, &token, &kSeed, kVersion, /*compressed=*/0);
+    REQUIRE(ok != 0);
+
+    // Re-wrap the resulting 43-byte payload in an ek_private so we can
+    // compare against the expected base58-check string.
+    kth_ek_private_mut_t priv = kth_wallet_ek_private_construct_from_value(&out_private);
+    REQUIRE(priv != NULL);
+    char* encoded = kth_wallet_ek_private_encoded(priv);
+    REQUIRE(encoded != NULL);
+    REQUIRE(strcmp(encoded, kExpectedPrivate) == 0);
+    kth_core_destruct_string(encoded);
+    kth_wallet_ek_private_destruct(priv);
+}
+
+TEST_CASE("C-API wallet::encrypted_keys - create_key_pair_unsafe matches the safe variant",
+          "[C-API WalletEncryptedKeys][create_key_pair]") {
+    // Hit the same code path through the raw-pointer entry. Both must
+    // agree; otherwise the safe/unsafe pair has drifted.
+    kth_ek_token_mut_t token_handle = kth_wallet_ek_token_construct_from_encoded(kToken);
+    REQUIRE(token_handle != NULL);
+    kth_encrypted_token_t const token = kth_wallet_ek_token_token(token_handle);
+    kth_wallet_ek_token_destruct(token_handle);
+
+    kth_encrypted_private_t out_private_a = {{ 0 }};
+    kth_ec_compressed_t   out_point_a    = {{ 0 }};
+    REQUIRE(kth_wallet_encrypted_keys_create_key_pair(
+        &out_private_a, &out_point_a, &token, &kSeed, kVersion, 0) != 0);
+
+    kth_encrypted_private_t out_private_b = {{ 0 }};
+    kth_ec_compressed_t   out_point_b    = {{ 0 }};
+    REQUIRE(kth_wallet_encrypted_keys_create_key_pair_unsafe(
+        &out_private_b, &out_point_b, token.data, kSeed.data, kVersion, 0) != 0);
+
+    REQUIRE(memcmp(out_private_a.data, out_private_b.data, sizeof(out_private_a.data)) == 0);
+    REQUIRE(memcmp(out_point_a.data,   out_point_b.data,   sizeof(out_point_a.data))   == 0);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::encrypted_keys - create_key_pair(NULL out_private) aborts",
+          "[C-API WalletEncryptedKeys][precondition]") {
+    kth_encrypted_token_t const token = {{ 0 }};
+    kth_ec_compressed_t out_point = {{ 0 }};
+    KTH_EXPECT_ABORT(kth_wallet_encrypted_keys_create_key_pair(
+        NULL, &out_point, &token, &kSeed, 0, 0));
+}
+
+TEST_CASE("C-API wallet::encrypted_keys - create_key_pair(NULL out_point) aborts",
+          "[C-API WalletEncryptedKeys][precondition]") {
+    kth_encrypted_token_t const token = {{ 0 }};
+    kth_encrypted_private_t out_private = {{ 0 }};
+    KTH_EXPECT_ABORT(kth_wallet_encrypted_keys_create_key_pair(
+        &out_private, NULL, &token, &kSeed, 0, 0));
+}
+
+TEST_CASE("C-API wallet::encrypted_keys - create_key_pair(NULL token) aborts",
+          "[C-API WalletEncryptedKeys][precondition]") {
+    kth_encrypted_private_t out_private = {{ 0 }};
+    kth_ec_compressed_t out_point = {{ 0 }};
+    KTH_EXPECT_ABORT(kth_wallet_encrypted_keys_create_key_pair(
+        &out_private, &out_point, NULL, &kSeed, 0, 0));
+}
+
+TEST_CASE("C-API wallet::encrypted_keys - create_key_pair(NULL seed) aborts",
+          "[C-API WalletEncryptedKeys][precondition]") {
+    kth_encrypted_token_t const token = {{ 0 }};
+    kth_encrypted_private_t out_private = {{ 0 }};
+    kth_ec_compressed_t out_point = {{ 0 }};
+    KTH_EXPECT_ABORT(kth_wallet_encrypted_keys_create_key_pair(
+        &out_private, &out_point, &token, NULL, 0, 0));
+}


### PR DESCRIPTION
## Summary
Follow-up to #311 (BIP38 wrappers). That PR exposed the three opaque wrapper classes (`ek_private`, `ek_public`, `ek_token`) but not the free function that creates the encrypted payloads they wrap. This one wires up `kth::domain::wallet::create_key_pair` — the operation that turns an intermediate-passphrase token + random seed into an encrypted private key + the matching compressed public point.

### Exposed
- `kth_wallet_encrypted_keys_create_key_pair(out_private, out_point, token, seed, version, compressed)` — 6-arg modern form with typed `kth_encrypted_token_t` / `kth_ek_seed_t` inputs and typed `kth_encrypted_private_t` / `kth_ec_compressed_t` outputs.
- `kth_wallet_encrypted_keys_create_key_pair_unsafe(…)` — raw `uint8_t const*` companion.

### New infrastructure
- `kth_ek_seed_t` (24 B), `kth_ek_salt_t` (4 B), `kth_ek_entropy_t` (8 B) value-structs in `wallet/primitives.h`.
- Paired `to_*_t` / `*_to_cpp` helpers in `helpers.hpp`.

### Not in this PR (deferred)
- DEPRECATED 7-arg `create_key_pair` overload (the `encrypted_public` confirmation-code variant) — skipped.
- `create_token` / `encrypt` / `decrypt` — `WITH_ICU`-gated and not compiled in this build. Skipped until WITH_ICU support lands.

## Test plan
- [ ] `kth_capi_test "[C-API WalletEncryptedKeys]"` — 6 cases, 25 assertions, including canonical BIP38 vector 8 round-trip.
- [ ] Full suite still green (2607 assertions, 728 cases locally).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new C-API entry points for BIP38 key-pair generation and new fixed-size entropy types; mistakes could impact cryptographic correctness or memory-safety for FFI consumers (especially the `_unsafe` variants), though changes are well-covered by new vector-based tests.
> 
> **Overview**
> Exposes BIP38 encrypted key-pair generation in the C-API via new `kth_wallet_encrypted_keys_create_key_pair` and `_unsafe` variants, returning an encrypted private payload plus the matching public point.
> 
> Adds new fixed-size wallet primitives (`kth_ek_seed_t`, `kth_ek_salt_t`, `kth_ek_entropy_t`) and conversion helpers, wires the new header/source into the build, and includes a Catch2 test suite covering a canonical BIP38 vector plus precondition/ABI parity checks.
> 
> Also adjusts the existing `ek_private`/`ek_public`/`ek_token` “_unsafe” constructors to reuse the dedicated `*_to_cpp` conversion helpers instead of hardcoded array sizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8a9d08a5581974716aab55e52a73ae56989a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added C-API support for creating encrypted wallet key pairs with BIP38 encryption.
  * Provides both typed-safe and unsafe variants for encrypted key pair generation.
  * New C-API types for encryption parameters (seed, salt, entropy).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->