### PR TITLE
refactor(domain/chain): transaction is a structural aggregate (no is_valid, immutable)

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -412,7 +412,7 @@ struct KB_API block_chain {
             auto const tx_result = database_.internal_db().get_transaction(hash, max_size_t);
 
             if ( ! tx_result) {
-                handler(error::transaction_lookup_failed, 0, domain::chain::transaction{});
+                handler(error::transaction_lookup_failed, 0, domain::chain::transaction::null());
                 return;
             }
             KTH_ASSERT(tx_result->height() == height);
@@ -426,7 +426,7 @@ struct KB_API block_chain {
         while (f != l) {
             auto const& tx = *f;
             if ( ! tx.is_valid()) {
-                handler(error::transaction_lookup_failed, 0, domain::chain::transaction{});
+                handler(error::transaction_lookup_failed, 0, domain::chain::transaction::null());
                 return;
             }
             handler(error::success, height, tx);

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1640,8 +1640,11 @@ void block_chain::fill_tx_list_from_mempool(domain::message::compact_block const
                 have_txn[idit->second] = true;
                 ++mempool_count;
             } else {
-                if (txn_available[idit->second].is_valid()) {
-                    txn_available[idit->second] = domain::chain::transaction{};
+                // A second transaction maps to the same short id, so the slot
+                // is ambiguous and gets cleared. A cleared slot holds the null
+                // transaction, so clear (and decrement) only once.
+                if ( ! txn_available[idit->second].is_null()) {
+                    txn_available[idit->second] = domain::chain::transaction::null();
                     --mempool_count;
                 }
             }

--- a/src/c-api/include/kth/capi/chain/transaction.h
+++ b/src/c-api/include/kth/capi/chain/transaction.h
@@ -33,6 +33,10 @@ kth_error_code_t kth_chain_transaction_construct_from_data(uint8_t const* data, 
 KTH_EXPORT KTH_OWNED
 kth_transaction_mut_t kth_chain_transaction_construct(uint32_t version, uint32_t locktime, kth_input_list_const_t inputs, kth_output_list_const_t outputs);
 
+/** @return Owned `kth_transaction_mut_t`. Caller must release with `kth_chain_transaction_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_transaction_mut_t kth_chain_transaction_null(void);
+
 
 // Destructor
 
@@ -52,6 +56,9 @@ kth_transaction_mut_t kth_chain_transaction_copy(kth_transaction_const_t self);
 
 KTH_EXPORT
 kth_bool_t kth_chain_transaction_equals(kth_transaction_const_t self, kth_transaction_const_t other);
+
+KTH_EXPORT
+kth_bool_t kth_chain_transaction_not_equal(kth_transaction_const_t self, kth_transaction_const_t other);
 
 
 // Serialization
@@ -123,27 +130,7 @@ KTH_EXPORT
 kth_error_code_t kth_chain_transaction_connect_simple(kth_transaction_const_t self);
 
 
-// Setters
-
-KTH_EXPORT
-void kth_chain_transaction_set_version(kth_transaction_mut_t self, uint32_t value);
-
-KTH_EXPORT
-void kth_chain_transaction_set_locktime(kth_transaction_mut_t self, uint32_t value);
-
-/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_transaction_set_inputs(kth_transaction_mut_t self, kth_input_list_const_t value);
-
-/** @param value Borrowed input. Copied by value into the resulting object; ownership of `value` stays with the caller. */
-KTH_EXPORT
-void kth_chain_transaction_set_outputs(kth_transaction_mut_t self, kth_output_list_const_t value);
-
-
 // Predicates
-
-KTH_EXPORT
-kth_bool_t kth_chain_transaction_is_valid(kth_transaction_const_t self);
 
 KTH_EXPORT
 kth_bool_t kth_chain_transaction_is_coinbase(kth_transaction_const_t self);
@@ -187,6 +174,9 @@ kth_bool_t kth_chain_transaction_is_standard_simple(kth_transaction_const_t self
 KTH_EXPORT
 kth_bool_t kth_chain_transaction_is_standard(kth_transaction_const_t self, kth_script_flags_t flags);
 
+KTH_EXPORT
+kth_bool_t kth_chain_transaction_is_null(kth_transaction_const_t self);
+
 
 // Operations
 
@@ -207,9 +197,6 @@ kth_error_code_t kth_chain_transaction_connect(kth_transaction_const_t self, kth
 
 KTH_EXPORT
 kth_error_code_t kth_chain_transaction_connect_input(kth_transaction_const_t self, kth_chain_state_const_t state, kth_size_t input_index);
-
-KTH_EXPORT
-void kth_chain_transaction_reset(kth_transaction_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/src/chain/transaction.cpp
+++ b/src/c-api/src/chain/transaction.cpp
@@ -46,6 +46,10 @@ kth_transaction_mut_t kth_chain_transaction_construct(uint32_t version, uint32_t
     return kth::leak<cpp_t>(version, locktime, inputs_cpp, outputs_cpp);
 }
 
+kth_transaction_mut_t kth_chain_transaction_null(void) {
+    return kth::leak(cpp_t::null());
+}
+
 
 // Destructor
 
@@ -68,6 +72,12 @@ kth_bool_t kth_chain_transaction_equals(kth_transaction_const_t self, kth_transa
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(other != nullptr);
     return kth::eq<cpp_t>(self, other);
+}
+
+kth_bool_t kth_chain_transaction_not_equal(kth_transaction_const_t self, kth_transaction_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
 }
 
 
@@ -175,39 +185,7 @@ kth_error_code_t kth_chain_transaction_connect_simple(kth_transaction_const_t se
 }
 
 
-// Setters
-
-void kth_chain_transaction_set_version(kth_transaction_mut_t self, uint32_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).set_version(value);
-}
-
-void kth_chain_transaction_set_locktime(kth_transaction_mut_t self, uint32_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).set_locktime(value);
-}
-
-void kth_chain_transaction_set_inputs(kth_transaction_mut_t self, kth_input_list_const_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const& value_cpp = kth::cpp_ref<kth::domain::chain::input::list>(value);
-    kth::cpp_ref<cpp_t>(self).set_inputs(value_cpp);
-}
-
-void kth_chain_transaction_set_outputs(kth_transaction_mut_t self, kth_output_list_const_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(value != nullptr);
-    auto const& value_cpp = kth::cpp_ref<kth::domain::chain::output::list>(value);
-    kth::cpp_ref<cpp_t>(self).set_outputs(value_cpp);
-}
-
-
 // Predicates
-
-kth_bool_t kth_chain_transaction_is_valid(kth_transaction_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
 
 kth_bool_t kth_chain_transaction_is_coinbase(kth_transaction_const_t self) {
     KTH_PRECONDITION(self != nullptr);
@@ -283,6 +261,11 @@ kth_bool_t kth_chain_transaction_is_standard(kth_transaction_const_t self, kth_s
     return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_standard(flags));
 }
 
+kth_bool_t kth_chain_transaction_is_null(kth_transaction_const_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_null());
+}
+
 
 // Operations
 
@@ -328,11 +311,6 @@ kth_error_code_t kth_chain_transaction_connect_input(kth_transaction_const_t sel
     auto const& state_cpp = kth::cpp_ref<kth::domain::chain::chain_state>(state);
     auto const input_index_cpp = kth::sz(input_index);
     return kth::to_c_err(kth::cpp_ref<cpp_t>(self).connect_input(state_cpp, input_index_cpp));
-}
-
-void kth_chain_transaction_reset(kth_transaction_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/transaction.cpp
+++ b/src/c-api/test/chain/transaction.cpp
@@ -109,17 +109,9 @@ static kth_transaction_mut_t make_tx(void) {
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Transaction - default construct is invalid",
-          "[C-API Transaction]") {
-    kth_transaction_mut_t tx = kth_chain_transaction_construct_default();
-    REQUIRE(kth_chain_transaction_is_valid(tx) == 0);
-    kth_chain_transaction_destruct(tx);
-}
-
 TEST_CASE("C-API Transaction - field constructor preserves version & locktime",
           "[C-API Transaction]") {
     kth_transaction_mut_t tx = make_tx();
-    REQUIRE(kth_chain_transaction_is_valid(tx) != 0);
     REQUIRE(kth_chain_transaction_version(tx) == kVersion);
     REQUIRE(kth_chain_transaction_locktime(tx) == kLocktime);
     kth_chain_transaction_destruct(tx);
@@ -158,7 +150,6 @@ TEST_CASE("C-API Transaction - to_data / from_data roundtrip",
     kth_error_code_t ec = kth_chain_transaction_construct_from_data(raw, size, 1, &parsed);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(parsed != NULL);
-    REQUIRE(kth_chain_transaction_is_valid(parsed) != 0);
     REQUIRE(kth_chain_transaction_version(parsed) == kVersion);
     REQUIRE(kth_chain_transaction_locktime(parsed) == kLocktime);
     REQUIRE(kth_chain_transaction_equals(expected, parsed) != 0);
@@ -172,30 +163,36 @@ TEST_CASE("C-API Transaction - to_data / from_data roundtrip",
 // Getters / setters
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Transaction - version setter roundtrip",
+TEST_CASE("C-API Transaction - constructor sets version",
           "[C-API Transaction]") {
-    kth_transaction_mut_t tx = kth_chain_transaction_construct_default();
-    REQUIRE(kth_chain_transaction_version(tx) != kVersion);
-    kth_chain_transaction_set_version(tx, kVersion);
+    kth_input_list_mut_t ins = kth_chain_input_list_construct_default();
+    kth_output_list_mut_t outs = kth_chain_output_list_construct_default();
+    kth_transaction_mut_t tx = kth_chain_transaction_construct(kVersion, 0u, ins, outs);
     REQUIRE(kth_chain_transaction_version(tx) == kVersion);
     kth_chain_transaction_destruct(tx);
+    kth_chain_input_list_destruct(ins);
+    kth_chain_output_list_destruct(outs);
 }
 
-TEST_CASE("C-API Transaction - locktime setter roundtrip",
+TEST_CASE("C-API Transaction - constructor sets locktime",
           "[C-API Transaction]") {
-    kth_transaction_mut_t tx = kth_chain_transaction_construct_default();
-    kth_chain_transaction_set_locktime(tx, 12345u);
+    kth_input_list_mut_t ins = kth_chain_input_list_construct_default();
+    kth_output_list_mut_t outs = kth_chain_output_list_construct_default();
+    kth_transaction_mut_t tx = kth_chain_transaction_construct(0u, 12345u, ins, outs);
     REQUIRE(kth_chain_transaction_locktime(tx) == 12345u);
     kth_chain_transaction_destruct(tx);
+    kth_chain_input_list_destruct(ins);
+    kth_chain_output_list_destruct(outs);
 }
 
-TEST_CASE("C-API Transaction - inputs setter roundtrip",
+TEST_CASE("C-API Transaction - constructor deep-copies inputs",
           "[C-API Transaction]") {
-    kth_transaction_mut_t tx = kth_chain_transaction_construct_default();
     kth_input_list_mut_t ins = make_inputs();
-    kth_chain_transaction_set_inputs(tx, ins);
-    // Destroy the source list first to prove the setter deep-copied.
-    // An aliasing setter would leave a dangling view after this point.
+    kth_output_list_mut_t empty_outs = kth_chain_output_list_construct_default();
+    kth_transaction_mut_t tx = kth_chain_transaction_construct(0u, 0u, ins, empty_outs);
+    kth_chain_output_list_destruct(empty_outs);
+    // Destroy the source list first to prove the constructor deep-copied.
+    // An aliasing constructor would leave a dangling view after this point.
     kth_chain_input_list_destruct(ins);
     kth_input_list_const_t view = kth_chain_transaction_inputs(tx);
     REQUIRE(view != NULL);
@@ -203,11 +200,12 @@ TEST_CASE("C-API Transaction - inputs setter roundtrip",
     kth_chain_transaction_destruct(tx);
 }
 
-TEST_CASE("C-API Transaction - outputs setter roundtrip",
+TEST_CASE("C-API Transaction - constructor deep-copies outputs",
           "[C-API Transaction]") {
-    kth_transaction_mut_t tx = kth_chain_transaction_construct_default();
     kth_output_list_mut_t outs = make_outputs();
-    kth_chain_transaction_set_outputs(tx, outs);
+    kth_input_list_mut_t empty_ins = kth_chain_input_list_construct_default();
+    kth_transaction_mut_t tx = kth_chain_transaction_construct(0u, 0u, empty_ins, outs);
+    kth_chain_input_list_destruct(empty_ins);
     kth_chain_output_list_destruct(outs);
     kth_output_list_const_t view = kth_chain_transaction_outputs(tx);
     REQUIRE(view != NULL);
@@ -255,7 +253,6 @@ TEST_CASE("C-API Transaction - copy preserves fields",
     kth_transaction_mut_t original = make_tx();
     kth_transaction_mut_t copy = kth_chain_transaction_copy(original);
 
-    REQUIRE(kth_chain_transaction_is_valid(copy) != 0);
     REQUIRE(kth_chain_transaction_equals(original, copy) != 0);
     REQUIRE(kth_chain_transaction_version(copy) == kVersion);
     REQUIRE(kth_chain_transaction_locktime(copy) == kLocktime);
@@ -272,12 +269,16 @@ TEST_CASE("C-API Transaction - equals identical txs is true, different is false"
 
     // `mutated` differs from `a` only in the locktime — this would catch
     // an `equals()` impl that ignores fields.
-    kth_transaction_mut_t mutated = make_tx();
-    kth_chain_transaction_set_locktime(mutated, kLocktime + 1u);
+    kth_input_list_mut_t mut_ins = make_inputs();
+    kth_output_list_mut_t mut_outs = make_outputs();
+    kth_transaction_mut_t mutated = kth_chain_transaction_construct(
+        kVersion, kLocktime + 1u, mut_ins, mut_outs);
+    kth_chain_input_list_destruct(mut_ins);
+    kth_chain_output_list_destruct(mut_outs);
     // No recompute_hash needed — the new transaction value type has no
     // internal hash cache; `hash()` always reflects the current fields.
 
-    // `c` is a default (invalid) tx, structurally distinct from `a`.
+    // `c` is a default tx, structurally distinct from `a`.
     kth_transaction_mut_t c = kth_chain_transaction_construct_default();
 
     REQUIRE(kth_chain_transaction_equals(a, b) != 0);

--- a/src/database/src/databases/transaction_entry.cpp
+++ b/src/database/src/databases/transaction_entry.cpp
@@ -42,7 +42,7 @@ uint32_t transaction_entry::position() const {
 
 // private
 void transaction_entry::reset() {
-    transaction_ = domain::chain::transaction{};
+    transaction_ = domain::chain::transaction::null();
     height_ = max_uint32;
     median_time_past_ = max_uint32;
     position_ = position_max;
@@ -50,7 +50,9 @@ void transaction_entry::reset() {
 
 // Empty scripts are valid, validation relies on not_found only.
 bool transaction_entry::is_valid() const {
-    return transaction_.is_valid() && height_ != kth::max_uint32 && median_time_past_ != max_uint32 && position_ != position_max;
+    // A transaction is always syntactically valid, so only this entry's own
+    // sentinels are left to check.
+    return height_ != kth::max_uint32 && median_time_past_ != max_uint32 && position_ != position_max;
 }
 
 // Size.

--- a/src/database/src/databases/transaction_unconfirmed_entry.cpp
+++ b/src/database/src/databases/transaction_unconfirmed_entry.cpp
@@ -29,14 +29,16 @@ uint32_t transaction_unconfirmed_entry::height() const {
 
 // private
 void transaction_unconfirmed_entry::reset() {
-    transaction_ = domain::chain::transaction{};
+    transaction_ = domain::chain::transaction::null();
     arrival_time_ = max_uint32;
     height_ = max_uint32;
 }
 
 // Empty scripts are valid, validation relies on not_found only.
 bool transaction_unconfirmed_entry::is_valid() const {
-    return transaction_.is_valid() && arrival_time_ != kth::max_uint32  && height_ != kth::max_uint32;
+    // A transaction is always syntactically valid, so only this entry's own
+    // sentinels are left to check.
+    return arrival_time_ != kth::max_uint32 && height_ != kth::max_uint32;
 }
 
 // Size.

--- a/src/domain/include/kth/domain/chain/transaction.hpp
+++ b/src/domain/include/kth/domain/chain/transaction.hpp
@@ -102,9 +102,23 @@ struct KD_API transaction {
     // Constructors.
     //-----------------------------------------------------------------------------
 
+    // A transaction is a pure structural aggregate and does no consensus
+    // checks, so construction cannot fail and every state is syntactically
+    // valid — including the all-default one and the partial transactions the
+    // sighash algorithm builds (empty inputs or outputs). Consensus validity
+    // (`empty_transaction`, etc.) is validation's concern.
     transaction() = default;
-    transaction(uint32_t version, uint32_t locktime, ins const& inputs, outs const& outputs);
-    transaction(uint32_t version, uint32_t locktime, ins&& inputs, outs&& outputs);
+    transaction(uint32_t version, uint32_t locktime, ins inputs, outs outputs);
+
+    /// Returns the null transaction: the all-default value, used as an "empty
+    /// slot" marker (e.g. compact block reconstruction). It is a perfectly
+    /// valid transaction value — "null" here is structural, not a validity
+    /// claim.
+    [[nodiscard]]
+    static transaction null();
+
+    [[nodiscard]]
+    bool is_null() const;
 
     // Operators.
     //-----------------------------------------------------------------------------
@@ -133,29 +147,15 @@ struct KD_API transaction {
 
     [[nodiscard]]
     uint32_t version() const;
-    void set_version(uint32_t value);
 
     [[nodiscard]]
     uint32_t locktime() const;
-    void set_locktime(uint32_t value);
-
-    // [[deprecated]] // unsafe
-    ins& inputs();
 
     [[nodiscard]]
     ins const& inputs() const;
 
-    void set_inputs(ins const& value);
-    void set_inputs(ins&& value);
-
-    // [[deprecated]] // unsafe
-    outs& outputs();
-
     [[nodiscard]]
     outs const& outputs() const;
-
-    void set_outputs(outs const& value);
-    void set_outputs(outs&& value);
 
     // Hashes — recomputed on every call (no cache).
     //-----------------------------------------------------------------------------
@@ -177,9 +177,6 @@ struct KD_API transaction {
 
     // Validation.
     //-----------------------------------------------------------------------------
-
-    [[nodiscard]]
-    bool is_valid() const;
 
     [[nodiscard]]
     uint64_t fees() const;
@@ -282,8 +279,6 @@ struct KD_API transaction {
     /// passed flags only on the scriptPubKey side.
     [[nodiscard]]
     bool is_standard(script_flags_t flags) const;
-
-    void reset();
 
     // THIS IS FOR LIBRARY USE ONLY, DO NOT CREATE A DEPENDENCY ON IT.
     mutable validation_t validation{};

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -355,8 +355,7 @@ std::pair<hash_digest, size_t> sign_all(transaction const& tx, uint32_t input_in
         ins[input_index].set_script(script_code);
     }
 
-    transaction out(tx.version(), tx.locktime(), input::list{}, tx.outputs());
-    out.set_inputs(std::move(ins));
+    transaction const out(tx.version(), tx.locktime(), std::move(ins), tx.outputs());
     return signature_hash(out, sighash_type);
 }
 

--- a/src/domain/src/chain/transaction.cpp
+++ b/src/domain/src/chain/transaction.cpp
@@ -47,19 +47,24 @@ namespace kth::domain::chain {
 // Constructors.
 //-----------------------------------------------------------------------------
 
-transaction::transaction(uint32_t version, uint32_t locktime, input::list const& inputs, output::list const& outputs)
-    : version_(version)
-    , locktime_(locktime)
-    , inputs_(inputs)
-    , outputs_(outputs)
-{}
-
-transaction::transaction(uint32_t version, uint32_t locktime, input::list&& inputs, output::list&& outputs)
+transaction::transaction(uint32_t version, uint32_t locktime, input::list inputs, output::list outputs)
     : version_(version)
     , locktime_(locktime)
     , inputs_(std::move(inputs))
     , outputs_(std::move(outputs))
 {}
+
+// static
+transaction transaction::null() {
+    return transaction{};
+}
+
+bool transaction::is_null() const {
+    return version_ == 0
+        && locktime_ == 0
+        && inputs_.empty()
+        && outputs_.empty();
+}
 
 // Operators.
 //-----------------------------------------------------------------------------
@@ -69,19 +74,6 @@ bool transaction::operator==(transaction const& x) const {
         && locktime_ == x.locktime_
         && inputs_ == x.inputs_
         && outputs_ == x.outputs_;
-}
-
-void transaction::reset() {
-    version_ = 0;
-    locktime_ = 0;
-    inputs_.clear();
-    inputs_.shrink_to_fit();
-    outputs_.clear();
-    outputs_.shrink_to_fit();
-}
-
-bool transaction::is_valid() const {
-    return (version_ != 0) || (locktime_ != 0) || !inputs_.empty() || !outputs_.empty();
 }
 
 // Serialization.
@@ -184,19 +176,9 @@ size_t transaction::serialized_size(bool wire) const {
 //-----------------------------------------------------------------------------
 
 uint32_t transaction::version() const { return version_; }
-void transaction::set_version(uint32_t value) { version_ = value; }
 uint32_t transaction::locktime() const { return locktime_; }
-void transaction::set_locktime(uint32_t value) { locktime_ = value; }
-
-input::list& transaction::inputs() { return inputs_; }
 input::list const& transaction::inputs() const { return inputs_; }
-void transaction::set_inputs(input::list const& value) { inputs_ = value; }
-void transaction::set_inputs(input::list&& value) { inputs_ = std::move(value); }
-
-output::list& transaction::outputs() { return outputs_; }
 output::list const& transaction::outputs() const { return outputs_; }
-void transaction::set_outputs(output::list const& value) { outputs_ = value; }
-void transaction::set_outputs(output::list&& value) { outputs_ = std::move(value); }
 
 // Hashes — recomputed on every call (no cache).
 //-----------------------------------------------------------------------------

--- a/src/domain/src/message/prefilled_transaction.cpp
+++ b/src/domain/src/message/prefilled_transaction.cpp
@@ -28,12 +28,14 @@ prefilled_transaction::prefilled_transaction(uint64_t index, chain::transaction&
 }
 
 bool prefilled_transaction::is_valid() const {
-    return (index_ < max_index) && transaction_.is_valid();
+    // A transaction is always syntactically valid, so only the index sentinel
+    // is left to check here.
+    return index_ < max_index;
 }
 
 void prefilled_transaction::reset() {
     index_ = max_index;
-    transaction_ = chain::transaction{};
+    transaction_ = chain::transaction::null();
 }
 
 // Deserialization.

--- a/src/domain/src/message/transaction.cpp
+++ b/src/domain/src/message/transaction.cpp
@@ -35,7 +35,6 @@ transaction::transaction(uint32_t version, uint32_t locktime, const chain::input
 }
 
 transaction& transaction::operator=(chain::transaction&& x) {
-    reset();
     chain::transaction::operator=(std::move(x));
     return *this;
 }

--- a/src/domain/test/chain/block.cpp
+++ b/src/domain/test/chain/block.cpp
@@ -15,8 +15,6 @@ bool all_valid(chain::transaction::list const& transactions) {
     auto valid = true;
 
     for (auto const& tx : transactions) {
-        valid = valid && tx.is_valid();
-
         for (auto const& input : tx.inputs()) {
             valid = valid && input.script().is_valid();
         }

--- a/src/domain/test/chain/light_block.cpp
+++ b/src/domain/test/chain/light_block.cpp
@@ -113,7 +113,6 @@ TEST_CASE("light_block tx_bytes returns correct data", "[chain light_block]") {
     byte_reader tx_reader(tx0_bytes);
     auto const tx_result = chain::transaction::from_data(tx_reader, true);
     REQUIRE(tx_result.has_value());
-    REQUIRE(tx_result->is_valid());
 }
 
 TEST_CASE("light_block from_data insufficient bytes returns error", "[chain light_block]") {

--- a/src/domain/test/chain/script.cpp
+++ b/src/domain/test/chain/script.cpp
@@ -594,7 +594,6 @@ TEST_CASE("script bip16 valid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are valid prior to and after BIP16 activation.
         // Use all_rules minus bch_mersenne (pre-MINIMALDATA) since some scripts use non-minimal push encodings.
@@ -610,7 +609,6 @@ TEST_CASE("script bip16 invalid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are invalid prior to and after BIP16 activation.
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) != error::success, name);
@@ -625,7 +623,6 @@ TEST_CASE("script bip16 invalidated", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are valid prior to BIP16 activation and invalid after.
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) == error::success, name);
@@ -642,7 +639,6 @@ TEST_CASE("script bip65 valid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are valid prior to and after BIP65 activation.
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) == error::success, name);
@@ -657,7 +653,6 @@ TEST_CASE("script bip65 invalid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are invalid prior to and after BIP65 activation.
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) != error::success, name);
@@ -672,7 +667,6 @@ TEST_CASE("script bip65 invalidated", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are valid prior to BIP65 activation and invalid after.
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) == error::success, name);
@@ -688,7 +682,6 @@ TEST_CASE("script bip112 valid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are valid prior to and after BIP112 activation.
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) == error::success, name);
@@ -706,7 +699,6 @@ TEST_CASE("script bip112 invalid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are invalid prior to and after BIP112 activation.
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) != error::success, name);
@@ -721,7 +713,6 @@ TEST_CASE("script bip112 invalidated", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are valid prior to BIP112 activation and invalid after.
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) == error::success, name);
@@ -737,7 +728,6 @@ TEST_CASE("script multisig valid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are always valid.
         // These are scripts potentially affected by bip66 (but should not be).
@@ -753,7 +743,6 @@ TEST_CASE("script multisig invalid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are always invalid.
         // These are scripts potentially affected by bip66 (but should not be).
@@ -775,7 +764,6 @@ TEST_CASE("script context free valid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are always valid (pre-MINIMALDATA, since some use non-minimal push encodings).
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) == error::success, name);
@@ -795,7 +783,6 @@ TEST_CASE("script context free invalid", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are always invalid.
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) != error::success, name);
@@ -812,7 +799,6 @@ TEST_CASE("script bch_pythagoras invalidated", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are valid before bch_pythagoras activation
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) == error::success, name);
@@ -830,7 +816,6 @@ TEST_CASE("script bch_pythagoras validated", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // Note: these checks assumed div/mod/and/or/xor are gated by bch_reactivated_opcodes,
         //   but BCHN has no flag for these opcodes (they are always enabled). Our interpreter now
@@ -854,7 +839,6 @@ TEST_CASE("script bch_gauss invalidated", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are valid before bch_gauss activation (context-free hash256).
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) == error::success, name);
@@ -876,7 +860,6 @@ TEST_CASE("script bch_gauss validated", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are invalid before bch_gauss activation (32-bit arithmetic limits).
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) != error::success, name);
@@ -897,7 +880,6 @@ TEST_CASE("script bch_galois invalidated", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are valid before bch_galois activation (context-free hash256).
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) == error::success, name);
@@ -915,7 +897,6 @@ TEST_CASE("script bch_galois validated", "[script]") {
         auto const tx_exp = new_tx(test);
         REQUIRE(tx_exp);
         auto const& tx = *tx_exp;
-        REQUIRE_MESSAGE(tx.is_valid(), name);
 
         // These are invalid before bch_galois activation (32-bit arithmetic limits).
         CHECK_MESSAGE(verify(tx, 0, script_flags::no_rules) != error::success, name);
@@ -1325,7 +1306,6 @@ void run_bchn_test(bchn_script_test const& test) {
     REQUIRE_MESSAGE(bool(tx_exp), name);
 
     auto const& tx = *tx_exp;
-    REQUIRE_MESSAGE(tx.is_valid(), name);
 
     auto const actual = verify(tx, 0, test.flags);
     if (actual != test.expected_error) {

--- a/src/domain/test/chain/transaction.cpp
+++ b/src/domain/test/chain/transaction.cpp
@@ -9,6 +9,21 @@ using namespace kd;
 
 // Start Test Suite: chain transaction tests
 
+TEST_CASE("chain transaction null is the all-default value", "[chain transaction]") {
+    auto const null_tx = chain::transaction::null();
+    REQUIRE(null_tx.is_null());
+    REQUIRE(null_tx == chain::transaction{});
+    REQUIRE(null_tx.version() == 0u);
+    REQUIRE(null_tx.locktime() == 0u);
+    REQUIRE(null_tx.inputs().empty());
+    REQUIRE(null_tx.outputs().empty());
+}
+
+TEST_CASE("chain transaction is null false for a populated transaction", "[chain transaction]") {
+    chain::transaction const instance(1u, 0u, {}, {});
+    REQUIRE( ! instance.is_null());
+}
+
 constexpr auto tx0_inputs =
     "f08e44a96bfb5ae63eda1a6620adae37ee37ee4777fb0336e1bbbc4de65310fc"
     "010000006a473044022050d8368cacf9bf1b8fb1f7cfd9aff63294789eb17601"
@@ -135,7 +150,6 @@ constexpr auto tx7_hash = "cb1e303db604f066225eb14d59d3f8d2231200817bc9d4610d280
 
 TEST_CASE("chain transaction constructor 1 always returns default initialized", "[chain transaction]") {
     chain::transaction const instance;
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("chain transaction constructor 2 valid input returns input initialized", "[chain transaction]") {
@@ -165,7 +179,6 @@ TEST_CASE("chain transaction constructor 2 valid input returns input initialized
         outputs
     );
 
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(locktime == instance.locktime());
     REQUIRE(inputs == instance.inputs());
@@ -202,7 +215,6 @@ TEST_CASE("chain transaction constructor 3 valid input returns input initialized
         std::move(outputs)
     );
 
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(locktime == instance.locktime());
     REQUIRE(input_copy == instance.inputs());
@@ -216,7 +228,6 @@ TEST_CASE("chain transaction constructor 4 valid input returns input initialized
     auto const expected = std::move(*result);
 
     chain::transaction instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -227,7 +238,6 @@ TEST_CASE("chain transaction constructor 5 valid input returns input initialized
     auto const expected = std::move(*result);
 
     chain::transaction instance(std::move(expected));
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("chain transaction is coinbase empty inputs returns false", "[chain transaction]") {
@@ -240,8 +250,7 @@ TEST_CASE("chain transaction is coinbase one null input returns true", "[chain t
         {chain::point{null_hash, chain::point::null_index}, {}, 0}
     };
 
-    chain::transaction instance;
-    instance.set_inputs(inputs);
+    chain::transaction const instance(0, 0, inputs, {});
     REQUIRE(instance.is_coinbase());
 }
 
@@ -250,8 +259,7 @@ TEST_CASE("chain transaction is coinbase one non null input returns false", "[ch
         {chain::point{null_hash, 42}, {}, 0}
     };
 
-    chain::transaction instance;
-    instance.set_inputs(inputs);
+    chain::transaction const instance(0, 0, inputs, {});
     REQUIRE( ! instance.is_coinbase());
 }
 
@@ -261,8 +269,7 @@ TEST_CASE("chain transaction is coinbase two inputs first null returns false", "
         {chain::point{null_hash, 42}, {}, 0}
     };
 
-    chain::transaction instance;
-    instance.set_inputs(inputs);
+    chain::transaction const instance(0, 0, inputs, {});
     REQUIRE( ! instance.is_coinbase());
 }
 
@@ -276,8 +283,7 @@ TEST_CASE("chain transaction is null non coinbase one null input returns false",
         {chain::point{null_hash, chain::point::null_index}, {}, 0}
     };
 
-    chain::transaction instance;
-    instance.set_inputs(inputs);
+    chain::transaction const instance(0, 0, inputs, {});
     REQUIRE( ! instance.is_null_non_coinbase());
 }
 
@@ -286,8 +292,7 @@ TEST_CASE("chain transaction is null non coinbase one non null input returns fal
         {chain::point{null_hash, 42}, {}, 0}
     };
 
-    chain::transaction instance;
-    instance.set_inputs(inputs);
+    chain::transaction const instance(0, 0, inputs, {});
     REQUIRE( ! instance.is_null_non_coinbase());
 }
 
@@ -297,32 +302,28 @@ TEST_CASE("chain transaction is null non coinbase two inputs first null returns 
         {chain::point{null_hash, 42}, {}, 0}
     };
 
-    chain::transaction instance;
-    instance.set_inputs(inputs);
+    chain::transaction const instance(0, 0, inputs, {});
     REQUIRE(instance.is_null_non_coinbase());
 }
 
 TEST_CASE("chain transaction is final locktime zero returns true", "[chain transaction]") {
     constexpr size_t height = 100;
     constexpr uint32_t time = 100;
-    chain::transaction instance;
-    instance.set_locktime(0);
+    chain::transaction const instance(0, 0, {}, {});
     REQUIRE(instance.is_final(height, time));
 }
 
 TEST_CASE("chain transaction is final locktime less block time greater threshold returns true", "[chain transaction]") {
     constexpr size_t height = locktime_threshold + 100;
     constexpr uint32_t time = 100;
-    chain::transaction instance;
-    instance.set_locktime(locktime_threshold + 50);
+    chain::transaction const instance(0, locktime_threshold + 50, {}, {});
     REQUIRE(instance.is_final(height, time));
 }
 
 TEST_CASE("chain transaction is final locktime less block height less threshold returns true", "[chain transaction]") {
     constexpr size_t height = 100;
     constexpr uint32_t time = 100;
-    chain::transaction instance;
-    instance.set_locktime(50);
+    chain::transaction const instance(0, 50, {}, {});
     REQUIRE(instance.is_final(height, time));
 }
 
@@ -344,34 +345,27 @@ TEST_CASE("chain transaction is final locktime inputs final returns true", "[cha
 }
 
 TEST_CASE("chain transaction is locked version 1 empty returns false", "[chain transaction]") {
-    chain::transaction instance;
-    instance.set_version(1);
+    chain::transaction const instance(1, 0, {}, {});
     REQUIRE( ! instance.is_locked(0, 0));
 }
 
 TEST_CASE("chain transaction is locked version 2 empty returns false", "[chain transaction]") {
-    chain::transaction instance;
-    instance.set_version(2);
+    chain::transaction const instance(2, 0, {}, {});
     REQUIRE( ! instance.is_locked(0, 0));
 }
 
 TEST_CASE("chain transaction is locked version 1 one of two locked locked returns false", "[chain transaction]") {
-    chain::transaction instance;
-    instance.set_inputs({{{}, {}, 1}, {{}, {}, 0}});
-    instance.set_version(1);
+    chain::transaction const instance(1, 0, {{{}, {}, 1}, {{}, {}, 0}}, {});
     REQUIRE( ! instance.is_locked(0, 0));
 }
 
 TEST_CASE("chain transaction is locked version 4 one of two locked returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.set_inputs({{{}, {}, 1}, {{}, {}, 0}});
-    instance.set_version(4);
+    chain::transaction const instance(4, 0, {{{}, {}, 1}, {{}, {}, 0}}, {});
     REQUIRE(instance.is_locked(0, 0));
 }
 
 TEST_CASE("chain transaction is locktime conflict locktime zero returns false", "[chain transaction]") {
-    chain::transaction instance;
-    instance.set_locktime(0);
+    chain::transaction const instance(0, 0, {}, {});
     REQUIRE( ! instance.is_locktime_conflict());
 }
 
@@ -382,8 +376,7 @@ TEST_CASE("chain transaction is locktime conflict input sequence not maximum ret
 }
 
 TEST_CASE("chain transaction is locktime conflict no inputs returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.set_locktime(2143);
+    chain::transaction const instance(0, 2143, {}, {});
     REQUIRE(instance.is_locktime_conflict());
 }
 
@@ -453,7 +446,6 @@ TEST_CASE("chain transaction factory data 1 case 1 success", "[chain transaction
     REQUIRE(result_exp);
     auto const tx = std::move(*result_exp);
 
-    REQUIRE(tx.is_valid());
     REQUIRE(tx.serialized_size() == 225u);
     REQUIRE(tx.hash() == tx_hash);
 
@@ -472,7 +464,6 @@ TEST_CASE("chain transaction factory data 1 case 2 success", "[chain transaction
     REQUIRE(result_exp);
     auto const tx = std::move(*result_exp);
 
-    REQUIRE(tx.is_valid());
     REQUIRE(tx.hash() == tx_hash);
 
     // Re-save tx and compare against original.
@@ -483,17 +474,13 @@ TEST_CASE("chain transaction factory data 1 case 2 success", "[chain transaction
 
 TEST_CASE("chain transaction version roundtrip success", "[chain transaction]") {
     uint32_t version = 1254u;
-    chain::transaction instance;
-    REQUIRE(version != instance.version());
-    instance.set_version(version);
+    chain::transaction const instance(version, 0, {}, {});
     REQUIRE(version == instance.version());
 }
 
 TEST_CASE("chain transaction locktime roundtrip success", "[chain transaction]") {
     uint32_t locktime = 1254u;
-    chain::transaction instance;
-    REQUIRE(locktime != instance.locktime());
-    instance.set_locktime(locktime);
+    chain::transaction const instance(0, locktime, {}, {});
     REQUIRE(locktime == instance.locktime());
 }
 
@@ -505,9 +492,7 @@ TEST_CASE("chain transaction inputs setter 1 roundtrip success", "[chain transac
         std::move(*result_exp)
     };
 
-    chain::transaction instance;
-    REQUIRE(inputs != instance.inputs());
-    instance.set_inputs(inputs);
+    chain::transaction const instance(0, 0, inputs, {});
     REQUIRE(inputs == instance.inputs());
 }
 
@@ -522,9 +507,7 @@ TEST_CASE("chain transaction inputs setter 2 roundtrip success", "[chain transac
     // This must be non-const.
     auto dup_inputs = inputs;
 
-    chain::transaction instance;
-    REQUIRE(inputs != instance.inputs());
-    instance.set_inputs(std::move(dup_inputs));
+    chain::transaction const instance(0, 0, std::move(dup_inputs), {});
     REQUIRE(inputs == instance.inputs());
 }
 
@@ -536,9 +519,7 @@ TEST_CASE("chain transaction outputs setter 1 roundtrip success", "[chain transa
         std::move(*result_exp)
     };
 
-    chain::transaction instance;
-    REQUIRE(outputs != instance.outputs());
-    instance.set_outputs(outputs);
+    chain::transaction const instance(0, 0, {}, outputs);
     REQUIRE(outputs == instance.outputs());
 }
 
@@ -553,9 +534,7 @@ TEST_CASE("chain transaction outputs setter 2 roundtrip success", "[chain transa
     // This must be non-const.
     auto dup_outputs = outputs;
 
-    chain::transaction instance;
-    REQUIRE(outputs != instance.outputs());
-    instance.set_outputs(std::move(dup_outputs));
+    chain::transaction const instance(0, 0, {}, std::move(dup_outputs));
     REQUIRE(outputs == instance.outputs());
 }
 
@@ -569,16 +548,16 @@ TEST_CASE("chain transaction is oversized coinbase non coinbase tx returns false
 }
 
 TEST_CASE("chain transaction is oversized coinbase script size below min returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point::null(), chain::script{}, 0u);
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point::null(), chain::script{}, 0u);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.is_coinbase());
     REQUIRE(instance.inputs().back().script().serialized_size(false) < min_coinbase_size);
     REQUIRE(instance.is_oversized_coinbase());
 }
 
 TEST_CASE("chain transaction is oversized coinbase script size above max returns true", "[chain transaction]") {
-    chain::transaction instance;
-    auto& inputs = instance.inputs();
+    chain::input::list inputs;
     inputs.emplace_back(chain::output_point::null(), chain::script{}, 0u);
 
     data_chunk oversized_script(max_coinbase_size + 10);
@@ -586,15 +565,15 @@ TEST_CASE("chain transaction is oversized coinbase script size above max returns
     auto result = chain::script::from_data(reader, false);
     REQUIRE(result);
     inputs.back().set_script(std::move(*result));
-
-    REQUIRE(instance.is_coinbase());
     REQUIRE(inputs.back().script().serialized_size(false) > max_coinbase_size);
+
+    chain::transaction const instance(0, 0, std::move(inputs), {});
+    REQUIRE(instance.is_coinbase());
     REQUIRE(instance.is_oversized_coinbase());
 }
 
 TEST_CASE("chain transaction is oversized coinbase script size within bounds returns false", "[chain transaction]") {
-    chain::transaction instance;
-    auto& inputs = instance.inputs();
+    chain::input::list inputs;
     inputs.emplace_back(chain::output_point::null(), chain::script{}, 0u);
 
     data_chunk valid_script(50);
@@ -602,10 +581,11 @@ TEST_CASE("chain transaction is oversized coinbase script size within bounds ret
     auto result = chain::script::from_data(reader, false);
     REQUIRE(result);
     inputs.back().set_script(std::move(*result));
-
-    REQUIRE(instance.is_coinbase());
     REQUIRE(inputs.back().script().serialized_size(false) >= min_coinbase_size);
     REQUIRE(inputs.back().script().serialized_size(false) <= max_coinbase_size);
+
+    chain::transaction const instance(0, 0, std::move(inputs), {});
+    REQUIRE(instance.is_coinbase());
     REQUIRE( ! instance.is_oversized_coinbase());
 }
 
@@ -624,29 +604,30 @@ TEST_CASE("chain transaction is null non coinbase no null input prevout returns 
 }
 
 TEST_CASE("chain transaction is null non coinbase null input prevout returns true", "[chain transaction]") {
-    chain::transaction instance;
-    auto& inputs = instance.inputs();
+    chain::input::list inputs;
     inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
     inputs.emplace_back(chain::output_point::null(), chain::script{}, 0u);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE( ! instance.is_coinbase());
     REQUIRE(instance.inputs().back().previous_output().is_null());
     REQUIRE(instance.is_null_non_coinbase());
 }
 
 TEST_CASE("chain transaction total input value no cache returns zero", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.total_input_value() == 0u);
 }
 
 TEST_CASE("chain transaction total input value cache returns cache value sum", "[chain transaction]") {
-    chain::transaction instance;
-    auto& inputs = instance.inputs();
+    chain::input::list inputs;
     inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().validation.cache.set_value(123u);
     inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().validation.cache.set_value(321u);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.total_input_value() == 444u);
 }
 
@@ -656,8 +637,6 @@ TEST_CASE("chain transaction total output value empty outputs returns zero", "[c
 }
 
 TEST_CASE("chain transaction total output value non empty outputs returns sum", "[chain transaction]") {
-    chain::transaction instance;
-
     // This must be non-const.
     chain::output::list outputs;
 
@@ -665,19 +644,23 @@ TEST_CASE("chain transaction total output value non empty outputs returns sum", 
     outputs.back().set_value(1200);
     outputs.emplace_back();
     outputs.back().set_value(34);
-    instance.set_outputs(std::move(outputs));
+
+    chain::transaction const instance(0, 0, {}, std::move(outputs));
     REQUIRE(instance.total_output_value() == 1234u);
 }
 
 TEST_CASE("chain transaction fees nonempty returns outputs minus inputs", "[chain transaction]") {
-    chain::transaction instance;
-    auto& inputs = instance.inputs();
+    chain::input::list inputs;
     inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().validation.cache.set_value(123u);
     inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
     inputs.back().previous_output().validation.cache.set_value(321u);
-    instance.outputs().emplace_back();
-    instance.outputs().back().set_value(44u);
+
+    chain::output::list outputs;
+    outputs.emplace_back();
+    outputs.back().set_value(44u);
+
+    chain::transaction const instance(0, 0, std::move(inputs), std::move(outputs));
     REQUIRE(instance.fees() == 400u);
 }
 
@@ -687,19 +670,21 @@ TEST_CASE("chain transaction is overspent output does not exceed input returns f
 }
 
 TEST_CASE("chain transaction is overspent output exceeds input returns true", "[chain transaction]") {
-    chain::transaction instance;
-    auto& outputs = instance.outputs();
+    chain::output::list outputs;
     outputs.emplace_back();
     outputs.back().set_value(1200);
     outputs.emplace_back();
     outputs.back().set_value(34);
+    chain::transaction const instance(0, 0, {}, std::move(outputs));
     REQUIRE(instance.is_overspent());
 }
 
 TEST_CASE("chain transaction signature operations uninitialized input output returns zero", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
-    instance.outputs().emplace_back();
+    chain::input::list inputs;
+    chain::output::list outputs;
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    outputs.emplace_back();
+    chain::transaction const instance(0, 0, std::move(inputs), std::move(outputs));
     REQUIRE(instance.signature_operations(false, false) == 0u);
 }
 
@@ -732,15 +717,17 @@ TEST_CASE("chain transaction is missing previous outputs empty inputs returns fa
 }
 
 TEST_CASE("chain transaction is missing previous outputs inputs without cache value returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.is_missing_previous_outputs());
 }
 
 TEST_CASE("chain transaction is missing previous outputs inputs with cache value returns false", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
-    instance.inputs().back().previous_output().validation.cache.set_value(123u);
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    inputs.back().previous_output().validation.cache.set_value(123u);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE( ! instance.is_missing_previous_outputs());
 }
 
@@ -752,23 +739,26 @@ TEST_CASE("chain transaction missing previous outputs empty inputs returns empty
 TEST_CASE("chain transaction missing previous outputs default input returns point", "[chain transaction]") {
     // Default-constructed input has index=0, not null_index, so it's NOT null
     // and since it has no cache, it's considered "missing"
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.missing_previous_outputs().size() == 1u);
 }
 
 TEST_CASE("chain transaction missing previous outputs null input returns empty", "[chain transaction]") {
     // Truly null input (coinbase-like) is not considered missing
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::point::null(), chain::script{}, 0);
+    chain::input::list inputs;
+    inputs.emplace_back(chain::point::null(), chain::script{}, 0);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.missing_previous_outputs().empty());
 }
 
 TEST_CASE("chain transaction missing previous outputs non null input without cache returns point", "[chain transaction]") {
-    chain::transaction instance;
     auto const expected_hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
     constexpr uint32_t expected_index = 42u;
-    instance.inputs().emplace_back(chain::output_point{expected_hash, expected_index}, chain::script{}, 0);
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{expected_hash, expected_index}, chain::script{}, 0);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     auto const result = instance.missing_previous_outputs();
     REQUIRE(result.size() == 1u);
     REQUIRE(result.front().hash() == expected_hash);
@@ -776,10 +766,11 @@ TEST_CASE("chain transaction missing previous outputs non null input without cac
 }
 
 TEST_CASE("chain transaction missing previous outputs non null input with cache returns empty", "[chain transaction]") {
-    chain::transaction instance;
     auto const some_hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
-    instance.inputs().emplace_back(chain::output_point{some_hash, 42}, chain::script{}, 0);
-    instance.inputs().back().previous_output().validation.cache.set_value(123u);
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{some_hash, 42}, chain::script{}, 0);
+    inputs.back().previous_output().validation.cache.set_value(123u);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.missing_previous_outputs().empty());
 }
 
@@ -790,31 +781,35 @@ TEST_CASE("chain transaction is double spend empty inputs returns false", "[chai
 }
 
 TEST_CASE("chain transaction is double spend unspent inputs returns false", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE( ! instance.is_double_spend(false));
     REQUIRE( ! instance.is_double_spend(true));
 }
 
 TEST_CASE("chain transaction is double spend include unconfirmed false with unconfirmed returns false", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
-    instance.inputs().back().previous_output().validation.spent = true;
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    inputs.back().previous_output().validation.spent = true;
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE( ! instance.is_double_spend(false));
 }
 
 TEST_CASE("chain transaction is double spend include unconfirmed false with confirmed returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
-    instance.inputs().back().previous_output().validation.spent = true;
-    instance.inputs().back().previous_output().validation.confirmed = true;
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    inputs.back().previous_output().validation.spent = true;
+    inputs.back().previous_output().validation.confirmed = true;
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.is_double_spend(false));
 }
 
 TEST_CASE("chain transaction is double spend include unconfirmed true with unconfirmed returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
-    instance.inputs().back().previous_output().validation.spent = true;
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{null_hash, 0u}, chain::script{}, 0u);
+    inputs.back().previous_output().validation.spent = true;
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.is_double_spend(true));
 }
 
@@ -871,44 +866,49 @@ TEST_CASE("chain transaction is mature no inputs returns true", "[chain transact
 }
 
 TEST_CASE("chain transaction is mature mature coinbase prevout returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{hash1, 42}, chain::script{}, 0);
-    instance.inputs().back().previous_output().validation.coinbase = true;
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{hash1, 42}, chain::script{}, 0);
+    inputs.back().previous_output().validation.coinbase = true;
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE( ! instance.inputs().back().previous_output().is_null());
     REQUIRE(instance.is_mature(453));
 }
 
 TEST_CASE("chain transaction is mature premature coinbase prevout returns false", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{hash1, 42}, chain::script{}, 0);
-    instance.inputs().back().previous_output().validation.height = 20;
-    instance.inputs().back().previous_output().validation.coinbase = true;
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{hash1, 42}, chain::script{}, 0);
+    inputs.back().previous_output().validation.height = 20;
+    inputs.back().previous_output().validation.coinbase = true;
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE( ! instance.inputs().back().previous_output().is_null());
     REQUIRE( ! instance.is_mature(50));
 }
 
 TEST_CASE("chain transaction is mature premature coinbase prevout null input returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{null_hash, chain::point::null_index}, chain::script{}, 0);
-    instance.inputs().back().previous_output().validation.height = 20;
-    instance.inputs().back().previous_output().validation.coinbase = true;
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{null_hash, chain::point::null_index}, chain::script{}, 0);
+    inputs.back().previous_output().validation.height = 20;
+    inputs.back().previous_output().validation.coinbase = true;
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE(instance.inputs().back().previous_output().is_null());
     REQUIRE(instance.is_mature(50));
 }
 
 TEST_CASE("chain transaction is mature mature non coinbase prevout returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{hash1, 42}, chain::script{}, 0);
-    instance.inputs().back().previous_output().validation.coinbase = false;
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{hash1, 42}, chain::script{}, 0);
+    inputs.back().previous_output().validation.coinbase = false;
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE( ! instance.inputs().back().previous_output().is_null());
     REQUIRE(instance.is_mature(453));
 }
 
 TEST_CASE("chain transaction is mature premature non coinbase prevout returns true", "[chain transaction]") {
-    chain::transaction instance;
-    instance.inputs().emplace_back(chain::output_point{hash1, 42}, chain::script{}, 0);
-    instance.inputs().back().previous_output().validation.height = 20;
-    instance.inputs().back().previous_output().validation.coinbase = false;
+    chain::input::list inputs;
+    inputs.emplace_back(chain::output_point{hash1, 42}, chain::script{}, 0);
+    inputs.back().previous_output().validation.height = 20;
+    inputs.back().previous_output().validation.coinbase = false;
+    chain::transaction const instance(0, 0, std::move(inputs), {});
     REQUIRE( ! instance.inputs().back().previous_output().is_null());
     REQUIRE(instance.is_mature(50));
 }

--- a/src/domain/test/machine/interpreter.cpp
+++ b/src/domain/test/machine/interpreter.cpp
@@ -431,8 +431,9 @@ TEST_CASE("OP_CHECKLOCKTIMEVERIFY propagates top_number parse error",
     // Empty stack → top_number() returns insufficient_main_stack.
     // Needs a transaction context with at least one input (CLTV
     // reads tx.inputs()[input_index]).
-    chain::transaction tx;
-    tx.inputs().emplace_back(chain::output_point{}, chain::script{}, 0u);
+    chain::input::list tx_inputs;
+    tx_inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
+    chain::transaction const tx(0, 0, std::move(tx_inputs), {});
     auto scr = script_of({operation(opcode::checklocktimeverify)});
     program prog(scr, tx, 0, script_flags::bip65_rule, 0);
     auto const result = interpreter::run(prog);
@@ -449,8 +450,9 @@ TEST_CASE("OP_CHECKSEQUENCEVERIFY propagates top_number parse error",
     // `invalid_operand_size`. Run without `bch_minimaldata` so the
     // pre-check at the top of `op_check_sequence_verify` doesn't
     // preempt with its own error.
-    chain::transaction tx;
-    tx.inputs().emplace_back(chain::output_point{}, chain::script{}, 0u);
+    chain::input::list tx_inputs;
+    tx_inputs.emplace_back(chain::output_point{}, chain::script{}, 0u);
+    chain::transaction const tx(0, 0, std::move(tx_inputs), {});
     auto scr = script_of({
         operation(data_chunk{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}),
         operation(opcode::checksequenceverify),

--- a/src/domain/test/message/prefilled_transaction.cpp
+++ b/src/domain/test/message/prefilled_transaction.cpp
@@ -26,11 +26,9 @@ TEST_CASE("prefilled transaction constructor 2 always equals params", "[prefille
 TEST_CASE("prefilled transaction constructor 3 always equals params", "[prefilled transaction]") {
     uint64_t index = 125u;
     chain::transaction tx(1, 0, {}, {});
-    REQUIRE(tx.is_valid());
     message::prefilled_transaction instance(index, std::move(tx));
     REQUIRE(instance.is_valid());
     REQUIRE(index == instance.index());
-    REQUIRE(instance.transaction().is_valid());
 }
 
 TEST_CASE("prefilled transaction constructor 4 always equals params", "[prefilled transaction]") {

--- a/src/domain/test/message/transaction.cpp
+++ b/src/domain/test/message/transaction.cpp
@@ -52,7 +52,6 @@ static auto const raw_tx2_hash = "8a6d9302fbe24f0ec756a94ecfc837eaffe16c43d1e68c
 
 TEST_CASE("message transaction constructor 1 always initialized invalid", "[message transaction]") {
     transaction instance;
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("message transaction constructor 2 always equals transaction", "[message transaction]") {
@@ -64,7 +63,6 @@ TEST_CASE("message transaction constructor 2 always equals transaction", "[messa
     REQUIRE(result);
     tx = std::move(*result);
     transaction instance(tx);
-    REQUIRE(instance.is_valid());
     REQUIRE(instance == tx);
 }
 
@@ -77,11 +75,9 @@ TEST_CASE("message transaction constructor 3 always equals param", "[message tra
     REQUIRE(result);
     tx = std::move(*result);
     transaction alpha(tx);
-    REQUIRE(alpha.is_valid());
     REQUIRE(alpha == tx);
 
     transaction beta(alpha);
-    REQUIRE(beta.is_valid());
     REQUIRE(beta == alpha);
 }
 
@@ -96,7 +92,6 @@ TEST_CASE("message transaction constructor 4 always equals equivalent tx", "[mes
     auto const inputs = tx.inputs();
     auto const outputs = tx.outputs();
     transaction instance(tx.version(), tx.locktime(), inputs, outputs);
-    REQUIRE(instance.is_valid());
     REQUIRE(instance == tx);
 }
 
@@ -114,7 +109,6 @@ TEST_CASE("message transaction constructor 5 always equals equivalent tx", "[mes
     REQUIRE(result_exp);
     auto instance = std::move(*result_exp);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(instance == tx);
 }
 
@@ -132,7 +126,6 @@ TEST_CASE("message transaction constructor 6 always equals equivalent tx", "[mes
     REQUIRE(result);
     tx = std::move(*result);
     transaction instance(std::move(value));
-    REQUIRE(instance.is_valid());
     REQUIRE(instance == tx);
 }
 
@@ -145,7 +138,6 @@ TEST_CASE("message transaction constructor 7 always equals equivalent tx", "[mes
     transaction instance(15u, 1234u,
         chain::input::list{empty_in, empty_in},
         chain::output::list{empty_out, empty_out, empty_out});
-    REQUIRE(instance.is_valid());
     REQUIRE(instance.version() == 15u);
     REQUIRE(instance.locktime() == 1234u);
     REQUIRE(instance.inputs().size() == 2);
@@ -158,7 +150,6 @@ TEST_CASE("message transaction from data insufficient data failure", "[message t
     byte_reader reader(data);
     auto result = transaction::from_data(reader, version::level::minimum);
     REQUIRE( ! result);
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("message transaction from data valid junk success", "[message transaction]") {
@@ -178,7 +169,6 @@ TEST_CASE("message transaction from data case 1 valid data success", "[message t
     auto const result_exp = transaction::from_data(reader, version::level::minimum);
     REQUIRE(result_exp);
     auto const tx = std::move(*result_exp);
-    REQUIRE(tx.is_valid());
     REQUIRE(tx.serialized_size(version::level::minimum) == 225u);
     REQUIRE(tx.hash() == tx_hash);
 
@@ -197,7 +187,6 @@ TEST_CASE("message transaction from data case 2 valid data success", "[message t
     auto const result_exp = transaction::from_data(reader, version::level::minimum);
     REQUIRE(result_exp);
     auto const tx = std::move(*result_exp);
-    REQUIRE(tx.is_valid());
     REQUIRE(tx.hash() == tx_hash);
 
     // Re-save tx and compare against original.


### PR DESCRIPTION
Applies the settled rule to `chain::transaction`: it performs no consensus checks, so every state is syntactically valid — the all-default one included, and so are the **partial transactions the sighash algorithm builds** (empty inputs or outputs, for `SIGHASH_NONE` / `SIGHASH_SINGLE`). Construction cannot fail and needs no factory, so the constructors stay public.

## Changes

- Collapse the two field constructors into a single **by-value** one; keep the default constructor (its state is a valid domain value).
- Remove `is_valid()` — it only ever asked *"is this the uninitialized default?"* — plus `reset()`, the setters, and the non-const `inputs()` / `outputs()` accessors. **The type is now immutable.**
- `from_data` still returns `expect<>`: malformed bytes remain the only way construction can fail.
- Rewrite the call sites that populated a transaction through setters or the non-const accessors to build the lists first and construct once. The sighash path (`script.cpp`) now passes its inputs straight to the constructor, which moves them.
- The `is_valid()` users outside the domain drop the transaction term and keep their own sentinels (`transaction_entry`, `transaction_unconfirmed_entry`, `prefilled_transaction`). `block_chain`'s compact-block reconstruction compares against a default transaction — exactly what the old `is_valid()` tested, so the short-id collision handling is unchanged.
- Regenerate the C-API bindings and update their tests.

## Note

`prefilled_transaction` surfaced as the **first genuine `create()` → `expect<>` case**: its index has a real range (`index < max_index`) that the constructor does not enforce, and its default constructor starts at the invalid sentinel. Left as a follow-up.

## Testing

Full build green — every target, benchmarks included. Domain suite (3831 cases) and C-API suite (740 cases) pass.