### PR TITLE
feat(c-api): expose stealth_receiver + stealth_sender (BIP63)

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -215,6 +215,8 @@ set(kth_sources
   src/wallet/payment_address.cpp
   src/wallet/payment_address_list.cpp
   src/wallet/stealth_address.cpp
+  src/wallet/stealth_receiver.cpp
+  src/wallet/stealth_sender.cpp
   src/wallet/wallet.cpp
   src/wallet/ec_compressed_list.cpp
   src/wallet/wallet_data.cpp
@@ -357,6 +359,8 @@ set(kth_headers
   include/kth/capi/wallet/payment_address.h
   include/kth/capi/wallet/payment_address_list.h
   include/kth/capi/wallet/stealth_address.h
+  include/kth/capi/wallet/stealth_receiver.h
+  include/kth/capi/wallet/stealth_sender.h
   include/kth/capi/wallet/wallet.h
   include/kth/capi/wallet/ec_compressed_list.h
   include/kth/capi/wallet/wallet_data.h
@@ -586,6 +590,8 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/wallet/message.cpp
         test/wallet/mnemonic.cpp
         test/wallet/stealth_address.cpp
+        test/wallet/stealth_receiver.cpp
+        test/wallet/stealth_sender.cpp
         test/wallet/wallet_data.cpp
         test/vm/big_number.cpp
         test/vm/program.cpp

--- a/src/c-api/include/kth/capi/capi.h
+++ b/src/c-api/include/kth/capi/capi.h
@@ -113,6 +113,8 @@
 #include <kth/capi/wallet/mnemonic.h>
 #include <kth/capi/wallet/payment_address.h>
 #include <kth/capi/wallet/stealth_address.h>
+#include <kth/capi/wallet/stealth_receiver.h>
+#include <kth/capi/wallet/stealth_sender.h>
 #include <kth/capi/wallet/payment_address_list.h>
 #include <kth/capi/wallet/primitives.h>
 #include <kth/capi/wallet/wallet.h>

--- a/src/c-api/include/kth/capi/handles.h
+++ b/src/c-api/include/kth/capi/handles.h
@@ -187,6 +187,10 @@ typedef void const* kth_wallet_data_const_t;
 
 typedef void* kth_stealth_address_mut_t;
 typedef void const* kth_stealth_address_const_t;
+typedef void* kth_stealth_receiver_mut_t;
+typedef void const* kth_stealth_receiver_const_t;
+typedef void* kth_stealth_sender_mut_t;
+typedef void const* kth_stealth_sender_const_t;
 typedef void* kth_bitcoin_uri_mut_t;
 typedef void const* kth_bitcoin_uri_const_t;
 

--- a/src/c-api/include/kth/capi/wallet/stealth_receiver.h
+++ b/src/c-api/include/kth/capi/wallet/stealth_receiver.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_STEALTH_RECEIVER_H_
+#define KTH_CAPI_WALLET_STEALTH_RECEIVER_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/**
+ * @return Owned `kth_stealth_receiver_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_receiver_destruct`.
+ * @param filter Borrowed input. Copied by value into the resulting object; ownership of `filter` stays with the caller.
+ * @param scan_private Borrowed input; must be non-null. Copied into the resulting object; ownership of `scan_private` stays with the caller.
+ * @param spend_private Borrowed input; must be non-null. Copied into the resulting object; ownership of `spend_private` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_stealth_receiver_mut_t kth_wallet_stealth_receiver_construct(kth_hash_t const* scan_private, kth_hash_t const* spend_private, kth_binary_const_t filter, uint8_t version);
+
+/**
+ * @return Owned `kth_stealth_receiver_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_receiver_destruct`.
+ * @param filter Borrowed input. Copied by value into the resulting object; ownership of `filter` stays with the caller.
+ * @warning `scan_private` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ * @warning `spend_private` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_stealth_receiver_mut_t kth_wallet_stealth_receiver_construct_unsafe(uint8_t const* scan_private, uint8_t const* spend_private, kth_binary_const_t filter, uint8_t version);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_wallet_stealth_receiver_destruct(kth_stealth_receiver_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_stealth_receiver_mut_t`. Caller must release with `kth_wallet_stealth_receiver_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_stealth_receiver_mut_t kth_wallet_stealth_receiver_copy(kth_stealth_receiver_const_t self);
+
+
+// Getters
+
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
+KTH_EXPORT
+kth_bool_t kth_wallet_stealth_receiver_valid(kth_stealth_receiver_const_t self);
+
+/** @return Borrowed `kth_stealth_address_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_stealth_address_const_t kth_wallet_stealth_receiver_stealth_address(kth_stealth_receiver_const_t self);
+
+
+// Operations
+
+/** @param ephemeral_public Borrowed input; must be non-null. Read during the call; ownership of `ephemeral_public` stays with the caller. */
+KTH_EXPORT
+kth_bool_t kth_wallet_stealth_receiver_derive_address(kth_stealth_receiver_const_t self, kth_payment_address_mut_t out_address, kth_ec_compressed_t const* ephemeral_public);
+
+/** @warning `ephemeral_public` MUST point to a buffer of at least 33 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ec_compressed_t`. */
+KTH_EXPORT
+kth_bool_t kth_wallet_stealth_receiver_derive_address_unsafe(kth_stealth_receiver_const_t self, kth_payment_address_mut_t out_address, uint8_t const* ephemeral_public);
+
+/** @param ephemeral_public Borrowed input; must be non-null. Read during the call; ownership of `ephemeral_public` stays with the caller. */
+KTH_EXPORT
+kth_bool_t kth_wallet_stealth_receiver_derive_private(kth_stealth_receiver_const_t self, kth_hash_t* out_private, kth_ec_compressed_t const* ephemeral_public);
+
+/** @warning `ephemeral_public` MUST point to a buffer of at least 33 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_ec_compressed_t`. */
+KTH_EXPORT
+kth_bool_t kth_wallet_stealth_receiver_derive_private_unsafe(kth_stealth_receiver_const_t self, kth_hash_t* out_private, uint8_t const* ephemeral_public);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_STEALTH_RECEIVER_H_

--- a/src/c-api/include/kth/capi/wallet/stealth_sender.h
+++ b/src/c-api/include/kth/capi/wallet/stealth_sender.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_WALLET_STEALTH_SENDER_H_
+#define KTH_CAPI_WALLET_STEALTH_SENDER_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/wallet/primitives.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Constructors
+
+/**
+ * @return Owned `kth_stealth_sender_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_sender_destruct`.
+ * @param address Borrowed input. Copied by value into the resulting object; ownership of `address` stays with the caller.
+ * @param filter Borrowed input. Copied by value into the resulting object; ownership of `filter` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_stealth_sender_mut_t kth_wallet_stealth_sender_construct_from_stealth_address_seed_binary_version(kth_stealth_address_const_t address, uint8_t const* seed, kth_size_t n, kth_binary_const_t filter, uint8_t version);
+
+/**
+ * @return Owned `kth_stealth_sender_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_sender_destruct`.
+ * @param address Borrowed input. Copied by value into the resulting object; ownership of `address` stays with the caller.
+ * @param filter Borrowed input. Copied by value into the resulting object; ownership of `filter` stays with the caller.
+ * @param ephemeral_private Borrowed input; must be non-null. Copied into the resulting object; ownership of `ephemeral_private` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_stealth_sender_mut_t kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version(kth_hash_t const* ephemeral_private, kth_stealth_address_const_t address, uint8_t const* seed, kth_size_t n, kth_binary_const_t filter, uint8_t version);
+
+/**
+ * @return Owned `kth_stealth_sender_mut_t`, or NULL if construction/parsing fails. Caller must release non-NULL results with `kth_wallet_stealth_sender_destruct`.
+ * @param address Borrowed input. Copied by value into the resulting object; ownership of `address` stays with the caller.
+ * @param filter Borrowed input. Copied by value into the resulting object; ownership of `filter` stays with the caller.
+ * @warning `ephemeral_private` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_stealth_sender_mut_t kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version_unsafe(uint8_t const* ephemeral_private, kth_stealth_address_const_t address, uint8_t const* seed, kth_size_t n, kth_binary_const_t filter, uint8_t version);
+
+
+// Destructor
+
+/** No-op if `self` is null. */
+KTH_EXPORT
+void kth_wallet_stealth_sender_destruct(kth_stealth_sender_mut_t self);
+
+
+// Copy
+
+/** @return Owned `kth_stealth_sender_mut_t`. Caller must release with `kth_wallet_stealth_sender_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_stealth_sender_mut_t kth_wallet_stealth_sender_copy(kth_stealth_sender_const_t self);
+
+
+// Getters
+
+/** @return Non-zero if `self` is in a valid state, zero otherwise. */
+KTH_EXPORT
+kth_bool_t kth_wallet_stealth_sender_valid(kth_stealth_sender_const_t self);
+
+/** @return Borrowed `kth_script_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_script_const_t kth_wallet_stealth_sender_stealth_script(kth_stealth_sender_const_t self);
+
+/** @return Borrowed `kth_payment_address_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
+KTH_EXPORT
+kth_payment_address_const_t kth_wallet_stealth_sender_payment_address(kth_stealth_sender_const_t self);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_WALLET_STEALTH_SENDER_H_

--- a/src/c-api/src/wallet/stealth_receiver.cpp
+++ b/src/c-api/src/wallet/stealth_receiver.cpp
@@ -1,0 +1,125 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <cstring>
+
+#include <kth/capi/wallet/stealth_receiver.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/stealth_receiver.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::wallet::stealth_receiver;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_stealth_receiver_mut_t kth_wallet_stealth_receiver_construct(kth_hash_t const* scan_private, kth_hash_t const* spend_private, kth_binary_const_t filter, uint8_t version) {
+    KTH_PRECONDITION(scan_private != nullptr);
+    KTH_PRECONDITION(spend_private != nullptr);
+    KTH_PRECONDITION(filter != nullptr);
+    auto scan_private_cpp = kth::hash_to_cpp(scan_private->hash);
+    kth::secure_scrub scan_private_cpp_scrub{&scan_private_cpp, sizeof(scan_private_cpp)};
+    auto spend_private_cpp = kth::hash_to_cpp(spend_private->hash);
+    kth::secure_scrub spend_private_cpp_scrub{&spend_private_cpp, sizeof(spend_private_cpp)};
+    auto const& filter_cpp = kth::cpp_ref<kth::binary>(filter);
+    return kth::leak_if_valid(cpp_t(scan_private_cpp, spend_private_cpp, filter_cpp, version));
+}
+
+kth_stealth_receiver_mut_t kth_wallet_stealth_receiver_construct_unsafe(uint8_t const* scan_private, uint8_t const* spend_private, kth_binary_const_t filter, uint8_t version) {
+    KTH_PRECONDITION(scan_private != nullptr);
+    KTH_PRECONDITION(spend_private != nullptr);
+    KTH_PRECONDITION(filter != nullptr);
+    auto scan_private_cpp = kth::hash_to_cpp(scan_private);
+    kth::secure_scrub scan_private_cpp_scrub{&scan_private_cpp, sizeof(scan_private_cpp)};
+    auto spend_private_cpp = kth::hash_to_cpp(spend_private);
+    kth::secure_scrub spend_private_cpp_scrub{&spend_private_cpp, sizeof(spend_private_cpp)};
+    auto const& filter_cpp = kth::cpp_ref<kth::binary>(filter);
+    return kth::leak_if_valid(cpp_t(scan_private_cpp, spend_private_cpp, filter_cpp, version));
+}
+
+
+// Destructor
+
+void kth_wallet_stealth_receiver_destruct(kth_stealth_receiver_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_stealth_receiver_mut_t kth_wallet_stealth_receiver_copy(kth_stealth_receiver_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Getters
+
+kth_bool_t kth_wallet_stealth_receiver_valid(kth_stealth_receiver_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(static_cast<bool>(kth::cpp_ref<cpp_t>(self)));
+}
+
+kth_stealth_address_const_t kth_wallet_stealth_receiver_stealth_address(kth_stealth_receiver_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<cpp_t>(self).stealth_address());
+}
+
+
+// Operations
+
+kth_bool_t kth_wallet_stealth_receiver_derive_address(kth_stealth_receiver_const_t self, kth_payment_address_mut_t out_address, kth_ec_compressed_t const* ephemeral_public) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_address != nullptr);
+    KTH_PRECONDITION(ephemeral_public != nullptr);
+    auto& out_address_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(out_address);
+    auto const ephemeral_public_cpp = kth::ec_compressed_to_cpp(ephemeral_public->data);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).derive_address(out_address_cpp, ephemeral_public_cpp));
+}
+
+kth_bool_t kth_wallet_stealth_receiver_derive_address_unsafe(kth_stealth_receiver_const_t self, kth_payment_address_mut_t out_address, uint8_t const* ephemeral_public) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_address != nullptr);
+    KTH_PRECONDITION(ephemeral_public != nullptr);
+    auto& out_address_cpp = kth::cpp_ref<kth::domain::wallet::payment_address>(out_address);
+    auto const ephemeral_public_cpp = kth::ec_compressed_to_cpp(ephemeral_public);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).derive_address(out_address_cpp, ephemeral_public_cpp));
+}
+
+kth_bool_t kth_wallet_stealth_receiver_derive_private(kth_stealth_receiver_const_t self, kth_hash_t* out_private, kth_ec_compressed_t const* ephemeral_public) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_private != nullptr);
+    KTH_PRECONDITION(ephemeral_public != nullptr);
+    kth::hash_digest out_private_cpp;
+    kth::secure_scrub out_private_cpp_scrub{&out_private_cpp, sizeof(out_private_cpp)};
+    auto const ephemeral_public_cpp = kth::ec_compressed_to_cpp(ephemeral_public->data);
+    auto const cpp_result = kth::cpp_ref<cpp_t>(self).derive_private(out_private_cpp, ephemeral_public_cpp);
+    if (cpp_result) {
+        std::memcpy(out_private->hash, out_private_cpp.data(), out_private_cpp.size());
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+kth_bool_t kth_wallet_stealth_receiver_derive_private_unsafe(kth_stealth_receiver_const_t self, kth_hash_t* out_private, uint8_t const* ephemeral_public) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_private != nullptr);
+    KTH_PRECONDITION(ephemeral_public != nullptr);
+    kth::hash_digest out_private_cpp;
+    kth::secure_scrub out_private_cpp_scrub{&out_private_cpp, sizeof(out_private_cpp)};
+    auto const ephemeral_public_cpp = kth::ec_compressed_to_cpp(ephemeral_public);
+    auto const cpp_result = kth::cpp_ref<cpp_t>(self).derive_private(out_private_cpp, ephemeral_public_cpp);
+    if (cpp_result) {
+        std::memcpy(out_private->hash, out_private_cpp.data(), out_private_cpp.size());
+    }
+    return kth::bool_to_int(cpp_result);
+}
+
+} // extern "C"

--- a/src/c-api/src/wallet/stealth_sender.cpp
+++ b/src/c-api/src/wallet/stealth_sender.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/wallet/stealth_sender.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/domain/wallet/stealth_sender.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::domain::wallet::stealth_sender;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Constructors
+
+kth_stealth_sender_mut_t kth_wallet_stealth_sender_construct_from_stealth_address_seed_binary_version(kth_stealth_address_const_t address, uint8_t const* seed, kth_size_t n, kth_binary_const_t filter, uint8_t version) {
+    KTH_PRECONDITION(address != nullptr);
+    KTH_PRECONDITION(seed != nullptr || n == 0);
+    KTH_PRECONDITION(filter != nullptr);
+    auto const& address_cpp = kth::cpp_ref<kth::domain::wallet::stealth_address>(address);
+    auto const seed_cpp = n != 0 ? kth::data_chunk(seed, seed + n) : kth::data_chunk{};
+    auto const& filter_cpp = kth::cpp_ref<kth::binary>(filter);
+    return kth::leak_if_valid(cpp_t(address_cpp, seed_cpp, filter_cpp, version));
+}
+
+kth_stealth_sender_mut_t kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version(kth_hash_t const* ephemeral_private, kth_stealth_address_const_t address, uint8_t const* seed, kth_size_t n, kth_binary_const_t filter, uint8_t version) {
+    KTH_PRECONDITION(ephemeral_private != nullptr);
+    KTH_PRECONDITION(address != nullptr);
+    KTH_PRECONDITION(seed != nullptr || n == 0);
+    KTH_PRECONDITION(filter != nullptr);
+    auto ephemeral_private_cpp = kth::hash_to_cpp(ephemeral_private->hash);
+    kth::secure_scrub ephemeral_private_cpp_scrub{&ephemeral_private_cpp, sizeof(ephemeral_private_cpp)};
+    auto const& address_cpp = kth::cpp_ref<kth::domain::wallet::stealth_address>(address);
+    auto const seed_cpp = n != 0 ? kth::data_chunk(seed, seed + n) : kth::data_chunk{};
+    auto const& filter_cpp = kth::cpp_ref<kth::binary>(filter);
+    return kth::leak_if_valid(cpp_t(ephemeral_private_cpp, address_cpp, seed_cpp, filter_cpp, version));
+}
+
+kth_stealth_sender_mut_t kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version_unsafe(uint8_t const* ephemeral_private, kth_stealth_address_const_t address, uint8_t const* seed, kth_size_t n, kth_binary_const_t filter, uint8_t version) {
+    KTH_PRECONDITION(ephemeral_private != nullptr);
+    KTH_PRECONDITION(address != nullptr);
+    KTH_PRECONDITION(seed != nullptr || n == 0);
+    KTH_PRECONDITION(filter != nullptr);
+    auto ephemeral_private_cpp = kth::hash_to_cpp(ephemeral_private);
+    kth::secure_scrub ephemeral_private_cpp_scrub{&ephemeral_private_cpp, sizeof(ephemeral_private_cpp)};
+    auto const& address_cpp = kth::cpp_ref<kth::domain::wallet::stealth_address>(address);
+    auto const seed_cpp = n != 0 ? kth::data_chunk(seed, seed + n) : kth::data_chunk{};
+    auto const& filter_cpp = kth::cpp_ref<kth::binary>(filter);
+    return kth::leak_if_valid(cpp_t(ephemeral_private_cpp, address_cpp, seed_cpp, filter_cpp, version));
+}
+
+
+// Destructor
+
+void kth_wallet_stealth_sender_destruct(kth_stealth_sender_mut_t self) {
+    kth::del<cpp_t>(self);
+}
+
+
+// Copy
+
+kth_stealth_sender_mut_t kth_wallet_stealth_sender_copy(kth_stealth_sender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::clone<cpp_t>(self);
+}
+
+
+// Getters
+
+kth_bool_t kth_wallet_stealth_sender_valid(kth_stealth_sender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(static_cast<bool>(kth::cpp_ref<cpp_t>(self)));
+}
+
+kth_script_const_t kth_wallet_stealth_sender_stealth_script(kth_stealth_sender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<cpp_t>(self).stealth_script());
+}
+
+kth_payment_address_const_t kth_wallet_stealth_sender_payment_address(kth_stealth_sender_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return &(kth::cpp_ref<cpp_t>(self).payment_address());
+}
+
+} // extern "C"

--- a/src/c-api/test/wallet/stealth_receiver.cpp
+++ b/src/c-api/test/wallet/stealth_receiver.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+#include <string.h>
+
+#include <kth/capi/binary.h>
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/stealth_address.h>
+#include <kth/capi/wallet/stealth_receiver.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Two distinct 32-byte secrets. Arbitrary pseudo-random bytes — the
+// BIP63 math only requires that they be valid secp256k1 scalars (below
+// the curve order), which any byte pattern that isn't all-zero and
+// isn't the max-values neighbourhood satisfies. Chosen so the
+// compressed public points are distinct.
+static kth_hash_t const kScanPrivate = {{
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}};
+
+static kth_hash_t const kSpendPrivate = {{
+    0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8,
+    0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0,
+    0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8,
+    0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xc0,
+}};
+
+// Mainnet P2KH: 0x00 (libbitcoin convention); testnet is 0x6f. BIP63
+// carries the same version byte through to the derived payment
+// address, so we pin mainnet here.
+static uint8_t const kMainnetP2KH = 0x00u;
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::stealth_receiver - construct + valid + destruct",
+          "[C-API WalletStealthReceiver][lifecycle]") {
+    // Empty binary filter: the receiver accepts every prefix. The
+    // stealth_address factory inside the C++ ctor scans the curve for
+    // a valid prefix match; an empty filter makes this trivial.
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    kth_stealth_receiver_mut_t r = kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, filter, kMainnetP2KH);
+    REQUIRE(r != NULL);
+    REQUIRE(kth_wallet_stealth_receiver_valid(r) != 0);
+
+    kth_wallet_stealth_receiver_destruct(r);
+    kth_core_binary_destruct(filter);
+}
+
+TEST_CASE("C-API wallet::stealth_receiver - destruct(NULL) is a no-op",
+          "[C-API WalletStealthReceiver][lifecycle]") {
+    kth_wallet_stealth_receiver_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// stealth_address accessor
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::stealth_receiver - stealth_address returns a valid handle",
+          "[C-API WalletStealthReceiver][accessor]") {
+    // Accessor returns a borrowed view into `self`. It must be
+    // non-null and the returned stealth_address must be in a valid
+    // state (the ctor otherwise short-circuits to NULL).
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    kth_stealth_receiver_mut_t r = kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, filter, kMainnetP2KH);
+    REQUIRE(r != NULL);
+
+    kth_stealth_address_const_t addr = kth_wallet_stealth_receiver_stealth_address(r);
+    REQUIRE(addr != NULL);
+    REQUIRE(kth_wallet_stealth_address_valid(addr) != 0);
+
+    kth_wallet_stealth_receiver_destruct(r);
+    kth_core_binary_destruct(filter);
+}
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::stealth_receiver - copy yields a distinct, valid handle",
+          "[C-API WalletStealthReceiver][value]") {
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    kth_stealth_receiver_mut_t a = kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, filter, kMainnetP2KH);
+    REQUIRE(a != NULL);
+
+    kth_stealth_receiver_mut_t b = kth_wallet_stealth_receiver_copy(a);
+    REQUIRE(b != NULL);
+    REQUIRE(b != a);
+    REQUIRE(kth_wallet_stealth_receiver_valid(b) != 0);
+
+    kth_wallet_stealth_receiver_destruct(b);
+    kth_wallet_stealth_receiver_destruct(a);
+    kth_core_binary_destruct(filter);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::stealth_receiver - construct(NULL scan_private) aborts",
+          "[C-API WalletStealthReceiver][precondition]") {
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    KTH_EXPECT_ABORT(kth_wallet_stealth_receiver_construct(
+        NULL, &kSpendPrivate, filter, kMainnetP2KH));
+    kth_core_binary_destruct(filter);
+}
+
+TEST_CASE("C-API wallet::stealth_receiver - construct(NULL spend_private) aborts",
+          "[C-API WalletStealthReceiver][precondition]") {
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    KTH_EXPECT_ABORT(kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, NULL, filter, kMainnetP2KH));
+    kth_core_binary_destruct(filter);
+}
+
+TEST_CASE("C-API wallet::stealth_receiver - construct(NULL filter) aborts",
+          "[C-API WalletStealthReceiver][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, NULL, kMainnetP2KH));
+}
+
+TEST_CASE("C-API wallet::stealth_receiver - valid(NULL) aborts",
+          "[C-API WalletStealthReceiver][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_stealth_receiver_valid(NULL));
+}
+
+TEST_CASE("C-API wallet::stealth_receiver - stealth_address(NULL) aborts",
+          "[C-API WalletStealthReceiver][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_stealth_receiver_stealth_address(NULL));
+}

--- a/src/c-api/test/wallet/stealth_sender.cpp
+++ b/src/c-api/test/wallet/stealth_sender.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// This file is named .cpp solely so it can use Catch2 (which is C++).
+// Everything inside the test bodies is plain C: no namespaces, no
+// templates, no <chrono>, no std::*, no auto, no references, no constexpr.
+// Only Catch2's TEST_CASE / REQUIRE macros are C++. The point is that
+// these tests must exercise the C-API exactly the way a C consumer would.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdint.h>
+
+#include <kth/capi/binary.h>
+#include <kth/capi/chain/script.h>
+#include <kth/capi/primitives.h>
+#include <kth/capi/wallet/elliptic_curve.h>
+#include <kth/capi/wallet/payment_address.h>
+#include <kth/capi/wallet/stealth_address.h>
+#include <kth/capi/wallet/stealth_receiver.h>
+#include <kth/capi/wallet/stealth_sender.h>
+
+#include "../test_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// Fixtures — shared with the stealth_receiver tests so the
+// round-trip scenario below can exercise both sides with a single
+// derivation.
+// ---------------------------------------------------------------------------
+
+static kth_hash_t const kScanPrivate = {{
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}};
+
+static kth_hash_t const kSpendPrivate = {{
+    0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8,
+    0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0,
+    0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8,
+    0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xc0,
+}};
+
+// Arbitrary valid secp256k1 scalar, distinct from the scan/spend keys.
+static kth_hash_t const kEphemeralPrivate = {{
+    0xf9, 0x1e, 0x67, 0x31, 0x03, 0x86, 0x3b, 0xbe,
+    0xb0, 0xef, 0x18, 0x52, 0xcd, 0x8e, 0xad, 0xe6,
+    0xb7, 0x3e, 0xa5, 0x5a, 0xfc, 0x9b, 0x18, 0x73,
+    0xbe, 0x62, 0xbf, 0x62, 0x8e, 0xac, 0x07, 0x2a,
+}};
+
+static uint8_t const kMainnetP2KH = 0x00u;
+
+// Seed bytes passed to the non-ephemeral-private ctor. BIP63's sender
+// uses this to salt its internal RNG for the ephemeral key. Using a
+// fixed seed makes the test deterministic but non-trivially chosen;
+// the exact value doesn't matter for the unit-test invariants we
+// check (handle non-null, payment_address accessible, script present).
+static uint8_t const kSeedBytes[] = {
+    0xde, 0xad, 0xbe, 0xef, 0xfe, 0xed, 0xfa, 0xce,
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+};
+
+// ---------------------------------------------------------------------------
+// Lifecycle — via the ephemeral-private ctor (deterministic)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::stealth_sender - construct from ephemeral_private",
+          "[C-API WalletStealthSender][lifecycle]") {
+    // To build a sender we need a stealth_address. Generate one via
+    // stealth_receiver so the fixture is self-contained — avoids
+    // pinning a pre-encoded stealth_address string that would drift
+    // if the encoding ever changes.
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    kth_stealth_receiver_mut_t r = kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, filter, kMainnetP2KH);
+    REQUIRE(r != NULL);
+    kth_stealth_address_const_t addr = kth_wallet_stealth_receiver_stealth_address(r);
+    REQUIRE(addr != NULL);
+
+    kth_stealth_sender_mut_t s =
+        kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version(
+            &kEphemeralPrivate, addr, kSeedBytes, sizeof(kSeedBytes),
+            filter, kMainnetP2KH);
+    REQUIRE(s != NULL);
+    REQUIRE(kth_wallet_stealth_sender_valid(s) != 0);
+
+    kth_wallet_stealth_sender_destruct(s);
+    kth_wallet_stealth_receiver_destruct(r);
+    kth_core_binary_destruct(filter);
+}
+
+TEST_CASE("C-API wallet::stealth_sender - destruct(NULL) is a no-op",
+          "[C-API WalletStealthSender][lifecycle]") {
+    kth_wallet_stealth_sender_destruct(NULL);
+}
+
+// ---------------------------------------------------------------------------
+// Getters — stealth_script + payment_address
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::stealth_sender - stealth_script returns a non-null handle",
+          "[C-API WalletStealthSender][accessor]") {
+    // The sender's stealth_script is the OP_RETURN-prefixed output
+    // that carries the ephemeral public key. It must be non-null
+    // after successful construction.
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    kth_stealth_receiver_mut_t r = kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, filter, kMainnetP2KH);
+    kth_stealth_address_const_t addr = kth_wallet_stealth_receiver_stealth_address(r);
+
+    kth_stealth_sender_mut_t s =
+        kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version(
+            &kEphemeralPrivate, addr, kSeedBytes, sizeof(kSeedBytes),
+            filter, kMainnetP2KH);
+    REQUIRE(s != NULL);
+
+    kth_script_const_t script = kth_wallet_stealth_sender_stealth_script(s);
+    REQUIRE(script != NULL);
+
+    kth_wallet_stealth_sender_destruct(s);
+    kth_wallet_stealth_receiver_destruct(r);
+    kth_core_binary_destruct(filter);
+}
+
+TEST_CASE("C-API wallet::stealth_sender - payment_address returns a valid handle",
+          "[C-API WalletStealthSender][accessor]") {
+    // The sender's derived payment_address is what the sender would
+    // actually send funds to. Downstream: the receiver can regenerate
+    // the same address from just the ephemeral_public via
+    // `derive_address` — covered separately.
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    kth_stealth_receiver_mut_t r = kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, filter, kMainnetP2KH);
+    kth_stealth_address_const_t addr = kth_wallet_stealth_receiver_stealth_address(r);
+
+    kth_stealth_sender_mut_t s =
+        kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version(
+            &kEphemeralPrivate, addr, kSeedBytes, sizeof(kSeedBytes),
+            filter, kMainnetP2KH);
+    REQUIRE(s != NULL);
+
+    kth_payment_address_const_t pay = kth_wallet_stealth_sender_payment_address(s);
+    REQUIRE(pay != NULL);
+    REQUIRE(kth_wallet_payment_address_valid(pay) != 0);
+
+    kth_wallet_stealth_sender_destruct(s);
+    kth_wallet_stealth_receiver_destruct(r);
+    kth_core_binary_destruct(filter);
+}
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::stealth_sender - copy yields a distinct, valid handle",
+          "[C-API WalletStealthSender][value]") {
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    kth_stealth_receiver_mut_t r = kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, filter, kMainnetP2KH);
+    kth_stealth_address_const_t addr = kth_wallet_stealth_receiver_stealth_address(r);
+
+    kth_stealth_sender_mut_t a =
+        kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version(
+            &kEphemeralPrivate, addr, kSeedBytes, sizeof(kSeedBytes),
+            filter, kMainnetP2KH);
+    REQUIRE(a != NULL);
+
+    kth_stealth_sender_mut_t b = kth_wallet_stealth_sender_copy(a);
+    REQUIRE(b != NULL);
+    REQUIRE(b != a);
+    REQUIRE(kth_wallet_stealth_sender_valid(b) != 0);
+
+    kth_wallet_stealth_sender_destruct(b);
+    kth_wallet_stealth_sender_destruct(a);
+    kth_wallet_stealth_receiver_destruct(r);
+    kth_core_binary_destruct(filter);
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::stealth_sender - construct(NULL address) aborts",
+          "[C-API WalletStealthSender][precondition]") {
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    KTH_EXPECT_ABORT(
+        kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version(
+            &kEphemeralPrivate, NULL, kSeedBytes, sizeof(kSeedBytes),
+            filter, kMainnetP2KH));
+    kth_core_binary_destruct(filter);
+}
+
+TEST_CASE("C-API wallet::stealth_sender - construct(NULL ephemeral_private) aborts",
+          "[C-API WalletStealthSender][precondition]") {
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    kth_stealth_receiver_mut_t r = kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, filter, kMainnetP2KH);
+    kth_stealth_address_const_t addr = kth_wallet_stealth_receiver_stealth_address(r);
+
+    KTH_EXPECT_ABORT(
+        kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version(
+            NULL, addr, kSeedBytes, sizeof(kSeedBytes),
+            filter, kMainnetP2KH));
+
+    kth_wallet_stealth_receiver_destruct(r);
+    kth_core_binary_destruct(filter);
+}
+
+TEST_CASE("C-API wallet::stealth_sender - valid(NULL) aborts",
+          "[C-API WalletStealthSender][precondition]") {
+    KTH_EXPECT_ABORT(kth_wallet_stealth_sender_valid(NULL));
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end round-trip: sender → receiver.derive_address
+// ---------------------------------------------------------------------------
+
+TEST_CASE("C-API wallet::stealth - sender.payment_address matches receiver.derive_address",
+          "[C-API WalletStealthSender][round_trip]") {
+    // The BIP63 contract: given the sender's output script containing
+    // the ephemeral_public, the receiver can regenerate the same
+    // payment_address using only its scan+spend private keys. If this
+    // round-trip ever breaks, stealth payments become undiscoverable.
+    //
+    // We construct both sides from the same fixtures, pull out the
+    // sender's payment_address, and derive it again on the receiver
+    // via `derive_address(out, ephemeral_public)`. The ephemeral
+    // public is recoverable from `stealth_sender::stealth_script()`
+    // in principle, but extracting it from the script at the C layer
+    // is out of scope for this suite — we use the ephemeral_private's
+    // matching public via the secret_to_public helper.
+    kth_binary_mut_t filter = kth_core_binary_construct_default();
+    kth_stealth_receiver_mut_t r = kth_wallet_stealth_receiver_construct(
+        &kScanPrivate, &kSpendPrivate, filter, kMainnetP2KH);
+    REQUIRE(r != NULL);
+    kth_stealth_address_const_t addr = kth_wallet_stealth_receiver_stealth_address(r);
+
+    kth_stealth_sender_mut_t s =
+        kth_wallet_stealth_sender_construct_from_ephemeral_private_stealth_address_seed_binary_version(
+            &kEphemeralPrivate, addr, kSeedBytes, sizeof(kSeedBytes),
+            filter, kMainnetP2KH);
+    REQUIRE(s != NULL);
+
+    // Pick off the sender-side payment_address — the one a real send
+    // transaction would fund. We compare its encoding against the
+    // receiver-derived one below.
+    kth_payment_address_const_t sender_pay =
+        kth_wallet_stealth_sender_payment_address(s);
+    REQUIRE(sender_pay != NULL);
+    char* sender_encoded = kth_wallet_payment_address_encoded_legacy(sender_pay);
+    REQUIRE(sender_encoded != NULL);
+
+    // The receiver's derive_address requires the ephemeral *public*
+    // point; compute it from the ephemeral private via the EC helper.
+    kth_ec_compressed_t ephemeral_public = {{ 0 }};
+    REQUIRE(kth_wallet_secret_to_public(&ephemeral_public,
+                                        *(kth_ec_secret_t const*)&kEphemeralPrivate) != 0);
+
+    // Pre-construct an empty payment_address the derive_address
+    // function will mutate in place (opaque out-param by ref).
+    kth_payment_address_mut_t derived = kth_wallet_payment_address_construct_default();
+    REQUIRE(derived != NULL);
+
+    REQUIRE(kth_wallet_stealth_receiver_derive_address(
+        r, derived, &ephemeral_public) != 0);
+
+    char* derived_encoded = kth_wallet_payment_address_encoded_legacy(derived);
+    REQUIRE(derived_encoded != NULL);
+
+    REQUIRE(strcmp(sender_encoded, derived_encoded) == 0);
+
+    kth_core_destruct_string(derived_encoded);
+    kth_core_destruct_string(sender_encoded);
+    kth_wallet_payment_address_destruct(derived);
+    kth_wallet_stealth_sender_destruct(s);
+    kth_wallet_stealth_receiver_destruct(r);
+    kth_core_binary_destruct(filter);
+}


### PR DESCRIPTION
## Summary
Follow-up to #308 (`stealth_address`). That PR exposed the anchor address type; this one wires up the two dual classes that drive the BIP63 payment flow end-to-end.

### Exposed
- **`stealth_receiver`** (recipient side) — holds scan + spend secrets, owns the `stealth_address` it advertises, and derives a payment_address + spend-private for each ephemeral_public the sender publishes.
- **`stealth_sender`** (payer side) — given the receiver's stealth_address + filter, emits a `stealth_script` (the OP_RETURN-prefixed companion output) and the `payment_address` to fund.

All generator-driven: 2 opaque handles, construct / destruct / copy / valid lifecycle, 4 accessors (`stealth_address`, `stealth_script`, `payment_address`) + receiver-side `derive_address` / `derive_private`.

The `payment_address&` opaque out-param on `derive_address` is emitted as a caller-provided `kth_payment_address_mut_t` that the function mutates in place via `cpp_ref` — same pattern the generator already uses for non-const lvalue value-struct refs.

## Test plan
- [ ] `kth_capi_test "[C-API WalletStealthReceiver],[C-API WalletStealthSender]"` — 18 cases, 63 assertions.
  - Receiver: lifecycle, stealth_address accessor, copy, 5 NULL-precondition aborts.
  - Sender: lifecycle, script + payment_address accessors, copy, 3 NULL-precondition aborts.
  - **End-to-end round-trip**: `sender.payment_address()` and `receiver.derive_address(ephemeral_public)` encode to the same legacy base58-check string (the core BIP63 contract).
- [ ] Full suite still green (2645 assertions, 740 cases locally).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new C-API surface for BIP63 stealth payment derivation and key handling; while mostly thin wrappers, mistakes could break address derivation or leak/mishandle secret material.
> 
> **Overview**
> Adds new C-API modules for BIP63 stealth payments by exposing opaque handles for `stealth_receiver` and `stealth_sender`, including constructors (safe + `_unsafe` variants), `copy`/`destruct`, `valid`, and accessors for the receiver’s `stealth_address` and the sender’s `stealth_script`/`payment_address`.
> 
> Implements receiver-side derivation operations (`derive_address` and `derive_private`) and wires the new headers/sources into the build (`CMakeLists.txt`), umbrella include (`capi.h`), and handle typedefs (`handles.h`).
> 
> Adds Catch2 tests covering lifecycle/preconditions plus an end-to-end round-trip asserting `sender.payment_address()` matches `receiver.derive_address()` for the same ephemeral key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 617804ff4ed6c4f917a85890df39a3695e6768e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->