### PR TITLE
refactor(domain/message): prefilled_transaction is valid-by-construction

### DIFF
--- a/src/c-api/include/kth/capi/chain/prefilled_transaction.h
+++ b/src/c-api/include/kth/capi/chain/prefilled_transaction.h
@@ -16,20 +16,13 @@ extern "C" {
 
 // Constructors
 
-/** @return Owned `kth_prefilled_transaction_mut_t`. Caller must release with `kth_chain_prefilled_transaction_destruct`. */
-KTH_EXPORT KTH_OWNED
-kth_prefilled_transaction_mut_t kth_chain_prefilled_transaction_construct_default(void);
-
 /** @param[out] out Must point to a null `kth_prefilled_transaction_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_prefilled_transaction_destruct`. Untouched on error. */
 KTH_EXPORT
 kth_error_code_t kth_chain_prefilled_transaction_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_prefilled_transaction_mut_t* out);
 
-/**
- * @return Owned `kth_prefilled_transaction_mut_t`. Caller must release with `kth_chain_prefilled_transaction_destruct`.
- * @param tx Borrowed input. Copied by value into the resulting object; ownership of `tx` stays with the caller.
- */
-KTH_EXPORT KTH_OWNED
-kth_prefilled_transaction_mut_t kth_chain_prefilled_transaction_construct(uint64_t index, kth_transaction_const_t tx);
+/** @param[out] out Must point to a null `kth_prefilled_transaction_mut_t` slot. On success, populated with an owned handle that the caller must release via `kth_chain_prefilled_transaction_destruct`. Untouched on error. */
+KTH_EXPORT
+kth_error_code_t kth_chain_prefilled_transaction_create(uint64_t index, kth_transaction_const_t tx, KTH_OUT_OWNED kth_prefilled_transaction_mut_t* out);
 
 
 // Destructor
@@ -51,6 +44,9 @@ kth_prefilled_transaction_mut_t kth_chain_prefilled_transaction_copy(kth_prefill
 KTH_EXPORT
 kth_bool_t kth_chain_prefilled_transaction_equals(kth_prefilled_transaction_const_t self, kth_prefilled_transaction_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_prefilled_transaction_not_equal(kth_prefilled_transaction_const_t self, kth_prefilled_transaction_const_t other);
+
 
 // Serialization
 
@@ -70,28 +66,6 @@ uint64_t kth_chain_prefilled_transaction_index(kth_prefilled_transaction_const_t
 /** @return Borrowed `kth_transaction_const_t` view into `self`. Do not destruct; the parent object retains ownership. Invalidated by any mutation of `self`. */
 KTH_EXPORT
 kth_transaction_const_t kth_chain_prefilled_transaction_transaction(kth_prefilled_transaction_const_t self);
-
-
-// Setters
-
-KTH_EXPORT
-void kth_chain_prefilled_transaction_set_index(kth_prefilled_transaction_mut_t self, uint64_t value);
-
-/** @param tx Borrowed input. Copied by value into the resulting object; ownership of `tx` stays with the caller. */
-KTH_EXPORT
-void kth_chain_prefilled_transaction_set_transaction(kth_prefilled_transaction_mut_t self, kth_transaction_const_t tx);
-
-
-// Predicates
-
-KTH_EXPORT
-kth_bool_t kth_chain_prefilled_transaction_is_valid(kth_prefilled_transaction_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_prefilled_transaction_reset(kth_prefilled_transaction_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/src/chain/prefilled_transaction.cpp
+++ b/src/c-api/src/chain/prefilled_transaction.cpp
@@ -22,10 +22,6 @@ extern "C" {
 
 // Constructors
 
-kth_prefilled_transaction_mut_t kth_chain_prefilled_transaction_construct_default(void) {
-    return kth::leak<cpp_t>();
-}
-
 kth_error_code_t kth_chain_prefilled_transaction_construct_from_data(uint8_t const* data, kth_size_t n, uint32_t version, KTH_OUT_OWNED kth_prefilled_transaction_mut_t* out) {
     KTH_PRECONDITION(data != nullptr || n == 0);
     KTH_PRECONDITION(out != nullptr);
@@ -37,10 +33,15 @@ kth_error_code_t kth_chain_prefilled_transaction_construct_from_data(uint8_t con
     return kth_ec_success;
 }
 
-kth_prefilled_transaction_mut_t kth_chain_prefilled_transaction_construct(uint64_t index, kth_transaction_const_t tx) {
+kth_error_code_t kth_chain_prefilled_transaction_create(uint64_t index, kth_transaction_const_t tx, KTH_OUT_OWNED kth_prefilled_transaction_mut_t* out) {
     KTH_PRECONDITION(tx != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    KTH_PRECONDITION(*out == nullptr);
     auto const& tx_cpp = kth::cpp_ref<kth::domain::chain::transaction>(tx);
-    return kth::leak<cpp_t>(index, tx_cpp);
+    auto result = cpp_t::create(index, tx_cpp);
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::leak(std::move(*result));
+    return kth_ec_success;
 }
 
 
@@ -65,6 +66,12 @@ kth_bool_t kth_chain_prefilled_transaction_equals(kth_prefilled_transaction_cons
     KTH_PRECONDITION(self != nullptr);
     KTH_PRECONDITION(other != nullptr);
     return kth::eq<cpp_t>(self, other);
+}
+
+kth_bool_t kth_chain_prefilled_transaction_not_equal(kth_prefilled_transaction_const_t self, kth_prefilled_transaction_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
 }
 
 
@@ -92,37 +99,6 @@ uint64_t kth_chain_prefilled_transaction_index(kth_prefilled_transaction_const_t
 kth_transaction_const_t kth_chain_prefilled_transaction_transaction(kth_prefilled_transaction_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return &(kth::cpp_ref<cpp_t>(self).transaction());
-}
-
-
-// Setters
-
-void kth_chain_prefilled_transaction_set_index(kth_prefilled_transaction_mut_t self, uint64_t value) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).set_index(value);
-}
-
-void kth_chain_prefilled_transaction_set_transaction(kth_prefilled_transaction_mut_t self, kth_transaction_const_t tx) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(tx != nullptr);
-    auto const& tx_cpp = kth::cpp_ref<kth::domain::chain::transaction>(tx);
-    kth::cpp_ref<cpp_t>(self).set_transaction(tx_cpp);
-}
-
-
-// Predicates
-
-kth_bool_t kth_chain_prefilled_transaction_is_valid(kth_prefilled_transaction_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
-
-// Operations
-
-void kth_chain_prefilled_transaction_reset(kth_prefilled_transaction_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/compact_block.cpp
+++ b/src/c-api/test/chain/compact_block.cpp
@@ -81,8 +81,8 @@ static kth_prefilled_transaction_list_mut_t
 make_prefilled_list(kth_transaction_const_t tx) {
     kth_prefilled_transaction_list_mut_t list =
         kth_chain_prefilled_transaction_list_construct_default();
-    kth_prefilled_transaction_mut_t pt =
-        kth_chain_prefilled_transaction_construct(0u, tx);
+    kth_prefilled_transaction_mut_t pt = NULL;
+    REQUIRE(kth_chain_prefilled_transaction_create(0u, tx, &pt) == kth_ec_success);
     kth_chain_prefilled_transaction_list_push_back(list, pt);
     kth_chain_prefilled_transaction_destruct(pt);
     return list;

--- a/src/c-api/test/chain/prefilled_transaction.cpp
+++ b/src/c-api/test/chain/prefilled_transaction.cpp
@@ -44,27 +44,38 @@ static kth_transaction_mut_t make_tx(void) {
     return tx;
 }
 
+// BIP152 caps the prefilled index; mirrors the domain's own limit.
+static uint64_t const kMaxIndex = 0xffffffffu;
+
+static kth_prefilled_transaction_mut_t make_prefilled(uint64_t index) {
+    kth_transaction_mut_t tx = make_tx();
+    kth_prefilled_transaction_mut_t pt = NULL;
+    kth_error_code_t ec = kth_chain_prefilled_transaction_create(index, tx, &pt);
+    REQUIRE(ec == kth_ec_success);
+    REQUIRE(pt != NULL);
+    kth_chain_transaction_destruct(tx);
+    return pt;
+}
+
 // ---------------------------------------------------------------------------
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API PrefilledTransaction - default construct is invalid",
-          "[C-API PrefilledTransaction]") {
-    kth_prefilled_transaction_mut_t pt =
-        kth_chain_prefilled_transaction_construct_default();
-    REQUIRE(kth_chain_prefilled_transaction_is_valid(pt) == 0);
-    kth_chain_prefilled_transaction_destruct(pt);
-}
-
-TEST_CASE("C-API PrefilledTransaction - field constructor preserves index",
+TEST_CASE("C-API PrefilledTransaction - create rejects an out of range index",
           "[C-API PrefilledTransaction]") {
     kth_transaction_mut_t tx = make_tx();
-    kth_prefilled_transaction_mut_t pt =
-        kth_chain_prefilled_transaction_construct(7u, tx);
-    REQUIRE(pt != NULL);
+    kth_prefilled_transaction_mut_t pt = NULL;
+    kth_error_code_t ec = kth_chain_prefilled_transaction_create(kMaxIndex, tx, &pt);
+    REQUIRE(ec != kth_ec_success);
+    REQUIRE(pt == NULL);
+    kth_chain_transaction_destruct(tx);
+}
+
+TEST_CASE("C-API PrefilledTransaction - create preserves index",
+          "[C-API PrefilledTransaction]") {
+    kth_prefilled_transaction_mut_t pt = make_prefilled(7u);
     REQUIRE(kth_chain_prefilled_transaction_index(pt) == 7u);
     kth_chain_prefilled_transaction_destruct(pt);
-    kth_chain_transaction_destruct(tx);
 }
 
 TEST_CASE("C-API PrefilledTransaction - destruct null is safe",
@@ -78,9 +89,7 @@ TEST_CASE("C-API PrefilledTransaction - destruct null is safe",
 
 TEST_CASE("C-API PrefilledTransaction - to_data / from_data round-trip",
           "[C-API PrefilledTransaction]") {
-    kth_transaction_mut_t tx = make_tx();
-    kth_prefilled_transaction_mut_t original =
-        kth_chain_prefilled_transaction_construct(3u, tx);
+    kth_prefilled_transaction_mut_t original = make_prefilled(3u);
 
     kth_size_t out_size = 0;
     uint8_t* raw = kth_chain_prefilled_transaction_to_data(
@@ -98,14 +107,11 @@ TEST_CASE("C-API PrefilledTransaction - to_data / from_data round-trip",
     kth_core_destruct_array(raw);
     kth_chain_prefilled_transaction_destruct(decoded);
     kth_chain_prefilled_transaction_destruct(original);
-    kth_chain_transaction_destruct(tx);
 }
 
 TEST_CASE("C-API PrefilledTransaction - serialized_size matches to_data length",
           "[C-API PrefilledTransaction]") {
-    kth_transaction_mut_t tx = make_tx();
-    kth_prefilled_transaction_mut_t pt =
-        kth_chain_prefilled_transaction_construct(0u, tx);
+    kth_prefilled_transaction_mut_t pt = make_prefilled(0u);
 
     kth_size_t expected =
         kth_chain_prefilled_transaction_serialized_size(pt, kProtoVersion);
@@ -117,7 +123,6 @@ TEST_CASE("C-API PrefilledTransaction - serialized_size matches to_data length",
 
     kth_core_destruct_array(raw);
     kth_chain_prefilled_transaction_destruct(pt);
-    kth_chain_transaction_destruct(tx);
 }
 
 // ---------------------------------------------------------------------------
@@ -126,9 +131,7 @@ TEST_CASE("C-API PrefilledTransaction - serialized_size matches to_data length",
 
 TEST_CASE("C-API PrefilledTransaction - copy preserves equality",
           "[C-API PrefilledTransaction]") {
-    kth_transaction_mut_t tx = make_tx();
-    kth_prefilled_transaction_mut_t original =
-        kth_chain_prefilled_transaction_construct(5u, tx);
+    kth_prefilled_transaction_mut_t original = make_prefilled(5u);
 
     kth_prefilled_transaction_mut_t copy =
         kth_chain_prefilled_transaction_copy(original);
@@ -137,62 +140,38 @@ TEST_CASE("C-API PrefilledTransaction - copy preserves equality",
 
     kth_chain_prefilled_transaction_destruct(copy);
     kth_chain_prefilled_transaction_destruct(original);
-    kth_chain_transaction_destruct(tx);
 }
 
 // ---------------------------------------------------------------------------
 // Getters / setters
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API PrefilledTransaction - set_index round-trips",
+TEST_CASE("C-API PrefilledTransaction - create sets index",
           "[C-API PrefilledTransaction]") {
-    kth_prefilled_transaction_mut_t pt =
-        kth_chain_prefilled_transaction_construct_default();
-    kth_chain_prefilled_transaction_set_index(pt, 42u);
+    kth_prefilled_transaction_mut_t pt = make_prefilled(42u);
     REQUIRE(kth_chain_prefilled_transaction_index(pt) == 42u);
     kth_chain_prefilled_transaction_destruct(pt);
 }
 
 TEST_CASE("C-API PrefilledTransaction - transaction getter returns borrowed view",
           "[C-API PrefilledTransaction]") {
-    kth_transaction_mut_t tx = make_tx();
-    kth_prefilled_transaction_mut_t pt =
-        kth_chain_prefilled_transaction_construct(1u, tx);
+    kth_prefilled_transaction_mut_t pt = make_prefilled(1u);
 
     kth_transaction_const_t inner = kth_chain_prefilled_transaction_transaction(pt);
     REQUIRE(inner != NULL);
     // Do NOT destruct `inner` — it is borrowed.
 
     kth_chain_prefilled_transaction_destruct(pt);
-    kth_chain_transaction_destruct(tx);
-}
-
-// ---------------------------------------------------------------------------
-// Operations
-// ---------------------------------------------------------------------------
-
-TEST_CASE("C-API PrefilledTransaction - reset invalidates the object",
-          "[C-API PrefilledTransaction]") {
-    // C++ `reset()` sets index_ to a sentinel value (max_uint32) and
-    // clears the transaction, so is_valid() flips to false. The numeric
-    // value of index after reset is an implementation detail, but the
-    // validity flip is the observable contract.
-    kth_transaction_mut_t tx = make_tx();
-    kth_prefilled_transaction_mut_t pt =
-        kth_chain_prefilled_transaction_construct(9u, tx);
-    kth_chain_prefilled_transaction_reset(pt);
-    REQUIRE(kth_chain_prefilled_transaction_is_valid(pt) == 0);
-    kth_chain_prefilled_transaction_destruct(pt);
-    kth_chain_transaction_destruct(tx);
 }
 
 // ---------------------------------------------------------------------------
 // Preconditions (death tests via fork)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API PrefilledTransaction - construct null tx aborts",
+TEST_CASE("C-API PrefilledTransaction - create null tx aborts",
           "[C-API PrefilledTransaction][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_prefilled_transaction_construct(0u, NULL));
+    kth_prefilled_transaction_mut_t out = NULL;
+    KTH_EXPECT_ABORT(kth_chain_prefilled_transaction_create(0u, NULL, &out));
 }
 
 TEST_CASE("C-API PrefilledTransaction - construct_from_data null data with non-zero size aborts",
@@ -213,8 +192,7 @@ TEST_CASE("C-API PrefilledTransaction - construct_from_data null out aborts",
 
 TEST_CASE("C-API PrefilledTransaction - to_data null out_size aborts",
           "[C-API PrefilledTransaction][precondition]") {
-    kth_prefilled_transaction_mut_t pt =
-        kth_chain_prefilled_transaction_construct_default();
+    kth_prefilled_transaction_mut_t pt = make_prefilled(0u);
     KTH_EXPECT_ABORT(kth_chain_prefilled_transaction_to_data(
         pt, kProtoVersion, NULL));
     kth_chain_prefilled_transaction_destruct(pt);
@@ -227,8 +205,7 @@ TEST_CASE("C-API PrefilledTransaction - copy null aborts",
 
 TEST_CASE("C-API PrefilledTransaction - equals null aborts",
           "[C-API PrefilledTransaction][precondition]") {
-    kth_prefilled_transaction_mut_t other =
-        kth_chain_prefilled_transaction_construct_default();
+    kth_prefilled_transaction_mut_t other = make_prefilled(0u);
     KTH_EXPECT_ABORT(kth_chain_prefilled_transaction_equals(NULL, other));
     kth_chain_prefilled_transaction_destruct(other);
 }
@@ -238,10 +215,3 @@ TEST_CASE("C-API PrefilledTransaction - transaction getter null aborts",
     KTH_EXPECT_ABORT(kth_chain_prefilled_transaction_transaction(NULL));
 }
 
-TEST_CASE("C-API PrefilledTransaction - set_transaction null value aborts",
-          "[C-API PrefilledTransaction][precondition]") {
-    kth_prefilled_transaction_mut_t pt =
-        kth_chain_prefilled_transaction_construct_default();
-    KTH_EXPECT_ABORT(kth_chain_prefilled_transaction_set_transaction(pt, NULL));
-    kth_chain_prefilled_transaction_destruct(pt);
-}

--- a/src/domain/include/kth/domain/message/prefilled_transaction.hpp
+++ b/src/domain/include/kth/domain/message/prefilled_transaction.hpp
@@ -21,9 +21,14 @@ struct KD_API prefilled_transaction {
     using list = std::vector<prefilled_transaction>;
     using const_ptr = std::shared_ptr<const prefilled_transaction>;
 
-    prefilled_transaction();
-    prefilled_transaction(uint64_t index, chain::transaction const& tx);
-    prefilled_transaction(uint64_t index, chain::transaction&& tx);
+    /// Build from parts. Unlike most domain types, construction here *can*
+    /// yield a syntactically invalid object: BIP152 caps the prefilled index,
+    /// and nothing else constrains the caller. Returns
+    /// `error::invalid_compact_block` when `index` is out of range, so a
+    /// constructed `prefilled_transaction` always carries a usable index.
+    static
+    expect<prefilled_transaction> create(uint64_t index, chain::transaction tx);
+
     prefilled_transaction(prefilled_transaction const& x) = default;
     prefilled_transaction(prefilled_transaction&& x) = default;
 
@@ -37,15 +42,8 @@ struct KD_API prefilled_transaction {
     [[nodiscard]]
     uint64_t index() const;
 
-    void set_index(uint64_t value);
-
-    chain::transaction& transaction();
-
     [[nodiscard]]
     chain::transaction const& transaction() const;
-
-    void set_transaction(chain::transaction const& tx);
-    void set_transaction(chain::transaction&& tx);
 
     static
     expect<prefilled_transaction> from_data(byte_reader& reader, uint32_t version);
@@ -54,15 +52,14 @@ struct KD_API prefilled_transaction {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
 
 private:
+    // Construction goes through `create` / `from_data`, which guarantee an
+    // in-range index.
+    prefilled_transaction(uint64_t index, chain::transaction tx);
+
     uint64_t index_;
     chain::transaction transaction_;
 };

--- a/src/domain/src/message/compact_block.cpp
+++ b/src/domain/src/message/compact_block.cpp
@@ -28,7 +28,9 @@ compact_block compact_block::factory_from_block(message::block const& block) {
     uint64_t nonce = 0;
     pseudo_random::fill(reinterpret_cast<uint8_t*>(&nonce), sizeof(nonce));
 
-    prefilled_transaction::list prefilled_list{prefilled_transaction{0, block.transactions()[0]}};
+    // Index 0 (the coinbase) is always in range, so `create` cannot fail here.
+    prefilled_transaction::list prefilled_list{
+        prefilled_transaction::create(0, block.transactions()[0]).value()};
 
     auto header_hash = hash(block, nonce);
     auto k0 = from_little_endian_unsafe<uint64_t>(header_hash);

--- a/src/domain/src/message/prefilled_transaction.cpp
+++ b/src/domain/src/message/prefilled_transaction.cpp
@@ -15,27 +15,17 @@ constexpr size_t max_index = max_uint32;
 constexpr size_t max_index = max_uint16;
 #endif
 
-prefilled_transaction::prefilled_transaction()
-    : index_(max_index)
-{}
-
-prefilled_transaction::prefilled_transaction(uint64_t index, chain::transaction const& tx)
-    : index_(index), transaction_(tx) {
-}
-
-prefilled_transaction::prefilled_transaction(uint64_t index, chain::transaction&& tx)
+prefilled_transaction::prefilled_transaction(uint64_t index, chain::transaction tx)
     : index_(index), transaction_(std::move(tx)) {
 }
 
-bool prefilled_transaction::is_valid() const {
-    // A transaction is always syntactically valid, so only the index sentinel
-    // is left to check here.
-    return index_ < max_index;
-}
-
-void prefilled_transaction::reset() {
-    index_ = max_index;
-    transaction_ = chain::transaction::null();
+// static
+expect<prefilled_transaction> prefilled_transaction::create(uint64_t index, chain::transaction tx) {
+    // BIP152 caps the prefilled index; anything above it cannot be encoded.
+    if (index >= max_index) {
+        return std::unexpected(error::invalid_compact_block);
+    }
+    return prefilled_transaction(index, std::move(tx));
 }
 
 // Deserialization.
@@ -51,7 +41,7 @@ expect<prefilled_transaction> prefilled_transaction::from_data(byte_reader& read
     if ( ! transaction) {
         return std::unexpected(transaction.error());
     }
-    return prefilled_transaction(*index, std::move(*transaction));
+    return create(*index, std::move(*transaction));
 }
 
 // Serialization.
@@ -68,24 +58,8 @@ uint64_t prefilled_transaction::index() const {
     return index_;
 }
 
-void prefilled_transaction::set_index(uint64_t value) {
-    index_ = value;
-}
-
-chain::transaction& prefilled_transaction::transaction() {
-    return transaction_;
-}
-
 chain::transaction const& prefilled_transaction::transaction() const {
     return transaction_;
-}
-
-void prefilled_transaction::set_transaction(chain::transaction const& tx) {
-    transaction_ = tx;
-}
-
-void prefilled_transaction::set_transaction(chain::transaction&& tx) {
-    transaction_ = std::move(tx);
 }
 
 expect<void> prefilled_transaction::to_data(byte_writer& writer, uint32_t version) const {

--- a/src/domain/test/message/compact_block.cpp
+++ b/src/domain/test/message/compact_block.cpp
@@ -30,9 +30,9 @@ message::compact_block::short_id_list const test_short_ids{
     convert_to_uint64t("f0f0f0f0f0f0")};
 
 message::prefilled_transaction::list const test_transactions{
-    message::prefilled_transaction(10, chain::transaction(1, 48, {}, {})),
-    message::prefilled_transaction(20, chain::transaction(2, 32, {}, {})),
-    message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))};
+    message::prefilled_transaction::create(10, chain::transaction(1, 48, {}, {})).value(),
+    message::prefilled_transaction::create(20, chain::transaction(2, 32, {}, {})).value(),
+    message::prefilled_transaction::create(30, chain::transaction(4, 16, {}, {})).value()};
 
 message::compact_block make_compact_block(uint64_t nonce = 453245u) {
     return message::compact_block(test_header, nonce, test_short_ids, test_transactions);

--- a/src/domain/test/message/prefilled_transaction.cpp
+++ b/src/domain/test/message/prefilled_transaction.cpp
@@ -7,63 +7,66 @@
 using namespace kth;
 using namespace kd;
 
-// Start Test Suite: prefilled transaction tests
+namespace {
 
-TEST_CASE("prefilled transaction constructor 1 always invalid", "[prefilled transaction]") {
-    message::prefilled_transaction instance;
-    REQUIRE( ! instance.is_valid());
+// BIP152 caps the prefilled index; mirrors the domain's own limit.
+#if defined(KTH_CURRENCY_BCH)
+constexpr uint64_t max_index = max_uint32;
+#else
+constexpr uint64_t max_index = max_uint16;
+#endif
+
+message::prefilled_transaction make_prefilled(uint64_t index = 1234u) {
+    return message::prefilled_transaction::create(index, chain::transaction{6u, 10u, {}, {}}).value();
 }
 
-TEST_CASE("prefilled transaction constructor 2 always equals params", "[prefilled transaction]") {
-    uint64_t index = 125u;
-    chain::transaction tx(1, 0, {}, {});
-    message::prefilled_transaction instance(index, tx);
-    REQUIRE(instance.is_valid());
+} // namespace
+
+// Start Test Suite: prefilled transaction tests
+
+TEST_CASE("prefilled transaction create rejects an out of range index", "[prefilled transaction]") {
+    auto const result = message::prefilled_transaction::create(max_index, chain::transaction{1, 0, {}, {}});
+    REQUIRE( ! result);
+    REQUIRE(result.error() == error::invalid_compact_block);
+}
+
+TEST_CASE("prefilled transaction create accepts the last in range index", "[prefilled transaction]") {
+    auto const result = message::prefilled_transaction::create(max_index - 1u, chain::transaction{1, 0, {}, {}});
+    REQUIRE(result);
+    REQUIRE(result->index() == max_index - 1u);
+}
+
+TEST_CASE("prefilled transaction create always equals params", "[prefilled transaction]") {
+    uint64_t const index = 125u;
+    chain::transaction const tx(1, 0, {}, {});
+    auto const instance = message::prefilled_transaction::create(index, tx).value();
     REQUIRE(index == instance.index());
     REQUIRE(tx == instance.transaction());
 }
 
-TEST_CASE("prefilled transaction constructor 3 always equals params", "[prefilled transaction]") {
-    uint64_t index = 125u;
-    chain::transaction tx(1, 0, {}, {});
-    message::prefilled_transaction instance(index, std::move(tx));
-    REQUIRE(instance.is_valid());
-    REQUIRE(index == instance.index());
-}
-
-TEST_CASE("prefilled transaction constructor 4 always equals params", "[prefilled transaction]") {
-    const message::prefilled_transaction expected(125u,
-                                                  chain::transaction{1, 0, {}, {}});
-
+TEST_CASE("prefilled transaction copy always equals params", "[prefilled transaction]") {
+    auto const expected = make_prefilled(125u);
     message::prefilled_transaction instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
-TEST_CASE("prefilled transaction constructor 5 always equals params", "[prefilled transaction]") {
-    message::prefilled_transaction expected(125u,
-                                            chain::transaction{1, 0, {}, {}});
-
+TEST_CASE("prefilled transaction move always equals params", "[prefilled transaction]") {
+    auto expected = make_prefilled(125u);
+    auto const copy = expected;
     message::prefilled_transaction instance(std::move(expected));
-    REQUIRE(instance.is_valid());
+    REQUIRE(copy == instance);
 }
 
 TEST_CASE("prefilled transaction from data insufficient bytes failure", "[prefilled transaction]") {
     data_chunk const raw{1};
-    message::prefilled_transaction instance{};
     byte_reader reader(raw);
     auto result = message::prefilled_transaction::from_data(reader, message::version::level::minimum);
     REQUIRE( ! result);
 }
 
 TEST_CASE("prefilled transaction from data valid input success", "[prefilled transaction]") {
-    const message::prefilled_transaction expected(
-        16,
-        chain::transaction{
-            1,
-            0,
-            {},
-            {}});
+    auto const expected = message::prefilled_transaction::create(
+        16, chain::transaction{1, 0, {}, {}}).value();
 
     auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
     byte_reader reader(data);
@@ -71,120 +74,51 @@ TEST_CASE("prefilled transaction from data valid input success", "[prefilled tra
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
 }
 
-
-
 TEST_CASE("prefilled transaction index accessor always returns initialized value", "[prefilled transaction]") {
-    uint64_t index = 634u;
-    chain::transaction tx(5, 23, {}, {});
-    message::prefilled_transaction instance(index, tx);
+    uint64_t const index = 634u;
+    auto const instance = message::prefilled_transaction::create(index, chain::transaction{5, 23, {}, {}}).value();
     REQUIRE(index == instance.index());
 }
 
-TEST_CASE("prefilled transaction index setter roundtrip success", "[prefilled transaction]") {
-    uint64_t index = 634u;
-    message::prefilled_transaction instance;
-    REQUIRE(index != instance.index());
-    instance.set_index(index);
-    REQUIRE(index == instance.index());
-}
-
-TEST_CASE("prefilled transaction message accessor 1 always returns initialized value", "[prefilled transaction]") {
-    uint64_t index = 634u;
+TEST_CASE("prefilled transaction transaction accessor always returns initialized value", "[prefilled transaction]") {
     chain::transaction const tx(5, 23, {}, {});
-    message::prefilled_transaction instance(index, tx);
+    auto const instance = message::prefilled_transaction::create(634u, tx).value();
     REQUIRE(tx == instance.transaction());
 }
 
-TEST_CASE("prefilled transaction message accessor 2 always returns initialized value", "[prefilled transaction]") {
-    uint64_t index = 634u;
-    chain::transaction const tx(5, 23, {}, {});
-    const message::prefilled_transaction instance(index, tx);
-    REQUIRE(tx == instance.transaction());
-}
-
-TEST_CASE("prefilled transaction message setter 1 roundtrip success", "[prefilled transaction]") {
-    chain::transaction const tx(5, 23, {}, {});
-    message::prefilled_transaction instance;
-    REQUIRE(tx != instance.transaction());
-    instance.set_transaction(tx);
-    REQUIRE(tx == instance.transaction());
-}
-
-TEST_CASE("prefilled transaction message setter 2 roundtrip success", "[prefilled transaction]") {
-    chain::transaction const duplicate(16, 57, {}, {});
-    chain::transaction tx(16, 57, {}, {});
-    message::prefilled_transaction instance;
-    REQUIRE(duplicate != instance.transaction());
-    instance.set_transaction(std::move(tx));
-    REQUIRE(duplicate == instance.transaction());
-}
-
-TEST_CASE("prefilled transaction operator assign equals 1 always matches equivalent", "[prefilled transaction]") {
-    message::prefilled_transaction value(
-        1234u,
-        chain::transaction{6u, 10u, {}, {}});
-
-    REQUIRE(value.is_valid());
-
-    message::prefilled_transaction instance;
-    REQUIRE( ! instance.is_valid());
+TEST_CASE("prefilled transaction operator assign always matches equivalent", "[prefilled transaction]") {
+    auto value = make_prefilled();
+    auto const copy = value;
+    auto instance = make_prefilled(1u);
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
-}
-
-TEST_CASE("prefilled transaction operator assign equals 2 always matches equivalent", "[prefilled transaction]") {
-    const message::prefilled_transaction value(
-        1234u,
-        chain::transaction{6u, 10u, {}, {}});
-
-    REQUIRE(value.is_valid());
-
-    message::prefilled_transaction instance;
-    REQUIRE( ! instance.is_valid());
-
-    instance = value;
-    REQUIRE(instance.is_valid());
-    REQUIRE(value == instance);
+    REQUIRE(copy == instance);
 }
 
 TEST_CASE("prefilled transaction operator boolean equals duplicates returns true", "[prefilled transaction]") {
-    const message::prefilled_transaction expected(
-        1234u,
-        chain::transaction{6u, 10u, {}, {}});
-
+    auto const expected = make_prefilled();
     message::prefilled_transaction instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("prefilled transaction operator boolean equals differs returns false", "[prefilled transaction]") {
-    const message::prefilled_transaction expected(
-        1234u,
-        chain::transaction{6u, 10u, {}, {}});
-
-    message::prefilled_transaction instance;
-    REQUIRE(instance != expected);
+    auto const expected = make_prefilled();
+    auto const instance = make_prefilled(4321u);
+    REQUIRE( ! (instance == expected));
 }
 
 TEST_CASE("prefilled transaction operator boolean not equals duplicates returns false", "[prefilled transaction]") {
-    const message::prefilled_transaction expected(
-        1234u,
-        chain::transaction{6u, 10u, {}, {}});
-
+    auto const expected = make_prefilled();
     message::prefilled_transaction instance(expected);
-    REQUIRE(instance == expected);
+    REQUIRE( ! (instance != expected));
 }
 
 TEST_CASE("prefilled transaction operator boolean not equals differs returns true", "[prefilled transaction]") {
-    const message::prefilled_transaction expected(
-        1234u,
-        chain::transaction{6u, 10u, {}, {}});
-
-    message::prefilled_transaction instance;
+    auto const expected = make_prefilled();
+    auto const instance = make_prefilled(4321u);
     REQUIRE(instance != expected);
 }
 


### PR DESCRIPTION
The first type in the sweep where a factory is genuinely warranted. Unlike the rest of the block family, constructing a `prefilled_transaction` **can** yield a syntactically invalid object:

- BIP152 caps the prefilled index (`max_uint32` on BCH, `max_uint16` elsewhere).
- The constructor took a `uint64_t index` and checked nothing.
- `from_data` read a variable-length integer straight into it.

So a wire message with an out-of-range index parsed into an object that then reported *itself* invalid via `is_valid()`. That is exactly the case `::create` → `expect<>` is for.

## Changes

- Add `create(index, tx)` returning `expect<>`, rejecting an out-of-range index with `error::invalid_compact_block` — a prefilled index that cannot be encoded makes the compact block malformed. Field constructor made private.
- **Drop the default constructor**: its state was `index_ = max_index`, i.e. the invalid sentinel itself.
- Remove `is_valid()` and `reset()` (both existed only to observe and restore that sentinel), the setters, and the non-const `transaction()` accessor.
- `from_data` routes through `create`, so an out-of-range index is now a **parse error** instead of a silently-invalid object.
- `compact_block::factory_from_block` prefills index 0 — always in range — so it unwraps the factory.
- Regenerate the C-API bindings (`_create` now returns an error code) and rewrite the domain + C-API tests against the factory.

## Testing

Full build green — every target, benchmarks included. Domain suite (3828 cases) and C-API suite (738 cases) pass, including new coverage that `create` rejects `max_index` and accepts `max_index - 1`.