### PR TITLE
refactor(domain/message): types with wire caps are valid-by-construction

### DIFF
--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1289,20 +1289,25 @@ block_chain::fetch_locator_block_hashes(get_blocks_const_ptr locator,
         }
     }
 
-    auto hashes = std::make_shared<inventory>();
-    hashes->inventories().reserve(floor_subtract(end, begin));
+    inventory_vector::list inventories;
+    inventories.reserve(floor_subtract(end, begin));
 
     for (auto height = begin; height < end; ++height) {
         auto const result = database_.internal_db().get_header(height);
         if ( ! result) {
-            hashes->inventories().shrink_to_fit();
+            inventories.shrink_to_fit();
             break;
         }
         static auto const id = inventory::type_id::block;
-        hashes->inventories().emplace_back(id, domain::chain::hash(*result));
+        inventories.emplace_back(id, domain::chain::hash(*result));
     }
 
-    co_return hashes;
+    auto hashes = inventory::create(std::move(inventories));
+    if ( ! hashes) {
+        co_return std::unexpected(hashes.error());
+    }
+
+    co_return std::make_shared<inventory>(std::move(*hashes));
 }
 
 awaitable_expected<headers_ptr>
@@ -1339,19 +1344,24 @@ block_chain::fetch_locator_block_headers(get_headers_const_ptr locator,
         }
     }
 
-    auto message = std::make_shared<domain::message::headers>();
-    message->elements().reserve(floor_subtract(end, begin));
+    domain::message::header::list elements;
+    elements.reserve(floor_subtract(end, begin));
 
     for (auto height = begin; height < end; ++height) {
         auto const result = database_.internal_db().get_header(height);
         if ( ! result) {
-            message->elements().shrink_to_fit();
+            elements.shrink_to_fit();
             break;
         }
-        message->elements().push_back(*result);
+        elements.push_back(*result);
     }
 
-    co_return message;
+    auto message = domain::message::headers::create(std::move(elements));
+    if ( ! message) {
+        co_return std::unexpected(message.error());
+    }
+
+    co_return std::make_shared<domain::message::headers>(std::move(*message));
 }
 
 awaitable_expected<get_headers_ptr>
@@ -1662,17 +1672,11 @@ void block_chain::fill_tx_list_from_mempool(domain::message::compact_block const
     }
 
     block_organizer_.filter(message);
-    auto& inventories = message->inventories();
     auto const& internal_db = database_.internal_db();
 
-    for (auto it = inventories.begin(); it != inventories.end();) {
-        auto const header = internal_db.get_header(it->hash());
-        if (it->is_block_type() && header) {
-            it = inventories.erase(it);
-        } else {
-            ++it;
-        }
-    }
+    message->erase_if([&internal_db](auto const& inv) {
+        return inv.is_block_type() && internal_db.get_header(inv.hash());
+    });
 
     co_return error::success;
 }
@@ -1682,8 +1686,6 @@ void block_chain::fill_tx_list_from_mempool(domain::message::compact_block const
         co_return error::service_stopped;
     }
 
-    auto& inventories = message->inventories();
-
 #if defined(KTH_WITH_MEMPOOL)
     auto validated_txs = mempool_.get_validated_txs_low();
 
@@ -1691,23 +1693,15 @@ void block_chain::fill_tx_list_from_mempool(domain::message::compact_block const
         co_return error::success;
     }
 
-    for (auto it = inventories.begin(); it != inventories.end();) {
-        auto found = validated_txs.find(it->hash());
-        if (it->is_transaction_type() && found != validated_txs.end()) {
-            it = inventories.erase(it);
-        } else {
-            ++it;
-        }
-    }
+    message->erase_if([&validated_txs](auto const& inv) {
+        return inv.is_transaction_type() &&
+               validated_txs.find(inv.hash()) != validated_txs.end();
+    });
 #else
-    for (auto it = inventories.begin(); it != inventories.end();) {
-        auto const pos = get_transaction_position(it->hash(), false);
-        if (it->is_transaction_type() && pos) {
-            it = inventories.erase(it);
-        } else {
-            ++it;
-        }
-    }
+    message->erase_if([this](auto const& inv) {
+        return inv.is_transaction_type() &&
+               get_transaction_position(inv.hash(), false);
+    });
 #endif
 
     co_return error::success;

--- a/src/blockchain/src/pools/block_pool.cpp
+++ b/src/blockchain/src/pools/block_pool.cpp
@@ -177,27 +177,19 @@ void block_pool::prune(size_t top_height) {
 }
 
 void block_pool::filter(get_data_ptr message) const {
-    auto& inventories = message->inventories();
     auto const& left = blocks_.left;
 
-    for (auto it = inventories.begin(); it != inventories.end();) {
-        if ( ! it->is_block_type()) {
-            ++it;
-            continue;
-        }
+    ///////////////////////////////////////////////////////////////////////////
+    // Critical Section
+    mutex_.lock_shared();
 
-        block_entry const entry{ it->hash() };
+    message->erase_if([&left](auto const& inv) {
+        return inv.is_block_type() &&
+               left.find(block_entry{ inv.hash() }) != left.end();
+    });
 
-        ///////////////////////////////////////////////////////////////////////
-        // Critical Section
-        mutex_.lock_shared();
-        auto const found = (left.find(entry) != left.end());
-        mutex_.unlock_shared();
-        ///////////////////////////////////////////////////////////////////////
-
-        // TODO(legacy): optimize (prevent repeating vector moves).
-        it = found ? inventories.erase(it) : it + 1;
-    }
+    mutex_.unlock_shared();
+    ///////////////////////////////////////////////////////////////////////////
 }
 
 // protected

--- a/src/blockchain/test/block_pool.cpp
+++ b/src/blockchain/test/block_pool.cpp
@@ -437,15 +437,14 @@ TEST_CASE("block pool filter matched blocks non blocks and mismatches remain", "
     const domain::message::inventory_vector expected1{ domain::message::inventory::type_id::error, block1->hash() };
     const domain::message::inventory_vector expected2{ domain::message::inventory::type_id::transaction, block3->hash() };
     const domain::message::inventory_vector expected3{ domain::message::inventory::type_id::block, block3->hash() };
-    domain::message::get_data data
-    {
+    auto data = domain::message::get_data::create({
         expected1,
         { domain::message::inventory::type_id::block, block1->hash() },
         expected2,
         { domain::message::inventory::type_id::block, block2->hash() },
         { domain::message::inventory::type_id::block, block2->hash() },
         expected3
-    };
+    }).value();
     auto const message = std::make_shared<domain::message::get_data>(std::move(data));
     instance.filter(message);
     REQUIRE(message->inventories().size() == 3u);

--- a/src/c-api/include/kth/capi/error.h
+++ b/src/c-api/include/kth/capi/error.h
@@ -243,6 +243,7 @@ typedef enum kth_error_code {
     kth_ec_script_invalid_size,
     kth_ec_invalid_address_count,
     kth_ec_bad_inventory_count,
+    kth_ec_invalid_headers_count,
     kth_ec_version_too_low,
     kth_ec_version_too_new,
     kth_ec_invalid_compact_block,

--- a/src/domain/include/kth/domain/message/address.hpp
+++ b/src/domain/include/kth/domain/message/address.hpp
@@ -5,7 +5,6 @@
 #ifndef KTH_DOMAIN_MESSAGE_ADDRESS_HPP
 #define KTH_DOMAIN_MESSAGE_ADDRESS_HPP
 
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -24,19 +23,17 @@ struct KD_API address {
     using const_ptr = std::shared_ptr<const address>;
 
     address() = default;
-    address(infrastructure::message::network_address::list const& addresses);
-    address(infrastructure::message::network_address::list&& addresses);
+
+    /// Fails with error::invalid_address_count over max_address entries.
+    static
+    expect<address> create(infrastructure::message::network_address::list addresses);
 
     [[nodiscard]]
     friend bool operator==(address const&, address const&) = default;
 
-    infrastructure::message::network_address::list& addresses();
-
     [[nodiscard]]
     infrastructure::message::network_address::list const& addresses() const;
 
-    void set_addresses(infrastructure::message::network_address::list const& value);
-    void set_addresses(infrastructure::message::network_address::list&& value);
 
     static
     expect<address> from_data(byte_reader& reader, uint32_t version);
@@ -59,6 +56,8 @@ struct KD_API address {
     uint32_t const version_maximum;
 
 private:
+    address(infrastructure::message::network_address::list addresses);
+
     infrastructure::message::network_address::list addresses_;
 };
 

--- a/src/domain/include/kth/domain/message/addrv2.hpp
+++ b/src/domain/include/kth/domain/message/addrv2.hpp
@@ -5,7 +5,6 @@
 #ifndef KTH_DOMAIN_MESSAGE_ADDRV2_HPP
 #define KTH_DOMAIN_MESSAGE_ADDRV2_HPP
 
-#include <istream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -65,19 +64,17 @@ struct KD_API addrv2 {
     using entry_list = std::vector<addrv2_entry>;
 
     addrv2() = default;
-    addrv2(entry_list const& addresses);
-    addrv2(entry_list&& addresses);
+
+    /// Fails with error::invalid_address_count over max_addresses entries.
+    static
+    expect<addrv2> create(entry_list addresses);
 
     [[nodiscard]]
     friend bool operator==(addrv2 const&, addrv2 const&) = default;
 
-    entry_list& addresses();
-
     [[nodiscard]]
     entry_list const& addresses() const;
 
-    void set_addresses(entry_list const& value);
-    void set_addresses(entry_list&& value);
 
     /// Convert to legacy network_address list (IPv4/IPv6 only)
     [[nodiscard]]
@@ -108,6 +105,8 @@ struct KD_API addrv2 {
     static constexpr size_t max_addr_size = 512;
 
 private:
+    addrv2(entry_list addresses);
+
     entry_list addresses_;
 };
 

--- a/src/domain/include/kth/domain/message/filter_add.hpp
+++ b/src/domain/include/kth/domain/message/filter_add.hpp
@@ -5,7 +5,6 @@
 #ifndef KTH_DOMAIN_MESSAGE_FILTER_ADD_HPP
 #define KTH_DOMAIN_MESSAGE_FILTER_ADD_HPP
 
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -23,26 +22,22 @@ struct KD_API filter_add {
     using const_ptr = std::shared_ptr<const filter_add>;
 
     filter_add() = default;
-    filter_add(data_chunk const& data);
-    filter_add(data_chunk&& data);
+
+    /// Fails with error::invalid_filter_add over max_filter_add bytes (BIP37).
+    static
+    expect<filter_add> create(data_chunk data);
 
     [[nodiscard]]
     friend bool operator==(filter_add const&, filter_add const&) = default;
 
-    data_chunk& data();
-
     [[nodiscard]]
     data_chunk const& data() const;
 
-    void set_data(data_chunk const& value);
-    void set_data(data_chunk&& value);
-
     static
-    expect<filter_add> from_data(byte_reader& reader, uint32_t /*version*/);
+    expect<filter_add> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
-
 
     [[nodiscard]]
     size_t serialized_size(uint32_t version) const;
@@ -57,6 +52,8 @@ struct KD_API filter_add {
     uint32_t const version_maximum;
 
 private:
+    filter_add(data_chunk data);
+
     data_chunk data_;
 };
 

--- a/src/domain/include/kth/domain/message/filter_load.hpp
+++ b/src/domain/include/kth/domain/message/filter_load.hpp
@@ -5,7 +5,6 @@
 #ifndef KTH_DOMAIN_MESSAGE_FILTER_LOAD_HPP
 #define KTH_DOMAIN_MESSAGE_FILTER_LOAD_HPP
 
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -23,34 +22,27 @@ struct KD_API filter_load {
     using const_ptr = std::shared_ptr<const filter_load>;
 
     filter_load() = default;
-    filter_load(data_chunk const& filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags);
-    filter_load(data_chunk&& filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags);
+
+    /// Fails with error::invalid_filter_load over max_filter_load bytes or
+    /// max_filter_functions hash functions (BIP37).
+    static
+    expect<filter_load> create(data_chunk filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags);
 
     [[nodiscard]]
     friend bool operator==(filter_load const&, filter_load const&) = default;
 
-    data_chunk& filter();
-
     [[nodiscard]]
     data_chunk const& filter() const;
 
-    void set_filter(data_chunk const& value);
-    void set_filter(data_chunk&& value);
 
     [[nodiscard]]
     uint32_t hash_functions() const;
 
-    void set_hash_functions(uint32_t value);
-
     [[nodiscard]]
     uint32_t tweak() const;
 
-    void set_tweak(uint32_t value);
-
     [[nodiscard]]
     uint8_t flags() const;
-
-    void set_flags(uint8_t value);
 
     static
     expect<filter_load> from_data(byte_reader& reader, uint32_t version);
@@ -72,6 +64,8 @@ struct KD_API filter_load {
     uint32_t const version_maximum;
 
 private:
+    filter_load(data_chunk filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags);
+
     data_chunk filter_;
     uint32_t hash_functions_{0};
     uint32_t tweak_{0};

--- a/src/domain/include/kth/domain/message/get_block_transactions.hpp
+++ b/src/domain/include/kth/domain/message/get_block_transactions.hpp
@@ -5,7 +5,6 @@
 #ifndef KTH_DOMAIN_MESSAGE_GET_BLOCK_TRANSACTIONS_HPP
 #define KTH_DOMAIN_MESSAGE_GET_BLOCK_TRANSACTIONS_HPP
 
-#include <istream>
 #include <memory>
 
 #include <kth/domain/constants.hpp>
@@ -24,26 +23,21 @@ struct KD_API get_block_transactions {
     using const_ptr = std::shared_ptr<const get_block_transactions>;
 
     get_block_transactions();
-    get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t> const& indexes);
-    get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t>&& indexes);
+
+    /// Fails with error::invalid_size over the number of transactions a block
+    /// could hold.
+    static
+    expect<get_block_transactions> create(hash_digest const& block_hash, std::vector<uint64_t> indexes);
 
     [[nodiscard]]
     friend bool operator==(get_block_transactions const&, get_block_transactions const&) = default;
 
-    hash_digest& block_hash();
-
     [[nodiscard]]
     hash_digest const& block_hash() const;
-
-    void set_block_hash(hash_digest const& value);
-
-    std::vector<uint64_t>& indexes();
 
     [[nodiscard]]
     std::vector<uint64_t> const& indexes() const;
 
-    void set_indexes(std::vector<uint64_t> const& values);
-    void set_indexes(std::vector<uint64_t>&& values);
 
     static
     expect<get_block_transactions> from_data(byte_reader& reader, uint32_t /*version*/);
@@ -64,6 +58,8 @@ struct KD_API get_block_transactions {
     uint32_t const version_maximum;
 
 private:
+    get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t> indexes);
+
     hash_digest block_hash_;
     std::vector<uint64_t> indexes_;
 };

--- a/src/domain/include/kth/domain/message/get_data.hpp
+++ b/src/domain/include/kth/domain/message/get_data.hpp
@@ -28,10 +28,12 @@ public:
     using const_ptr = std::shared_ptr<const get_data>;
 
     get_data() = default;
-    get_data(inventory_vector::list const& values);
-    get_data(inventory_vector::list&& values);
-    get_data(hash_list const& hashes, type_id type);
-    get_data(std::initializer_list<inventory_vector> const& values);
+
+    /// Same cap as the inventory it is.
+    static
+    expect<get_data> create(inventory_vector::list inventories);
+    static
+    expect<get_data> create(hash_list const& hashes, type_id type);
     get_data(inventory&& inv)
         : inventory(std::move(inv))
     {}

--- a/src/domain/include/kth/domain/message/headers.hpp
+++ b/src/domain/include/kth/domain/message/headers.hpp
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <initializer_list>
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -28,20 +27,18 @@ struct KD_API headers {
     using const_ptr = std::shared_ptr<const headers>;
 
     headers() = default;
-    headers(header::list const& values);
-    headers(header::list&& values);
+
+    /// Fails with error::invalid_headers_count over max_get_headers entries.
+    static
+    expect<headers> create(header::list elements);
     headers(std::initializer_list<header> const& values);
 
     [[nodiscard]]
     friend bool operator==(headers const&, headers const&) = default;
 
-    header::list& elements();
-
     [[nodiscard]]
     header::list const& elements() const;
 
-    void set_elements(header::list const& values);
-    void set_elements(header::list&& values);
 
     [[nodiscard]]
     bool is_sequential() const;
@@ -70,6 +67,8 @@ struct KD_API headers {
 
 
 private:
+    headers(header::list elements);
+
     header::list elements_;
 };
 

--- a/src/domain/include/kth/domain/message/inventory.hpp
+++ b/src/domain/include/kth/domain/message/inventory.hpp
@@ -5,10 +5,10 @@
 #ifndef KTH_DOMAIN_MESSAGE_INVENTORY_HPP
 #define KTH_DOMAIN_MESSAGE_INVENTORY_HPP
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
-#include <istream>
 #include <memory>
 #include <string>
 
@@ -29,27 +29,34 @@ struct KD_API inventory {
     using type_id = inventory_vector::type_id;
 
     inventory() = default;
-    inventory(inventory_vector::list const& values);
-    inventory(inventory_vector::list&& values);
-    inventory(hash_list const& hashes, type_id type);
-    inventory(std::initializer_list<inventory_vector> const& values);
+
+    /// Fails with error::bad_inventory_count over max_inventory entries.
+    static
+    expect<inventory> create(inventory_vector::list inventories);
+
+    /// One vector per hash, all of `type`. Same cap.
+    static
+    expect<inventory> create(hash_list const& hashes, type_id type);
 
     [[nodiscard]]
     friend bool operator==(inventory const&, inventory const&) = default;
 
-    inventory_vector::list& inventories();
-
     [[nodiscard]]
     inventory_vector::list const& inventories() const;
 
-    void set_inventories(inventory_vector::list const& value);
-    void set_inventories(inventory_vector::list&& value);
 
     static
     expect<inventory> from_data(byte_reader& reader, uint32_t version);
 
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer, uint32_t version) const;
+
+    /// Drop the vectors matching `pred`. Safe where a mutable accessor is not:
+    /// removing entries cannot exceed a maximum.
+    template <typename Predicate>
+    void erase_if(Predicate pred) {
+        std::erase_if(inventories_, pred);
+    }
 
     void to_hashes(hash_list& out, type_id type) const;
     void reduce(inventory_vector::list& out, type_id type) const;
@@ -71,6 +78,8 @@ struct KD_API inventory {
 
 
 private:
+    inventory(inventory_vector::list inventories);
+
     inventory_vector::list inventories_;
 };
 

--- a/src/domain/include/kth/domain/message/not_found.hpp
+++ b/src/domain/include/kth/domain/message/not_found.hpp
@@ -29,10 +29,12 @@ public:
     using const_ptr = std::shared_ptr<const not_found>;
 
     not_found() = default;
-    not_found(inventory_vector::list const& values);
-    not_found(inventory_vector::list&& values);
-    not_found(hash_list const& hashes, type_id type);
-    not_found(std::initializer_list<inventory_vector> const& values);
+
+    /// Same cap as the inventory it is.
+    static
+    expect<not_found> create(inventory_vector::list inventories);
+    static
+    expect<not_found> create(hash_list const& hashes, type_id type);
     not_found(inventory&& inv)
         : inventory(std::move(inv))
     {}

--- a/src/domain/src/message/address.cpp
+++ b/src/domain/src/message/address.cpp
@@ -14,13 +14,17 @@ std::string const address::command = "addr";
 uint32_t const address::version_minimum = version::level::minimum;
 uint32_t const address::version_maximum = version::level::maximum;
 
-address::address(infrastructure::message::network_address::list const& addresses)
-    : addresses_(addresses)
-{}
-
-address::address(infrastructure::message::network_address::list&& addresses)
+address::address(infrastructure::message::network_address::list addresses)
     : addresses_(std::move(addresses))
 {}
+
+// static
+expect<address> address::create(infrastructure::message::network_address::list addresses) {
+    if (addresses.size() > max_address) {
+        return std::unexpected(error::invalid_address_count);
+    }
+    return address(std::move(addresses));
+}
 
 // Deserialization.
 //-----------------------------------------------------------------------------
@@ -48,33 +52,19 @@ expect<address> address::from_data(byte_reader& reader, uint32_t version) {
         addresses.push_back(std::move(*address));
     }
 
-    return address(std::move(addresses));
+    return create(std::move(addresses));
 }
 
 // Serialization.
 //-----------------------------------------------------------------------------
-
-
 
 size_t address::serialized_size(uint32_t version) const {
     return infrastructure::message::variable_uint_size(addresses_.size()) +
            (addresses_.size() * infrastructure::message::network_address::satoshi_fixed_size(version, true));
 }
 
-infrastructure::message::network_address::list& address::addresses() {
-    return addresses_;
-}
-
 infrastructure::message::network_address::list const& address::addresses() const {
     return addresses_;
-}
-
-void address::set_addresses(infrastructure::message::network_address::list const& value) {
-    addresses_ = value;
-}
-
-void address::set_addresses(infrastructure::message::network_address::list&& value) {
-    addresses_ = std::move(value);
 }
 
 expect<void> address::to_data(byte_writer& writer, uint32_t version) const {

--- a/src/domain/src/message/addrv2.cpp
+++ b/src/domain/src/message/addrv2.cpp
@@ -121,28 +121,20 @@ std::string const addrv2::command = "addrv2";
 uint32_t const addrv2::version_minimum = version::level::feature_negotiation;
 uint32_t const addrv2::version_maximum = version::level::maximum;
 
-addrv2::addrv2(entry_list const& addresses)
-    : addresses_(addresses)
-{}
-
-addrv2::addrv2(entry_list&& addresses)
+addrv2::addrv2(entry_list addresses)
     : addresses_(std::move(addresses))
 {}
 
-addrv2::entry_list& addrv2::addresses() {
+// static
+expect<addrv2> addrv2::create(entry_list addresses) {
+    if (addresses.size() > max_addresses) {
+        return std::unexpected(error::invalid_address_count);
+    }
+    return addrv2(std::move(addresses));
+}
+
+addrv2::addrv2::entry_list const& addrv2::addresses() const {
     return addresses_;
-}
-
-addrv2::entry_list const& addrv2::addresses() const {
-    return addresses_;
-}
-
-void addrv2::set_addresses(entry_list const& value) {
-    addresses_ = value;
-}
-
-void addrv2::set_addresses(entry_list&& value) {
-    addresses_ = std::move(value);
 }
 
 infrastructure::message::network_address::list addrv2::to_network_addresses() const {
@@ -235,13 +227,11 @@ expect<addrv2> addrv2::from_data(byte_reader& reader, uint32_t version) {
         addresses.push_back(std::move(entry));
     }
 
-    return addrv2(std::move(addresses));
+    return create(std::move(addresses));
 }
 
 // Serialization.
 //-----------------------------------------------------------------------------
-
-
 
 size_t addrv2::serialized_size(uint32_t /*version*/) const {
     size_t size = infrastructure::message::variable_uint_size(addresses_.size());

--- a/src/domain/src/message/filter_add.cpp
+++ b/src/domain/src/message/filter_add.cpp
@@ -15,12 +15,17 @@ std::string const filter_add::command = "filteradd";
 uint32_t const filter_add::version_minimum = version::level::bip37;
 uint32_t const filter_add::version_maximum = version::level::maximum;
 
-filter_add::filter_add(data_chunk const& data)
-    : data_(data) {
-}
+filter_add::filter_add(data_chunk data)
+    : data_(std::move(data))
+{}
 
-filter_add::filter_add(data_chunk&& data)
-    : data_(std::move(data)) {
+// static
+expect<filter_add> filter_add::create(data_chunk data) {
+    // BIP37 caps filteradd; anything above it cannot be encoded.
+    if (data.size() > max_filter_add) {
+        return std::unexpected(error::invalid_filter_add);
+    }
+    return filter_add(std::move(data));
 }
 
 // Deserialization.
@@ -36,6 +41,7 @@ expect<filter_add> filter_add::from_data(byte_reader& reader, uint32_t version) 
     if ( ! size) {
         return std::unexpected(size.error());
     }
+    // Checked before reading, so an oversized claim cannot make us allocate.
     if (*size > max_filter_add) {
         return std::unexpected(error::invalid_filter_add);
     }
@@ -44,7 +50,7 @@ expect<filter_add> filter_add::from_data(byte_reader& reader, uint32_t version) 
     if ( ! data) {
         return std::unexpected(data.error());
     }
-    return filter_add(data_chunk(data->begin(), data->end()));
+    return create(data_chunk(data->begin(), data->end()));
 }
 
 // Serialization.
@@ -56,20 +62,8 @@ size_t filter_add::serialized_size(uint32_t /*version*/) const {
     return infrastructure::message::variable_uint_size(data_.size()) + data_.size();
 }
 
-data_chunk& filter_add::data() {
-    return data_;
-}
-
 data_chunk const& filter_add::data() const {
     return data_;
-}
-
-void filter_add::set_data(data_chunk const& value) {
-    data_ = value;
-}
-
-void filter_add::set_data(data_chunk&& value) {
-    data_ = std::move(value);
 }
 
 expect<void> filter_add::to_data(byte_writer& writer, uint32_t version) const {

--- a/src/domain/src/message/filter_load.cpp
+++ b/src/domain/src/message/filter_load.cpp
@@ -14,12 +14,20 @@ std::string const filter_load::command = "filterload";
 uint32_t const filter_load::version_minimum = version::level::bip37;
 uint32_t const filter_load::version_maximum = version::level::maximum;
 
-filter_load::filter_load(data_chunk const& filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags)
-    : filter_(filter), hash_functions_(hash_functions), tweak_(tweak), flags_(flags) {
-}
+filter_load::filter_load(data_chunk filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags)
+    : filter_(std::move(filter)), hash_functions_(hash_functions), tweak_(tweak), flags_(flags)
+{}
 
-filter_load::filter_load(data_chunk&& filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags)
-    : filter_(std::move(filter)), hash_functions_(hash_functions), tweak_(tweak), flags_(flags) {
+// static
+expect<filter_load> filter_load::create(data_chunk filter, uint32_t hash_functions, uint32_t tweak, uint8_t flags) {
+    // BIP37 caps both; neither can be encoded above the cap.
+    if (filter.size() > max_filter_load) {
+        return std::unexpected(error::invalid_filter_load);
+    }
+    if (hash_functions > max_filter_functions) {
+        return std::unexpected(error::invalid_filter_load);
+    }
+    return filter_load(std::move(filter), hash_functions, tweak, flags);
 }
 
 // Deserialization.
@@ -54,7 +62,7 @@ expect<filter_load> filter_load::from_data(byte_reader& reader, uint32_t version
     if (version < filter_load::version_minimum) {
         return std::unexpected(error::version_too_low);
     }
-    return filter_load(
+    return create(
         data_chunk(filter->begin(), filter->end()),
         *hash_functions,
         *tweak,
@@ -65,50 +73,24 @@ expect<filter_load> filter_load::from_data(byte_reader& reader, uint32_t version
 // Serialization.
 //-----------------------------------------------------------------------------
 
-
-
 size_t filter_load::serialized_size(uint32_t /*version*/) const {
     return 1u + 4u + 4u + infrastructure::message::variable_uint_size(filter_.size()) + filter_.size();
-}
-
-data_chunk& filter_load::filter() {
-    return filter_;
 }
 
 data_chunk const& filter_load::filter() const {
     return filter_;
 }
 
-void filter_load::set_filter(data_chunk const& value) {
-    filter_ = value;
-}
-
-void filter_load::set_filter(data_chunk&& value) {
-    filter_ = std::move(value);
-}
-
 uint32_t filter_load::hash_functions() const {
     return hash_functions_;
-}
-
-void filter_load::set_hash_functions(uint32_t value) {
-    hash_functions_ = value;
 }
 
 uint32_t filter_load::tweak() const {
     return tweak_;
 }
 
-void filter_load::set_tweak(uint32_t value) {
-    tweak_ = value;
-}
-
 uint8_t filter_load::flags() const {
     return flags_;
-}
-
-void filter_load::set_flags(uint8_t value) {
-    flags_ = value;
 }
 
 expect<void> filter_load::to_data(byte_writer& writer, uint32_t version) const {

--- a/src/domain/src/message/get_block_transactions.cpp
+++ b/src/domain/src/message/get_block_transactions.cpp
@@ -20,15 +20,19 @@ get_block_transactions::get_block_transactions()
     : block_hash_(null_hash)
 {}
 
-get_block_transactions::get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t> const& indexes)
-    : block_hash_(block_hash)
-    , indexes_(indexes)
-{}
-
-get_block_transactions::get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t>&& indexes)
+get_block_transactions::get_block_transactions(hash_digest const& block_hash, std::vector<uint64_t> indexes)
     : block_hash_(block_hash)
     , indexes_(std::move(indexes))
 {}
+
+// static
+expect<get_block_transactions> get_block_transactions::create(hash_digest const& block_hash, std::vector<uint64_t> indexes) {
+    // More indexes than a block could hold describes no block.
+    if (indexes.size() > static_absolute_max_block_size()) {
+        return std::unexpected(error::invalid_size);
+    }
+    return get_block_transactions(block_hash, std::move(indexes));
+}
 
 // Deserialization.
 //-----------------------------------------------------------------------------
@@ -55,13 +59,11 @@ expect<get_block_transactions> get_block_transactions::from_data(byte_reader& re
         }
         indexes.push_back(*index);
     }
-    return get_block_transactions(*block_hash, std::move(indexes));
+    return create(*block_hash, std::move(indexes));
 }
 
 // Serialization.
 //-----------------------------------------------------------------------------
-
-
 
 size_t get_block_transactions::serialized_size(uint32_t /*version*/) const {
     auto size = hash_size + infrastructure::message::variable_uint_size(indexes_.size());
@@ -73,32 +75,12 @@ size_t get_block_transactions::serialized_size(uint32_t /*version*/) const {
     return size;
 }
 
-hash_digest& get_block_transactions::block_hash() {
-    return block_hash_;
-}
-
 hash_digest const& get_block_transactions::block_hash() const {
     return block_hash_;
 }
 
-void get_block_transactions::set_block_hash(hash_digest const& value) {
-    block_hash_ = value;
-}
-
-std::vector<uint64_t>& get_block_transactions::indexes() {
-    return indexes_;
-}
-
 std::vector<uint64_t> const& get_block_transactions::indexes() const {
     return indexes_;
-}
-
-void get_block_transactions::set_indexes(std::vector<uint64_t> const& values) {
-    indexes_ = values;
-}
-
-void get_block_transactions::set_indexes(std::vector<uint64_t>&& values) {
-    indexes_ = values;
 }
 
 expect<void> get_block_transactions::to_data(byte_writer& writer, uint32_t version) const {

--- a/src/domain/src/message/get_data.cpp
+++ b/src/domain/src/message/get_data.cpp
@@ -19,20 +19,22 @@ std::string const get_data::command = "getdata";
 uint32_t const get_data::version_minimum = version::level::minimum;
 uint32_t const get_data::version_maximum = version::level::maximum;
 
-get_data::get_data(inventory_vector::list const& values)
-    : inventory(values) {
+// static
+expect<get_data> get_data::create(inventory_vector::list inventories) {
+    auto inv = inventory::create(std::move(inventories));
+    if ( ! inv) {
+        return std::unexpected(inv.error());
+    }
+    return get_data(std::move(*inv));
 }
 
-get_data::get_data(inventory_vector::list&& values)
-    : inventory(values) {
-}
-
-get_data::get_data(hash_list const& hashes, inventory::type_id type)
-    : inventory(hashes, type) {
-}
-
-get_data::get_data(std::initializer_list<inventory_vector> const& values)
-    : inventory(values) {
+// static
+expect<get_data> get_data::create(hash_list const& hashes, type_id type) {
+    auto inv = inventory::create(hashes, type);
+    if ( ! inv) {
+        return std::unexpected(inv.error());
+    }
+    return get_data(std::move(*inv));
 }
 
 // Deserialization.

--- a/src/domain/src/message/headers.cpp
+++ b/src/domain/src/message/headers.cpp
@@ -22,12 +22,16 @@ uint32_t const headers::version_minimum = version::level::headers;
 uint32_t const headers::version_maximum = version::level::maximum;
 
 // Uses headers copy assignment.
-headers::headers(header::list const& values)
-    : elements_(values) {
-}
+headers::headers(header::list elements)
+    : elements_(std::move(elements))
+{}
 
-headers::headers(header::list&& values)
-    : elements_(std::move(values)) {
+// static
+expect<headers> headers::create(header::list elements) {
+    if (elements.size() > max_get_headers) {
+        return std::unexpected(error::invalid_headers_count);
+    }
+    return headers(std::move(elements));
 }
 
 headers::headers(std::initializer_list<header> const& values)
@@ -59,13 +63,11 @@ expect<headers> headers::from_data(byte_reader& reader, uint32_t version) {
     if (version < headers::version_minimum) {
         return std::unexpected(error::version_too_new);
     }
-    return headers(std::move(elements));
+    return create(std::move(elements));
 }
 
 // Serialization.
 //-----------------------------------------------------------------------------
-
-
 
 bool headers::is_sequential() const {
     if (elements_.empty()) {
@@ -111,20 +113,8 @@ size_t headers::serialized_size(uint32_t version) const {
            (elements_.size() * header::satoshi_fixed_size(version));
 }
 
-header::list& headers::elements() {
-    return elements_;
-}
-
 header::list const& headers::elements() const {
     return elements_;
-}
-
-void headers::set_elements(header::list const& values) {
-    elements_ = values;
-}
-
-void headers::set_elements(header::list&& values) {
-    elements_ = std::move(values);
 }
 
 expect<void> headers::to_data(byte_writer& writer, uint32_t version) const {

--- a/src/domain/src/message/inventory.cpp
+++ b/src/domain/src/message/inventory.cpp
@@ -19,27 +19,27 @@ std::string const inventory::command = "inv";
 uint32_t const inventory::version_minimum = version::level::minimum;
 uint32_t const inventory::version_maximum = version::level::maximum;
 
-inventory::inventory(inventory_vector::list const& values)
-    : inventories_(values)
+inventory::inventory(inventory_vector::list inventories)
+    : inventories_(std::move(inventories))
 {}
 
-inventory::inventory(inventory_vector::list&& values)
-    : inventories_(std::move(values))
-{}
-
-inventory::inventory(hash_list const& hashes, type_id type) {
-    inventories_.clear();
-    inventories_.reserve(hashes.size());
-    auto const map = [type, this](hash_digest const& hash) {
-        inventories_.emplace_back(type, hash);
-    };
-
-    std::for_each(hashes.begin(), hashes.end(), map);
+// static
+expect<inventory> inventory::create(inventory_vector::list inventories) {
+    if (inventories.size() > max_inventory) {
+        return std::unexpected(error::bad_inventory_count);
+    }
+    return inventory(std::move(inventories));
 }
 
-inventory::inventory(std::initializer_list<inventory_vector> const& values)
-    : inventories_(values)
-{}
+// static
+expect<inventory> inventory::create(hash_list const& hashes, type_id type) {
+    inventory_vector::list inventories;
+    inventories.reserve(hashes.size());
+    for (auto const& hash : hashes) {
+        inventories.emplace_back(type, hash);
+    }
+    return create(std::move(inventories));
+}
 
 // Deserialization.
 //-----------------------------------------------------------------------------
@@ -63,13 +63,11 @@ expect<inventory> inventory::from_data(byte_reader& reader, uint32_t version) {
         }
         inventories.emplace_back(std::move(*inventory));
     }
-    return inventory(std::move(inventories));
+    return create(std::move(inventories));
 }
 
 // Serialization.
 //-----------------------------------------------------------------------------
-
-
 
 void inventory::to_hashes(hash_list& out, type_id type) const {
     out.reserve(inventories_.size());
@@ -107,20 +105,8 @@ size_t inventory::count(type_id type) const {
     return count_if(inventories_.begin(), inventories_.end(), is_type);
 }
 
-inventory_vector::list& inventory::inventories() {
-    return inventories_;
-}
-
 inventory_vector::list const& inventory::inventories() const {
     return inventories_;
-}
-
-void inventory::set_inventories(inventory_vector::list const& value) {
-    inventories_ = value;
-}
-
-void inventory::set_inventories(inventory_vector::list&& value) {
-    inventories_ = std::move(value);
 }
 
 expect<void> inventory::to_data(byte_writer& writer, uint32_t version) const {

--- a/src/domain/src/message/not_found.cpp
+++ b/src/domain/src/message/not_found.cpp
@@ -16,20 +16,22 @@ std::string const not_found::command = "notfound";
 uint32_t const not_found::version_minimum = version::level::bip37;
 uint32_t const not_found::version_maximum = version::level::maximum;
 
-not_found::not_found(inventory_vector::list const& values)
-    : inventory(values) {
+// static
+expect<not_found> not_found::create(inventory_vector::list inventories) {
+    auto inv = inventory::create(std::move(inventories));
+    if ( ! inv) {
+        return std::unexpected(inv.error());
+    }
+    return not_found(std::move(*inv));
 }
 
-not_found::not_found(inventory_vector::list&& values)
-    : inventory(values) {
-}
-
-not_found::not_found(hash_list const& hashes, inventory::type_id type)
-    : inventory(hashes, type) {
-}
-
-not_found::not_found(std::initializer_list<inventory_vector> const& values)
-    : inventory(values) {
+// static
+expect<not_found> not_found::create(hash_list const& hashes, type_id type) {
+    auto inv = inventory::create(hashes, type);
+    if ( ! inv) {
+        return std::unexpected(inv.error());
+    }
+    return not_found(std::move(*inv));
 }
 
 // Deserialization.

--- a/src/domain/test/message/address.cpp
+++ b/src/domain/test/message/address.cpp
@@ -40,7 +40,7 @@ TEST_CASE("address constructor 2 always equals params", "[address]") {
             "19573257168426842319857321595126"_base16,
             159u)};
 
-    address instance(addresses);
+    auto const instance = address::create(addresses).value();
 
     REQUIRE(addresses == instance.addresses());
 }
@@ -65,7 +65,7 @@ TEST_CASE("address constructor 3 always equals params", "[address]") {
 
     auto dup_addresses = addresses;
 
-    address instance(std::move(dup_addresses));
+    auto const instance = address::create(std::move(dup_addresses)).value();
 
     REQUIRE(addresses == instance.addresses());
 }
@@ -88,7 +88,7 @@ TEST_CASE("address constructor 4 always equals params", "[address]") {
             "19573257168426842319857321595126"_base16,
             159u)};
 
-    address value(addresses);
+    auto value = address::create(addresses).value();
     address instance(value);
 
     REQUIRE(value == instance);
@@ -113,7 +113,7 @@ TEST_CASE("address constructor 5 always equals params", "[address]") {
             "19573257168426842319857321595126"_base16,
             159u)};
 
-    address value(addresses);
+    auto value = address::create(addresses).value();
     address instance(std::move(value));
 
     REQUIRE(addresses == instance.addresses());
@@ -129,11 +129,11 @@ TEST_CASE("address from data insufficient bytes failure", "[address]") {
 }
 
 TEST_CASE("address from data roundtrip success", "[address]") {
-    address const expected(
+    auto const expected = address::create(
         {{734678u,
           5357534u,
           "47816a40bb92bdb4e0b8256861f96a55"_base16,
-          123u}});
+          123u}}).value();
 
     auto const data = kth::to_data_chunk(expected, version::level::minimum);
     byte_reader reader(data);
@@ -147,7 +147,7 @@ TEST_CASE("address from data roundtrip success", "[address]") {
     REQUIRE(expected.serialized_size(version::level::minimum) == serialized_size);
 }
 
-TEST_CASE("address addresses setter 1 roundtrip success", "[address]") {
+TEST_CASE("address addresses are set at construction", "[address]") {
     infrastructure::message::network_address::list const value{
         network_address(
             734678u,
@@ -165,13 +165,14 @@ TEST_CASE("address addresses setter 1 roundtrip success", "[address]") {
             "19573257168426842319857321595126"_base16,
             159u)};
 
-    address instance;
-    REQUIRE(instance.addresses() != value);
-    instance.set_addresses(value);
+    address const empty;
+    REQUIRE(empty.addresses() != value);
+
+    auto const instance = address::create(value).value();
     REQUIRE(value == instance.addresses());
 }
 
-TEST_CASE("address addresses setter 2 roundtrip success", "[address]") {
+TEST_CASE("address addresses are set at construction, by move", "[address]") {
     infrastructure::message::network_address::list const value{
         network_address(
             734678u,
@@ -190,9 +191,10 @@ TEST_CASE("address addresses setter 2 roundtrip success", "[address]") {
             159u)};
 
     auto dup_value = value;
-    address instance;
-    REQUIRE(instance.addresses() != value);
-    instance.set_addresses(std::move(dup_value));
+    address const empty;
+    REQUIRE(empty.addresses() != value);
+
+    auto const instance = address::create(std::move(dup_value)).value();
     REQUIRE(value == instance.addresses());
 }
 
@@ -214,7 +216,7 @@ TEST_CASE("address operator assign equals always matches equivalent", "[address]
             "19573257168426842319857321595126"_base16,
             159u)};
 
-    address value(addresses);
+    auto value = address::create(addresses).value();
 
 
     address instance;
@@ -224,7 +226,7 @@ TEST_CASE("address operator assign equals always matches equivalent", "[address]
 }
 
 TEST_CASE("address operator boolean equals duplicates returns true", "[address]") {
-    address const expected(
+    auto const expected = address::create(
         {network_address(
              734678u,
              5357534u,
@@ -239,14 +241,14 @@ TEST_CASE("address operator boolean equals duplicates returns true", "[address]"
              265453u,
              2115325u,
              "19573257168426842319857321595126"_base16,
-             159u)});
+             159u)}).value();
 
     address instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("address operator boolean equals differs returns false", "[address]") {
-    address const expected(
+    auto const expected = address::create(
         {network_address(
              734678u,
              5357534u,
@@ -261,14 +263,14 @@ TEST_CASE("address operator boolean equals differs returns false", "[address]") 
              265453u,
              2115325u,
              "19573257168426842319857321595126"_base16,
-             159u)});
+             159u)}).value();
 
     address instance;
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("address operator boolean not equals duplicates returns false", "[address]") {
-    address const expected(
+    auto const expected = address::create(
         {network_address(
              734678u,
              5357534u,
@@ -283,14 +285,14 @@ TEST_CASE("address operator boolean not equals duplicates returns false", "[addr
              265453u,
              2115325u,
              "19573257168426842319857321595126"_base16,
-             159u)});
+             159u)}).value();
 
     address instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("address operator boolean not equals differs returns true", "[address]") {
-    address const expected(
+    auto const expected = address::create(
         {network_address(
              734678u,
              5357534u,
@@ -305,10 +307,20 @@ TEST_CASE("address operator boolean not equals differs returns true", "[address]
              265453u,
              2115325u,
              "19573257168426842319857321595126"_base16,
-             159u)});
+             159u)}).value();
 
     address instance;
     REQUIRE(instance != expected);
+}
+
+TEST_CASE("address create rejects more entries than the protocol allows", "[address]") {
+    infrastructure::message::network_address::list at_cap(max_address);
+    REQUIRE(address::create(at_cap));
+
+    infrastructure::message::network_address::list over(max_address + 1);
+    auto const result = address::create(std::move(over));
+    REQUIRE( ! result);
+    REQUIRE(result.error() == error::invalid_address_count);
 }
 
 // End Test Suite

--- a/src/domain/test/message/filter_add.cpp
+++ b/src/domain/test/message/filter_add.cpp
@@ -10,20 +10,20 @@ using namespace kd;
 // Start Test Suite: filter add tests
 TEST_CASE("filter add constructor 2 always equals params", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
-    message::filter_add instance(data);
+    auto const instance = message::filter_add::create(data).value();
     REQUIRE(data == instance.data());
 }
 
 TEST_CASE("filter add constructor 3 always equals params", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
     auto dup = data;
-    message::filter_add instance(std::move(dup));
+    auto const instance = message::filter_add::create(std::move(dup)).value();
     REQUIRE(data == instance.data());
 }
 
 TEST_CASE("filter add constructor 4 always equals params", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
-    const message::filter_add value(data);
+    auto const value = message::filter_add::create(data).value();
     message::filter_add instance(value);
     REQUIRE(value == instance);
     REQUIRE(data == instance.data());
@@ -31,7 +31,7 @@ TEST_CASE("filter add constructor 4 always equals params", "[filter add]") {
 
 TEST_CASE("filter add constructor 5 always equals params", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
-    message::filter_add value(data);
+    auto value = message::filter_add::create(data).value();
     message::filter_add instance(std::move(value));
     REQUIRE(data == instance.data());
 }
@@ -46,11 +46,11 @@ TEST_CASE("filter add from data insufficient bytes failure", "[filter add]") {
 }
 
 TEST_CASE("filter add from data insufficient version failure", "[filter add]") {
-    const message::filter_add expected{
+    auto const expected = message::filter_add::create({
         {0x1F, 0x9a, 0x0d, 0x24, 0x9a, 0xd5, 0x39, 0x89,
          0xbb, 0x85, 0x0a, 0x3d, 0x79, 0x24, 0xed, 0x0f,
          0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
-         0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}};
+         0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}).value();
 
     auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
@@ -60,11 +60,11 @@ TEST_CASE("filter add from data insufficient version failure", "[filter add]") {
 }
 
 TEST_CASE("filter add from data valid input success", "[filter add]") {
-    const message::filter_add expected{
+    auto const expected = message::filter_add::create({
         {0x1F, 0x9a, 0x0d, 0x24, 0x9a, 0xd5, 0x39, 0x89,
          0xbb, 0x85, 0x0a, 0x3d, 0x79, 0x24, 0xed, 0x0f,
          0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
-         0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}};
+         0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}).value();
 
     auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
@@ -80,61 +80,68 @@ TEST_CASE("filter add from data valid input success", "[filter add]") {
 
 TEST_CASE("filter add data accessor 1 always returns initialized value", "[filter add]") {
     data_chunk const value = {0x0f, 0xf0, 0x55, 0xaa};
-    message::filter_add instance(value);
+    auto const instance = message::filter_add::create(value).value();
     REQUIRE(value == instance.data());
 }
 
 TEST_CASE("filter add data accessor 2 always returns initialized value", "[filter add]") {
     data_chunk const value = {0x0f, 0xf0, 0x55, 0xaa};
-    const message::filter_add instance(value);
+    auto const instance = message::filter_add::create(value).value();
     REQUIRE(value == instance.data());
 }
 
-TEST_CASE("filter add data setter 1 roundtrip success", "[filter add]") {
+TEST_CASE("filter add data is set at construction", "[filter add]") {
     data_chunk const value = {0x0f, 0xf0, 0x55, 0xaa};
-    message::filter_add instance;
-    REQUIRE(value != instance.data());
-    instance.set_data(value);
-    REQUIRE(value == instance.data());
-}
 
-TEST_CASE("filter add data setter 2 roundtrip success", "[filter add]") {
-    data_chunk const value = {0x0f, 0xf0, 0x55, 0xaa};
+    message::filter_add const empty;
+    REQUIRE(value != empty.data());
+
+    auto const instance = message::filter_add::create(value).value();
+    REQUIRE(value == instance.data());
+
     data_chunk dup = value;
-    message::filter_add instance;
-    REQUIRE(value != instance.data());
-    instance.set_data(std::move(dup));
-    REQUIRE(value == instance.data());
+    auto const moved = message::filter_add::create(std::move(dup)).value();
+    REQUIRE(value == moved.data());
+}
+
+TEST_CASE("filter add create rejects data over the BIP37 cap", "[filter add]") {
+    auto const at_cap = message::filter_add::create(data_chunk(max_filter_add, 0x00));
+    REQUIRE(at_cap);
+    REQUIRE(at_cap->data().size() == max_filter_add);
+
+    auto const over = message::filter_add::create(data_chunk(max_filter_add + 1, 0x00));
+    REQUIRE( ! over);
+    REQUIRE(over.error() == error::invalid_filter_add);
 }
 
 TEST_CASE("filter add operator assign equals always matches equivalent", "[filter add]") {
     data_chunk const data = {0x0f, 0xf0, 0x55, 0xaa};
-    message::filter_add value(data);
+    auto value = message::filter_add::create(data).value();
     message::filter_add instance;
     instance = std::move(value);
     REQUIRE(data == instance.data());
 }
 
 TEST_CASE("filter add operator boolean equals duplicates returns true", "[filter add]") {
-    const message::filter_add expected({0x0f, 0xf0, 0x55, 0xaa});
+    auto const expected = message::filter_add::create({0x0f, 0xf0, 0x55, 0xaa}).value();
     message::filter_add instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("filter add operator boolean equals differs returns false", "[filter add]") {
-    const message::filter_add expected({0x0f, 0xf0, 0x55, 0xaa});
+    auto const expected = message::filter_add::create({0x0f, 0xf0, 0x55, 0xaa}).value();
     message::filter_add instance;
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("filter add operator boolean not equals duplicates returns false", "[filter add]") {
-    const message::filter_add expected({0x0f, 0xf0, 0x55, 0xaa});
+    auto const expected = message::filter_add::create({0x0f, 0xf0, 0x55, 0xaa}).value();
     message::filter_add instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("filter add operator boolean not equals differs returns true", "[filter add]") {
-    const message::filter_add expected({0x0f, 0xf0, 0x55, 0xaa});
+    auto const expected = message::filter_add::create({0x0f, 0xf0, 0x55, 0xaa}).value();
     message::filter_add instance;
     REQUIRE(instance != expected);
 }

--- a/src/domain/test/message/filter_load.cpp
+++ b/src/domain/test/message/filter_load.cpp
@@ -14,7 +14,7 @@ TEST_CASE("filter load constructor 2 always equals params", "[filter load]") {
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
 
-    message::filter_load instance(filter, hash_functions, tweak, flags);
+    auto const instance = message::filter_load::create(filter, hash_functions, tweak, flags).value();
     REQUIRE(filter == instance.filter());
     REQUIRE(hash_functions == instance.hash_functions());
     REQUIRE(tweak == instance.tweak());
@@ -28,7 +28,7 @@ TEST_CASE("filter load constructor 3 always equals params", "[filter load]") {
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
 
-    message::filter_load instance(std::move(dup_filter), hash_functions, tweak, flags);
+    auto const instance = message::filter_load::create(std::move(dup_filter), hash_functions, tweak, flags).value();
     REQUIRE(filter == instance.filter());
     REQUIRE(hash_functions == instance.hash_functions());
     REQUIRE(tweak == instance.tweak());
@@ -41,7 +41,7 @@ TEST_CASE("filter load constructor 4 always equals params", "[filter load]") {
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
 
-    const message::filter_load value(filter, hash_functions, tweak, flags);
+    auto const value = message::filter_load::create(filter, hash_functions, tweak, flags).value();
     message::filter_load instance(value);
     REQUIRE(value == instance);
     REQUIRE(filter == instance.filter());
@@ -56,7 +56,7 @@ TEST_CASE("filter load constructor 5 always equals params", "[filter load]") {
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
 
-    message::filter_load value(filter, hash_functions, tweak, flags);
+    auto value = message::filter_load::create(filter, hash_functions, tweak, flags).value();
     message::filter_load instance(std::move(value));
     REQUIRE(filter == instance.filter());
     REQUIRE(hash_functions == instance.hash_functions());
@@ -74,12 +74,12 @@ TEST_CASE("filter load from data insufficient bytes failure", "[filter load]") {
 }
 
 TEST_CASE("filter load from data insufficient version failure", "[filter load]") {
-    const message::filter_load expected {
+    auto const expected = message::filter_load::create(
         {0x05, 0xaa, 0xbb, 0xcc, 0xdd, 0xee},
         25,
         10,
         0xab
-    };
+    ).value();
 
     data_chunk const data = kth::to_data_chunk(expected, message::version::level::maximum);
     
@@ -89,11 +89,11 @@ TEST_CASE("filter load from data insufficient version failure", "[filter load]")
 }
 
 TEST_CASE("filter load from data valid input success", "[filter load]") {
-    const message::filter_load expected{
+    auto const expected = message::filter_load::create(
         {0x05, 0xaa, 0xbb, 0xcc, 0xdd, 0xee},
         25,
         10,
-        0xab};
+        0xab).value();
 
     auto const data = kth::to_data_chunk(expected, message::version::level::maximum);
     byte_reader reader(data);
@@ -113,7 +113,7 @@ TEST_CASE("filter load filter accessor 1 always returns initialized value", "[fi
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
 
-    message::filter_load instance(filter, hash_functions, tweak, flags);
+    auto const instance = message::filter_load::create(filter, hash_functions, tweak, flags).value();
     REQUIRE(filter == instance.filter());
 }
 
@@ -123,25 +123,28 @@ TEST_CASE("filter load filter accessor 2 always returns initialized value", "[fi
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
 
-    const message::filter_load instance(filter, hash_functions, tweak, flags);
+    auto const instance = message::filter_load::create(filter, hash_functions, tweak, flags).value();
     REQUIRE(filter == instance.filter());
 }
 
-TEST_CASE("filter load filter setter 1 roundtrip success", "[filter load]") {
+TEST_CASE("filter load filter is set at construction", "[filter load]") {
     data_chunk const filter = {0x0f, 0xf0, 0x55, 0xaa};
-    message::filter_load instance;
-    REQUIRE(filter != instance.filter());
-    instance.set_filter(filter);
+
+    message::filter_load const empty;
+    REQUIRE(filter != empty.filter());
+
+    auto const instance = message::filter_load::create(filter, 0u, 0u, 0x00).value();
     REQUIRE(filter == instance.filter());
 }
 
-TEST_CASE("filter load filter setter 2 roundtrip success", "[filter load]") {
+TEST_CASE("filter load filter is set at construction, by move", "[filter load]") {
     data_chunk const filter = {0x0f, 0xf0, 0x55, 0xaa};
     data_chunk dup = filter;
 
-    message::filter_load instance;
-    REQUIRE(filter != instance.filter());
-    instance.set_filter(std::move(dup));
+    message::filter_load const empty;
+    REQUIRE(filter != empty.filter());
+
+    auto const instance = message::filter_load::create(std::move(dup), 0u, 0u, 0x00).value();
     REQUIRE(filter == instance.filter());
 }
 
@@ -151,15 +154,17 @@ TEST_CASE("filter load hash functions accessor always returns initialized value"
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
 
-    message::filter_load instance(filter, hash_functions, tweak, flags);
+    auto const instance = message::filter_load::create(filter, hash_functions, tweak, flags).value();
     REQUIRE(hash_functions == instance.hash_functions());
 }
 
-TEST_CASE("filter load hash functions setter roundtrip success", "[filter load]") {
+TEST_CASE("filter load hash functions are set at construction", "[filter load]") {
     uint32_t hash_functions = 48u;
-    message::filter_load instance;
-    REQUIRE(hash_functions != instance.hash_functions());
-    instance.set_hash_functions(hash_functions);
+
+    message::filter_load const empty;
+    REQUIRE(hash_functions != empty.hash_functions());
+
+    auto const instance = message::filter_load::create({}, hash_functions, 0u, 0x00).value();
     REQUIRE(hash_functions == instance.hash_functions());
 }
 
@@ -169,15 +174,17 @@ TEST_CASE("filter load tweak accessor always returns initialized value", "[filte
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
 
-    message::filter_load instance(filter, hash_functions, tweak, flags);
+    auto const instance = message::filter_load::create(filter, hash_functions, tweak, flags).value();
     REQUIRE(tweak == instance.tweak());
 }
 
-TEST_CASE("filter load tweak setter roundtrip success", "[filter load]") {
+TEST_CASE("filter load tweak is set at construction", "[filter load]") {
     uint32_t tweak = 36u;
-    message::filter_load instance;
-    REQUIRE(tweak != instance.tweak());
-    instance.set_tweak(tweak);
+
+    message::filter_load const empty;
+    REQUIRE(tweak != empty.tweak());
+
+    auto const instance = message::filter_load::create({}, 0u, tweak, 0x00).value();
     REQUIRE(tweak == instance.tweak());
 }
 
@@ -187,15 +194,17 @@ TEST_CASE("filter load flags accessor always returns initialized value", "[filte
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
 
-    message::filter_load instance(filter, hash_functions, tweak, flags);
+    auto const instance = message::filter_load::create(filter, hash_functions, tweak, flags).value();
     REQUIRE(flags == instance.flags());
 }
 
-TEST_CASE("filter load flags setter roundtrip success", "[filter load]") {
+TEST_CASE("filter load flags are set at construction", "[filter load]") {
     uint8_t flags = 0xae;
-    message::filter_load instance;
-    REQUIRE(flags != instance.flags());
-    instance.set_flags(flags);
+
+    message::filter_load const empty;
+    REQUIRE(flags != empty.flags());
+
+    auto const instance = message::filter_load::create({}, 0u, 0u, flags).value();
     REQUIRE(flags == instance.flags());
 }
 
@@ -204,7 +213,7 @@ TEST_CASE("filter load operator assign equals always matches equivalent", "[filt
     uint32_t hash_functions = 48u;
     uint32_t tweak = 36u;
     uint8_t flags = 0xae;
-    message::filter_load value(filter, hash_functions, tweak, flags);
+    auto value = message::filter_load::create(filter, hash_functions, tweak, flags).value();
 
 
     message::filter_load instance;
@@ -217,35 +226,53 @@ TEST_CASE("filter load operator assign equals always matches equivalent", "[filt
 }
 
 TEST_CASE("filter load operator boolean equals duplicates returns true", "[filter load]") {
-    const message::filter_load expected(
-        {0x0f, 0xf0, 0x55, 0xaa}, 643u, 575u, 0xaa);
+    auto const expected = message::filter_load::create(
+        {0x0f, 0xf0, 0x55, 0xaa}, 43u, 575u, 0xaa).value();
 
     message::filter_load instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("filter load operator boolean equals differs returns false", "[filter load]") {
-    const message::filter_load expected(
-        {0x0f, 0xf0, 0x55, 0xaa}, 643u, 575u, 0xaa);
+    auto const expected = message::filter_load::create(
+        {0x0f, 0xf0, 0x55, 0xaa}, 43u, 575u, 0xaa).value();
 
     message::filter_load instance;
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("filter load operator boolean not equals duplicates returns false", "[filter load]") {
-    const message::filter_load expected(
-        {0x0f, 0xf0, 0x55, 0xaa}, 643u, 575u, 0xaa);
+    auto const expected = message::filter_load::create(
+        {0x0f, 0xf0, 0x55, 0xaa}, 43u, 575u, 0xaa).value();
 
     message::filter_load instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("filter load operator boolean not equals differs returns true", "[filter load]") {
-    const message::filter_load expected(
-        {0x0f, 0xf0, 0x55, 0xaa}, 643u, 575u, 0xaa);
+    auto const expected = message::filter_load::create(
+        {0x0f, 0xf0, 0x55, 0xaa}, 43u, 575u, 0xaa).value();
 
     message::filter_load instance;
     REQUIRE(instance != expected);
+}
+
+TEST_CASE("filter load create rejects a filter over the BIP37 cap", "[filter load]") {
+    auto const at_cap = message::filter_load::create(data_chunk(max_filter_load, 0x00), 1u, 0u, 0x00);
+    REQUIRE(at_cap);
+
+    auto const over = message::filter_load::create(data_chunk(max_filter_load + 1, 0x00), 1u, 0u, 0x00);
+    REQUIRE( ! over);
+    REQUIRE(over.error() == error::invalid_filter_load);
+}
+
+TEST_CASE("filter load create rejects too many hash functions", "[filter load]") {
+    auto const at_cap = message::filter_load::create({0x00}, max_filter_functions, 0u, 0x00);
+    REQUIRE(at_cap);
+
+    auto const over = message::filter_load::create({0x00}, max_filter_functions + 1, 0u, 0x00);
+    REQUIRE( ! over);
+    REQUIRE(over.error() == error::invalid_filter_load);
 }
 
 // End Test Suite

--- a/src/domain/test/message/get_block_transactions.cpp
+++ b/src/domain/test/message/get_block_transactions.cpp
@@ -12,7 +12,7 @@ TEST_CASE("get block transactions constructor 2 always equals params", "[get blo
     hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
 
-    message::get_block_transactions instance(hash, indexes);
+    auto const instance = message::get_block_transactions::create(hash, indexes).value();
     REQUIRE(hash == instance.block_hash());
     REQUIRE(indexes == instance.indexes());
 }
@@ -23,15 +23,15 @@ TEST_CASE("get block transactions constructor 3 always equals params", "[get blo
     std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
     auto indexes_dup = indexes;
 
-    message::get_block_transactions instance(std::move(hash_dup), std::move(indexes_dup));
+    auto const instance = message::get_block_transactions::create(hash_dup, std::move(indexes_dup)).value();
     REQUIRE(hash == instance.block_hash());
     REQUIRE(indexes == instance.indexes());
 }
 
 TEST_CASE("get block transactions constructor 4 always equals params", "[get block transactions]") {
-    message::get_block_transactions value(
+    auto const value = message::get_block_transactions::create(
         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        {1u, 3454u, 4234u, 75123u, 455323u});
+        {1u, 3454u, 4234u, 75123u, 455323u}).value();
 
     message::get_block_transactions instance(value);
     REQUIRE(value == instance);
@@ -41,7 +41,7 @@ TEST_CASE("get block transactions constructor 5 always equals params", "[get blo
     hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
 
-    message::get_block_transactions value(hash, indexes);
+    auto value = message::get_block_transactions::create(hash, indexes).value();
     message::get_block_transactions instance(std::move(value));
     REQUIRE(hash == instance.block_hash());
     REQUIRE(indexes == instance.indexes());
@@ -57,12 +57,12 @@ TEST_CASE("get block transactions from data insufficient bytes failure", "[get b
 }
 
 TEST_CASE("get block transactions from data valid input success", "[get block transactions]") {
-    const message::get_block_transactions expected{
+    auto const expected = message::get_block_transactions::create(
         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
         {16,
          32,
          37,
-         44}};
+         44}).value();
 
     auto const data = kth::to_data_chunk(expected, message::version::level::minimum);
     byte_reader reader(data);
@@ -78,69 +78,75 @@ TEST_CASE("get block transactions from data valid input success", "[get block tr
 TEST_CASE("get block transactions block hash accessor 1 always returns initialized value", "[get block transactions]") {
     hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
-    message::get_block_transactions instance(hash, indexes);
+    auto const instance = message::get_block_transactions::create(hash, indexes).value();
     REQUIRE(hash == instance.block_hash());
 }
 
 TEST_CASE("get block transactions block hash accessor 2 always returns initialized value", "[get block transactions]") {
     hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
-    const message::get_block_transactions instance(hash, indexes);
+    auto const instance = message::get_block_transactions::create(hash, indexes).value();
     REQUIRE(hash == instance.block_hash());
 }
 
 TEST_CASE("get block transactions block hash setter 1 roundtrip success", "[get block transactions]") {
     hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    message::get_block_transactions instance;
-    REQUIRE(hash != instance.block_hash());
-    instance.set_block_hash(hash);
+    message::get_block_transactions const empty;
+    REQUIRE(hash != empty.block_hash());
+
+    auto const instance = message::get_block_transactions::create(hash, {}).value();
     REQUIRE(hash == instance.block_hash());
 }
 
 TEST_CASE("get block transactions block hash setter 2 roundtrip success", "[get block transactions]") {
     hash_digest hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     auto dup = hash;
-    message::get_block_transactions instance;
-    REQUIRE(hash != instance.block_hash());
-    instance.set_block_hash(std::move(dup));
+    message::get_block_transactions const empty;
+    REQUIRE(hash != empty.block_hash());
+
+    auto const instance = message::get_block_transactions::create(dup, {}).value();
     REQUIRE(hash == instance.block_hash());
 }
 
 TEST_CASE("get block transactions indexes accessor 1 always returns initialized value", "[get block transactions]") {
     hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
-    message::get_block_transactions instance(hash, indexes);
+    auto const instance = message::get_block_transactions::create(hash, indexes).value();
     REQUIRE(indexes == instance.indexes());
 }
 
 TEST_CASE("get block transactions indexes accessor 2 always returns initialized value", "[get block transactions]") {
     hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
-    const message::get_block_transactions instance(hash, indexes);
+    auto const instance = message::get_block_transactions::create(hash, indexes).value();
     REQUIRE(indexes == instance.indexes());
 }
 
-TEST_CASE("get block transactions indexes setter 1 roundtrip success", "[get block transactions]") {
+TEST_CASE("get block transactions indexes are set at construction", "[get block transactions]") {
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
-    message::get_block_transactions instance;
-    REQUIRE(indexes != instance.indexes());
-    instance.set_indexes(indexes);
+
+    message::get_block_transactions const empty;
+    REQUIRE(indexes != empty.indexes());
+
+    auto const instance = message::get_block_transactions::create(null_hash, indexes).value();
     REQUIRE(indexes == instance.indexes());
 }
 
-TEST_CASE("get block transactions indexes setter 2 roundtrip success", "[get block transactions]") {
+TEST_CASE("get block transactions indexes are set at construction, by move", "[get block transactions]") {
     std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
     auto dup = indexes;
-    message::get_block_transactions instance;
-    REQUIRE(indexes != instance.indexes());
-    instance.set_indexes(std::move(dup));
+
+    message::get_block_transactions const empty;
+    REQUIRE(indexes != empty.indexes());
+
+    auto const instance = message::get_block_transactions::create(null_hash, std::move(dup)).value();
     REQUIRE(indexes == instance.indexes());
 }
 
 TEST_CASE("get block transactions operator assign equals always matches equivalent", "[get block transactions]") {
     hash_digest const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     const std::vector<uint64_t> indexes = {1u, 3454u, 4234u, 75123u, 455323u};
-    message::get_block_transactions value(hash, indexes);
+    auto value = message::get_block_transactions::create(hash, indexes).value();
 
 
     message::get_block_transactions instance;
@@ -151,36 +157,36 @@ TEST_CASE("get block transactions operator assign equals always matches equivale
 }
 
 TEST_CASE("get block transactions operator boolean equals duplicates returns true", "[get block transactions]") {
-    const message::get_block_transactions expected(
+    auto const expected = message::get_block_transactions::create(
         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        {1u, 3454u, 4234u, 75123u, 455323u});
+        {1u, 3454u, 4234u, 75123u, 455323u}).value();
 
     message::get_block_transactions instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("get block transactions operator boolean equals differs returns false", "[get block transactions]") {
-    const message::get_block_transactions expected(
+    auto const expected = message::get_block_transactions::create(
         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        {1u, 3454u, 4234u, 75123u, 455323u});
+        {1u, 3454u, 4234u, 75123u, 455323u}).value();
 
     message::get_block_transactions instance;
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("get block transactions operator boolean not equals duplicates returns false", "[get block transactions]") {
-    const message::get_block_transactions expected(
+    auto const expected = message::get_block_transactions::create(
         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        {1u, 3454u, 4234u, 75123u, 455323u});
+        {1u, 3454u, 4234u, 75123u, 455323u}).value();
 
     message::get_block_transactions instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("get block transactions operator boolean not equals differs returns true", "[get block transactions]") {
-    const message::get_block_transactions expected(
+    auto const expected = message::get_block_transactions::create(
         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash,
-        {1u, 3454u, 4234u, 75123u, 455323u});
+        {1u, 3454u, 4234u, 75123u, 455323u}).value();
 
     message::get_block_transactions instance;
     REQUIRE(instance != expected);

--- a/src/domain/test/message/get_data.cpp
+++ b/src/domain/test/message/get_data.cpp
@@ -19,7 +19,7 @@ TEST_CASE("get data constructor 2 always equals params", "[get data]") {
                   0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
                   0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}};
 
-    get_data const instance(values);
+    auto const instance = get_data::create(values).value();
     REQUIRE(values == instance.inventories());
 }
 
@@ -29,7 +29,7 @@ TEST_CASE("get data constructor 3 always equals params", "[get data]") {
     inventory_vector::list const values{
         inventory_vector(type, hash)};
 
-    get_data const instance(std::move(values));
+    auto const instance = get_data::create(std::move(values)).value();
     auto const inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -41,7 +41,7 @@ TEST_CASE("get data constructor 4 always equals params", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     static hash_list const hashes{hash};
 
-    get_data const instance(hashes, type);
+    auto const instance = get_data::create(hashes, type).value();
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -52,7 +52,7 @@ TEST_CASE("get data constructor 5 always equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    get_data const instance{{type, hash}};
+    auto const instance = get_data::create({inventory_vector(type, hash)}).value();
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -63,7 +63,7 @@ TEST_CASE("get data constructor 6 always equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    get_data const value{{type, hash}};
+    auto const value = get_data::create({inventory_vector(type, hash)}).value();
     get_data const instance(value);
     auto const inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -76,7 +76,7 @@ TEST_CASE("get data constructor 7 always equals params", "[get data]") {
     static auto const type = inventory_vector::type_id::error;
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    get_data const value{{type, hash}};
+    auto const value = get_data::create({inventory_vector(type, hash)}).value();
     get_data const instance(std::move(value));
     auto const inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -94,9 +94,9 @@ TEST_CASE("get data from data insufficient bytes failure", "[get data]") {
 }
 
 TEST_CASE("get data from data insufficient version failure", "[get data]") {
-    static const get_data expected{
-        {inventory_vector::type_id::error,
-         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash}};
+    static auto const expected = get_data::create(
+        {inventory_vector(inventory_vector::type_id::error,
+                          "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     auto const raw = kth::to_data_chunk(expected, version::level::maximum);
     byte_reader reader(raw);
@@ -105,9 +105,9 @@ TEST_CASE("get data from data insufficient version failure", "[get data]") {
 }
 
 TEST_CASE("get data from data valid input success", "[get data]") {
-    static const get_data expected{
-        {inventory_vector::type_id::error,
-         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash}};
+    static auto const expected = get_data::create(
+        {inventory_vector(inventory_vector::type_id::error,
+                          "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     static auto const version = version::level::maximum;
     auto const data = kth::to_data_chunk(expected, version);
@@ -125,7 +125,7 @@ TEST_CASE("get data operator assign equals always matches equivalent", "[get dat
     static inventory_vector::list const elements{
         inventory_vector(inventory_vector::type_id::error, hash)};
 
-    get_data value(elements);
+    auto value = get_data::create(elements).value();
 
     get_data instance;
 
@@ -135,8 +135,8 @@ TEST_CASE("get data operator assign equals always matches equivalent", "[get dat
 
 TEST_CASE("get data operator boolean equals duplicates returns true", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    get_data const expected{
-        inventory_vector(inventory_vector::type_id::error, hash)};
+    auto const expected = get_data::create(
+        {inventory_vector(inventory_vector::type_id::error, hash)}).value();
 
     get_data const instance(expected);
     REQUIRE(instance == expected);
@@ -144,8 +144,8 @@ TEST_CASE("get data operator boolean equals duplicates returns true", "[get data
 
 TEST_CASE("get data operator boolean equals differs returns false", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    get_data const expected{
-        inventory_vector(inventory_vector::type_id::error, hash)};
+    auto const expected = get_data::create(
+        {inventory_vector(inventory_vector::type_id::error, hash)}).value();
 
     get_data const instance;
     REQUIRE(instance != expected);
@@ -153,8 +153,8 @@ TEST_CASE("get data operator boolean equals differs returns false", "[get data]"
 
 TEST_CASE("get data operator boolean not equals duplicates returns false", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    get_data const expected{
-        inventory_vector(inventory_vector::type_id::error, hash)};
+    auto const expected = get_data::create(
+        {inventory_vector(inventory_vector::type_id::error, hash)}).value();
 
     get_data const instance(expected);
     REQUIRE(instance == expected);
@@ -162,8 +162,8 @@ TEST_CASE("get data operator boolean not equals duplicates returns false", "[get
 
 TEST_CASE("get data operator boolean not equals differs returns true", "[get data]") {
     static auto const hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
-    get_data const expected{
-        inventory_vector(inventory_vector::type_id::error, hash)};
+    auto const expected = get_data::create(
+        {inventory_vector(inventory_vector::type_id::error, hash)}).value();
 
     get_data const instance;
     REQUIRE(instance != expected);

--- a/src/domain/test/message/headers.cpp
+++ b/src/domain/test/message/headers.cpp
@@ -26,7 +26,7 @@ TEST_CASE("headers constructor 2 always equals params", "[headers]") {
             4356344u,
             34564u)};
 
-    headers instance(expected);
+    auto const instance = headers::create(expected).value();
     REQUIRE(instance.elements() == expected);
 }
 
@@ -47,7 +47,7 @@ TEST_CASE("headers constructor 3 always equals params", "[headers]") {
             4356344u,
             34564u)};
 
-    headers instance(std::move(expected));
+    auto const instance = headers::create(std::move(expected)).value();
     REQUIRE(instance.elements().size() == 2u);
 }
 
@@ -88,12 +88,12 @@ TEST_CASE("headers constructor 5 always equals params", "[headers]") {
              4356344u,
              34564u)});
 
-    headers instance(expected);
+    headers const instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("headers constructor 6 always equals params", "[headers]") {
-    headers expected(
+    auto expected = headers::create(
         {header(
              10u,
              "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"_hash,
@@ -107,9 +107,9 @@ TEST_CASE("headers constructor 6 always equals params", "[headers]") {
              "fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"_hash,
              753234u,
              4356344u,
-             34564u)});
+             34564u)}).value();
 
-    headers instance(std::move(expected));
+    headers const instance(std::move(expected));
     REQUIRE(instance.elements().size() == 2u);
 }
 
@@ -174,7 +174,7 @@ TEST_CASE("headers elements accessor 1 always returns initialized value", "[head
             4356344u,
             34564u)};
 
-    message::headers instance(expected);
+    auto const instance = message::headers::create(expected).value();
     REQUIRE(instance.elements() == expected);
 }
 
@@ -195,7 +195,7 @@ TEST_CASE("headers elements accessor 2 always returns initialized value", "[head
             4356344u,
             34564u)};
 
-    const message::headers instance(expected);
+    auto const instance = message::headers::create(expected).value();
     REQUIRE(instance.elements() == expected);
 }
 
@@ -216,9 +216,10 @@ TEST_CASE("headers command setter 1 roundtrip success", "[headers]") {
             4356344u,
             34564u)};
 
-    message::headers instance;
-    REQUIRE(instance.elements() != expected);
-    instance.set_elements(expected);
+    message::headers const empty;
+    REQUIRE(empty.elements() != expected);
+
+    auto const instance = message::headers::create(expected).value();
     REQUIRE(instance.elements() == expected);
 }
 
@@ -239,9 +240,10 @@ TEST_CASE("headers command setter 2 roundtrip success", "[headers]") {
             4356344u,
             34564u)};
 
-    message::headers instance;
-    REQUIRE(instance.elements().empty());
-    instance.set_elements(std::move(values));
+    message::headers const empty;
+    REQUIRE(empty.elements().empty());
+
+    auto const instance = message::headers::create(std::move(values)).value();
     REQUIRE(instance.elements().size() == 2u);
 }
 
@@ -269,7 +271,7 @@ TEST_CASE("headers operator boolean equals duplicates returns true", "[headers]"
              300u,
              3000u}});
 
-    message::headers instance(expected);
+    message::headers const instance(expected);
     REQUIRE(instance == expected);
 }
 
@@ -325,7 +327,7 @@ TEST_CASE("headers operator boolean not equals duplicates returns false", "[head
              300u,
              3000u}});
 
-    message::headers instance(expected);
+    message::headers const instance(expected);
     REQUIRE(instance == expected);
 }
 

--- a/src/domain/test/message/inventory.cpp
+++ b/src/domain/test/message/inventory.cpp
@@ -19,7 +19,7 @@ TEST_CASE("inventory constructor 2 always equals params", "[inventory]") {
                   0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
                   0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}})};
 
-    message::inventory instance(values);
+    auto const instance = message::inventory::create(values).value();
     REQUIRE(values == instance.inventories());
 }
 
@@ -30,7 +30,7 @@ TEST_CASE("inventory constructor 3 always equals params", "[inventory]") {
         {
             message::inventory_vector(type, hash)};
 
-    message::inventory instance(std::move(values));
+    auto const instance = message::inventory::create(std::move(values)).value();
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -42,7 +42,7 @@ TEST_CASE("inventory constructor 4 always equals params", "[inventory]") {
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     hash_list const hashes = {hash};
 
-    message::inventory instance(hashes, type);
+    auto const instance = message::inventory::create(hashes, type).value();
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -53,7 +53,7 @@ TEST_CASE("inventory constructor 5 always equals params", "[inventory]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    message::inventory instance{{type, hash}};
+    auto const instance = message::inventory::create({message::inventory_vector(type, hash)}).value();
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -64,7 +64,7 @@ TEST_CASE("inventory constructor 6 always equals params", "[inventory]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    const message::inventory value{{type, hash}};
+    auto const value = message::inventory::create({message::inventory_vector(type, hash)}).value();
     message::inventory instance(value);
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -77,7 +77,7 @@ TEST_CASE("inventory constructor 7 always equals params", "[inventory]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    message::inventory value{{type, hash}};
+    auto value = message::inventory::create({message::inventory_vector(type, hash)}).value();
     message::inventory instance(std::move(value));
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -95,12 +95,12 @@ TEST_CASE("inventory from data insufficient bytes failure", "[inventory]") {
 }
 
 TEST_CASE("inventory from data valid input success", "[inventory]") {
-    static inventory const expected{
+    static auto const expected = inventory::create(
         {{inventory::type_id::error,
           {{0x44, 0x9a, 0x0d, 0x24, 0x9a, 0xd5, 0x39, 0x89,
             0xbb, 0x85, 0x0a, 0x3d, 0x79, 0x24, 0xed, 0x0f,
             0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
-            0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}}};
+            0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}}).value();
 
     static auto const version = version::level::minimum;
     auto const data = kth::to_data_chunk(expected, version);
@@ -119,7 +119,7 @@ TEST_CASE("inventory inventories accessor 1 always returns initialized value", "
             message::inventory_vector(message::inventory_vector::type_id::error,
                                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
-    message::inventory instance(values);
+    auto const instance = message::inventory::create(values).value();
     REQUIRE(values == instance.inventories());
 }
 
@@ -129,31 +129,33 @@ TEST_CASE("inventory inventories accessor 2 always returns initialized value", "
             message::inventory_vector(message::inventory_vector::type_id::error,
                                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
-    const message::inventory instance(values);
+    auto const instance = message::inventory::create(values).value();
     REQUIRE(values == instance.inventories());
 }
 
-TEST_CASE("inventory inventories setter 1 roundtrip success", "[inventory]") {
+TEST_CASE("inventory inventories are set at construction", "[inventory]") {
     const message::inventory_vector::list values =
         {
             message::inventory_vector(message::inventory_vector::type_id::error,
                                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
-    message::inventory instance;
-    REQUIRE(values != instance.inventories());
-    instance.set_inventories(values);
+    message::inventory const empty;
+    REQUIRE(values != empty.inventories());
+
+    auto const instance = message::inventory::create(values).value();
     REQUIRE(values == instance.inventories());
 }
 
-TEST_CASE("inventory inventories setter 2 roundtrip success", "[inventory]") {
+TEST_CASE("inventory inventories are set at construction, by move", "[inventory]") {
     message::inventory_vector::list values =
         {
             message::inventory_vector(message::inventory_vector::type_id::error,
                                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
-    message::inventory instance;
-    REQUIRE(0u == instance.inventories().size());
-    instance.set_inventories(std::move(values));
+    message::inventory const empty;
+    REQUIRE(0u == empty.inventories().size());
+
+    auto const instance = message::inventory::create(std::move(values)).value();
     REQUIRE(1u == instance.inventories().size());
 }
 
@@ -165,56 +167,56 @@ TEST_CASE("inventory operator assign equals always matches equivalent", "[invent
 
     message::inventory instance;
 
-    instance = message::inventory(elements);
+    instance = message::inventory::create(elements).value();
     REQUIRE(elements == instance.inventories());
 }
 
 TEST_CASE("inventory operator boolean equals duplicates returns true", "[inventory]") {
-    const message::inventory expected(
+    auto const expected = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     message::inventory instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("inventory operator boolean equals differs returns false", "[inventory]") {
-    const message::inventory expected(
+    auto const expected = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     message::inventory instance;
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("inventory operator boolean not equals duplicates returns false", "[inventory]") {
-    const message::inventory expected(
+    auto const expected = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     message::inventory instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("inventory operator boolean not equals differs returns true", "[inventory]") {
-    const message::inventory expected(
+    auto const expected = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     message::inventory instance;
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("inventory count no matching type returns zero", "[inventory]") {
-    message::inventory instance(
+    auto const instance = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     REQUIRE(0u == instance.count(message::inventory_vector::type_id::block));
 }
 
 TEST_CASE("inventory count matching type returns count", "[inventory]") {
-    message::inventory instance(
+    auto const instance = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
                                    "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
@@ -222,7 +224,7 @@ TEST_CASE("inventory count matching type returns count", "[inventory]") {
          message::inventory_vector(message::inventory_vector::type_id::block,
                                    "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     REQUIRE(3u == instance.count(message::inventory_vector::type_id::error));
 }
@@ -230,7 +232,7 @@ TEST_CASE("inventory count matching type returns count", "[inventory]") {
 TEST_CASE("inventory to hashes matching type returns empty list", "[inventory]") {
     hash_list const hashes = {};
 
-    message::inventory instance(
+    auto const instance = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
                                    "1111111111111111111111111111111111111111111111111111111111111111"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
@@ -238,7 +240,7 @@ TEST_CASE("inventory to hashes matching type returns empty list", "[inventory]")
          message::inventory_vector(message::inventory_vector::type_id::block,
                                    "3333333333333333333333333333333333333333333333333333333333333333"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)});
+                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)}).value();
 
     hash_list result;
     instance.to_hashes(result, message::inventory_vector::type_id::transaction);
@@ -251,7 +253,7 @@ TEST_CASE("inventory to hashes matching type returns hashes", "[inventory]") {
         "2222222222222222222222222222222222222222222222222222222222222222"_hash,
         "4444444444444444444444444444444444444444444444444444444444444444"_hash};
 
-    message::inventory instance(
+    auto const instance = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
                                    "1111111111111111111111111111111111111111111111111111111111111111"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
@@ -259,7 +261,7 @@ TEST_CASE("inventory to hashes matching type returns hashes", "[inventory]") {
          message::inventory_vector(message::inventory_vector::type_id::block,
                                    "3333333333333333333333333333333333333333333333333333333333333333"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)});
+                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)}).value();
 
     hash_list result;
     instance.to_hashes(result, message::inventory_vector::type_id::error);
@@ -269,7 +271,7 @@ TEST_CASE("inventory to hashes matching type returns hashes", "[inventory]") {
 TEST_CASE("inventory reduce matching type returns empty list", "[inventory]") {
     const message::inventory_vector::list expected = {};
 
-    message::inventory instance(
+    auto const instance = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
                                    "1111111111111111111111111111111111111111111111111111111111111111"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
@@ -277,7 +279,7 @@ TEST_CASE("inventory reduce matching type returns empty list", "[inventory]") {
          message::inventory_vector(message::inventory_vector::type_id::block,
                                    "3333333333333333333333333333333333333333333333333333333333333333"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)});
+                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)}).value();
 
     message::inventory_vector::list result;
     instance.reduce(result, message::inventory_vector::type_id::transaction);
@@ -293,7 +295,7 @@ TEST_CASE("inventory reduce matching type returns matches", "[inventory]") {
         message::inventory_vector(message::inventory_vector::type_id::error,
                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)};
 
-    message::inventory instance(
+    auto const instance = message::inventory::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
                                    "1111111111111111111111111111111111111111111111111111111111111111"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
@@ -301,12 +303,22 @@ TEST_CASE("inventory reduce matching type returns matches", "[inventory]") {
          message::inventory_vector(message::inventory_vector::type_id::block,
                                    "3333333333333333333333333333333333333333333333333333333333333333"_hash),
          message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)});
+                                   "4444444444444444444444444444444444444444444444444444444444444444"_hash)}).value();
 
     message::inventory_vector::list result;
     instance.reduce(result, message::inventory_vector::type_id::error);
     REQUIRE(expected.size() == result.size());
     REQUIRE(expected == result);
+}
+
+TEST_CASE("inventory create rejects more entries than the protocol allows", "[inventory]") {
+    message::inventory_vector::list at_cap(max_inventory);
+    REQUIRE(message::inventory::create(at_cap));
+
+    message::inventory_vector::list over(max_inventory + 1);
+    auto const result = message::inventory::create(std::move(over));
+    REQUIRE( ! result);
+    REQUIRE(result.error() == error::bad_inventory_count);
 }
 
 // End Test Suite

--- a/src/domain/test/message/not_found.cpp
+++ b/src/domain/test/message/not_found.cpp
@@ -19,7 +19,7 @@ TEST_CASE("not found constructor 2 always equals params", "[not found]") {
                   0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
                   0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}})};
 
-    message::not_found instance(values);
+    auto const instance = message::not_found::create(values).value();
     REQUIRE(values == instance.inventories());
 }
 
@@ -30,7 +30,7 @@ TEST_CASE("not found constructor 3 always equals params", "[not found]") {
         {
             message::inventory_vector(type, hash)};
 
-    message::not_found instance(std::move(values));
+    auto const instance = message::not_found::create(std::move(values)).value();
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -42,7 +42,7 @@ TEST_CASE("not found constructor 4 always equals params", "[not found]") {
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
     hash_list const hashes = {hash};
 
-    message::not_found instance(hashes, type);
+    auto const instance = message::not_found::create(hashes, type).value();
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -53,7 +53,7 @@ TEST_CASE("not found constructor 5 always equals params", "[not found]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    message::not_found instance{{type, hash}};
+    auto const instance = message::not_found::create({message::inventory_vector(type, hash)}).value();
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
     REQUIRE(type == inventories[0].type());
@@ -64,7 +64,7 @@ TEST_CASE("not found constructor 6 always equals params", "[not found]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    const message::not_found value{{type, hash}};
+    auto const value = message::not_found::create({message::inventory_vector(type, hash)}).value();
     message::not_found instance(value);
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -77,7 +77,7 @@ TEST_CASE("not found constructor 7 always equals params", "[not found]") {
     message::inventory_vector::type_id type = message::inventory_vector::type_id::error;
     auto hash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash;
 
-    message::not_found value{{type, hash}};
+    auto value = message::not_found::create({message::inventory_vector(type, hash)}).value();
     message::not_found instance(std::move(value));
     auto inventories = instance.inventories();
     REQUIRE(1u == inventories.size());
@@ -94,12 +94,12 @@ TEST_CASE("not found from data insufficient bytes failure", "[not found]") {
 }
 
 TEST_CASE("not found from data insufficient version failure", "[not found]") {
-    static not_found const expected{
+    static auto const expected = not_found::create(
         {{inventory_vector::type_id::error,
           {{0x44, 0x9a, 0x0d, 0x24, 0x9a, 0xd5, 0x39, 0x89,
             0xbb, 0x85, 0x0a, 0x3d, 0x79, 0x24, 0xed, 0x0f,
             0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
-            0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}}};
+            0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}}).value();
 
     auto const version = version::level::maximum;
     data_chunk const raw = kth::to_data_chunk(expected, version);
@@ -110,12 +110,12 @@ TEST_CASE("not found from data insufficient version failure", "[not found]") {
 }
 
 TEST_CASE("not found from data valid input success", "[not found]") {
-    static not_found const expected{
+    static auto const expected = not_found::create(
         {{inventory_vector::type_id::error,
           {{0x44, 0x9a, 0x0d, 0x24, 0x9a, 0xd5, 0x39, 0x89,
             0xbb, 0x85, 0x0a, 0x3d, 0x79, 0x24, 0xed, 0x0f,
             0xc3, 0x0d, 0x6f, 0x55, 0x7d, 0x71, 0x12, 0x1a,
-            0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}}};
+            0x37, 0xc0, 0xb0, 0x32, 0xf0, 0xd6, 0x6e, 0xdf}}}}).value();
 
     auto const version = version::level::maximum;
     auto const data = kth::to_data_chunk(expected, version);
@@ -134,7 +134,7 @@ TEST_CASE("not found operator assign equals always matches equivalent", "[not fo
             message::inventory_vector(message::inventory_vector::type_id::error,
                                       "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)};
 
-    message::not_found value(elements);
+    auto value = message::not_found::create(elements).value();
 
     message::not_found instance;
 
@@ -143,36 +143,36 @@ TEST_CASE("not found operator assign equals always matches equivalent", "[not fo
 }
 
 TEST_CASE("not found operator boolean equals duplicates returns true", "[not found]") {
-    const message::not_found expected(
+    auto const expected = message::not_found::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     message::not_found instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("not found operator boolean equals differs returns false", "[not found]") {
-    const message::not_found expected(
+    auto const expected = message::not_found::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     message::not_found instance;
     REQUIRE(instance != expected);
 }
 
 TEST_CASE("not found operator boolean not equals duplicates returns false", "[not found]") {
-    const message::not_found expected(
+    auto const expected = message::not_found::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     message::not_found instance(expected);
     REQUIRE(instance == expected);
 }
 
 TEST_CASE("not found operator boolean not equals differs returns true", "[not found]") {
-    const message::not_found expected(
+    auto const expected = message::not_found::create(
         {message::inventory_vector(message::inventory_vector::type_id::error,
-                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)});
+                                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"_hash)}).value();
 
     message::not_found instance;
     REQUIRE(instance != expected);

--- a/src/infrastructure/include/kth/infrastructure/error.hpp
+++ b/src/infrastructure/include/kth/infrastructure/error.hpp
@@ -274,6 +274,7 @@ enum error_code_t {
     script_invalid_size,
     invalid_address_count,
     bad_inventory_count,
+    invalid_headers_count,
     version_too_low,
     version_too_new,
     invalid_compact_block,

--- a/src/network/src/protocols_coro.cpp
+++ b/src/network/src/protocols_coro.cpp
@@ -536,7 +536,11 @@ awaitable_expected<domain::message::address> request_addresses(
         spdlog::debug("[protocol] Parsed addrv2 from [{}]: {} entries, {} convertible to legacy",
             peer.authority(), addrv2_result->addresses().size(), addresses.size());
 
-        co_return domain::message::address(std::move(addresses));
+        auto legacy = domain::message::address::create(std::move(addresses));
+        if ( ! legacy) {
+            co_return std::unexpected(legacy.error());
+        }
+        co_return std::move(*legacy);
     }
 
     // Parse as legacy addr
@@ -575,9 +579,17 @@ awaitable_expected<domain::message::address> request_addresses(
         for (auto const& addr : addresses) {
             entries.push_back(domain::message::addrv2_entry::from_network_address(addr));
         }
-        co_return co_await peer.send(domain::message::addrv2(std::move(entries)));
+        auto message = domain::message::addrv2::create(std::move(entries));
+        if ( ! message) {
+            co_return message.error();
+        }
+        co_return co_await peer.send(*message);
     } else {
-        co_return co_await peer.send(domain::message::address(addresses));
+        auto message = domain::message::address::create(addresses);
+        if ( ! message) {
+            co_return message.error();
+        }
+        co_return co_await peer.send(*message);
     }
 }
 
@@ -672,13 +684,18 @@ awaitable_expected<domain::message::headers> request_headers_from(
         inventories.emplace_back(domain::message::inventory_vector::type_id::block, hash);
     }
 
-    domain::message::get_data request(std::move(inventories));
+    auto request = domain::message::get_data::create(std::move(inventories));
+    if ( ! request) {
+        spdlog::warn("[protocol] Refusing to request {} blocks from [{}]: {}",
+            block_hashes.size(), peer.authority(), request.error().message());
+        co_return request.error();
+    }
 
     spdlog::debug("[protocol] Requesting {} blocks from [{}]",
         block_hashes.size(), peer.authority());
 
     // Send getdata - blocks will arrive asynchronously
-    co_return co_await peer.send(request);
+    co_return co_await peer.send(*request);
 }
 
 // awaitable_expected<domain::message::block> request_block(
@@ -775,7 +792,12 @@ awaitable_expected<std::vector<block_result<Mode>>> request_blocks_batch(
         inventories.emplace_back(domain::message::inventory_vector::type_id::block, hash);
     }
 
-    domain::message::get_data request(std::move(inventories));
+    auto request = domain::message::get_data::create(std::move(inventories));
+    if ( ! request) {
+        spdlog::warn("[protocol] Refusing to request {} blocks in batch from [{}]: {}",
+            blocks.size(), peer.authority(), request.error().message());
+        co_return std::unexpected(request.error());
+    }
 
     spdlog::debug("[protocol] Requesting {} blocks in batch from [{}] ({}-{})",
         blocks.size(), peer.authority(),
@@ -783,7 +805,7 @@ awaitable_expected<std::vector<block_result<Mode>>> request_blocks_batch(
 
     // Send ONE getdata with all block hashes - measure send time
     auto send_start = std::chrono::steady_clock::now();
-    auto ec = co_await peer.send(request);
+    auto ec = co_await peer.send(*request);
     auto send_us = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - send_start).count();
 

--- a/src/node/include/kth/node/utility/reservation.hpp
+++ b/src/node/include/kth/node/utility/reservation.hpp
@@ -63,7 +63,9 @@ public:
 
     /// The block data request message for the outstanding block hashes.
     /// Set new if the preceding request was unsuccessful or discarded.
-    domain::message::get_data request(bool new_channel);
+    /// Fails if the reserved heights outgrow the inv cap.
+    [[nodiscard]]
+    expect<domain::message::get_data> request(bool new_channel);
 
     /// Add the block hash to the reservation.
     void insert(hash_digest&& hash, size_t height);

--- a/src/node/src/utility/reservation.cpp
+++ b/src/node/src/utility/reservation.cpp
@@ -225,9 +225,7 @@ bool reservation::stopped() const {
 }
 
 // Obtain and clear the outstanding blocks request.
-domain::message::get_data reservation::request(bool new_channel) {
-    domain::message::get_data packet;
-
+expect<domain::message::get_data> reservation::request(bool new_channel) {
     // We are a new channel, clear history and rate data, next block starts.
     if (new_channel) {
         reset();
@@ -240,13 +238,16 @@ domain::message::get_data reservation::request(bool new_channel) {
     if ( ! new_channel && ! pending_) {
         hash_mutex_.unlock_upgrade();
         //---------------------------------------------------------------------
-        return packet;
+        return domain::message::get_data();
     }
 
     // Build get_blocks request message.
+    domain::message::inventory_vector::list inventories;
+    inventories.reserve(heights_.size());
+
     for (auto height = heights_.right.begin(); height != heights_.right.end(); ++height) {
         static auto const id = domain::message::inventory::type_id::block;
-        packet.inventories().emplace_back(id, height->second);
+        inventories.emplace_back(id, height->second);
     }
 
     //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -255,7 +256,7 @@ domain::message::get_data reservation::request(bool new_channel) {
     hash_mutex_.unlock();
     ///////////////////////////////////////////////////////////////////////////
 
-    return packet;
+    return domain::message::get_data::create(std::move(inventories));
 }
 
 void reservation::insert(hash_digest&& hash, size_t height) {

--- a/src/node/test/utility.cpp
+++ b/src/node/test/utility.cpp
@@ -35,14 +35,17 @@ domain::message::headers::ptr message_factory(size_t count) {
 domain::message::headers::ptr message_factory(size_t count,
     hash_digest const& previous) {
     auto previous_hash = previous;
-    auto const headers = std::make_shared<domain::message::headers>();
-    auto& elements = headers->elements();
+    domain::message::header::list elements;
+    elements.reserve(count);
 
     for (size_t height = 0; height < count; ++height) {
         header const current_header{ 0, previous_hash, {}, 0, 0, 0 };
         elements.push_back(current_header);
         previous_hash = kth::domain::chain::hash(current_header);
     }
+
+    auto const headers = std::make_shared<domain::message::headers>(
+        domain::message::headers::create(std::move(elements)).value());
 
     return headers;
 }


### PR DESCRIPTION
Closes #476. `addrv2_entry` is deferred — see below.

Nine message types could be constructed in a state that cannot legally go on the wire. Only `from_data` guarded the cap; the public constructor, the setters and the mutable accessor all walked past it:

```cpp
filter_add fa(data_chunk(10'000, 0x00));   // BIP37 says 520 max. Constructed.
fa.to_data(writer, version);               // and serialized.

auto ok = filter_add(data_chunk(100, 0x00));
ok.data().resize(10'000);                  // or get there through the accessor
ok.set_data(data_chunk(10'000, 0x00));     // or the setter
```

| type | invariant |
|---|---|
| `filter_add` | data ≤ `max_filter_add` (520, BIP37) |
| `filter_load` | filter ≤ `max_filter_load` (36000) **and** hash functions ≤ 50 (BIP37) |
| `address` | ≤ `max_address` (1000) entries |
| `addrv2` | ≤ `max_addresses` entries |
| `headers` | ≤ `max_get_headers` (2000) entries |
| `inventory` | ≤ `max_inventory` (50000) entries |
| `get_data`, `not_found` | inherit `inventory`'s cap |
| `get_block_transactions` | indexes ≤ max block size |

Each gets `create` returning `expect<>`, a private constructor, and **no setters or mutable accessors** — `create` is pointless if `set_data()` or `data().resize()` can undo it. `from_data` delegates rather than repeating the check, keeping its own early size check, which guards a different thing: refusing to allocate on an oversized claim *before* reading.

The inbound path was already covered, so this is not a parsing hole. It is the outbound path, where we could build a message no peer accepts.

## Found on the way

**`filter_load` never enforced BIP37's hash-function cap.** `max_filter_functions` existed as a constant with no callers, and `from_data` checked only the filter size — so a filterload with 643 hash functions parsed clean. Four of our own test fixtures were doing exactly that. BCHN checks both together and bans:

```cpp
bool CBloomFilter::IsWithinSizeConstraints() const {
    return vData.size() <= MAX_BLOOM_FILTER_SIZE &&
           nHashFuncs <= MAX_HASH_FUNCS;
}
```

This does **not** change our BIP37 posture (#477): `filter_load` stays parse-only and nothing handles one. It only parses the format as the BIP defines it.

**`headers::from_data` reported `error::version_too_new` for "too many headers"** — a peer sending 3000 headers was told its version was too new. Added `error::invalid_headers_count`.

**Closes a `TODO(legacy)`.** `block_pool::filter` said *"optimize (prevent repeating vector moves)"* — it erased one element at a time, shifting the tail on every hit. `inventory::erase_if` does the single pass it asked for.

## Callers

`block_chain::fetch_locator_block_hashes` and the two outbound `getdata` sites in `protocols_coro` built their payloads by appending, bounded only by a caller-supplied `limit` that nothing checked against the protocol cap. Both now route through `create`; the enclosing functions already returned `expect<>` or `code`, so the error propagates without an API change.

The four filter sites (`filter_blocks`, `filter_transactions` on both branches of the `KTH_WITH_MEMPOOL` `#if`, and `block_pool::filter`) **only remove** entries, which cannot take a list back over a maximum — so `inventory` gets an `erase_if` rather than a mutable accessor.

`reservation::request` returns `expect<get_data>`; it builds from the reserved heights with nothing bounding them by the cap.

## Not in scope

`send_compact` looks like it belongs here and does not: its `mode > 1` check is on the wire byte while the constructor takes a `bool`, so the type already makes the invalid state unrepresentable.

**`addrv2_entry` is deferred** to its own PR. It is the one aggregate in the set — public fields, 30 use sites — so turning it into a class is a different shape of change from the other nine. #470 already documents that its `is_valid()` is kept deliberately, awaiting exactly this.

## Testing

Every `create` gets a test that it rejects at the cap and accepts at it — none of these types had one. Full build green across every target; domain (3814 cases), infrastructure (454), network (98), blockchain (107), node (45) and C-API (734) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a dedicated error code for invalid header counts, improving error reporting for malformed or inconsistent data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->