### PR TITLE
ci(coverage): replace gcovr --jobs with -j (8.x compat)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -95,7 +95,14 @@ jobs:
         if: always()
         timeout-minutes: 20
         run: |
-          python3 -m pip install gcovr
+          # Pin to the 8.x major. Letting `pip install gcovr` resolve
+          # to whatever PyPI ships HEAD'd this very fix when 8.6
+          # tightened the option grammar (`--jobs` removed) and broke
+          # every coverage run silently. The upper bound catches the
+          # next major early — a future 9.x option-grammar change
+          # surfaces at dependency-bump review time, not in a red CI
+          # run on an unrelated PR.
+          python3 -m pip install 'gcovr>=8.6,<9'
           mkdir -p coverage-report
           # gcovr accepts search paths as positional args (not a
           # flag); listing the in-tree build dir + the dirs we filter
@@ -103,12 +110,18 @@ jobs:
           # sandbox (including conan caches), which balloons both
           # memory and wall time. `-j` parallelises the scan so large
           # projects stay within the step's 20-min budget.
+          #
+          # gcovr 8.x dropped the `--jobs` long form; only the `-j`
+          # short form survives ("Set the number of threads to use
+          # in parallel" in the 8.6 --help). PR #309 originally used
+          # `--jobs $(nproc)` and started failing once the runner
+          # picked up gcovr 8.6 from PyPI.
           gcovr --root . \
             --filter 'src/domain/' \
             --filter 'src/infrastructure/' \
             --filter 'src/blockchain/' \
             --exclude '.*test.*' \
-            --jobs $(nproc) \
+            -j $(nproc) \
             --xml coverage.xml \
             --html-details coverage-report/index.html \
             --print-summary \


### PR DESCRIPTION
## Summary
gcovr 8.x removed the `--jobs` long form; only the `-j` short form remains in the 8.6 release on PyPI. Every coverage run since the runner picked up the new version started failing the `📊 Generate coverage report` step with:

```
gcovr: error: unrecognized arguments: --jobs <NPROC> ...
```

PR #309 introduced the parallelism flag using the long form; this PR switches to the short form to keep the same semantics across the gcovr version range we encounter on GH-hosted runners.

## Test plan
- [ ] Coverage workflow run on this PR completes the `📊 Generate coverage report` step successfully and uploads to Codecov.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that tweaks dependency versioning and a command-line flag; low blast radius outside the coverage workflow.
> 
> **Overview**
> Updates the coverage workflow to **stabilize `gcovr` behavior on GitHub runners** by pinning the dependency to `gcovr>=8.6,<9` instead of installing latest.
> 
> Adjusts the coverage generation command to replace the removed `--jobs` option with `-j $(nproc)` (and documents the rationale), preventing coverage runs from failing on `gcovr` 8.6+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa003466dd7a413d0dced883c9b27d33079197a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure configuration for compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->