### PR TITLE
refactor(domain/message): drop the default-sentinel is_valid()

### DIFF
--- a/src/c-api/include/kth/capi/chain/get_blocks.h
+++ b/src/c-api/include/kth/capi/chain/get_blocks.h
@@ -60,6 +60,9 @@ kth_get_blocks_mut_t kth_chain_get_blocks_copy(kth_get_blocks_const_t self);
 KTH_EXPORT
 kth_bool_t kth_chain_get_blocks_equals(kth_get_blocks_const_t self, kth_get_blocks_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_get_blocks_not_equal(kth_get_blocks_const_t self, kth_get_blocks_const_t other);
+
 
 // Serialization
 
@@ -94,18 +97,6 @@ void kth_chain_get_blocks_set_stop_hash(kth_get_blocks_mut_t self, kth_hash_t co
 /** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_get_blocks_set_stop_hash_unsafe(kth_get_blocks_mut_t self, uint8_t const* value);
-
-
-// Predicates
-
-KTH_EXPORT
-kth_bool_t kth_chain_get_blocks_is_valid(kth_get_blocks_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_get_blocks_reset(kth_get_blocks_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/chain/get_headers.h
+++ b/src/c-api/include/kth/capi/chain/get_headers.h
@@ -60,6 +60,9 @@ kth_get_headers_mut_t kth_chain_get_headers_copy(kth_get_headers_const_t self);
 KTH_EXPORT
 kth_bool_t kth_chain_get_headers_equals(kth_get_headers_const_t self, kth_get_headers_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_get_headers_not_equal(kth_get_headers_const_t self, kth_get_headers_const_t other);
+
 
 // Serialization
 
@@ -94,18 +97,6 @@ void kth_chain_get_headers_set_stop_hash(kth_get_headers_mut_t self, kth_hash_t 
 /** @warning `value` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
 KTH_EXPORT
 void kth_chain_get_headers_set_stop_hash_unsafe(kth_get_headers_mut_t self, uint8_t const* value);
-
-
-// Predicates
-
-KTH_EXPORT
-kth_bool_t kth_chain_get_headers_is_valid(kth_get_headers_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_get_headers_reset(kth_get_headers_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/src/chain/get_blocks.cpp
+++ b/src/c-api/src/chain/get_blocks.cpp
@@ -77,6 +77,12 @@ kth_bool_t kth_chain_get_blocks_equals(kth_get_blocks_const_t self, kth_get_bloc
     return kth::eq<cpp_t>(self, other);
 }
 
+kth_bool_t kth_chain_get_blocks_not_equal(kth_get_blocks_const_t self, kth_get_blocks_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
 
 // Serialization
 
@@ -126,22 +132,6 @@ void kth_chain_get_blocks_set_stop_hash_unsafe(kth_get_blocks_mut_t self, uint8_
     KTH_PRECONDITION(value != nullptr);
     auto const value_cpp = kth::hash_to_cpp(value);
     kth::cpp_ref<cpp_t>(self).set_stop_hash(value_cpp);
-}
-
-
-// Predicates
-
-kth_bool_t kth_chain_get_blocks_is_valid(kth_get_blocks_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
-
-// Operations
-
-void kth_chain_get_blocks_reset(kth_get_blocks_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/src/chain/get_headers.cpp
+++ b/src/c-api/src/chain/get_headers.cpp
@@ -77,6 +77,12 @@ kth_bool_t kth_chain_get_headers_equals(kth_get_headers_const_t self, kth_get_he
     return kth::eq<cpp_t>(self, other);
 }
 
+kth_bool_t kth_chain_get_headers_not_equal(kth_get_headers_const_t self, kth_get_headers_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
 
 // Serialization
 
@@ -126,22 +132,6 @@ void kth_chain_get_headers_set_stop_hash_unsafe(kth_get_headers_mut_t self, uint
     KTH_PRECONDITION(value != nullptr);
     auto const value_cpp = kth::hash_to_cpp(value);
     kth::cpp_ref<cpp_t>(self).set_stop_hash(value_cpp);
-}
-
-
-// Predicates
-
-kth_bool_t kth_chain_get_headers_is_valid(kth_get_headers_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
-
-// Operations
-
-void kth_chain_get_headers_reset(kth_get_headers_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/get_blocks.cpp
+++ b/src/c-api/test/chain/get_blocks.cpp
@@ -62,17 +62,10 @@ static kth_hash_list_mut_t make_hash_list_of_two(void) {
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API GetBlocks - default construct is invalid", "[C-API GetBlocks]") {
-    kth_get_blocks_mut_t gb = kth_chain_get_blocks_construct_default();
-    REQUIRE(kth_chain_get_blocks_is_valid(gb) == 0);
-    kth_chain_get_blocks_destruct(gb);
-}
-
-TEST_CASE("C-API GetBlocks - field constructor is valid", "[C-API GetBlocks]") {
+TEST_CASE("C-API GetBlocks - field constructor returns a handle", "[C-API GetBlocks]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_blocks_mut_t gb = kth_chain_get_blocks_construct(starts, &kStopHash);
     REQUIRE(gb != NULL);
-    REQUIRE(kth_chain_get_blocks_is_valid(gb) != 0);
     kth_chain_get_blocks_destruct(gb);
     kth_core_hash_list_destruct(starts);
 }
@@ -90,6 +83,21 @@ TEST_CASE("C-API GetBlocks - construct_unsafe matches safe variant",
 
     kth_chain_get_blocks_destruct(safe);
     kth_chain_get_blocks_destruct(unsafe);
+    kth_core_hash_list_destruct(starts);
+}
+
+TEST_CASE("C-API GetBlocks - not_equal is the negation of equals", "[C-API GetBlocks]") {
+    kth_hash_list_mut_t starts = make_hash_list_of_two();
+    kth_get_blocks_mut_t gb = kth_chain_get_blocks_construct(starts, &kStopHash);
+    kth_get_blocks_mut_t same = kth_chain_get_blocks_copy(gb);
+    kth_get_blocks_mut_t other = kth_chain_get_blocks_construct_default();
+
+    REQUIRE(kth_chain_get_blocks_not_equal(gb, same) == 0);
+    REQUIRE(kth_chain_get_blocks_not_equal(gb, other) != 0);
+
+    kth_chain_get_blocks_destruct(other);
+    kth_chain_get_blocks_destruct(same);
+    kth_chain_get_blocks_destruct(gb);
     kth_core_hash_list_destruct(starts);
 }
 
@@ -118,7 +126,6 @@ TEST_CASE("C-API GetBlocks - to_data / from_data round-trip",
         raw, out_size, kProtoVersion, &decoded);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(decoded != NULL);
-    REQUIRE(kth_chain_get_blocks_is_valid(decoded) != 0);
 
     REQUIRE(kth_chain_get_blocks_equals(original, decoded) != 0);
 
@@ -229,20 +236,6 @@ TEST_CASE("C-API GetBlocks - start_hashes count reflects input list",
 // Operations
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API GetBlocks - reset clears the object", "[C-API GetBlocks]") {
-    kth_hash_list_mut_t starts = make_hash_list_of_two();
-    kth_get_blocks_mut_t gb =
-        kth_chain_get_blocks_construct(starts, &kStopHash);
-
-    kth_chain_get_blocks_reset(gb);
-
-    kth_hash_list_const_t view = kth_chain_get_blocks_start_hashes(gb);
-    REQUIRE(kth_core_hash_list_count(view) == 0u);
-
-    kth_chain_get_blocks_destruct(gb);
-    kth_core_hash_list_destruct(starts);
-}
-
 // ---------------------------------------------------------------------------
 // Preconditions (death tests via fork)
 // ---------------------------------------------------------------------------
@@ -298,11 +291,6 @@ TEST_CASE("C-API GetBlocks - equals null self aborts",
     kth_get_blocks_mut_t other = kth_chain_get_blocks_construct_default();
     KTH_EXPECT_ABORT(kth_chain_get_blocks_equals(NULL, other));
     kth_chain_get_blocks_destruct(other);
-}
-
-TEST_CASE("C-API GetBlocks - is_valid null aborts",
-          "[C-API GetBlocks][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_get_blocks_is_valid(NULL));
 }
 
 TEST_CASE("C-API GetBlocks - start_hashes null aborts",

--- a/src/c-api/test/chain/get_headers.cpp
+++ b/src/c-api/test/chain/get_headers.cpp
@@ -62,17 +62,10 @@ static kth_hash_list_mut_t make_hash_list_of_two(void) {
 // Constructors / lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API GetHeaders - default construct is invalid", "[C-API GetHeaders]") {
-    kth_get_headers_mut_t gh = kth_chain_get_headers_construct_default();
-    REQUIRE(kth_chain_get_headers_is_valid(gh) == 0);
-    kth_chain_get_headers_destruct(gh);
-}
-
-TEST_CASE("C-API GetHeaders - field constructor is valid", "[C-API GetHeaders]") {
+TEST_CASE("C-API GetHeaders - field constructor returns a handle", "[C-API GetHeaders]") {
     kth_hash_list_mut_t starts = make_hash_list_of_two();
     kth_get_headers_mut_t gh = kth_chain_get_headers_construct(starts, &kStopHash);
     REQUIRE(gh != NULL);
-    REQUIRE(kth_chain_get_headers_is_valid(gh) != 0);
     kth_chain_get_headers_destruct(gh);
     kth_core_hash_list_destruct(starts);
 }
@@ -90,6 +83,21 @@ TEST_CASE("C-API GetHeaders - construct_unsafe matches safe variant",
 
     kth_chain_get_headers_destruct(safe);
     kth_chain_get_headers_destruct(unsafe);
+    kth_core_hash_list_destruct(starts);
+}
+
+TEST_CASE("C-API GetHeaders - not_equal is the negation of equals", "[C-API GetHeaders]") {
+    kth_hash_list_mut_t starts = make_hash_list_of_two();
+    kth_get_headers_mut_t gb = kth_chain_get_headers_construct(starts, &kStopHash);
+    kth_get_headers_mut_t same = kth_chain_get_headers_copy(gb);
+    kth_get_headers_mut_t other = kth_chain_get_headers_construct_default();
+
+    REQUIRE(kth_chain_get_headers_not_equal(gb, same) == 0);
+    REQUIRE(kth_chain_get_headers_not_equal(gb, other) != 0);
+
+    kth_chain_get_headers_destruct(other);
+    kth_chain_get_headers_destruct(same);
+    kth_chain_get_headers_destruct(gb);
     kth_core_hash_list_destruct(starts);
 }
 
@@ -118,7 +126,6 @@ TEST_CASE("C-API GetHeaders - to_data / from_data round-trip",
         raw, out_size, kProtoVersion, &decoded);
     REQUIRE(ec == kth_ec_success);
     REQUIRE(decoded != NULL);
-    REQUIRE(kth_chain_get_headers_is_valid(decoded) != 0);
 
     REQUIRE(kth_chain_get_headers_equals(original, decoded) != 0);
 
@@ -229,20 +236,6 @@ TEST_CASE("C-API GetHeaders - start_hashes count reflects input list",
 // Operations
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API GetHeaders - reset clears the object", "[C-API GetHeaders]") {
-    kth_hash_list_mut_t starts = make_hash_list_of_two();
-    kth_get_headers_mut_t gh =
-        kth_chain_get_headers_construct(starts, &kStopHash);
-
-    kth_chain_get_headers_reset(gh);
-
-    kth_hash_list_const_t view = kth_chain_get_headers_start_hashes(gh);
-    REQUIRE(kth_core_hash_list_count(view) == 0u);
-
-    kth_chain_get_headers_destruct(gh);
-    kth_core_hash_list_destruct(starts);
-}
-
 // ---------------------------------------------------------------------------
 // Preconditions (death tests via fork)
 // ---------------------------------------------------------------------------
@@ -298,11 +291,6 @@ TEST_CASE("C-API GetHeaders - equals null self aborts",
     kth_get_headers_mut_t other = kth_chain_get_headers_construct_default();
     KTH_EXPECT_ABORT(kth_chain_get_headers_equals(NULL, other));
     kth_chain_get_headers_destruct(other);
-}
-
-TEST_CASE("C-API GetHeaders - is_valid null aborts",
-          "[C-API GetHeaders][precondition]") {
-    KTH_EXPECT_ABORT(kth_chain_get_headers_is_valid(NULL));
 }
 
 TEST_CASE("C-API GetHeaders - start_hashes null aborts",

--- a/src/domain/include/kth/domain/message/address.hpp
+++ b/src/domain/include/kth/domain/message/address.hpp
@@ -46,11 +46,6 @@ struct KD_API address {
 
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
 

--- a/src/domain/include/kth/domain/message/addrv2.hpp
+++ b/src/domain/include/kth/domain/message/addrv2.hpp
@@ -90,11 +90,6 @@ struct KD_API addrv2 {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/include/kth/domain/message/alert.hpp
+++ b/src/domain/include/kth/domain/message/alert.hpp
@@ -52,11 +52,6 @@ struct KD_API alert {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
 

--- a/src/domain/include/kth/domain/message/alert_payload.hpp
+++ b/src/domain/include/kth/domain/message/alert_payload.hpp
@@ -183,11 +183,6 @@ struct KD_API alert_payload {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
 

--- a/src/domain/include/kth/domain/message/block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/block_transactions.hpp
@@ -58,11 +58,6 @@ struct KD_API block_transactions {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/include/kth/domain/message/filter_add.hpp
+++ b/src/domain/include/kth/domain/message/filter_add.hpp
@@ -45,11 +45,6 @@ struct KD_API filter_add {
 
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/include/kth/domain/message/filter_load.hpp
+++ b/src/domain/include/kth/domain/message/filter_load.hpp
@@ -59,11 +59,6 @@ struct KD_API filter_load {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
 

--- a/src/domain/include/kth/domain/message/get_address.hpp
+++ b/src/domain/include/kth/domain/message/get_address.hpp
@@ -39,11 +39,6 @@ struct KD_API get_address {
     }
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/include/kth/domain/message/get_block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/get_block_transactions.hpp
@@ -52,11 +52,6 @@ struct KD_API get_block_transactions {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/include/kth/domain/message/get_blocks.hpp
+++ b/src/domain/include/kth/domain/message/get_blocks.hpp
@@ -56,11 +56,6 @@ struct KD_API get_blocks {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/include/kth/domain/message/headers.hpp
+++ b/src/domain/include/kth/domain/message/headers.hpp
@@ -56,11 +56,6 @@ struct KD_API headers {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
 

--- a/src/domain/include/kth/domain/message/heading.hpp
+++ b/src/domain/include/kth/domain/message/heading.hpp
@@ -119,11 +119,6 @@ struct KD_API heading {
         return satoshi_fixed_size();
     }
 
-    [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
 
 private:
     uint32_t magic_{0};

--- a/src/domain/include/kth/domain/message/inventory.hpp
+++ b/src/domain/include/kth/domain/message/inventory.hpp
@@ -55,11 +55,6 @@ struct KD_API inventory {
     void reduce(inventory_vector::list& out, type_id type) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     [[nodiscard]]

--- a/src/domain/include/kth/domain/message/inventory_vector.hpp
+++ b/src/domain/include/kth/domain/message/inventory_vector.hpp
@@ -84,11 +84,6 @@ struct KD_API inventory_vector {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
 private:

--- a/src/domain/include/kth/domain/message/reject.hpp
+++ b/src/domain/include/kth/domain/message/reject.hpp
@@ -99,11 +99,6 @@ struct KD_API reject {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
 

--- a/src/domain/include/kth/domain/message/send_compact.hpp
+++ b/src/domain/include/kth/domain/message/send_compact.hpp
@@ -48,11 +48,6 @@ struct KD_API send_compact {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
 

--- a/src/domain/include/kth/domain/message/verack.hpp
+++ b/src/domain/include/kth/domain/message/verack.hpp
@@ -33,11 +33,6 @@ struct KD_API verack {
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/include/kth/domain/message/version.hpp
+++ b/src/domain/include/kth/domain/message/version.hpp
@@ -220,11 +220,6 @@ struct KD_API version {
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/include/kth/domain/message/xverack.hpp
+++ b/src/domain/include/kth/domain/message/xverack.hpp
@@ -37,11 +37,6 @@ struct KD_API xverack {
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/include/kth/domain/message/xversion.hpp
+++ b/src/domain/include/kth/domain/message/xversion.hpp
@@ -36,11 +36,6 @@ struct KD_API xversion {
     expect<xversion> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
-    bool is_valid() const;
-
-    void reset();
-
-    [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
 
     static

--- a/src/domain/src/message/address.cpp
+++ b/src/domain/src/message/address.cpp
@@ -22,15 +22,6 @@ address::address(infrastructure::message::network_address::list&& addresses)
     : addresses_(std::move(addresses))
 {}
 
-bool address::is_valid() const {
-    return !addresses_.empty();
-}
-
-void address::reset() {
-    addresses_.clear();
-    addresses_.shrink_to_fit();
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/addrv2.cpp
+++ b/src/domain/src/message/addrv2.cpp
@@ -129,15 +129,6 @@ addrv2::addrv2(entry_list&& addresses)
     : addresses_(std::move(addresses))
 {}
 
-bool addrv2::is_valid() const {
-    return !addresses_.empty();
-}
-
-void addrv2::reset() {
-    addresses_.clear();
-    addresses_.shrink_to_fit();
-}
-
 addrv2::entry_list& addrv2::addresses() {
     return addresses_;
 }

--- a/src/domain/src/message/alert.cpp
+++ b/src/domain/src/message/alert.cpp
@@ -23,17 +23,6 @@ alert::alert(data_chunk&& payload, data_chunk&& signature)
     : payload_(std::move(payload)), signature_(std::move(signature)) {
 }
 
-bool alert::is_valid() const {
-    return !payload_.empty() || !signature_.empty();
-}
-
-void alert::reset() {
-    payload_.clear();
-    payload_.shrink_to_fit();
-    signature_.clear();
-    signature_.shrink_to_fit();
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/alert_payload.cpp
+++ b/src/domain/src/message/alert_payload.cpp
@@ -127,33 +127,6 @@ alert_payload::alert_payload(
 //     return *this;
 // }
 
-bool alert_payload::is_valid() const {
-    return (version_ != 0) || (relay_until_ != 0) || (expiration_ != 0) || (id_ != 0) || (cancel_ != 0) || !set_cancel_.empty() || (min_version_ != 0) || (max_version_ != 0) || !set_sub_version_.empty() || (priority_ != 0) || !comment_.empty() || !status_bar_.empty() || !reserved_.empty();
-}
-
-void alert_payload::reset() {
-    version_ = 0;
-    relay_until_ = 0;
-    expiration_ = 0;
-    id_ = 0;
-    cancel_ = 0;
-    set_cancel_.clear();
-    set_cancel_.shrink_to_fit();
-    min_version_ = 0;
-    max_version_ = 0;
-    set_sub_version_.clear();
-    set_sub_version_.shrink_to_fit();
-    priority_ = 0;
-    comment_.clear();
-    comment_.shrink_to_fit();
-    status_bar_.clear();
-    status_bar_.shrink_to_fit();
-    reserved_.clear();
-    reserved_.shrink_to_fit();
-}
-
-
-
 size_t alert_payload::serialized_size(uint32_t /*version*/) const {
     size_t size = 40u +
                   infrastructure::message::variable_uint_size(comment_.size()) + comment_.size() +

--- a/src/domain/src/message/block_transactions.cpp
+++ b/src/domain/src/message/block_transactions.cpp
@@ -29,16 +29,6 @@ block_transactions::block_transactions(hash_digest const& block_hash, chain::tra
     , transactions_(std::move(transactions))
 {}
 
-bool block_transactions::is_valid() const {
-    return (block_hash_ != null_hash);
-}
-
-void block_transactions::reset() {
-    block_hash_ = null_hash;
-    transactions_.clear();
-    transactions_.shrink_to_fit();
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/filter_add.cpp
+++ b/src/domain/src/message/filter_add.cpp
@@ -23,15 +23,6 @@ filter_add::filter_add(data_chunk&& data)
     : data_(std::move(data)) {
 }
 
-bool filter_add::is_valid() const {
-    return !data_.empty();
-}
-
-void filter_add::reset() {
-    data_.clear();
-    data_.shrink_to_fit();
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/filter_load.cpp
+++ b/src/domain/src/message/filter_load.cpp
@@ -22,18 +22,6 @@ filter_load::filter_load(data_chunk&& filter, uint32_t hash_functions, uint32_t 
     : filter_(std::move(filter)), hash_functions_(hash_functions), tweak_(tweak), flags_(flags) {
 }
 
-bool filter_load::is_valid() const {
-    return !filter_.empty() || (hash_functions_ != 0) || (tweak_ != 0) || (flags_ != 0x00);
-}
-
-void filter_load::reset() {
-    filter_.clear();
-    filter_.shrink_to_fit();
-    hash_functions_ = 0;
-    tweak_ = 0;
-    flags_ = 0x00;
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/get_address.cpp
+++ b/src/domain/src/message/get_address.cpp
@@ -11,12 +11,6 @@ std::string const get_address::command = "getaddr";
 uint32_t const get_address::version_minimum = version::level::minimum;
 uint32_t const get_address::version_maximum = version::level::maximum;
 
-bool get_address::is_valid() const {
-    return true;
-}
-
-void get_address::reset() {}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/get_block_transactions.cpp
+++ b/src/domain/src/message/get_block_transactions.cpp
@@ -30,16 +30,6 @@ get_block_transactions::get_block_transactions(hash_digest const& block_hash, st
     , indexes_(std::move(indexes))
 {}
 
-bool get_block_transactions::is_valid() const {
-    return (block_hash_ != null_hash);
-}
-
-void get_block_transactions::reset() {
-    block_hash_ = null_hash;
-    indexes_.clear();
-    indexes_.shrink_to_fit();
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/get_blocks.cpp
+++ b/src/domain/src/message/get_blocks.cpp
@@ -25,16 +25,6 @@ get_blocks::get_blocks(hash_list&& start, hash_digest const& stop)
     : start_hashes_(std::move(start)), stop_hash_(stop) {
 }
 
-bool get_blocks::is_valid() const {
-    return !start_hashes_.empty() || (stop_hash_ != null_hash);
-}
-
-void get_blocks::reset() {
-    start_hashes_.clear();
-    start_hashes_.shrink_to_fit();
-    stop_hash_.fill(0);
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/headers.cpp
+++ b/src/domain/src/message/headers.cpp
@@ -34,16 +34,6 @@ headers::headers(std::initializer_list<header> const& values)
     : elements_(values) {
 }
 
-bool headers::is_valid() const {
-    return !elements_.empty();
-}
-
-void headers::reset() {
-    elements_.clear();
-    elements_.shrink_to_fit();
-}
-
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/heading.cpp
+++ b/src/domain/src/message/heading.cpp
@@ -55,18 +55,6 @@ heading::heading(uint32_t magic, std::string&& command, uint32_t payload_size, u
     : magic_(magic), command_(std::move(command)), payload_size_(payload_size), checksum_(checksum) {
 }
 
-bool heading::is_valid() const {
-    return (magic_ != 0) || (payload_size_ != 0) || (checksum_ != 0) || !command_.empty();
-}
-
-void heading::reset() {
-    magic_ = 0;
-    command_.clear();
-    command_.shrink_to_fit();
-    payload_size_ = 0;
-    checksum_ = 0;
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/inventory.cpp
+++ b/src/domain/src/message/inventory.cpp
@@ -41,15 +41,6 @@ inventory::inventory(std::initializer_list<inventory_vector> const& values)
     : inventories_(values)
 {}
 
-bool inventory::is_valid() const {
-    return !inventories_.empty();
-}
-
-void inventory::reset() {
-    inventories_.clear();
-    inventories_.shrink_to_fit();
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/inventory_vector.cpp
+++ b/src/domain/src/message/inventory_vector.cpp
@@ -44,15 +44,6 @@ inventory_vector::inventory_vector(type_id type, hash_digest const& hash)
     : type_(type), hash_(hash)
 {}
 
-bool inventory_vector::is_valid() const {
-    return (type_ != type_id::error) || (hash_ != null_hash);
-}
-
-void inventory_vector::reset() {
-    type_ = type_id::error;
-    hash_.fill(0);
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/reject.cpp
+++ b/src/domain/src/message/reject.cpp
@@ -59,19 +59,6 @@ reject::reject(reason_code code, std::string&& message, std::string&& reason, ha
 //     return *this;
 // }
 
-bool reject::is_valid() const {
-    return !message_.empty() || (code_ != reason_code::undefined) || !reason_.empty() || (data_ != null_hash);
-}
-
-void reject::reset() {
-    message_.clear();
-    message_.shrink_to_fit();
-    code_ = reason_code::undefined;
-    reason_.clear();
-    reason_.shrink_to_fit();
-    data_.fill(0);
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/send_compact.cpp
+++ b/src/domain/src/message/send_compact.cpp
@@ -22,15 +22,6 @@ send_compact::send_compact(bool high_bandwidth_mode, uint64_t version)
       version_(version) {
 }
 
-bool send_compact::is_valid() const {
-    return (version_ != 0);
-}
-
-void send_compact::reset() {
-    high_bandwidth_mode_ = false;
-    version_ = 0;
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/verack.cpp
+++ b/src/domain/src/message/verack.cpp
@@ -11,12 +11,6 @@ std::string const verack::command = "verack";
 uint32_t const verack::version_minimum = version::level::minimum;
 uint32_t const verack::version_maximum = version::level::maximum;
 
-bool verack::is_valid() const {
-    return true;
-}
-
-void verack::reset() {}
-
 // Serialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/version.cpp
+++ b/src/domain/src/message/version.cpp
@@ -21,31 +21,6 @@ version::version(uint32_t value, uint64_t services, uint64_t timestamp, network_
     : value_(value), services_(services), timestamp_(timestamp), address_receiver_(address_receiver), address_sender_(address_sender), nonce_(nonce), user_agent_(std::move(user_agent)), start_height_(start_height), relay_(relay) {
 }
 
-bool version::is_valid() const {
-    return value_ != 0
-        || services_ != 0
-        || timestamp_ != 0
-        || address_receiver_.is_valid()
-        || address_sender_.is_valid()
-        || nonce_ != 0
-        || ! user_agent_.empty()
-        || start_height_ != 0
-        || relay_;
-}
-
-void version::reset() {
-    value_ = 0;
-    services_ = 0;
-    timestamp_ = 0;
-    address_receiver_.reset();
-    address_sender_.reset();
-    nonce_ = 0;
-    user_agent_.clear();
-    user_agent_.shrink_to_fit();
-    start_height_ = 0;
-    relay_ = false;
-}
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/xverack.cpp
+++ b/src/domain/src/message/xverack.cpp
@@ -11,13 +11,6 @@ std::string const xverack::command = "xverack";
 uint32_t const xverack::version_minimum = version::level::minimum;
 uint32_t const xverack::version_maximum = version::level::maximum;
 
-bool xverack::is_valid() const {
-    return true;
-}
-
-void xverack::reset() {
-}
-
 // Serialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/src/message/xversion.cpp
+++ b/src/domain/src/message/xversion.cpp
@@ -12,13 +12,6 @@ std::string const xversion::command = "xversion";
 uint32_t const message::xversion::version_minimum = version::level::minimum;
 uint32_t const message::xversion::version_maximum = version::level::maximum;
 
-bool xversion::is_valid() const {
-    return true;
-}
-
-void xversion::reset() {}
-
-
 // Deserialization.
 //-----------------------------------------------------------------------------
 

--- a/src/domain/test/message/address.cpp
+++ b/src/domain/test/message/address.cpp
@@ -22,12 +22,6 @@ bool equal(address const& x, address const& y) {
 }
 
 // Start Test Suite: address tests
-
-TEST_CASE("address constructor 1 always invalid", "[address]") {
-    address instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("address constructor 2 always equals params", "[address]") {
     infrastructure::message::network_address::list const addresses{
         network_address(
@@ -48,7 +42,6 @@ TEST_CASE("address constructor 2 always equals params", "[address]") {
 
     address instance(addresses);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(addresses == instance.addresses());
 }
 
@@ -74,7 +67,6 @@ TEST_CASE("address constructor 3 always equals params", "[address]") {
 
     address instance(std::move(dup_addresses));
 
-    REQUIRE(instance.is_valid());
     REQUIRE(addresses == instance.addresses());
 }
 
@@ -99,7 +91,6 @@ TEST_CASE("address constructor 4 always equals params", "[address]") {
     address value(addresses);
     address instance(value);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
     REQUIRE(addresses == instance.addresses());
 }
@@ -125,7 +116,6 @@ TEST_CASE("address constructor 5 always equals params", "[address]") {
     address value(addresses);
     address instance(std::move(value));
 
-    REQUIRE(instance.is_valid());
     REQUIRE(addresses == instance.addresses());
 }
 
@@ -151,14 +141,11 @@ TEST_CASE("address from data roundtrip success", "[address]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(equal(expected, result));
     auto const serialized_size = result.serialized_size(version::level::minimum);
     REQUIRE(data.size() == serialized_size);
     REQUIRE(expected.serialized_size(version::level::minimum) == serialized_size);
 }
-
-
 
 TEST_CASE("address addresses setter 1 roundtrip success", "[address]") {
     infrastructure::message::network_address::list const value{
@@ -229,13 +216,10 @@ TEST_CASE("address operator assign equals always matches equivalent", "[address]
 
     address value(addresses);
 
-    REQUIRE(value.is_valid());
 
     address instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(addresses == instance.addresses());
 }
 

--- a/src/domain/test/message/alert.cpp
+++ b/src/domain/test/message/alert.cpp
@@ -8,19 +8,12 @@ using namespace kth;
 using namespace kd;
 
 // Start Test Suite: alert tests
-
-TEST_CASE("alert constructor 1 always invalid", "[alert]") {
-    message::alert instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("alert constructor 2 always equals params", "[alert]") {
     data_chunk const payload = to_chunk("0123456789abcdef"_base16);
     data_chunk const signature = to_chunk("fedcba9876543210"_base16);
 
     message::alert instance(payload, signature);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(payload == instance.payload());
     REQUIRE(signature == instance.signature());
 }
@@ -33,7 +26,6 @@ TEST_CASE("alert constructor 3 always equals params", "[alert]") {
 
     message::alert instance(std::move(dup_payload), std::move(dup_signature));
 
-    REQUIRE(instance.is_valid());
     REQUIRE(payload == instance.payload());
     REQUIRE(signature == instance.signature());
 }
@@ -45,7 +37,6 @@ TEST_CASE("alert constructor 4 always equals params", "[alert]") {
     message::alert value(payload, signature);
     message::alert instance(value);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
     REQUIRE(payload == instance.payload());
     REQUIRE(signature == instance.signature());
@@ -58,7 +49,6 @@ TEST_CASE("alert constructor 5 always equals params", "[alert]") {
     message::alert value(payload, signature);
     message::alert instance(std::move(value));
 
-    REQUIRE(instance.is_valid());
     REQUIRE(payload == instance.payload());
     REQUIRE(signature == instance.signature());
 }
@@ -70,7 +60,6 @@ TEST_CASE("alert from data insufficient bytes failure", "[alert]") {
     byte_reader reader(raw);
     auto result = message::alert::from_data(reader, message::version::level::minimum);
     REQUIRE( ! result);
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("alert from data wiki sample success", "[alert]") {
@@ -125,7 +114,6 @@ TEST_CASE("alert from data wiki sample success", "[alert]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(raw.size() == result.serialized_size(message::version::level::minimum));
     REQUIRE(result == expected);
 
@@ -146,13 +134,10 @@ TEST_CASE("alert from data roundtrip success", "[alert]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(message::version::level::minimum));
     REQUIRE(expected.serialized_size(message::version::level::minimum) == result.serialized_size(message::version::level::minimum));
 }
-
-
 
 TEST_CASE("alert payload accessor 1 always returns initialized", "[alert]") {
     data_chunk const payload = to_chunk("0123456789abcdef"_base16);
@@ -226,13 +211,10 @@ TEST_CASE("alert operator assign equals always matches equivalent", "[alert]") {
 
     message::alert value(payload, signature);
 
-    REQUIRE(value.is_valid());
 
     message::alert instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(payload == instance.payload());
     REQUIRE(signature == instance.signature());
 }

--- a/src/domain/test/message/alert_payload.cpp
+++ b/src/domain/test/message/alert_payload.cpp
@@ -8,12 +8,6 @@ using namespace kth;
 using namespace kd;
 
 // Start Test Suite: alert payload tests
-
-TEST_CASE("alert payload constructor 1 always invalid", "[alert payload]") {
-    message::alert_payload instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("alert payload constructor 2 always equals params", "[alert payload]") {
     uint32_t const version = 3452u;
     uint64_t const relay_until = 64556u;
@@ -33,7 +27,6 @@ TEST_CASE("alert payload constructor 2 always equals params", "[alert payload]")
                                     cancel, set_cancel, min_version, max_version, set_sub_version,
                                     priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(relay_until == instance.relay_until());
     REQUIRE(expiration == instance.expiration());
@@ -75,7 +68,6 @@ TEST_CASE("alert payload constructor 3 always equals params", "[alert payload]")
                                     std::move(dup_set_sub_version), priority, std::move(dup_comment),
                                     std::move(dup_status_bar), std::move(dup_reserved));
 
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(relay_until == instance.relay_until());
     REQUIRE(expiration == instance.expiration());
@@ -112,7 +104,6 @@ TEST_CASE("alert payload constructor 4 always equals params", "[alert payload]")
 
     message::alert_payload instance(value);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(relay_until == instance.relay_until());
     REQUIRE(expiration == instance.expiration());
@@ -149,7 +140,6 @@ TEST_CASE("alert payload constructor 5 always equals params", "[alert payload]")
 
     message::alert_payload instance(std::move(value));
 
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(relay_until == instance.relay_until());
     REQUIRE(expiration == instance.expiration());
@@ -172,7 +162,6 @@ TEST_CASE("alert payload from data insufficient bytes failure", "[alert payload]
     byte_reader reader(raw);
     auto result = message::alert_payload::from_data(reader, message::version::level::minimum);
     REQUIRE( ! result);
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("alert payload from data wiki sample test success", "[alert payload]") {
@@ -210,7 +199,6 @@ TEST_CASE("alert payload from data wiki sample test success", "[alert payload]")
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(raw.size() == result.serialized_size(message::version::level::minimum));
     REQUIRE(result == expected);
 
@@ -242,13 +230,10 @@ TEST_CASE("alert payload from data roundtrip success", "[alert payload]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(message::version::level::minimum));
     REQUIRE(expected.serialized_size(message::version::level::minimum) == result.serialized_size(message::version::level::minimum));
 }
-
-
 
 TEST_CASE("alert payload version roundtrip success", "[alert payload]") {
     uint32_t value = 1234u;
@@ -309,7 +294,6 @@ TEST_CASE("alert payload set cancel accessor 1 always returns initialized", "[al
                                     cancel, set_cancel, min_version, max_version, set_sub_version,
                                     priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(set_cancel == instance.set_cancel());
 }
 
@@ -332,7 +316,6 @@ TEST_CASE("alert payload set cancel accessor 2 always returns initialized", "[al
                                           cancel, set_cancel, min_version, max_version, set_sub_version,
                                           priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(set_cancel == instance.set_cancel());
 }
 
@@ -388,7 +371,6 @@ TEST_CASE("alert payload set sub version accessor 1 always returns initialized",
                                     cancel, set_cancel, min_version, max_version, set_sub_version,
                                     priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(set_sub_version == instance.set_sub_version());
 }
 
@@ -411,7 +393,6 @@ TEST_CASE("alert payload set sub version accessor 2 always returns initialized",
                                           cancel, set_cancel, min_version, max_version, set_sub_version,
                                           priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(set_sub_version == instance.set_sub_version());
 }
 
@@ -459,7 +440,6 @@ TEST_CASE("alert payload comment accessor 1 always returns initialized", "[alert
                                     cancel, set_cancel, min_version, max_version, set_sub_version,
                                     priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(comment == instance.comment());
 }
 
@@ -482,7 +462,6 @@ TEST_CASE("alert payload comment accessor 2 always returns initialized", "[alert
                                           cancel, set_cancel, min_version, max_version, set_sub_version,
                                           priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(comment == instance.comment());
 }
 
@@ -522,7 +501,6 @@ TEST_CASE("alert payload status bar accessor 1 always returns initialized", "[al
                                     cancel, set_cancel, min_version, max_version, set_sub_version,
                                     priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(status_bar == instance.status_bar());
 }
 
@@ -545,7 +523,6 @@ TEST_CASE("alert payload status bar accessor 2 always returns initialized", "[al
                                           cancel, set_cancel, min_version, max_version, set_sub_version,
                                           priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(status_bar == instance.status_bar());
 }
 
@@ -585,7 +562,6 @@ TEST_CASE("alert payload reserved accessor 1 always returns initialized", "[aler
                                     cancel, set_cancel, min_version, max_version, set_sub_version,
                                     priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(reserved == instance.reserved());
 }
 
@@ -608,7 +584,6 @@ TEST_CASE("alert payload reserved accessor 2 always returns initialized", "[aler
                                           cancel, set_cancel, min_version, max_version, set_sub_version,
                                           priority, comment, status_bar, reserved);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(reserved == instance.reserved());
 }
 
@@ -648,13 +623,10 @@ TEST_CASE("alert payload operator assign equals always matches equivalent", "[al
                                  cancel, set_cancel, min_version, max_version, set_sub_version,
                                  priority, comment, status_bar, reserved);
 
-    REQUIRE(value.is_valid());
 
     message::alert_payload instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(version == instance.version());
     REQUIRE(relay_until == instance.relay_until());
     REQUIRE(expiration == instance.expiration());

--- a/src/domain/test/message/block.cpp
+++ b/src/domain/test/message/block.cpp
@@ -167,8 +167,6 @@ TEST_CASE("block factory data 1 genesis mainnet success", "[message block]") {
     REQUIRE(raw_reserialization.size() == block.serialized_size(version::level::minimum));
 }
 
-
-
 TEST_CASE("block operator assign equals 1 always matches equivalent", "[message block]") {
     chain::header const header(10u,
                                "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,

--- a/src/domain/test/message/block_transactions.cpp
+++ b/src/domain/test/message/block_transactions.cpp
@@ -8,12 +8,6 @@ using namespace kth;
 using namespace kd;
 
 // Start Test Suite: block transactions tests
-
-TEST_CASE("block transactions constructor 1 always invalid", "[block transactions]") {
-    message::block_transactions instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("block transactions constructor 2 always equals params", "[block transactions]") {
     hash_digest const hash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash;
 
@@ -23,7 +17,6 @@ TEST_CASE("block transactions constructor 2 always equals params", "[block trans
         chain::transaction(4, 16, {}, {})};
 
     message::block_transactions instance(hash, transactions);
-    REQUIRE(instance.is_valid());
     REQUIRE(hash == instance.block_hash());
     REQUIRE(transactions == instance.transactions());
 }
@@ -41,7 +34,6 @@ TEST_CASE("block transactions constructor 3 always equals params", "[block trans
     message::block_transactions instance(std::move(dup_hash),
                                          std::move(dup_transactions));
 
-    REQUIRE(instance.is_valid());
     REQUIRE(hash == instance.block_hash());
     REQUIRE(transactions == instance.transactions());
 }
@@ -57,7 +49,6 @@ TEST_CASE("block transactions constructor 4 always equals params", "[block trans
     message::block_transactions value(hash, transactions);
     message::block_transactions instance(value);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
     REQUIRE(hash == instance.block_hash());
     REQUIRE(transactions == instance.transactions());
@@ -74,7 +65,6 @@ TEST_CASE("block transactions constructor 5 always equals params", "[block trans
     message::block_transactions value(hash, transactions);
     message::block_transactions instance(std::move(value));
 
-    REQUIRE(instance.is_valid());
     REQUIRE(hash == instance.block_hash());
     REQUIRE(transactions == instance.transactions());
 }
@@ -207,7 +197,6 @@ TEST_CASE("block transactions from data valid input success", "[block transactio
     REQUIRE(result_exp2);
     auto const result = std::move(*result_exp2);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(message::block_transactions::version_minimum));
     REQUIRE(expected.serialized_size(message::block_transactions::version_minimum) == result.serialized_size(message::block_transactions::version_minimum));
@@ -314,11 +303,8 @@ TEST_CASE("block transactions operator assign equals always matches equivalent",
         chain::transaction(4, 16, {}, {})};
 
     message::block_transactions value(hash, transactions);
-    REQUIRE(value.is_valid());
     message::block_transactions instance;
-    REQUIRE( ! instance.is_valid());
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(hash == instance.block_hash());
     REQUIRE(transactions == instance.transactions());
 }

--- a/src/domain/test/message/double_spend_proof.cpp
+++ b/src/domain/test/message/double_spend_proof.cpp
@@ -58,33 +58,6 @@ TEST_CASE("double_spend_proof::spender default construct is invalid", "[double_s
     REQUIRE(s.push_data.empty());
 }
 
-TEST_CASE("double_spend_proof::spender any nonzero field is valid", "[double_spend_proof::spender]") {
-    {
-        message::double_spend_proof::spender s;
-        s.version = 1;
-    }
-    {
-        message::double_spend_proof::spender s;
-        s.out_sequence = 1;
-    }
-    {
-        message::double_spend_proof::spender s;
-        s.locktime = 1;
-    }
-    {
-        message::double_spend_proof::spender s;
-        s.prev_outs_hash = k_hash_a;
-    }
-    {
-        message::double_spend_proof::spender s;
-        s.sequence_hash = k_hash_a;
-    }
-    {
-        message::double_spend_proof::spender s;
-        s.outputs_hash = k_hash_a;
-    }
-}
-
 TEST_CASE("double_spend_proof::spender reset zeroes all fields", "[double_spend_proof::spender]") {
     auto s = make_spender();
     s.push_data = data_chunk{1, 2, 3};
@@ -179,11 +152,6 @@ TEST_CASE("double_spend_proof::spender round-trip with empty push_data preserves
 // ---------------------------------------------------------------------------
 // Constructors / predicates
 // ---------------------------------------------------------------------------
-
-TEST_CASE("double_spend_proof default construct is invalid", "[double_spend_proof]") {
-    message::double_spend_proof dsp;
-}
-
 TEST_CASE("double_spend_proof three-arg construct preserves fields", "[double_spend_proof]") {
     auto const out_point = make_out_point();
     auto const s1 = make_spender(1);

--- a/src/domain/test/message/filter_add.cpp
+++ b/src/domain/test/message/filter_add.cpp
@@ -8,16 +8,9 @@ using namespace kth;
 using namespace kd;
 
 // Start Test Suite: filter add tests
-
-TEST_CASE("filter add constructor 1 always invalid", "[filter add]") {
-    message::filter_add instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("filter add constructor 2 always equals params", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
     message::filter_add instance(data);
-    REQUIRE(instance.is_valid());
     REQUIRE(data == instance.data());
 }
 
@@ -25,7 +18,6 @@ TEST_CASE("filter add constructor 3 always equals params", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
     auto dup = data;
     message::filter_add instance(std::move(dup));
-    REQUIRE(instance.is_valid());
     REQUIRE(data == instance.data());
 }
 
@@ -33,7 +25,6 @@ TEST_CASE("filter add constructor 4 always equals params", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
     const message::filter_add value(data);
     message::filter_add instance(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
     REQUIRE(data == instance.data());
 }
@@ -42,7 +33,6 @@ TEST_CASE("filter add constructor 5 always equals params", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
     message::filter_add value(data);
     message::filter_add instance(std::move(value));
-    REQUIRE(instance.is_valid());
     REQUIRE(data == instance.data());
 }
 
@@ -82,14 +72,11 @@ TEST_CASE("filter add from data valid input success", "[filter add]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(message::version::level::maximum));
     REQUIRE(expected.serialized_size(message::version::level::maximum) ==
                         result.serialized_size(message::version::level::maximum));
 }
-
-
 
 TEST_CASE("filter add data accessor 1 always returns initialized value", "[filter add]") {
     data_chunk const value = {0x0f, 0xf0, 0x55, 0xaa};
@@ -123,11 +110,8 @@ TEST_CASE("filter add data setter 2 roundtrip success", "[filter add]") {
 TEST_CASE("filter add operator assign equals always matches equivalent", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
     message::filter_add value(data);
-    REQUIRE(value.is_valid());
     message::filter_add instance;
-    REQUIRE( ! instance.is_valid());
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(data == instance.data());
 }
 

--- a/src/domain/test/message/filter_load.cpp
+++ b/src/domain/test/message/filter_load.cpp
@@ -8,12 +8,6 @@ using namespace kth;
 using namespace kd;
 
 // Start Test Suite: filter load tests
-
-TEST_CASE("filter load constructor 1 always invalid", "[filter load]") {
-    message::filter_load instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("filter load constructor 2 always equals params", "[filter load]") {
     data_chunk const filter = {0x0f, 0xf0, 0x55, 0xaa};
     uint32_t hash_functions = 48u;
@@ -21,7 +15,6 @@ TEST_CASE("filter load constructor 2 always equals params", "[filter load]") {
     uint8_t flags = 0xae;
 
     message::filter_load instance(filter, hash_functions, tweak, flags);
-    REQUIRE(instance.is_valid());
     REQUIRE(filter == instance.filter());
     REQUIRE(hash_functions == instance.hash_functions());
     REQUIRE(tweak == instance.tweak());
@@ -36,7 +29,6 @@ TEST_CASE("filter load constructor 3 always equals params", "[filter load]") {
     uint8_t flags = 0xae;
 
     message::filter_load instance(std::move(dup_filter), hash_functions, tweak, flags);
-    REQUIRE(instance.is_valid());
     REQUIRE(filter == instance.filter());
     REQUIRE(hash_functions == instance.hash_functions());
     REQUIRE(tweak == instance.tweak());
@@ -51,7 +43,6 @@ TEST_CASE("filter load constructor 4 always equals params", "[filter load]") {
 
     const message::filter_load value(filter, hash_functions, tweak, flags);
     message::filter_load instance(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
     REQUIRE(filter == instance.filter());
     REQUIRE(hash_functions == instance.hash_functions());
@@ -67,7 +58,6 @@ TEST_CASE("filter load constructor 5 always equals params", "[filter load]") {
 
     message::filter_load value(filter, hash_functions, tweak, flags);
     message::filter_load instance(std::move(value));
-    REQUIRE(instance.is_valid());
     REQUIRE(filter == instance.filter());
     REQUIRE(hash_functions == instance.hash_functions());
     REQUIRE(tweak == instance.tweak());
@@ -111,14 +101,11 @@ TEST_CASE("filter load from data valid input success", "[filter load]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(message::version::level::maximum));
     REQUIRE(expected.serialized_size(message::version::level::maximum) ==
                         result.serialized_size(message::version::level::maximum));
 }
-
-
 
 TEST_CASE("filter load filter accessor 1 always returns initialized value", "[filter load]") {
     data_chunk const filter = {0x0f, 0xf0, 0x55, 0xaa};
@@ -219,13 +206,10 @@ TEST_CASE("filter load operator assign equals always matches equivalent", "[filt
     uint8_t flags = 0xae;
     message::filter_load value(filter, hash_functions, tweak, flags);
 
-    REQUIRE(value.is_valid());
 
     message::filter_load instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(filter == instance.filter());
     REQUIRE(hash_functions == instance.hash_functions());
     REQUIRE(tweak == instance.tweak());

--- a/src/domain/test/message/get_address.cpp
+++ b/src/domain/test/message/get_address.cpp
@@ -18,7 +18,6 @@ TEST_CASE("get address - roundtrip to data factory from data chunk", "[get addre
     auto const result = std::move(*result_exp);
 
     REQUIRE(0u == data.size());
-    REQUIRE(result.is_valid());
     REQUIRE(0u == result.serialized_size(message::version::level::minimum));
 }
 

--- a/src/domain/test/message/get_block_transactions.cpp
+++ b/src/domain/test/message/get_block_transactions.cpp
@@ -8,18 +8,11 @@ using namespace kth;
 using namespace kd;
 
 // Start Test Suite: get block transactions tests
-
-TEST_CASE("get block transactions constructor 1 always invalid", "[get block transactions]") {
-    message::get_block_transactions instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("get block transactions constructor 2 always equals params", "[get block transactions]") {
     hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
 
     message::get_block_transactions instance(hash, indexes);
-    REQUIRE(instance.is_valid());
     REQUIRE(hash == instance.block_hash());
     REQUIRE(indexes == instance.indexes());
 }
@@ -31,7 +24,6 @@ TEST_CASE("get block transactions constructor 3 always equals params", "[get blo
     auto indexes_dup = indexes;
 
     message::get_block_transactions instance(std::move(hash_dup), std::move(indexes_dup));
-    REQUIRE(instance.is_valid());
     REQUIRE(hash == instance.block_hash());
     REQUIRE(indexes == instance.indexes());
 }
@@ -42,7 +34,6 @@ TEST_CASE("get block transactions constructor 4 always equals params", "[get blo
         {1u, 3454u, 4234u, 75123u, 455323u});
 
     message::get_block_transactions instance(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
 }
 
@@ -52,7 +43,6 @@ TEST_CASE("get block transactions constructor 5 always equals params", "[get blo
 
     message::get_block_transactions value(hash, indexes);
     message::get_block_transactions instance(std::move(value));
-    REQUIRE(instance.is_valid());
     REQUIRE(hash == instance.block_hash());
     REQUIRE(indexes == instance.indexes());
 }
@@ -80,13 +70,10 @@ TEST_CASE("get block transactions from data valid input success", "[get block tr
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(message::version::level::minimum));
     REQUIRE(expected.serialized_size(message::version::level::minimum) == result.serialized_size(message::version::level::minimum));
 }
-
-
 
 TEST_CASE("get block transactions block hash accessor 1 always returns initialized value", "[get block transactions]") {
     hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
@@ -155,13 +142,10 @@ TEST_CASE("get block transactions operator assign equals always matches equivale
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
     message::get_block_transactions value(hash, indexes);
 
-    REQUIRE(value.is_valid());
 
     message::get_block_transactions instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(hash == instance.block_hash());
     REQUIRE(indexes == instance.indexes());
 }

--- a/src/domain/test/message/get_blocks.cpp
+++ b/src/domain/test/message/get_blocks.cpp
@@ -8,12 +8,6 @@ using namespace kth;
 using namespace kd;
 
 // Start Test Suite: get blocks tests
-
-TEST_CASE("get blocks constructor 1 always invalid", "[get blocks]") {
-    message::get_blocks instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("get blocks constructor 2 always equals params", "[get blocks]") {
     hash_list const starts = {
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
@@ -23,7 +17,6 @@ TEST_CASE("get blocks constructor 2 always equals params", "[get blocks]") {
     hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_blocks instance(starts, stop);
-    REQUIRE(instance.is_valid());
     REQUIRE(starts == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
 }
@@ -38,7 +31,6 @@ TEST_CASE("get blocks constructor 3 always equals params", "[get blocks]") {
     hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_blocks instance(std::move(starts_duplicate), std::move(stop));
-    REQUIRE(instance.is_valid());
     REQUIRE(starts == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
 }
@@ -53,7 +45,6 @@ TEST_CASE("get blocks constructor 4 always equals params", "[get blocks]") {
 
     const message::get_blocks expected(starts, stop);
     message::get_blocks instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
     REQUIRE(starts == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
@@ -69,7 +60,6 @@ TEST_CASE("get blocks constructor 5 always equals params", "[get blocks]") {
 
     message::get_blocks expected(starts, stop);
     message::get_blocks instance(std::move(expected));
-    REQUIRE(instance.is_valid());
     REQUIRE(starts == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
 }
@@ -98,13 +88,10 @@ TEST_CASE("get blocks from data valid input success", "[get blocks]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(message::version::level::minimum));
     REQUIRE(expected.serialized_size(message::version::level::minimum) == result.serialized_size(message::version::level::minimum));
 }
-
-
 
 TEST_CASE("get blocks start hashes accessor 1 always returns initialized value", "[get blocks]") {
     hash_list expected = {
@@ -222,13 +209,10 @@ TEST_CASE("get blocks operator assign equals always matches equivalent", "[get b
 
     message::get_blocks value{start, stop};
 
-    REQUIRE(value.is_valid());
 
     message::get_blocks instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(start == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
 }

--- a/src/domain/test/message/get_data.cpp
+++ b/src/domain/test/message/get_data.cpp
@@ -9,12 +9,6 @@ using namespace kd;
 using namespace kth::domain::message;
 
 // Start Test Suite: get data tests
-
-TEST_CASE("get data constructor 1 always invalid", "[get data]") {
-    get_data const instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("get data constructor 2 always equals params", "[get data]") {
     static inventory_vector::list const values =
         {
@@ -26,7 +20,6 @@ TEST_CASE("get data constructor 2 always equals params", "[get data]") {
                   0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}};
 
     get_data const instance(values);
-    REQUIRE(instance.is_valid());
     REQUIRE(values == instance.inventories());
 }
 
@@ -37,7 +30,6 @@ TEST_CASE("get data constructor 3 always equals params", "[get data]") {
         inventory_vector(type, hash)};
 
     get_data const instance(std::move(values));
-    REQUIRE(instance.is_valid());
     auto const inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -50,7 +42,6 @@ TEST_CASE("get data constructor 4 always equals params", "[get data]") {
     static hash_list const hashes{hash};
 
     get_data const instance(hashes, type);
-    REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -62,7 +53,6 @@ TEST_CASE("get data constructor 5 always equals params", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     get_data const instance{{type, hash}};
-    REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -74,7 +64,6 @@ TEST_CASE("get data constructor 6 always equals params", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     get_data const value{{type, hash}};
-    REQUIRE(value.is_valid());
     get_data const instance(value);
     auto const inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -88,7 +77,6 @@ TEST_CASE("get data constructor 7 always equals params", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     get_data const value{{type, hash}};
-    REQUIRE(value.is_valid());
     get_data const instance(std::move(value));
     auto const inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -127,13 +115,10 @@ TEST_CASE("get data from data valid input success", "[get data]") {
     auto const result_exp = get_data::from_data(reader, version);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(version));
     REQUIRE(expected.serialized_size(version) == result.serialized_size(version));
 }
-
-
 
 TEST_CASE("get data operator assign equals always matches equivalent", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
@@ -141,13 +126,10 @@ TEST_CASE("get data operator assign equals always matches equivalent", "[get dat
         inventory_vector(inventory_vector::type_id::error, hash)};
 
     get_data value(elements);
-    REQUIRE(value.is_valid());
 
     get_data instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(elements == instance.inventories());
 }
 

--- a/src/domain/test/message/get_headers.cpp
+++ b/src/domain/test/message/get_headers.cpp
@@ -8,12 +8,6 @@ using namespace kth;
 using namespace kd;
 
 // Start Test Suite: get headers tests
-
-TEST_CASE("get headers constructor 1 always invalid", "[get headers]") {
-    message::get_headers instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("get headers constructor 2 always equals params", "[get headers]") {
     hash_list starts = {
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hash,
@@ -23,7 +17,6 @@ TEST_CASE("get headers constructor 2 always equals params", "[get headers]") {
     hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_headers instance(starts, stop);
-    REQUIRE(instance.is_valid());
     REQUIRE(starts == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
 }
@@ -38,7 +31,6 @@ TEST_CASE("get headers constructor 3 always equals params", "[get headers]") {
     hash_digest stop = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::get_headers instance(std::move(starts_duplicate), std::move(stop));
-    REQUIRE(instance.is_valid());
     REQUIRE(starts == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
 }
@@ -53,7 +45,6 @@ TEST_CASE("get headers constructor 4 always equals params", "[get headers]") {
 
     const message::get_headers expected(starts, stop);
     message::get_headers instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
     REQUIRE(starts == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
@@ -69,7 +60,6 @@ TEST_CASE("get headers constructor 5 always equals params", "[get headers]") {
 
     message::get_headers expected(starts, stop);
     message::get_headers instance(std::move(expected));
-    REQUIRE(instance.is_valid());
     REQUIRE(starts == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
 }
@@ -119,15 +109,12 @@ TEST_CASE("get headers from data valid input success", "[get headers]") {
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
 
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(message::get_headers::version_minimum));
     REQUIRE(
         expected.serialized_size(message::get_headers::version_minimum) ==
         result.serialized_size(message::get_headers::version_minimum));
 }
-
-
 
 TEST_CASE("get headers operator assign equals always matches equivalent", "[get headers]") {
     hash_list const start = {
@@ -142,13 +129,10 @@ TEST_CASE("get headers operator assign equals always matches equivalent", "[get 
 
     message::get_headers value{start, stop};
 
-    REQUIRE(value.is_valid());
 
     message::get_headers instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(start == instance.start_hashes());
     REQUIRE(stop == instance.stop_hash());
 }

--- a/src/domain/test/message/header.cpp
+++ b/src/domain/test/message/header.cpp
@@ -155,8 +155,6 @@ TEST_CASE("message header from data valid input success", "[message header]") {
     REQUIRE(expected.serialized_size(version) == result.serialized_size(version));
 }
 
-
-
 TEST_CASE("message header operator assign equals 1 always matches equivalent", "[message header]") {
     chain::header value(
         10u,

--- a/src/domain/test/message/headers.cpp
+++ b/src/domain/test/message/headers.cpp
@@ -9,12 +9,6 @@ using namespace kd;
 using namespace kth::domain::message;
 
 // Start Test Suite: headers tests
-
-TEST_CASE("headers constructor 1 always initialized invalid", "[headers]") {
-    headers instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("headers constructor 2 always equals params", "[headers]") {
     header::list const expected{
         header(
@@ -33,7 +27,6 @@ TEST_CASE("headers constructor 2 always equals params", "[headers]") {
             34564u)};
 
     headers instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(instance.elements() == expected);
 }
 
@@ -55,7 +48,6 @@ TEST_CASE("headers constructor 3 always equals params", "[headers]") {
             34564u)};
 
     headers instance(std::move(expected));
-    REQUIRE(instance.is_valid());
     REQUIRE(instance.elements().size() == 2u);
 }
 
@@ -76,7 +68,6 @@ TEST_CASE("headers constructor 4 always equals params", "[headers]") {
              4356344u,
              34564u)});
 
-    REQUIRE(instance.is_valid());
     REQUIRE(instance.elements().size() == 2u);
 }
 
@@ -161,13 +152,10 @@ TEST_CASE("headers from data valid input success", "[headers]") {
     auto const result_exp = headers::from_data(reader, version);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(result == expected);
     REQUIRE(result.serialized_size(version) == data.size());
     REQUIRE(result.serialized_size(version) == expected.serialized_size(version));
 }
-
-
 
 TEST_CASE("headers elements accessor 1 always returns initialized value", "[headers]") {
     header::list const expected{
@@ -255,37 +243,6 @@ TEST_CASE("headers command setter 2 roundtrip success", "[headers]") {
     REQUIRE(instance.elements().empty());
     instance.set_elements(std::move(values));
     REQUIRE(instance.elements().size() == 2u);
-}
-
-TEST_CASE("headers operator assign equals always matches equivalent", "[headers]") {
-    message::headers value(
-        {header{
-             1u,
-             "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"_hash,
-             "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"_hash,
-             10u,
-             100u,
-             1000u},
-         header{
-             2u,
-             "abababababababababababababababababababababababababababababababab"_hash,
-             "babababababababababababababababababababababababababababababababa"_hash,
-             20u,
-             200u,
-             2000u},
-         header{
-             3u,
-             "e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2"_hash,
-             "7373737373737373737373737373737373737373737373737373737373737373"_hash,
-             30u,
-             300u,
-             3000u}});
-
-    REQUIRE(value.is_valid());
-    message::headers instance;
-    REQUIRE( ! instance.is_valid());
-    instance = std::move(value);
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("headers operator boolean equals duplicates returns true", "[headers]") {

--- a/src/domain/test/message/heading.cpp
+++ b/src/domain/test/message/heading.cpp
@@ -11,19 +11,12 @@ using namespace kd;
 using namespace kth::domain::message;
 
 // Start Test Suite: heading tests
-
-TEST_CASE("heading constructor 1 always initialized invalid", "[heading]") {
-    heading instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("heading constructor 2 always equals params", "[heading]") {
     uint32_t magic = 123u;
     std::string const command = "foo";
     uint32_t payload_size = 3454u;
     uint32_t checksum = 35746u;
     heading instance(magic, command, payload_size, checksum);
-    REQUIRE(instance.is_valid());
     REQUIRE(magic == instance.magic());
     REQUIRE(command == instance.command());
     REQUIRE(payload_size == instance.payload_size());
@@ -36,7 +29,6 @@ TEST_CASE("heading constructor 3 always equals params", "[heading]") {
     uint32_t payload_size = 3454u;
     uint32_t checksum = 35746u;
     heading instance(magic, "foo", payload_size, checksum);
-    REQUIRE(instance.is_valid());
     REQUIRE(magic == instance.magic());
     REQUIRE(command == instance.command());
     REQUIRE(payload_size == instance.payload_size());
@@ -46,7 +38,6 @@ TEST_CASE("heading constructor 3 always equals params", "[heading]") {
 TEST_CASE("heading constructor 4 always equals params", "[heading]") {
     heading expected(453u, "bar", 436u, 5743u);
     heading instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -57,7 +48,6 @@ TEST_CASE("heading constructor 5 always equals params", "[heading]") {
     uint32_t checksum = 35746u;
     heading value(magic, command, payload_size, checksum);
     heading instance(std::move(value));
-    REQUIRE(instance.is_valid());
     REQUIRE(magic == instance.magic());
     REQUIRE(command == instance.command());
     REQUIRE(payload_size == instance.payload_size());
@@ -101,12 +91,9 @@ TEST_CASE("heading from data valid input success", "[heading]") {
     auto const result_exp = heading::from_data(reader, true);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == heading::satoshi_fixed_size());
 }
-
-
 
 TEST_CASE("heading magic accessor always returns initialized value", "[heading]") {
     uint32_t expected = 3574u;
@@ -176,15 +163,6 @@ TEST_CASE("heading checksum setter roundtrip success", "[heading]") {
     REQUIRE(0 == instance.checksum());
     instance.set_checksum(expected);
     REQUIRE(expected == instance.checksum());
-}
-
-TEST_CASE("heading operator assign equals always matches equivalent", "[heading]") {
-    message::heading value(1u, "foobar", 2u, 3u);
-    REQUIRE(value.is_valid());
-    message::heading instance;
-    REQUIRE( ! instance.is_valid());
-    instance = std::move(value);
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("heading operator boolean equals duplicates returns true", "[heading]") {

--- a/src/domain/test/message/inventory.cpp
+++ b/src/domain/test/message/inventory.cpp
@@ -9,12 +9,6 @@ using namespace kd;
 using namespace kth::domain::message;
 
 // Start Test Suite: inventory tests
-
-TEST_CASE("inventory constructor 1 always invalid", "[inventory]") {
-    message::inventory instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("inventory constructor 2 always equals params", "[inventory]") {
     const message::inventory_vector::list values =
         {
@@ -26,7 +20,6 @@ TEST_CASE("inventory constructor 2 always equals params", "[inventory]") {
                   0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}})};
 
     message::inventory instance(values);
-    REQUIRE(instance.is_valid());
     REQUIRE(values == instance.inventories());
 }
 
@@ -38,7 +31,6 @@ TEST_CASE("inventory constructor 3 always equals params", "[inventory]") {
             message::inventory_vector(type, hash)};
 
     message::inventory instance(std::move(values));
-    REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -51,7 +43,6 @@ TEST_CASE("inventory constructor 4 always equals params", "[inventory]") {
     hash_list const hashes = {hash};
 
     message::inventory instance(hashes, type);
-    REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -63,7 +54,6 @@ TEST_CASE("inventory constructor 5 always equals params", "[inventory]") {
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::inventory instance{{type, hash}};
-    REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -75,7 +65,6 @@ TEST_CASE("inventory constructor 6 always equals params", "[inventory]") {
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     const message::inventory value{{type, hash}};
-    REQUIRE(value.is_valid());
     message::inventory instance(value);
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -89,7 +78,6 @@ TEST_CASE("inventory constructor 7 always equals params", "[inventory]") {
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::inventory value{{type, hash}};
-    REQUIRE(value.is_valid());
     message::inventory instance(std::move(value));
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -120,13 +108,10 @@ TEST_CASE("inventory from data valid input success", "[inventory]") {
     auto const result_exp = inventory::from_data(reader, version);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(version));
     REQUIRE(expected.serialized_size(version) == result.serialized_size(version));
 }
-
-
 
 TEST_CASE("inventory inventories accessor 1 always returns initialized value", "[inventory]") {
     const message::inventory_vector::list values =
@@ -179,10 +164,8 @@ TEST_CASE("inventory operator assign equals always matches equivalent", "[invent
                                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
     message::inventory instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = message::inventory(elements);
-    REQUIRE(instance.is_valid());
     REQUIRE(elements == instance.inventories());
 }
 

--- a/src/domain/test/message/inventory_vector.cpp
+++ b/src/domain/test/message/inventory_vector.cpp
@@ -58,34 +58,19 @@ TEST_CASE("inventory vector to type 0x94a0 returns double spend proofs", "[inven
     REQUIRE(inventory_vector::type_id::double_spend_proof == inventory_vector::to_type(0x94a0));
 }
 
-TEST_CASE("inventory vector constructor 1 always invalid", "[inventory vector]") {
-    inventory_vector instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("inventory vector constructor 2 always equals params", "[inventory vector]") {
     inventory_vector::type_id type = inventory_vector::type_id::block;
     hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector instance(type, hash);
-    REQUIRE(instance.is_valid());
     REQUIRE(type == instance.type());
     REQUIRE(hash == instance.hash());
-}
-
-TEST_CASE("inventory vector constructor 3 always equals params", "[inventory vector]") {
-    inventory_vector::type_id type = inventory_vector::type_id::block;
-    hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    inventory_vector instance(type, std::move(hash));
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("inventory vector constructor 4 always equals params", "[inventory vector]") {
     inventory_vector::type_id type = inventory_vector::type_id::block;
     hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector const expected(type, hash);
-    REQUIRE(expected.is_valid());
     inventory_vector instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
 }
 
@@ -93,9 +78,7 @@ TEST_CASE("inventory vector constructor 5 always equals params", "[inventory vec
     inventory_vector::type_id type = inventory_vector::type_id::block;
     hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     inventory_vector expected(type, hash);
-    REQUIRE(expected.is_valid());
     inventory_vector instance(std::move(expected));
-    REQUIRE(instance.is_valid());
     REQUIRE(type == instance.type());
     REQUIRE(hash == instance.hash());
 }
@@ -122,13 +105,10 @@ TEST_CASE("inventory vector from data valid input success", "[inventory vector]"
     auto const result_exp = inventory_vector::from_data(reader, version);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(version));
     REQUIRE(expected.serialized_size(version) == result.serialized_size(version));
 }
-
-
 
 TEST_CASE("inventory vector is block type block returns true", "[inventory vector]") {
     inventory_vector instance;
@@ -211,32 +191,15 @@ TEST_CASE("inventory vector hash setter 2 roundtrip success", "[inventory vector
     REQUIRE(duplicate == instance.hash());
 }
 
-TEST_CASE("inventory vector operator assign equals 1 always matches equivalent", "[inventory vector]") {
-    inventory_vector value(
-        inventory_vector::type_id::compact_block,
-        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
-
-    REQUIRE(value.is_valid());
-
-    inventory_vector instance;
-    REQUIRE( ! instance.is_valid());
-
-    instance = std::move(value);
-    REQUIRE(instance.is_valid());
-}
-
 TEST_CASE("inventory vector operator assign equals 2 always matches equivalent", "[inventory vector]") {
     inventory_vector value(
         inventory_vector::type_id::compact_block,
         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
 
-    REQUIRE(value.is_valid());
 
     inventory_vector instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = value;
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance);
 }
 

--- a/src/domain/test/message/not_found.cpp
+++ b/src/domain/test/message/not_found.cpp
@@ -9,12 +9,6 @@ using namespace kd;
 using namespace kth::domain::message;
 
 // Start Test Suite: not found tests
-
-TEST_CASE("not found constructor 1 always invalid", "[not found]") {
-    message::not_found instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("not found constructor 2 always equals params", "[not found]") {
     const message::inventory_vector::list values =
         {
@@ -26,7 +20,6 @@ TEST_CASE("not found constructor 2 always equals params", "[not found]") {
                   0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}})};
 
     message::not_found instance(values);
-    REQUIRE(instance.is_valid());
     REQUIRE(values == instance.inventories());
 }
 
@@ -38,7 +31,6 @@ TEST_CASE("not found constructor 3 always equals params", "[not found]") {
             message::inventory_vector(type, hash)};
 
     message::not_found instance(std::move(values));
-    REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -51,7 +43,6 @@ TEST_CASE("not found constructor 4 always equals params", "[not found]") {
     hash_list const hashes = {hash};
 
     message::not_found instance(hashes, type);
-    REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -63,7 +54,6 @@ TEST_CASE("not found constructor 5 always equals params", "[not found]") {
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::not_found instance{{type, hash}};
-    REQUIRE(instance.is_valid());
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -75,7 +65,6 @@ TEST_CASE("not found constructor 6 always equals params", "[not found]") {
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     const message::not_found value{{type, hash}};
-    REQUIRE(value.is_valid());
     message::not_found instance(value);
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -89,7 +78,6 @@ TEST_CASE("not found constructor 7 always equals params", "[not found]") {
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
     message::not_found value{{type, hash}};
-    REQUIRE(value.is_valid());
     message::not_found instance(std::move(value));
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -119,7 +107,6 @@ TEST_CASE("not found from data insufficient version failure", "[not found]") {
     byte_reader reader(raw);
     auto result = not_found::from_data(reader, not_found::version_minimum - 1);
     REQUIRE( ! result);
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("not found from data valid input success", "[not found]") {
@@ -136,13 +123,10 @@ TEST_CASE("not found from data valid input success", "[not found]") {
     auto const result_exp = not_found::from_data(reader, version);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(version));
     REQUIRE(expected.serialized_size(version) == result.serialized_size(version));
 }
-
-
 
 TEST_CASE("not found operator assign equals always matches equivalent", "[not found]") {
     const message::inventory_vector::list elements =
@@ -151,13 +135,10 @@ TEST_CASE("not found operator assign equals always matches equivalent", "[not fo
                                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
     message::not_found value(elements);
-    REQUIRE(value.is_valid());
 
     message::not_found instance;
-    REQUIRE( ! instance.is_valid());
 
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(elements == instance.inventories());
 }
 

--- a/src/domain/test/message/ping.cpp
+++ b/src/domain/test/message/ping.cpp
@@ -84,8 +84,6 @@ TEST_CASE("ping from data minimum version round trip zero nonce", "[ping]") {
     REQUIRE(result.nonce() == 0u);
 }
 
-
-
 TEST_CASE("ping from data 1 maximum version success expected nonce", "[ping]") {
     static const message::ping expected{
         213153u};
@@ -117,8 +115,6 @@ TEST_CASE("ping from data bip31 version round trip expected nonce", "[ping]") {
     REQUIRE(result.is_valid());
     REQUIRE(result == expected);
 }
-
-
 
 TEST_CASE("ping nonce accessor always returns initialized value", "[ping]") {
     uint64_t value = 43564u;

--- a/src/domain/test/message/pong.cpp
+++ b/src/domain/test/message/pong.cpp
@@ -58,8 +58,6 @@ TEST_CASE("pong from data round trip expected", "[pong]") {
     REQUIRE(expected.serialized_size(version) == result.serialized_size(version));
 }
 
-
-
 TEST_CASE("pong nonce accessor always returns initialized value", "[pong]") {
     uint64_t value = 43564u;
     message::pong instance(value);

--- a/src/domain/test/message/reject.cpp
+++ b/src/domain/test/message/reject.cpp
@@ -33,12 +33,6 @@ TEST_CASE("reject factory from data tx nonstandard empty data valid", "[reject]"
     auto const result_exp = message::reject::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const reject = std::move(*result_exp);
-    REQUIRE(reject.is_valid());
-}
-
-TEST_CASE("reject constructor 1 always invalid", "[reject]") {
-    message::reject instance;
-    REQUIRE( ! instance.is_valid());
 }
 
 TEST_CASE("reject constructor 2 always equals params", "[reject]") {
@@ -47,20 +41,10 @@ TEST_CASE("reject constructor 2 always equals params", "[reject]") {
     std::string reason = "Gamma Delta";
     hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject instance(code, message, reason, data);
-    REQUIRE(instance.is_valid());
     REQUIRE(code == instance.code());
     REQUIRE(message == instance.message());
     REQUIRE(reason == instance.reason());
     REQUIRE(data == instance.data());
-}
-
-TEST_CASE("reject constructor 3 always equals params", "[reject]") {
-    auto code = message::reject::reason_code::nonstandard;
-    std::string message = "sadfasdgd";
-    std::string reason = "jgfghkggfsr";
-    hash_digest data = "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333"_hash;
-    message::reject instance(code, std::move(message), std::move(reason), std::move(data));
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("reject constructor 4 always equals params", "[reject]") {
@@ -70,7 +54,6 @@ TEST_CASE("reject constructor 4 always equals params", "[reject]") {
     hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject expected(code, message, reason, data);
     message::reject instance(expected);
-    REQUIRE(instance.is_valid());
     REQUIRE(expected == instance);
     REQUIRE(code == instance.code());
     REQUIRE(message == instance.message());
@@ -85,7 +68,6 @@ TEST_CASE("reject constructor 5 always equals params", "[reject]") {
     hash_digest data = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     message::reject expected(code, message, reason, data);
     message::reject instance(std::move(expected));
-    REQUIRE(instance.is_valid());
     REQUIRE(code == instance.code());
     REQUIRE(message == instance.message());
     REQUIRE(reason == instance.reason());
@@ -273,13 +255,10 @@ TEST_CASE("reject from data valid input success", "[reject]") {
     auto const result_exp = message::reject::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
     REQUIRE(data.size() == result.serialized_size(version_maximum));
     REQUIRE(expected.serialized_size(version_maximum) == result.serialized_size(version_maximum));
 }
-
-
 
 TEST_CASE("reject code accessor always returns initialized value", "[reject]") {
     auto code = message::reject::reason_code::nonstandard;
@@ -404,22 +383,6 @@ TEST_CASE("reject data setter 2 roundtrip success", "[reject]") {
     REQUIRE(duplicate != instance.data());
     instance.set_data(std::move(data));
     REQUIRE(duplicate == instance.data());
-}
-
-TEST_CASE("reject operator assign equals always matches equivalent", "[reject]") {
-    message::reject value(
-        message::reject::reason_code::dust,
-        "My Message",
-        "My Reason",
-        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash);
-
-    REQUIRE(value.is_valid());
-
-    message::reject instance;
-    REQUIRE( ! instance.is_valid());
-
-    instance = std::move(value);
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("reject operator boolean equals duplicates returns true", "[reject]") {

--- a/src/domain/test/message/send_compact.cpp
+++ b/src/domain/test/message/send_compact.cpp
@@ -8,12 +8,6 @@ using namespace kth;
 using namespace kd;
 
 // Start Test Suite: send compact tests
-
-TEST_CASE("send compact constructor 1 always invalid", "[send compact]") {
-    message::send_compact instance;
-    REQUIRE( ! instance.is_valid());
-}
-
 TEST_CASE("send compact constructor 2 always equals params", "[send compact]") {
     bool mode = true;
     uint64_t version = 1245436u;
@@ -32,10 +26,8 @@ TEST_CASE("send compact constructor 4 always equals params", "[send compact]") {
     bool mode = true;
     uint64_t version = 1245436u;
     message::send_compact expected(mode, version);
-    REQUIRE(expected.is_valid());
 
     message::send_compact instance(std::move(expected));
-    REQUIRE(instance.is_valid());
     REQUIRE(mode == instance.high_bandwidth_mode());
     REQUIRE(version == instance.version());
 }
@@ -49,11 +41,8 @@ TEST_CASE("send compact from data valid input success", "[send compact]") {
     auto const result = std::move(*result_exp);
 
     REQUIRE(message::send_compact::satoshi_fixed_size(message::send_compact::version_minimum) == data.size());
-    REQUIRE(result.is_valid());
     REQUIRE(expected == result);
 }
-
-
 
 TEST_CASE("send compact from data 1 invalid mode byte failure", "[send compact]") {
     data_chunk raw_data{0x0f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
@@ -108,11 +97,9 @@ TEST_CASE("send compact operator assign equals always matches equivalent", "[sen
     bool mode = false;
     uint64_t version = 210u;
     message::send_compact value(mode, version);
-    REQUIRE(value.is_valid());
 
     message::send_compact instance;
     instance = std::move(value);
-    REQUIRE(instance.is_valid());
     REQUIRE(mode == instance.high_bandwidth_mode());
     REQUIRE(version == instance.version());
 }

--- a/src/domain/test/message/transaction.cpp
+++ b/src/domain/test/message/transaction.cpp
@@ -49,11 +49,6 @@ constexpr auto raw_tx2 =
 static auto const raw_tx2_hash = "8a6d9302fbe24f0ec756a94ecfc837eaffe16c43d1e68c62dfe980d99eea556f"_hash;
 
 // Start Test Suite: message transaction tests
-
-TEST_CASE("message transaction constructor 1 always initialized invalid", "[message transaction]") {
-    transaction instance;
-}
-
 TEST_CASE("message transaction constructor 2 always equals transaction", "[message transaction]") {
     data_chunk raw_tx = to_chunk(raw_tx1);
 

--- a/src/domain/test/message/verack.cpp
+++ b/src/domain/test/message/verack.cpp
@@ -18,7 +18,6 @@ TEST_CASE("verack - roundtrip to data factory from data chunk", "[verack]") {
     auto const result = std::move(*result_exp);
 
     REQUIRE(0u == data.size());
-    REQUIRE(result.is_valid());
     REQUIRE(0u == result.serialized_size(message::version::level::minimum));
 }
 

--- a/src/domain/test/message/version.cpp
+++ b/src/domain/test/message/version.cpp
@@ -35,7 +35,6 @@ TEST_CASE("version factory therealbitcoin dot org valid", "[version]") {
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const version = std::move(*result_exp);
-    REQUIRE(version.is_valid());
 }
 
 TEST_CASE("version factory anarchistprime1 valid", "[version]") {
@@ -45,7 +44,6 @@ TEST_CASE("version factory anarchistprime1 valid", "[version]") {
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const version = std::move(*result_exp);
-    REQUIRE(version.is_valid());
 }
 
 TEST_CASE("version factory anarchistprime2 valid", "[version]") {
@@ -55,7 +53,6 @@ TEST_CASE("version factory anarchistprime2 valid", "[version]") {
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const version = std::move(*result_exp);
-    REQUIRE(version.is_valid());
 }
 
 TEST_CASE("version factory falcon1 valid", "[version]") {
@@ -65,7 +62,6 @@ TEST_CASE("version factory falcon1 valid", "[version]") {
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const version = std::move(*result_exp);
-    REQUIRE(version.is_valid());
 }
 
 TEST_CASE("version factory falcon2 valid", "[version]") {
@@ -75,7 +71,6 @@ TEST_CASE("version factory falcon2 valid", "[version]") {
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const version = std::move(*result_exp);
-    REQUIRE(version.is_valid());
 }
 
 TEST_CASE("version factory satoshi1 valid", "[version]") {
@@ -85,12 +80,10 @@ TEST_CASE("version factory satoshi1 valid", "[version]") {
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const version = std::move(*result_exp);
-    REQUIRE(version.is_valid());
 }
 
 TEST_CASE("version constructor 1 always invalid", "[version]") {
     message::version instance;
-    REQUIRE( ! instance.is_valid());
     REQUIRE( ! instance.address_receiver().is_valid());
     REQUIRE( ! instance.address_sender().is_valid());
 }
@@ -121,7 +114,6 @@ TEST_CASE("version constructor 2 always equals params", "[version]") {
 
     message::version instance(value, services, timestamp, receiver, sender, nonce, agent, height, relay);
 
-    REQUIRE(instance.is_valid());
     REQUIRE(value == instance.value());
     REQUIRE(services == instance.services());
     REQUIRE(timestamp == instance.timestamp());
@@ -162,7 +154,6 @@ TEST_CASE("version constructor 3 always equals params", "[version]") {
 
     message::version instance(value, services, timestamp, std::move(receiver), std::move(sender), nonce, agent, height, relay);
 
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("version constructor 4 always equals params", "[version]") {
@@ -193,7 +184,6 @@ TEST_CASE("version constructor 4 always equals params", "[version]") {
     REQUIRE(sender.is_valid());
 
     message::version alpha(value, services, timestamp, receiver, sender, nonce, agent, height, relay);
-    REQUIRE(alpha.is_valid());
 
     message::version beta(alpha);
     REQUIRE(beta == alpha);
@@ -227,10 +217,8 @@ TEST_CASE("version constructor 5 always equals params", "[version]") {
     REQUIRE(sender.is_valid());
 
     message::version alpha(value, services, timestamp, receiver, sender, nonce, agent, height, relay);
-    REQUIRE(alpha.is_valid());
 
     message::version beta(std::move(alpha));
-    REQUIRE(beta.is_valid());
     REQUIRE(value == beta.value());
     REQUIRE(services == beta.services());
     REQUIRE(timestamp == beta.timestamp());
@@ -281,7 +269,6 @@ TEST_CASE("version from data mismatched sender services invalid", "[version]") {
     auto const result = std::move(*result_exp);
 
     // HACK: disabled check due to inconsistent node implementation.
-    REQUIRE(/*!*/ result.is_valid());
 }
 
 TEST_CASE("version from data version meets bip37 success", "[version]") {
@@ -310,7 +297,6 @@ TEST_CASE("version from data version meets bip37 success", "[version]") {
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
 }
 
 TEST_CASE("version from data valid input success", "[version]") {
@@ -339,7 +325,6 @@ TEST_CASE("version from data valid input success", "[version]") {
     auto const result_exp = message::version::from_data(reader, version_maximum);
     REQUIRE(result_exp);
     auto const result = std::move(*result_exp);
-    REQUIRE(result.is_valid());
     REQUIRE(data.size() == result.serialized_size(version_maximum));
     REQUIRE(expected.serialized_size(version_maximum) == result.serialized_size(version_maximum));
     REQUIRE(expected == result);
@@ -721,35 +706,6 @@ TEST_CASE("version relay setter roundtrip success", "[version]") {
     message::version instance;
     instance.set_relay(expected);
     REQUIRE(expected == instance.relay());
-}
-
-TEST_CASE("version operator assign equals always matches equivalent", "[version]") {
-    message::version value(
-        210u,
-        15234u,
-        979797u,
-        message::network_address{
-            734678u,
-            5357534u,
-            {{0x47, 0x81, 0x6a, 0x40, 0xbb, 0x92, 0xbd, 0xb4,
-              0xe0, 0xb8, 0x25, 0x68, 0x61, 0xf9, 0x6a, 0x55}},
-            123u},
-        message::network_address{
-            46324u,
-            57835u,
-            {{0xab, 0xcd, 0x6a, 0x40, 0x33, 0x92, 0x77, 0xb4,
-              0xe0, 0xb8, 0xda, 0x43, 0x61, 0x66, 0x6a, 0x88}},
-            351u},
-        13626u,
-        "my agent",
-        100u,
-        false);
-
-    REQUIRE(value.is_valid());
-
-    message::version instance;
-    instance = std::move(value);
-    REQUIRE(instance.is_valid());
 }
 
 TEST_CASE("version operator boolean equals duplicates returns true", "[version]") {

--- a/src/network/src/peer_session.cpp
+++ b/src/network/src/peer_session.cpp
@@ -632,11 +632,6 @@ awaitable_expected<raw_message> peer_session::read_message() {
 
     auto const& head = *head_result;
 
-    if (!head.is_valid()) {
-        spdlog::warn("[peer_session] Invalid heading from [{}]", authority());
-        co_return std::unexpected(error::bad_stream);
-    }
-
     if (head.magic() != protocol_magic_) {
         spdlog::debug("[peer_session] Invalid magic ({}) from [{}]", head.magic(), authority());
         co_return std::unexpected(error::bad_stream);


### PR DESCRIPTION
Twenty message types exposed an `is_valid()` whose body is some variation of *"am I still the all-default object?"*:

```cpp
bool alert::is_valid() const {
    return !payload_.empty() || !signature_.empty();
}

bool inventory_vector::is_valid() const {
    return (type_ != type_id::error) || (hash_ != null_hash);
}

bool verack::is_valid() const {
    return true;
}
```

None of them is a validity claim. Each only distinguishes *default-constructed* from *assigned to*, which is the caller's business, not the type's — an `alert` with an empty payload is a perfectly well-formed value. `from_data` already returns `expect<>` and is the only place a message can fail to exist.

`reset()` is the same idea from the other side: it puts the object back into the sentinel state so `is_valid()` reports false. With the predicate gone it has no callers and no meaning.

## Scope

Removed from `alert`, `alert_payload`, `filter_load`, `heading`, `get_blocks` (and `get_headers`, which derives from it), `reject`, `version`, `send_compact`, `block_transactions`, `get_block_transactions`, `inventory_vector`, `address`, `addrv2`, `filter_add`, `headers`, `inventory`, `get_address`, `verack`, `xverack`, `xversion`.

**This is a deletion of dead sentinels, and nothing more.** It is explicitly *not* a claim that these types have no invariants — several of them do (**#476**), and this PR neither adds nor removes a single check. That gap is on master today, with or without this PR.

`addrv2_entry::is_valid()` is deliberately kept: it is the one predicate here that encodes a real constraint (the address blob length must match the BIP155 network id) rather than a sentinel, so it belongs to the `create()` treatment rather than to deletion.

## What this PR does NOT fix

Eight of these types **can be constructed in a state that cannot legally go on the wire**, and only `from_data` guards it:

| type | invariant | enforced in |
|---|---|---|
| `filter_add` | data ≤ 520 B (BIP37) | `from_data` only |
| `filter_load` | filter ≤ 36000 B (BIP37) | `from_data` only |
| `address` | ≤ 1000 entries | `from_data` only |
| `addrv2` | ≤ `max_addresses` entries | `from_data` only |
| `addrv2_entry` | `addr.size()` matches the network id | nowhere |
| `headers` | ≤ 2000 entries | `from_data` only |
| `inventory` | ≤ 50000 entries | `from_data` only |
| `get_block_transactions` | ≤ max block size | `from_data` only |

The public constructors, the setters and the mutable accessors (`data_chunk& data()`) all let a caller step over those caps. That gap predates this PR — the sentinel `is_valid()` never checked any of it — so nothing here regresses. Tracked in **#476**, which carries the full table and the plan; `prefilled_transaction` (#468) is the precedent for the shape.

`send_compact` looks like it belongs on that list and does not: its `mode > 1` check is on the wire byte, while the constructor takes a `bool`, so the type already makes the invalid state unrepresentable.

## The one non-test caller

```cpp
if (!head.is_valid()) { ... reject ... }
if (head.magic() != protocol_magic_) { ... reject ... }
```

`heading::is_valid()` returned false only for an all-zero heading, and the protocol magic is a nonzero constant on every network (`netmagic::bch_mainnet` and friends), so the magic check that follows already rejects exactly that input. Dropped the first check as redundant — no behaviour change.

## Tests

The sentinel assertions go with the predicate, along with the `constructor 1 always invalid` cases that existed solely to observe it. This also removes the equivalent husks earlier steps of this sweep left in the `transaction` and `double_spend_proof` suites — test bodies that no longer assert anything:

```cpp
TEST_CASE("message transaction constructor 1 always initialized invalid", "[message transaction]") {
    transaction instance;
}
```

## C-API

The predicate was exposed for `get_blocks` and `get_headers` only; both are regenerated, which also picks up the `_not_equal` binding synthesized by their defaulted `operator==`. Covered by a new test.

Net **−892 / +50**.

## Testing

Full build green — every target, benchmarks included. Domain (3801 cases) and C-API (734 cases) suites pass.
