### PR TITLE
fix(network): never send a ping with a zero nonce

### DIFF
--- a/src/network/include/kth/network/p2p_node.hpp
+++ b/src/network/include/kth/network/p2p_node.hpp
@@ -345,6 +345,11 @@ private:
 
     uint64_t generate_nonce();
 
+    /// Draw a ping nonce. Never zero -- zero is peer_session's "no ping in
+    /// flight" sentinel.
+    static
+    uint64_t generate_ping_nonce();
+
     settings const& settings_;
     threadpool pool_;
     peer_manager manager_;

--- a/src/network/include/kth/network/peer_session.hpp
+++ b/src/network/include/kth/network/peer_session.hpp
@@ -404,6 +404,8 @@ private:
     // Ping tracking (lock-free)
     // We store time as nanoseconds since steady_clock epoch for atomic access
     // Benign data races are acceptable for statistics
+    // Zero means "no ping in flight", so a ping must never carry a zero nonce
+    // (see p2p_node::generate_ping_nonce). A nonce we receive may be anything.
     std::atomic<uint64_t> pending_ping_nonce_{0};
     std::atomic<int64_t> pending_ping_time_ns_{0};
 

--- a/src/network/src/p2p_node.cpp
+++ b/src/network/src/p2p_node.cpp
@@ -786,8 +786,7 @@ concurrent_channel<peer_notification>& p2p_node::peer_events() {
             // Check if it's time to send a ping
             auto now = std::chrono::steady_clock::now();
             if (now - last_ping >= ping_interval) {
-                uint64_t nonce = 0;
-                pseudo_random::fill(reinterpret_cast<uint8_t*>(&nonce), sizeof(nonce));
+                auto const nonce = generate_ping_nonce();
                 domain::message::ping ping_msg(nonce);
 
                 auto ec = co_await peer->send(ping_msg);
@@ -1180,8 +1179,7 @@ concurrent_channel<peer_notification>& p2p_node::peer_events() {
 
                         // Send initial ping to get latency data
                         {
-                            uint64_t ping_nonce = 0;
-                            pseudo_random::fill(reinterpret_cast<uint8_t*>(&ping_nonce), sizeof(ping_nonce));
+                            auto const ping_nonce = generate_ping_nonce();
                             domain::message::ping ping_msg(ping_nonce);
                             auto ec = co_await peer->send(ping_msg);
                             if (ec == error::success) {
@@ -1275,6 +1273,20 @@ concurrent_channel<peer_notification>& p2p_node::peer_events() {
 uint64_t p2p_node::generate_nonce() {
     uint64_t nonce = 0;
     pseudo_random::fill(reinterpret_cast<uint8_t*>(&nonce), sizeof(nonce));
+    return nonce;
+}
+
+// static
+uint64_t p2p_node::generate_ping_nonce() {
+    // peer_session tracks the in-flight ping in `pending_ping_nonce_`, using
+    // zero to mean "none in flight" (see record_pong_received). A zero nonce
+    // would therefore make the peer's own echo look unsolicited and drop the
+    // latency sample, so never hand one out. BCHN guards the same sentinel the
+    // same way (net_processing.cpp: `while (nonce == 0) GetRandBytes(...)`).
+    uint64_t nonce = 0;
+    while (nonce == 0) {
+        pseudo_random::fill(reinterpret_cast<uint8_t*>(&nonce), sizeof(nonce));
+    }
     return nonce;
 }
 

--- a/src/network/test/peer_session.cpp
+++ b/src/network/test/peer_session.cpp
@@ -138,6 +138,32 @@ TEST_CASE("peer_session negotiated version get set", "[peer_session]") {
     REQUIRE(session->negotiated_version() == 31402);
 }
 
+TEST_CASE("peer_session ping tracker reserves zero for no ping in flight", "[peer_session]") {
+    ::asio::io_context ctx;
+    auto settings = make_test_settings();
+    auto [client, server] = make_connected_sockets(ctx);
+
+    auto session = std::make_shared<peer_session>(std::move(server), settings);
+
+    // Nothing sent yet, so any pong is unsolicited.
+    REQUIRE( ! session->record_pong_received(0));
+    REQUIRE( ! session->record_pong_received(42u));
+
+    // A real nonce round-trips, and only the matching one does.
+    session->record_ping_sent(42u);
+    REQUIRE( ! session->record_pong_received(43u));
+    REQUIRE(session->record_pong_received(42u));
+
+    // ...and is consumed: the echo only counts once.
+    REQUIRE( ! session->record_pong_received(42u));
+
+    // This is why p2p_node::generate_ping_nonce never hands out zero: recording
+    // a zero ping is indistinguishable from having sent nothing, so the peer's
+    // own echo comes back looking unsolicited and the latency sample is lost.
+    session->record_ping_sent(0);
+    REQUIRE( ! session->record_pong_received(0));
+}
+
 TEST_CASE("peer_session nonce get set", "[peer_session]") {
     ::asio::io_context ctx;
     auto settings = make_test_settings();


### PR DESCRIPTION
`peer_session` tracks the in-flight ping in `pending_ping_nonce_`, using zero to mean *"none in flight"*:

```cpp
bool peer_session::record_pong_received(uint64_t nonce) {
    auto const expected_nonce = pending_ping_nonce_.load(std::memory_order_relaxed);
    if (expected_nonce == 0 || nonce != expected_nonce) {
        return false;
    }
```

Both ping sites drew the nonce straight from the CSPRNG, so zero was a possible draw:

```cpp
uint64_t nonce = 0;
pseudo_random::fill(reinterpret_cast<uint8_t*>(&nonce), sizeof(nonce));   // can be 0
domain::message::ping ping_msg(nonce);
peer->record_ping_sent(nonce);
```

When it came up we would send `ping(0)`, store zero as the pending nonce, and then read the peer's perfectly correct `pong(0)` back as unsolicited — dropping the latency sample for that round.

BCHN guards the same sentinel the same way (`net_processing.cpp`):

```cpp
uint64_t nonce = 0;
while (nonce == 0) {
    GetRandBytes((uint8_t *)&nonce, sizeof(nonce));
}
```

## Changes

Route both ping sites through `generate_ping_nonce()`, which does the same, and document the reservation on `pending_ping_nonce_` so the coupling is visible from the tracker's end too.

## Severity

Low, deliberately stated: the odds are 2⁻⁶⁴ per ping and the consequence is one lost latency sample — no disconnect, no misbehavior score. This is a latent wart, not a live problem. It is cheap to close and the constraint is otherwise invisible at the call site.

## What this is *not*

A constraint on what we **generate**, not on what we **accept**. BIP31 requires echoing whatever nonce arrives, so a peer may legitimately ping us with zero and we must pong zero back — `domain::message::ping` rightly takes any `uint64_t` and needs no validation.

The version nonce (`generate_nonce`) is unaffected: it is only used to identify the peer and is never compared against a reserved value.

## Testing

The test pins the sentinel contract on `peer_session` — the thing that makes zero dangerous in the first place, and what would silently un-break if the `expected_nonce == 0` check were ever dropped. Full build green across every target; network suite passes.