### PR TITLE
refactor(domain/message): drop the vestigial validity flags

### DIFF
--- a/src/domain/include/kth/domain/message/fee_filter.hpp
+++ b/src/domain/include/kth/domain/message/fee_filter.hpp
@@ -6,7 +6,6 @@
 #define KTH_DOMAIN_MESSAGE_FEE_FILTER_HPP
 
 #include <cstdint>
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -22,18 +21,24 @@ struct KD_API fee_filter {
     using const_ptr = std::shared_ptr<const fee_filter>;
 
     static constexpr
-    size_t satoshi_fixed_size(uint32_t version);
+    size_t satoshi_fixed_size(uint32_t /*version*/) {
+        return sizeof(minimum_fee_);
+    }
 
     fee_filter() = default;
-    fee_filter(uint64_t minimum);
-
-    bool operator==(fee_filter const& x) const;
-    bool operator!=(fee_filter const& x) const;
+    constexpr
+    fee_filter(uint64_t minimum)
+        : minimum_fee_(minimum)
+    {}
 
     [[nodiscard]]
-    uint64_t minimum_fee() const;
+    friend bool operator==(fee_filter const&, fee_filter const&) = default;
 
-    void set_minimum_fee(uint64_t value);
+    [[nodiscard]]
+    constexpr
+    uint64_t minimum_fee() const {
+        return minimum_fee_;
+    }
 
     static
     expect<fee_filter> from_data(byte_reader& reader, uint32_t version);
@@ -41,15 +46,11 @@ struct KD_API fee_filter {
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
-
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
-    size_t serialized_size(uint32_t version) const;
-
+    constexpr
+    size_t serialized_size(uint32_t version) const {
+        return satoshi_fixed_size(version);
+    }
 
     static
     std::string const command;
@@ -60,12 +61,8 @@ struct KD_API fee_filter {
     static
     uint32_t const version_maximum;
 
-protected:
-    fee_filter(uint64_t minimum, bool insufficient_version);
-
 private:
     uint64_t minimum_fee_{0};
-    bool insufficient_version_{true};
 };
 
 } // namespace kth::domain::message

--- a/src/domain/include/kth/domain/message/filter_clear.hpp
+++ b/src/domain/include/kth/domain/message/filter_clear.hpp
@@ -5,7 +5,6 @@
 #ifndef KTH_DOMAIN_MESSAGE_FILTER_CLEAR_HPP
 #define KTH_DOMAIN_MESSAGE_FILTER_CLEAR_HPP
 
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -13,7 +12,6 @@
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-
 
 #include <kth/domain/concepts.hpp>
 
@@ -23,20 +21,17 @@ struct KD_API filter_clear {
     using ptr = std::shared_ptr<filter_clear>;
     using const_ptr = std::shared_ptr<const filter_clear>;
 
-    static
-    size_t satoshi_fixed_size(uint32_t version);
+    [[nodiscard]]
+    friend bool operator==(filter_clear const&, filter_clear const&) = default;
 
-    // This is a default instance so is invalid.
-    // The only way to make this valid is to deserialize it :/.
-    filter_clear() = default;
-    filter_clear(filter_clear const& x) = default;
-    filter_clear(filter_clear&& x) = default;
+    static constexpr
+    size_t satoshi_fixed_size(uint32_t /*version*/) {
+        // `filter_clear` has an empty payload.
+        return 0;
+    }
 
     static
     expect<filter_clear> from_data(byte_reader& reader, uint32_t version);
-
-    [[nodiscard]]
-    data_chunk to_data(uint32_t version) const;
 
     [[nodiscard]]
     expect<void> to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
@@ -45,12 +40,10 @@ struct KD_API filter_clear {
     }
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
-    size_t serialized_size(uint32_t version) const;
+    constexpr
+    size_t serialized_size(uint32_t version) const {
+        return satoshi_fixed_size(version);
+    }
 
     static
     std::string const command;
@@ -60,12 +53,6 @@ struct KD_API filter_clear {
 
     static
     uint32_t const version_maximum;
-
-protected:
-    filter_clear(bool insufficient_version);
-
-private:
-    bool insufficient_version_{true};
 };
 
 } // namespace kth::domain::message

--- a/src/domain/include/kth/domain/message/memory_pool.hpp
+++ b/src/domain/include/kth/domain/message/memory_pool.hpp
@@ -5,7 +5,6 @@
 #ifndef KTH_DOMAIN_MESSAGE_MEMORY_POOL_HPP
 #define KTH_DOMAIN_MESSAGE_MEMORY_POOL_HPP
 
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -13,7 +12,6 @@
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-
 
 #include <kth/domain/concepts.hpp>
 
@@ -23,14 +21,14 @@ struct KD_API memory_pool {
     using ptr = std::shared_ptr<memory_pool>;
     using const_ptr = std::shared_ptr<const memory_pool>;
 
-    static
-    size_t satoshi_fixed_size(uint32_t version);
+    [[nodiscard]]
+    friend bool operator==(memory_pool const&, memory_pool const&) = default;
 
-    // This is a default instance so is invalid.
-    // The only way to make this valid is to deserialize it :/.
-    memory_pool() = default;
-    memory_pool(memory_pool const& x) = default;
-    memory_pool(memory_pool&& x) = default;
+    static constexpr
+    size_t satoshi_fixed_size(uint32_t /*version*/) {
+        // `memory_pool` has an empty payload.
+        return 0;
+    }
 
     static
     expect<memory_pool> from_data(byte_reader& reader, uint32_t version);
@@ -41,12 +39,10 @@ struct KD_API memory_pool {
     }
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
-    size_t serialized_size(uint32_t version) const;
+    constexpr
+    size_t serialized_size(uint32_t version) const {
+        return satoshi_fixed_size(version);
+    }
 
     static
     std::string const command;
@@ -56,13 +52,6 @@ struct KD_API memory_pool {
 
     static
     uint32_t const version_maximum;
-
-
-protected:
-    memory_pool(bool insufficient_version);
-
-private:
-    bool insufficient_version_{true};
 };
 
 } // namespace kth::domain::message

--- a/src/domain/include/kth/domain/message/ping.hpp
+++ b/src/domain/include/kth/domain/message/ping.hpp
@@ -6,7 +6,6 @@
 #define KTH_DOMAIN_MESSAGE_PING_HPP
 
 #include <cstdint>
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -23,19 +22,26 @@ struct KD_API ping {
     using ptr = std::shared_ptr<ping>;
     using const_ptr = std::shared_ptr<const ping>;
 
-    static
-    size_t satoshi_fixed_size(uint32_t version);
+    static constexpr
+    size_t satoshi_fixed_size(uint32_t version) {
+        // Before BIP31 a ping carries no nonce.
+        return version < version::level::bip31 ? 0 : sizeof(nonce_);
+    }
 
     ping() = default;
-    ping(uint64_t nonce, bool nonceless = false);
-
-    bool operator==(ping const& x) const;
-    bool operator!=(ping const& x) const;
+    constexpr
+    ping(uint64_t nonce)
+        : nonce_(nonce)
+    {}
 
     [[nodiscard]]
-    uint64_t nonce() const;
+    friend bool operator==(ping const&, ping const&) = default;
 
-    void set_nonce(uint64_t value);
+    [[nodiscard]]
+    constexpr
+    uint64_t nonce() const {
+        return nonce_;
+    }
 
     static
     expect<ping> from_data(byte_reader& reader, uint32_t version);
@@ -43,12 +49,10 @@ struct KD_API ping {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
-    size_t serialized_size(uint32_t version) const;
+    constexpr
+    size_t serialized_size(uint32_t version) const {
+        return satoshi_fixed_size(version);
+    }
 
     static
     std::string const command;
@@ -59,11 +63,8 @@ struct KD_API ping {
     static
     uint32_t const version_maximum;
 
-
 private:
     uint64_t nonce_{0};
-    bool nonceless_{false};
-    bool valid_{false};
 };
 
 } // namespace kth::domain::message

--- a/src/domain/include/kth/domain/message/pong.hpp
+++ b/src/domain/include/kth/domain/message/pong.hpp
@@ -6,7 +6,6 @@
 #define KTH_DOMAIN_MESSAGE_PONG_HPP
 
 #include <cstdint>
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -22,20 +21,25 @@ struct KD_API pong {
     using ptr = std::shared_ptr<pong>;
     using const_ptr = std::shared_ptr<const pong>;
 
-    static
-    size_t satoshi_fixed_size(uint32_t version);
+    static constexpr
+    size_t satoshi_fixed_size(uint32_t /*version*/) {
+        return sizeof(nonce_);
+    }
 
     pong() = default;
-    pong(uint64_t nonce);
-
-    bool operator==(pong const& x) const;
-    bool operator!=(pong const& x) const;
-
+    constexpr
+    pong(uint64_t nonce)
+        : nonce_(nonce)
+    {}
 
     [[nodiscard]]
-    uint64_t nonce() const;
+    friend bool operator==(pong const&, pong const&) = default;
 
-    void set_nonce(uint64_t value);
+    [[nodiscard]]
+    constexpr
+    uint64_t nonce() const {
+        return nonce_;
+    }
 
     static
     expect<pong> from_data(byte_reader& reader, uint32_t version);
@@ -44,13 +48,10 @@ struct KD_API pong {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
-    size_t serialized_size(uint32_t version) const;
-
+    constexpr
+    size_t serialized_size(uint32_t version) const {
+        return satoshi_fixed_size(version);
+    }
 
     static
     std::string const command;
@@ -61,10 +62,8 @@ struct KD_API pong {
     static
     uint32_t const version_maximum;
 
-
 private:
     uint64_t nonce_{0};
-    bool valid_{false};
 };
 
 } // namespace kth::domain::message

--- a/src/domain/include/kth/domain/message/send_addrv2.hpp
+++ b/src/domain/include/kth/domain/message/send_addrv2.hpp
@@ -5,7 +5,6 @@
 #ifndef KTH_DOMAIN_MESSAGE_SEND_ADDRV2_HPP
 #define KTH_DOMAIN_MESSAGE_SEND_ADDRV2_HPP
 
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -24,25 +23,26 @@ struct KD_API send_addrv2 {
     using ptr = std::shared_ptr<send_addrv2>;
     using const_ptr = std::shared_ptr<const send_addrv2>;
 
-    static
-    size_t satoshi_fixed_size(uint32_t version);
+    [[nodiscard]]
+    friend bool operator==(send_addrv2 const&, send_addrv2 const&) = default;
 
-    send_addrv2() = default;
-    send_addrv2(send_addrv2 const& x) = default;
-    send_addrv2(send_addrv2&& x) = default;
+    static constexpr
+    size_t satoshi_fixed_size(uint32_t /*version*/) {
+        // `send_addrv2` has an empty payload.
+        return 0;
+    }
 
     static
     expect<send_addrv2> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
-    [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
 
     [[nodiscard]]
-    size_t serialized_size(uint32_t version) const;
+    constexpr
+    size_t serialized_size(uint32_t version) const {
+        return satoshi_fixed_size(version);
+    }
 
     static
     std::string const command;
@@ -52,12 +52,6 @@ struct KD_API send_addrv2 {
 
     static
     uint32_t const version_maximum;
-
-protected:
-    send_addrv2(bool insufficient_version);
-
-private:
-    bool insufficient_version_{true};
 };
 
 } // namespace kth::domain::message

--- a/src/domain/include/kth/domain/message/send_headers.hpp
+++ b/src/domain/include/kth/domain/message/send_headers.hpp
@@ -5,7 +5,6 @@
 #ifndef KTH_DOMAIN_MESSAGE_SEND_HEADERS_HPP
 #define KTH_DOMAIN_MESSAGE_SEND_HEADERS_HPP
 
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -21,25 +20,26 @@ struct KD_API send_headers {
     using ptr = std::shared_ptr<send_headers>;
     using const_ptr = std::shared_ptr<const send_headers>;
 
-    static
-    size_t satoshi_fixed_size(uint32_t version);
+    [[nodiscard]]
+    friend bool operator==(send_headers const&, send_headers const&) = default;
 
-    send_headers() = default;
-    send_headers(send_headers const& x) = default;
-    send_headers(send_headers&& x) = default;
+    static constexpr
+    size_t satoshi_fixed_size(uint32_t /*version*/) {
+        // `send_headers` has an empty payload.
+        return 0;
+    }
 
     static
     expect<send_headers> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
-    [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
 
     [[nodiscard]]
-    size_t serialized_size(uint32_t version) const;
+    constexpr
+    size_t serialized_size(uint32_t version) const {
+        return satoshi_fixed_size(version);
+    }
 
     static
     std::string const command;
@@ -49,13 +49,6 @@ struct KD_API send_headers {
 
     static
     uint32_t const version_maximum;
-
-
-protected:
-    send_headers(bool insufficient_version);
-
-private:
-    bool insufficient_version_{true};
 };
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/fee_filter.cpp
+++ b/src/domain/src/message/fee_filter.cpp
@@ -12,31 +12,6 @@ std::string const fee_filter::command = "feefilter";
 uint32_t const fee_filter::version_minimum = version::level::bip133;
 uint32_t const fee_filter::version_maximum = version::level::bip133;
 
-// static
-constexpr
-size_t fee_filter::satoshi_fixed_size(uint32_t /*version*/) {
-    return sizeof(minimum_fee_);
-}
-
-// This is not a default instance so is valid.
-fee_filter::fee_filter(uint64_t minimum)
-    : minimum_fee_(minimum), insufficient_version_(false) {
-}
-
-// protected
-fee_filter::fee_filter(uint64_t minimum, bool insufficient_version)
-    : minimum_fee_(minimum), insufficient_version_(insufficient_version) {
-}
-
-//TODO(fernando): it does not compare all the data members, is it OK?
-bool fee_filter::operator==(fee_filter const& x) const {
-    return (minimum_fee_ == x.minimum_fee_);
-}
-
-bool fee_filter::operator!=(fee_filter const& x) const {
-    return !(*this == x);
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 
@@ -49,41 +24,13 @@ expect<fee_filter> fee_filter::from_data(byte_reader& reader, uint32_t version) 
     if (version < version_minimum) {
         return std::unexpected(error::version_too_low);
     }
-    auto const insufficient_version = false;
-    return fee_filter(*minimum, insufficient_version);
+    return fee_filter(*minimum);
 }
 
 // Serialization.
 //-----------------------------------------------------------------------------
 
-
-
-bool fee_filter::is_valid() const {
-    // return !insufficient_version_;
-    return !insufficient_version_ || (minimum_fee_ > 0);
-}
-
 // This is again a default instance so is invalid.
-void fee_filter::reset() {
-    insufficient_version_ = true;
-    minimum_fee_ = 0;
-}
-
-size_t fee_filter::serialized_size(uint32_t version) const {
-    return satoshi_fixed_size(version);
-}
-
-uint64_t fee_filter::minimum_fee() const {
-    return minimum_fee_;
-}
-
-void fee_filter::set_minimum_fee(uint64_t value) {
-    minimum_fee_ = value;
-
-    // This is no longer a default instance, so is valid.
-    insufficient_version_ = false;
-}
-
 expect<void> fee_filter::to_data(byte_writer& writer, uint32_t version) const {
         if (auto r = writer.write_little_endian<uint64_t>(minimum_fee_); ! r) return r;
         return {};

--- a/src/domain/src/message/filter_clear.cpp
+++ b/src/domain/src/message/filter_clear.cpp
@@ -12,45 +12,18 @@ std::string const filter_clear::command = "filterclear";
 uint32_t const filter_clear::version_minimum = version::level::bip37;
 uint32_t const filter_clear::version_maximum = version::level::maximum;
 
-// protected
-filter_clear::filter_clear(bool insufficient_version)
-    : insufficient_version_(insufficient_version) {
-}
-
-bool filter_clear::is_valid() const {
-    return !insufficient_version_;
-}
-
-// This is again a default instance so is invalid.
-void filter_clear::reset() {
-    insufficient_version_ = true;
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 
 // static
 expect<filter_clear> filter_clear::from_data(byte_reader& reader, uint32_t version) {
-    auto const insufficient_version = false;
     if (version < filter_clear::version_minimum) {
         return std::unexpected(error::version_too_low);
     }
-    return filter_clear(insufficient_version);
+    return filter_clear();
 }
 
 // Serialization.
 //-----------------------------------------------------------------------------
-
-data_chunk filter_clear::to_data(uint32_t version) const {
-    return kth::to_data_chunk(*this, version);
-}
-
-size_t filter_clear::serialized_size(uint32_t version) const {
-    return filter_clear::satoshi_fixed_size(version);
-}
-
-size_t filter_clear::satoshi_fixed_size(uint32_t /*version*/) {
-    return 0;
-}
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/memory_pool.cpp
+++ b/src/domain/src/message/memory_pool.cpp
@@ -11,20 +11,6 @@ std::string const memory_pool::command = "mempool";
 uint32_t const memory_pool::version_minimum = version::level::bip35;
 uint32_t const memory_pool::version_maximum = version::level::maximum;
 
-// protected
-memory_pool::memory_pool(bool insufficient_version)
-    : insufficient_version_(insufficient_version) {
-}
-
-bool memory_pool::is_valid() const {
-    return !insufficient_version_;
-}
-
-// This is again a default instance so is invalid.
-void memory_pool::reset() {
-    insufficient_version_ = true;
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 
@@ -33,20 +19,10 @@ expect<memory_pool> memory_pool::from_data(byte_reader& reader, uint32_t version
     if (version < memory_pool::version_minimum) {
         return std::unexpected(error::unsupported_version);
     }
-    auto const insufficient_version = false;
-    return memory_pool(insufficient_version);
+    return memory_pool();
 }
-
 
 // Serialization.
 //-----------------------------------------------------------------------------
-
-size_t memory_pool::serialized_size(uint32_t version) const {
-    return memory_pool::satoshi_fixed_size(version);
-}
-
-size_t memory_pool::satoshi_fixed_size(uint32_t /*version*/) {
-    return 0;
-}
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/ping.cpp
+++ b/src/domain/src/message/ping.cpp
@@ -11,67 +11,26 @@ std::string const ping::command = "ping";
 uint32_t const ping::version_minimum = version::level::minimum;
 uint32_t const ping::version_maximum = version::level::maximum;
 
-size_t ping::satoshi_fixed_size(uint32_t version) {
-    return version < version::level::bip31 ? 0 : sizeof(nonce_);
-}
-
-//TODO(fernando): nonceless_ is never used! Check it!
-ping::ping(uint64_t nonce, bool nonceless /* = false */)
-    : nonce_(nonce), valid_(true), nonceless_(nonceless)
-{}
-
-bool ping::operator==(ping const& x) const {
-    // Nonce should be zero if not used.
-    return (nonce_ == x.nonce_);
-}
-
-bool ping::operator!=(ping const& x) const {
-    // Nonce should be zero if not used.
-    return !(*this == x);
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 
 // static
 expect<ping> ping::from_data(byte_reader& reader, uint32_t version) {
-    auto const nonceless = (version < version::level::bip31);
-    if (nonceless) {
-        return ping(0, true);
+    // Before BIP31 a ping carries no nonce; the wire size and layout are
+    // driven by `version` in `to_data` / `satoshi_fixed_size`, so a zero nonce
+    // is all that is needed here.
+    if (version < version::level::bip31) {
+        return ping(0);
     }
     auto const nonce = reader.read_little_endian<uint64_t>();
     if ( ! nonce) {
         return std::unexpected(nonce.error());
     }
-    return ping(*nonce, false);
+    return ping(*nonce);
 }
 
 // Serialization.
 //-----------------------------------------------------------------------------
-
-
-
-bool ping::is_valid() const {
-    return valid_ || nonceless_ || nonce_ != 0;
-}
-
-void ping::reset() {
-    nonce_ = 0;
-    nonceless_ = false;
-    valid_ = false;
-}
-
-size_t ping::serialized_size(uint32_t version) const {
-    return satoshi_fixed_size(version);
-}
-
-uint64_t ping::nonce() const {
-    return nonce_;
-}
-
-void ping::set_nonce(uint64_t value) {
-    nonce_ = value;
-}
 
 expect<void> ping::to_data(byte_writer& writer, uint32_t version) const {
         if (version >= version::level::bip31) {

--- a/src/domain/src/message/pong.cpp
+++ b/src/domain/src/message/pong.cpp
@@ -11,23 +11,6 @@ std::string const pong::command = "pong";
 uint32_t const pong::version_minimum = version::level::minimum;
 uint32_t const pong::version_maximum = version::level::maximum;
 
-size_t pong::satoshi_fixed_size(uint32_t /*version*/) {
-    return sizeof(nonce_);
-}
-
-pong::pong(uint64_t nonce)
-    : nonce_(nonce), valid_(true) {
-}
-
-bool pong::operator==(pong const& x) const {
-    return (nonce_ == x.nonce_);
-}
-
-bool pong::operator!=(pong const& x) const {
-    return !(*this == x);
-}
-
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 
@@ -40,32 +23,8 @@ expect<pong> pong::from_data(byte_reader& reader, uint32_t version) {
     return pong(*nonce);
 }
 
-
 // Serialization.
 //-----------------------------------------------------------------------------
-
-
-
-bool pong::is_valid() const {
-    return valid_ || (nonce_ != 0);
-}
-
-void pong::reset() {
-    nonce_ = 0;
-    valid_ = false;
-}
-
-size_t pong::serialized_size(uint32_t version) const {
-    return satoshi_fixed_size(version);
-}
-
-uint64_t pong::nonce() const {
-    return nonce_;
-}
-
-void pong::set_nonce(uint64_t value) {
-    nonce_ = value;
-}
 
 expect<void> pong::to_data(byte_writer& writer, uint32_t version) const {
         if (auto r = writer.write_little_endian<uint64_t>(nonce_); ! r) return r;

--- a/src/domain/src/message/send_addrv2.cpp
+++ b/src/domain/src/message/send_addrv2.cpp
@@ -11,24 +11,6 @@ std::string const send_addrv2::command = "sendaddrv2";
 uint32_t const send_addrv2::version_minimum = version::level::feature_negotiation;
 uint32_t const send_addrv2::version_maximum = version::level::maximum;
 
-size_t send_addrv2::satoshi_fixed_size(uint32_t /*version*/) {
-    return 0;
-}
-
-// protected
-send_addrv2::send_addrv2(bool insufficient_version)
-    : insufficient_version_(insufficient_version) {
-}
-
-bool send_addrv2::is_valid() const {
-    return !insufficient_version_;
-}
-
-// This is again a default instance so is invalid.
-void send_addrv2::reset() {
-    insufficient_version_ = true;
-}
-
 // Serialization.
 //-----------------------------------------------------------------------------
 
@@ -37,17 +19,12 @@ expect<send_addrv2> send_addrv2::from_data(byte_reader& reader, uint32_t version
     if (version < send_addrv2::version_minimum) {
         return std::unexpected(error::version_too_low);
     }
-    auto const insufficient_version = false;
-    return send_addrv2(insufficient_version);
+    return send_addrv2();
 }
 
 expect<void> send_addrv2::to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
     // Empty message - no payload
     return {};
-}
-
-size_t send_addrv2::serialized_size(uint32_t version) const {
-    return send_addrv2::satoshi_fixed_size(version);
 }
 
 } // namespace kth::domain::message

--- a/src/domain/src/message/send_headers.cpp
+++ b/src/domain/src/message/send_headers.cpp
@@ -11,24 +11,6 @@ std::string const send_headers::command = "sendheaders";
 uint32_t const send_headers::version_minimum = version::level::bip130;
 uint32_t const send_headers::version_maximum = version::level::maximum;
 
-size_t send_headers::satoshi_fixed_size(uint32_t /*version*/) {
-    return 0;
-}
-
-// protected
-send_headers::send_headers(bool insufficient_version)
-    : insufficient_version_(insufficient_version) {
-}
-
-bool send_headers::is_valid() const {
-    return !insufficient_version_;
-}
-
-// This is again a default instance so is invalid.
-void send_headers::reset() {
-    insufficient_version_ = true;
-}
-
 // Serialization.
 //-----------------------------------------------------------------------------
 
@@ -37,16 +19,11 @@ expect<send_headers> send_headers::from_data(byte_reader& reader, uint32_t versi
     if (version < send_headers::version_minimum) {
         return std::unexpected(error::version_too_low);
     }
-    auto const insufficient_version = false;
-    return send_headers(insufficient_version);
+    return send_headers();
 }
 
 expect<void> send_headers::to_data(byte_writer& /*writer*/, uint32_t /*version*/) const {
     return {};
-}
-
-size_t send_headers::serialized_size(uint32_t version) const {
-    return send_headers::satoshi_fixed_size(version);
 }
 
 } // namespace kth::domain::message

--- a/src/domain/test/message/fee_filter.cpp
+++ b/src/domain/test/message/fee_filter.cpp
@@ -12,13 +12,11 @@ using namespace kth::domain::message;
 
 TEST_CASE("fee filter constructor 1 always invalid", "[fee filter]") {
     fee_filter const instance;
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("fee filter constructor 2 always equals params", "[fee filter]") {
     uint64_t const value = 6434u;
     fee_filter const instance(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance.minimum_fee());
 }
 
@@ -26,7 +24,6 @@ TEST_CASE("fee filter constructor 3 always equals params", "[fee filter]") {
     uint64_t const fee = 6434u;
     fee_filter const value(fee);
     fee_filter const instance(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(fee == instance.minimum_fee());
     REQUIRE(value == instance);
 }
@@ -35,7 +32,6 @@ TEST_CASE("fee filter constructor 4 always equals params", "[fee filter]") {
     uint64_t const fee = 6434u;
     fee_filter const value(fee);
     fee_filter const instance(std::move(value));
-    REQUIRE(instance.is_valid());
     REQUIRE(fee == instance.minimum_fee());
 }
 
@@ -61,7 +57,6 @@ TEST_CASE("fee filter from data roundtrip success", "[fee filter]") {
     auto const result_exp = fee_filter::from_data(reader, fee_filter::version_maximum);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
 
     auto const size = result.serialized_size(version::level::maximum);
@@ -69,24 +64,18 @@ TEST_CASE("fee filter from data roundtrip success", "[fee filter]") {
     REQUIRE(expected.serialized_size(version::level::maximum) == size);
 }
 
-TEST_CASE("fee filter minimum fee roundtrip success", "[fee filter]") {
+TEST_CASE("fee filter constructor sets minimum fee", "[fee filter]") {
     uint64_t const value = 42134u;
-    fee_filter instance;
-    REQUIRE(instance.minimum_fee() != value);
-
-    instance.set_minimum_fee(value);
+    fee_filter const instance(value);
     REQUIRE(value == instance.minimum_fee());
 }
 
 TEST_CASE("fee filter operator assign equals always matches equivalent", "[fee filter]") {
     fee_filter value(2453u);
-    REQUIRE(value.is_valid());
 
     fee_filter instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("fee filter operator boolean equals duplicates returns true", "[fee filter]") {
@@ -111,6 +100,15 @@ TEST_CASE("fee filter operator boolean not equals differs returns true", "[fee f
     fee_filter const expected(2453u);
     fee_filter instance;
     REQUIRE(instance != expected);
+}
+
+TEST_CASE("fee filter is usable in a constant expression", "[fee filter]") {
+    static_assert(message::fee_filter{42u}.minimum_fee() == 42u);
+    static_assert(message::fee_filter{}.minimum_fee() == 0u);
+    static_assert(message::fee_filter{1u} == message::fee_filter{1u});
+    static_assert(message::fee_filter{1u} != message::fee_filter{2u});
+    static_assert(message::fee_filter{}.serialized_size(message::version::level::maximum) == 8u);
+    REQUIRE(true);
 }
 
 // End Test Suite

--- a/src/domain/test/message/filter_clear.cpp
+++ b/src/domain/test/message/filter_clear.cpp
@@ -12,28 +12,48 @@ using namespace kth::domain::message;
 
 TEST_CASE("filter clear - from data insufficient version failure", "[filter clear]") {
     static const filter_clear expected{};
-    auto const raw = expected.to_data(version::level::maximum);
+    auto const raw = kth::to_data_chunk(expected, version::level::maximum);
     filter_clear instance{};
 
     byte_reader reader(raw);
     auto result = filter_clear::from_data(reader, filter_clear::version_minimum - 1);
     REQUIRE( ! result);
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("filter clear - roundtrip to data factory from data chunk", "[filter clear]") {
     static const filter_clear expected{};
-    auto const data = expected.to_data(version::level::maximum);
+    auto const data = kth::to_data_chunk(expected, version::level::maximum);
     byte_reader reader(data);
     auto const result_exp = filter_clear::from_data(reader, version::level::maximum);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
     REQUIRE(data.size() == 0u);
-    REQUIRE(result.is_valid());
     REQUIRE(result.serialized_size(version::level::maximum) == 0u);
 }
 
 
+
+TEST_CASE("filter clear is a regular type", "[filter clear]") {
+    // An empty-payload marker still has to behave like a value: declaring the
+    // move constructor here would delete copy-assignment and suppress
+    // move-assignment, leaving the type unassignable.
+    static_assert(std::is_default_constructible_v<message::filter_clear>);
+    static_assert(std::is_copy_constructible_v<message::filter_clear>);
+    static_assert(std::is_move_constructible_v<message::filter_clear>);
+    static_assert(std::is_copy_assignable_v<message::filter_clear>);
+    static_assert(std::is_move_assignable_v<message::filter_clear>);
+
+    message::filter_clear a;
+    message::filter_clear b;
+    a = b;
+    b = std::move(a);
+}
+
+TEST_CASE("filter clear is usable in a constant expression", "[filter clear]") {
+    static_assert(message::filter_clear::satoshi_fixed_size(message::version::level::maximum) == 0);
+    static_assert(message::filter_clear{}.serialized_size(message::version::level::maximum) == 0);
+    REQUIRE(true);
+}
 
 // End Test Suite

--- a/src/domain/test/message/memory_pool.cpp
+++ b/src/domain/test/message/memory_pool.cpp
@@ -16,7 +16,6 @@ TEST_CASE("memory pool - from data insufficient version failure", "[memory pool]
     byte_reader reader(data);
     auto result = message::memory_pool::from_data(reader, message::memory_pool::version_minimum - 1);
     REQUIRE( ! result);
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("memory pool - roundtrip to data factory from data chunk", "[memory pool]") {
@@ -28,10 +27,31 @@ TEST_CASE("memory pool - roundtrip to data factory from data chunk", "[memory po
     auto const result = std::move(*result_exp);
 
     REQUIRE(0u == data.size());
-    REQUIRE(result.is_valid());
     REQUIRE(0u == result.serialized_size(message::version::level::maximum));
 }
 
 
+
+TEST_CASE("memory pool is a regular type", "[memory pool]") {
+    // An empty-payload marker still has to behave like a value: declaring the
+    // move constructor here would delete copy-assignment and suppress
+    // move-assignment, leaving the type unassignable.
+    static_assert(std::is_default_constructible_v<message::memory_pool>);
+    static_assert(std::is_copy_constructible_v<message::memory_pool>);
+    static_assert(std::is_move_constructible_v<message::memory_pool>);
+    static_assert(std::is_copy_assignable_v<message::memory_pool>);
+    static_assert(std::is_move_assignable_v<message::memory_pool>);
+
+    message::memory_pool a;
+    message::memory_pool b;
+    a = b;
+    b = std::move(a);
+}
+
+TEST_CASE("memory pool is usable in a constant expression", "[memory pool]") {
+    static_assert(message::memory_pool::satoshi_fixed_size(message::version::level::maximum) == 0);
+    static_assert(message::memory_pool{}.serialized_size(message::version::level::maximum) == 0);
+    REQUIRE(true);
+}
 
 // End Test Suite

--- a/src/domain/test/message/ping.cpp
+++ b/src/domain/test/message/ping.cpp
@@ -11,21 +11,17 @@ using namespace kd;
 
 TEST_CASE("ping constructor 1 always invalid", "[ping]") {
     message::ping instance;
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("ping constructor 2 always equals params", "[ping]") {
     uint64_t nonce = 462434u;
     message::ping instance(nonce);
-    REQUIRE(instance.is_valid());
     REQUIRE(nonce == instance.nonce());
 }
 
 TEST_CASE("ping constructor 3 always equals params", "[ping]") {
     message::ping expected(24235u);
-    REQUIRE(expected.is_valid());
     message::ping instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -50,7 +46,6 @@ TEST_CASE("ping from data minimum version empty data valid", "[ping]") {
     auto const result_exp = message::ping::from_data(reader, version);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
 }
 
 TEST_CASE("ping from data 1 minimum version success zero nonce", "[ping]") {
@@ -66,7 +61,6 @@ TEST_CASE("ping from data 1 minimum version success zero nonce", "[ping]") {
     auto result = message::ping::from_data(reader, message::ping::version_minimum);
     REQUIRE(result);
     instance = std::move(*result);
-    REQUIRE(instance.is_valid());
     REQUIRE(instance.nonce() == 0u);
 }
 
@@ -80,7 +74,6 @@ TEST_CASE("ping from data minimum version round trip zero nonce", "[ping]") {
     auto const result_exp = message::ping::from_data(reader, version);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(result.nonce() == 0u);
 }
 
@@ -100,7 +93,6 @@ TEST_CASE("ping from data 1 maximum version success expected nonce", "[ping]") {
     auto result = message::ping::from_data(reader, message::ping::version_maximum);
     REQUIRE(result);
     instance = std::move(*result);
-    REQUIRE(instance.is_valid());
     REQUIRE(instance == expected);
 }
 
@@ -114,7 +106,6 @@ TEST_CASE("ping from data bip31 version round trip expected nonce", "[ping]") {
     auto const result_exp = message::ping::from_data(reader, version);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(result == expected);
 }
 
@@ -126,21 +117,16 @@ TEST_CASE("ping nonce accessor always returns initialized value", "[ping]") {
     REQUIRE(value == instance.nonce());
 }
 
-TEST_CASE("ping nonce setter roundtrip success", "[ping]") {
+TEST_CASE("ping constructor sets nonce", "[ping]") {
     uint64_t value = 43564u;
-    message::ping instance;
-    REQUIRE(value != instance.nonce());
-    instance.set_nonce(value);
+    message::ping const instance(value);
     REQUIRE(value == instance.nonce());
 }
 
 TEST_CASE("ping operator assign equals always matches equivalent", "[ping]") {
     message::ping value(356234u);
-    REQUIRE(value.is_valid());
     message::ping instance;
-    REQUIRE( ! instance.is_valid());
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("ping operator boolean equals duplicates returns true", "[ping]") {
@@ -165,6 +151,15 @@ TEST_CASE("ping operator boolean not equals differs returns true", "[ping]") {
     const message::ping expected(89764u);
     message::ping instance;
     REQUIRE(instance != expected);
+}
+
+TEST_CASE("ping is usable in a constant expression", "[ping]") {
+    static_assert(message::ping{7u}.nonce() == 7u);
+    static_assert(message::ping{1u} == message::ping{1u});
+    // Before BIP31 a ping is a bare marker; from BIP31 on it carries the nonce.
+    static_assert(message::ping{}.serialized_size(message::version::level::bip31 - 1u) == 0u);
+    static_assert(message::ping{}.serialized_size(message::version::level::bip31) == 8u);
+    REQUIRE(true);
 }
 
 // End Test Suite

--- a/src/domain/test/message/pong.cpp
+++ b/src/domain/test/message/pong.cpp
@@ -11,21 +11,17 @@ using namespace kd;
 
 TEST_CASE("pong constructor 1 always invalid", "[pong]") {
     message::pong instance;
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("pong constructor 2 always equals params", "[pong]") {
     uint64_t nonce = 462434u;
     message::pong instance(nonce);
-    REQUIRE(instance.is_valid());
     REQUIRE(nonce == instance.nonce());
 }
 
 TEST_CASE("pong constructor 3 always equals params", "[pong]") {
     message::pong expected(24235u);
-    REQUIRE(expected.is_valid());
     message::pong instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -52,7 +48,6 @@ TEST_CASE("pong from data round trip expected", "[pong]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(version));
     REQUIRE(expected.serialized_size(version) == result.serialized_size(version));
@@ -66,21 +61,16 @@ TEST_CASE("pong nonce accessor always returns initialized value", "[pong]") {
     REQUIRE(value == instance.nonce());
 }
 
-TEST_CASE("pong nonce setter roundtrip success", "[pong]") {
+TEST_CASE("pong constructor sets nonce", "[pong]") {
     uint64_t value = 43564u;
-    message::pong instance;
-    REQUIRE(value != instance.nonce());
-    instance.set_nonce(value);
+    message::pong const instance(value);
     REQUIRE(value == instance.nonce());
 }
 
 TEST_CASE("pong operator assign equals always matches equivalent", "[pong]") {
     message::pong value(356234u);
-    REQUIRE(value.is_valid());
     message::pong instance;
-    REQUIRE( ! instance.is_valid());
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("pong operator boolean equals duplicates returns true", "[pong]") {
@@ -105,6 +95,13 @@ TEST_CASE("pong operator boolean not equals differs returns true", "[pong]") {
     const message::pong expected(89764u);
     message::pong instance;
     REQUIRE(instance != expected);
+}
+
+TEST_CASE("pong is usable in a constant expression", "[pong]") {
+    static_assert(message::pong{7u}.nonce() == 7u);
+    static_assert(message::pong{1u} == message::pong{1u});
+    static_assert(message::pong{}.serialized_size(message::version::level::maximum) == 8u);
+    REQUIRE(true);
 }
 
 // End Test Suite

--- a/src/domain/test/message/send_headers.cpp
+++ b/src/domain/test/message/send_headers.cpp
@@ -18,12 +18,33 @@ TEST_CASE("send headers - roundtrip to data factory from data chunk", "[send hea
     auto const result = std::move(*result_exp);
 
     REQUIRE(0u == data.size());
-    REQUIRE(result.is_valid());
     REQUIRE(0u == result.serialized_size(message::version::level::maximum));
 }
 
 
 
 
+
+TEST_CASE("send headers is a regular type", "[send headers]") {
+    // An empty-payload marker still has to behave like a value: declaring the
+    // move constructor here would delete copy-assignment and suppress
+    // move-assignment, leaving the type unassignable.
+    static_assert(std::is_default_constructible_v<message::send_headers>);
+    static_assert(std::is_copy_constructible_v<message::send_headers>);
+    static_assert(std::is_move_constructible_v<message::send_headers>);
+    static_assert(std::is_copy_assignable_v<message::send_headers>);
+    static_assert(std::is_move_assignable_v<message::send_headers>);
+
+    message::send_headers a;
+    message::send_headers b;
+    a = b;
+    b = std::move(a);
+}
+
+TEST_CASE("send headers is usable in a constant expression", "[send headers]") {
+    static_assert(message::send_headers::satoshi_fixed_size(message::version::level::maximum) == 0);
+    static_assert(message::send_headers{}.serialized_size(message::version::level::maximum) == 0);
+    REQUIRE(true);
+}
 
 // End Test Suite


### PR DESCRIPTION
Seven messages carried a boolean member whose only purpose was to answer *"was I built by `from_data`, or am I still the default?"*: the field constructor always set it to the valid value, the default constructor left it at the invalid one, and `is_valid()` reported it. These types run no consensus checks, so the flag carried no information.

The migration to `expect<>` had already happened and left the member behind. `from_data` rejects an insufficient protocol version *and then* passes a hard-coded `false`:

```cpp
expect<filter_clear> filter_clear::from_data(byte_reader& reader, uint32_t version) {
    auto const insufficient_version = false;               // <- always false
    if (version < filter_clear::version_minimum) {
        return std::unexpected(error::version_too_low);    // <- already correct
    }
    return filter_clear(insufficient_version);
}
```

## The flags

- Drop `insufficient_version_` from `filter_clear`, `memory_pool`, `send_addrv2`, `send_headers` and `fee_filter`, along with the protected constructor that took it. **The first four now have no members at all**, which is what a marker message should be.
- Drop `valid_` from `ping` and `pong`.
- With `valid_` gone, **`ping::nonceless_` is dead too** — written and never read, as its own `TODO(fernando)` suspected. The pre-BIP31 layout is driven by the `version` argument in `to_data` / `satoshi_fixed_size`, not by the member, so `ping` keeps its behaviour and loses the constructor's defaulted parameter.
- Remove the resulting `is_valid()`, `reset()` and the setters; `nonce_` and `minimum_fee_` are set at construction.

## While in these files

**A latent bug.** The four empty markers had this block:

```cpp
filter_clear() = default;
filter_clear(filter_clear const& x) = default;
filter_clear(filter_clear&& x) = default;
```

Declaring the move constructor **deletes copy-assignment and suppresses move-assignment**, so `filter_clear` was not assignable at all. With no members, every special member should stay implicit — the block is gone and a `static_assert` pins the value semantics down.

**A comment that had become false.** `filter_clear` and `memory_pool` documented exactly the sentinel this PR removes:

```cpp
// This is a default instance so is invalid.
// The only way to make this valid is to deserialize it :/.
```

**Equality is defaulted everywhere it can be.** `fee_filter`'s hand-written `operator==` carried `TODO(fernando): it does not compare all the data members, is it OK?` — a defaulted `operator==` compares all members by definition, which answers it and synthesizes `!=` for free.

**Everything that can be `constexpr` is.** `satoshi_fixed_size`, `serialized_size`, the accessors and the field constructors are now `constexpr` and defined inline. `fee_filter` declared `satoshi_fixed_size` `constexpr` in the header but defined it *without* `constexpr` in the `.cpp`, so it could never appear in a constant expression. Each type now has a test that proves it can:

```cpp
static_assert(message::fee_filter{42u}.minimum_fee() == 42u);
static_assert(message::fee_filter{1u} != message::fee_filter{2u});   // synthesized from the defaulted ==
static_assert(message::ping{}.serialized_size(message::version::level::bip31 - 1u) == 0u);
static_assert(message::ping{}.serialized_size(message::version::level::bip31) == 8u);
```

**Dead weight.** Dropped `#include <istream>` (left over from the `data_source`/`data_sink` era) and `filter_clear`'s stray `data_chunk to_data(uint32_t)` overload, which only its own tests used while every other message goes through the free `kth::to_data_chunk`.

## Not done here

`X::command` is `std::string const`, which is neither `constexpr` nor free of static-init-order risk. Turning it into `constexpr std::string_view` is the bigger win, but `heading`'s constructor takes `std::string const&` and the handler map is keyed by `std::string`, so it is a protocol-wide convention change across all ~40 message types rather than a cleanup of these seven. Separate PR.

## Testing

Full build green — every target, benchmarks included. Domain (3842 cases) and C-API (740 cases) suites pass. These types are not exposed through the C-API, so no regen.