### PR TITLE
ci: bump actions/cache to v5 + fix coverage cache hit rate + split restore/save

### DIFF
--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -85,12 +85,18 @@ jobs:
         with:
           submodules: true
 
-      - name: 💾 Cache Conan packages
-        uses: actions/cache@v4
+      # Split restore/save so a flaky GH Cache Service can't fail
+      # the whole job during the post-action. See `coverage.yml`
+      # for the longer rationale; the short version is that the
+      # save POSTs to the cache service have been timing out at
+      # 18+ min and marking otherwise-green jobs as `failure`.
+      - name: 💾 Restore Conan packages
+        id: restore-conan
+        uses: actions/cache/restore@v5
         with:
           path: ~/.conan/data
           key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
-      # - uses: actions/cache@v4
+      # - uses: actions/cache@v5
       #   with:
       #     path: ~/.cache/pip
       #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -128,8 +134,9 @@ jobs:
           ccache --version || true
 
       - name: 🗄️ Restore ccache
+        id: restore-ccache
         if: ${{ inputs.upload != true }}
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v5
         with:
           path: /github/home/.cache/ccache
           key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ github.sha }}
@@ -208,6 +215,38 @@ jobs:
               ccache --show-stats
             fi
           fi
+
+      # Persist caches as soon as the build finishes — saves get the
+      # most benefit on every run (even ones where tests fail later).
+      # `continue-on-error` keeps a flaky GH Cache Service save from
+      # failing the whole job; the failure becomes a non-fatal
+      # warning rather than the 18+ min hangs we've been seeing on
+      # the post-action.
+      # `key` reuses the restore step's cache-primary-key output —
+      # `hashFiles('**/conan.lock')` would re-evaluate here against
+      # the post-build tree (`build/conan.lock` now exists) and
+      # produce a different hash than at restore time, causing
+      # every save to land under a fresh key the next restore can
+      # never match. The restore step is also the right ground
+      # truth for whether to save (`cache-hit != 'true'`), and the
+      # save deliberately runs for both regular and upload jobs —
+      # there's no reason to deny upload jobs the chance to
+      # repopulate a cold conan cache.
+      - name: 💾 Save Conan packages
+        if: always() && steps.restore-conan.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.conan/data
+          key: ${{ steps.restore-conan.outputs.cache-primary-key }}
+
+      - name: 🗄️ Save ccache
+        if: always() && inputs.upload != true && steps.restore-ccache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: /github/home/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ github.sha }}
 
       - name: 📊 Build summary
         if: always()

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -81,11 +81,11 @@ jobs:
           submodules: true
 
       - name: 💾 Cache Conan packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.conan/data
           key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
-      # - uses: actions/cache@v4
+      # - uses: actions/cache@v5
       #   with:
       #     path: ~/.cache/pip
       #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: 🗄️ Restore ccache
         if: ${{ inputs.upload != true }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Caches/ccache
           key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ github.sha }}

--- a/.github/workflows/calc-deps-with-container.yml
+++ b/.github/workflows/calc-deps-with-container.yml
@@ -41,7 +41,7 @@ jobs:
           submodules: true
 
       - name: 💾 Cache Conan packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.conan/data
           key: alpine-${{ hashFiles('**/conan.lock') }}

--- a/.github/workflows/calc-deps-without-container.yml
+++ b/.github/workflows/calc-deps-without-container.yml
@@ -37,7 +37,7 @@ jobs:
           submodules: true
 
       - name: 💾 Cache Conan packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.conan/data
           key: alpine-${{ hashFiles('**/conan.lock') }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,12 +13,15 @@ concurrency:
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    # Ceiling for the whole job. The coverage run had been hovering at
-    # ~65–85 min with `-O0` and losing the runner intermittently during
-    # the gcovr / upload tail; the optimizations below should bring it
-    # well under 60 min, and this cap keeps a wedged job from burning
-    # the full 6-hour GHA default before surfacing as a failure.
-    timeout-minutes: 90
+    # Ceiling for the whole job. With a hot ccache, the run finishes
+    # in ~25–30 min (build ~10–15 min on 86 %+ hits, tests ~7 min,
+    # report + upload ~5 min). A genuinely cold run — fresh cache
+    # version bump, key prefix change, or the first run after a
+    # compiler upgrade in the container image — pushes the build
+    # alone to ~80 min, so the cap has to clear that. 130 leaves
+    # margin without letting a wedged job burn the full 6-hour
+    # GHA default.
+    timeout-minutes: 130
     container:
       image: kthnode/gcc15-ubuntu24.04
 
@@ -38,18 +41,31 @@ jobs:
         run: |
           apt-get update -qq && apt-get install -y -qq ccache > /dev/null 2>&1 || true
           ccache --version || true
-          # Relativise absolute paths in the cache key so moving the
-          # workspace around (different branches, re-checkouts) doesn't
-          # evict entries that are otherwise byte-identical. The `.gcno`
-          # files emitted by `--coverage` also embed the cwd; pairing
-          # `CCACHE_BASEDIR` with `CCACHE_NOHASHDIR` keeps them out of
-          # the hash too. Written to the GHA env so subsequent steps
-          # (the actual build) inherit it.
-          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
-          echo "CCACHE_NOHASHDIR=1" >> "$GITHUB_ENV"
+          # Match the sister `build-with-container.yml` workflow's
+          # ccache config, which on the same hosted runner hits 86 %
+          # against the same 1074 TUs. PR #309 added
+          # `CCACHE_BASEDIR=$GITHUB_WORKSPACE` + `CCACHE_NOHASHDIR=1`
+          # here on the theory that coverage's `.gcno` files embed
+          # the cwd and the relativisation would help. In practice
+          # the inverse held: hit rate dropped to 0 / 1074 (every
+          # TU a miss, even for files that hadn't changed in
+          # months). Probable interaction with `--coverage`'s
+          # path bookkeeping in ccache 4.9.1; rather than chase
+          # that, drop the two envs and rely on absolute paths
+          # the way the other CI jobs do — Actions containers
+          # always check out at `/__w/kth/kth`, so absolute paths
+          # are stable across runs anyway.
 
+      # Split restore/save so a flaky GH Cache Service can't fail
+      # the whole job during the post-action. Recent runs have been
+      # losing the runner here for 18+ min as the save POSTs to
+      # `cache-service` time out — the build + tests had already
+      # passed, but the job ended up red. The save below carries
+      # `continue-on-error: true` so a cache-side failure becomes a
+      # non-fatal warning rather than a job failure.
       - name: 🗄️ Restore ccache
-        uses: actions/cache@v4
+        id: restore-ccache
+        uses: actions/cache/restore@v5
         with:
           path: /github/home/.cache/ccache
           key: ccache-coverage-${{ github.sha }}
@@ -66,26 +82,42 @@ jobs:
           export PATH="/usr/lib/ccache:$PATH"
           ccache --zero-stats
 
-          # Coverage flags intentionally do NOT force `-O0`. The
-          # Release preset applies `-O3`, which combined with `--coverage`
-          # still yields usable line/branch metrics and cuts test
-          # runtime by ~5× versus the unoptimised instrumentation.
-          # Compile-time grows slightly but the net end-to-end win
-          # comes from the test phase — which on this repo runs the
-          # full suite per job.
+          # Force -O0 on the coverage build. PR #309 dropped this
+          # to "cut test runtime by ~5×", but with -O3 + --coverage
+          # gcc 15 emits much larger .gcno/.gcda files (every inlined
+          # copy gets its own block bookkeeping), and gcovr 8.6 then
+          # hangs for 45+ min on report generation until the GHA
+          # runner kills the step. The last green coverage run on
+          # master (24851108475, 2026-04-23) was on -O0 with gcovr
+          # finishing in ~4 min. Slower tests are the right trade —
+          # this job's purpose is the report, not benchmarking.
           cmake --preset conan-release \
             -DCMAKE_VERBOSE_MAKEFILE=OFF \
             -DGLOBAL_BUILD=ON \
             -DENABLE_TEST=ON \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_FLAGS="--coverage" \
-            -DCMAKE_CXX_FLAGS="--coverage" \
+            -DCMAKE_C_FLAGS="-O0 --coverage" \
+            -DCMAKE_CXX_FLAGS="-O0 --coverage" \
             -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
           cmake --build --preset conan-release -j$(nproc)
           ccache --show-stats
+
+      # Persist ccache as soon as the build finishes — the compile
+      # output is what populates it, so saving here gets the most
+      # benefit on every run (even ones where tests / report fail
+      # later). `continue-on-error` keeps a flaky GH Cache Service
+      # save from failing the whole job; the failure becomes a
+      # non-fatal warning.
+      - name: 🗄️ Save ccache
+        if: always() && steps.restore-ccache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: /github/home/.cache/ccache
+          key: ccache-coverage-${{ github.sha }}
 
       - name: 🧪 Run tests
         run: |
@@ -104,28 +136,29 @@ jobs:
           # run on an unrelated PR.
           python3 -m pip install 'gcovr>=8.6,<9'
           mkdir -p coverage-report
-          # gcovr accepts search paths as positional args (not a
-          # flag); listing the in-tree build dir + the dirs we filter
-          # on keeps the .gcda/.gcno crawl from walking the whole
-          # sandbox (including conan caches), which balloons both
-          # memory and wall time. `-j` parallelises the scan so large
-          # projects stay within the step's 20-min budget.
-          #
-          # gcovr 8.x dropped the `--jobs` long form; only the `-j`
-          # short form survives ("Set the number of threads to use
-          # in parallel" in the 8.6 --help). PR #309 originally used
-          # `--jobs $(nproc)` and started failing once the runner
-          # picked up gcovr 8.6 from PyPI.
+          # The gcovr invocation here is intentionally minimal —
+          # this is the form that was last green on master
+          # (run 24851108475, 2026-04-23, gcovr step ~4 min).
+          # PR #309 added `--jobs $(nproc)` + narrowed search paths
+          # to "stay within the 20-min budget", but `--jobs` was
+          # silently ignored by gcovr 8.6 (the long form was removed
+          # in 8.x), so coverage kept running serial and was still
+          # green. PR #316 then "fixed" it to `-j $(nproc)`, which
+          # actually engaged parallelism — and gcovr 8.6 with `-j`
+          # on this project's TU count hangs for 15+ min producing
+          # no output until the GHA runner cancels the step. The
+          # narrowed search paths likewise interacted poorly. Going
+          # back to the working form fixes the symptom; if we ever
+          # need to shave runtime later, profile gcovr first instead
+          # of reaching for `-j`.
           gcovr --root . \
             --filter 'src/domain/' \
             --filter 'src/infrastructure/' \
             --filter 'src/blockchain/' \
             --exclude '.*test.*' \
-            -j $(nproc) \
             --xml coverage.xml \
             --html-details coverage-report/index.html \
-            --print-summary \
-            build/ src/domain/ src/infrastructure/ src/blockchain/
+            --print-summary
 
       - name: ☁️ Upload to Codecov
         if: always()

--- a/ci_utils/.github/workflows/build-with-container.yml
+++ b/ci_utils/.github/workflows/build-with-container.yml
@@ -66,11 +66,11 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.conan/data
           key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
-      # - uses: actions/cache@v4
+      # - uses: actions/cache@v5
       #   with:
       #     path: ~/.cache/pip
       #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/ci_utils/.github/workflows/build-without-container.yml
+++ b/ci_utils/.github/workflows/build-without-container.yml
@@ -61,11 +61,11 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.conan/data
           key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
-      # - uses: actions/cache@v4
+      # - uses: actions/cache@v5
       #   with:
       #     path: ~/.cache/pip
       #     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/ci_utils/.github/workflows/calc-deps-with-container.yml
+++ b/ci_utils/.github/workflows/calc-deps-with-container.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.conan/data
           key: alpine-${{ hashFiles('**/conan.lock') }}

--- a/ci_utils/.github/workflows/calc-deps-without-container.yml
+++ b/ci_utils/.github/workflows/calc-deps-without-container.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.conan/data
           key: alpine-${{ hashFiles('**/conan.lock') }}


### PR DESCRIPTION
Three CI reliability fixes bundled. Both the coverage and sanitizers jobs have been red on recent PRs; this PR addresses every distinct root cause.

## 1. Bump `actions/cache@v4` → `@v5` (probable root cause of post-action hangs)
v5.0.2 release notes (Jan 2026):

> When creating cache entries, 429s returned from the cache service will not be retried.

That fits the symptom precisely: post-action hangs at exactly 18+ minutes on every recent PR (#313, #314, #315, #317), then the runner timeout kills the job and marks it `failure`. v4 retries 429s aggressively; v5.0.2+ fails fast. Runner version 2.334.0 (current GH-hosted) supports the v5 minimum (2.327.1).

Touches all 9 workflow files that pull `actions/cache@v4`.

## 2. Coverage ccache: 0% → 86% hit rate (independent issue)
`ccache --show-stats` of two jobs running the same 1074 TUs against the same container on the same SHA:

| Workflow | Config | Hits |
|---|---|---|
| `build-with-container.yml` (Sanitizers) | default ccache env | **925 / 1074 (86 %)** |
| `coverage.yml` | `CCACHE_BASEDIR=\$GITHUB_WORKSPACE` + `CCACHE_NOHASHDIR=1` | **0 / 1074 (0 %)** |

Likely an interaction with `--coverage`'s path bookkeeping in ccache 4.9.1. Drop the two envs and align with the sister workflow. GH-Actions containers always check out at `/__w/kth/kth`, so absolute paths are stable across runs anyway.

**Expected impact:** build step ~78 min cold → ~10–15 min hot. End-to-end coverage run ~85 min → ~25–30 min.

## 3. Split `actions/cache` into restore + save with `continue-on-error` (defense in depth)
Even with the v5 bump, the cache service can have other failure modes. Splitting `actions/cache@v5` into `actions/cache/restore@v5` + `actions/cache/save@v5` with `continue-on-error: true` on the save means a future cache-side issue surfaces as a warning rather than a job failure.

The save step also runs immediately after the build (not at job end), so we still get cache benefit on the next run if the test or report steps fail.

## Test plan
- [ ] Coverage and Sanitizers jobs both succeed on this PR.
- [ ] On the SECOND run after merge, coverage build hits >80% ccache (cold→hot transition).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI caching semantics and coverage build/report flags, which may impact cache effectiveness, job duration, and workflow stability until validated across runners.
> 
> **Overview**
> **Improves CI reliability and cache behavior across build, deps, and coverage workflows.** Updates `actions/cache` usage to `@v5` everywhere, and in containerized builds/coverage splits caching into explicit `restore` + early `save` steps with `continue-on-error` to prevent cache-service timeouts from failing otherwise-green jobs.
> 
> **Coverage workflow tweaks to reduce hangs and improve cache hits.** In `coverage.yml`, removes the `CCACHE_BASEDIR`/`CCACHE_NOHASHDIR` config, saves ccache immediately after the build, increases the job timeout, forces `-O0 --coverage` for compilation, and simplifies the `gcovr` invocation by dropping parallelism/search-path narrowing that was triggering report-generation stalls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecddd7537baef9571602461bd2b0ee8c9fe833a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows: increased job timeout and refactored caching to separate restore/save steps with non-fatal saves for greater reliability and faster builds.
  * Coverage reporting: narrowed report inputs, removed bulky HTML artifact, and continue uploading only the machine-readable coverage XML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->