### PR TITLE
fix(infrastructure): build pseudo_random on macOS

### DIFF
--- a/src/infrastructure/src/utility/pseudo_random.cpp
+++ b/src/infrastructure/src/utility/pseudo_random.cpp
@@ -13,12 +13,13 @@
 
 #if defined(_WIN32)
 #include <windows.h>
-#elif defined(__EMSCRIPTEN__) || defined(__APPLE__)
-#include <unistd.h>
-#include <strings.h>
+#elif defined(__APPLE__)
+#include <sys/random.h>   // getentropy: on macOS it lives here, not <unistd.h>
+#elif defined(__EMSCRIPTEN__)
+#include <unistd.h>       // getentropy
 #else
-#include <sys/random.h>
-#include <strings.h>
+#include <sys/random.h>   // getrandom
+#include <strings.h>      // explicit_bzero
 #endif
 
 namespace kth {
@@ -77,15 +78,18 @@ void pseudo_random::wipe_bytes(std::span<std::byte> out) noexcept {
 #if defined(_WIN32)
     // Documented never to be optimized away.
     ::SecureZeroMemory(out.data(), out.size());
-#elif defined(__GLIBC__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#elif defined(__GLIBC__) || defined(__FreeBSD__) || defined(__OpenBSD__)
     // Same contract, and it is the libc's job to keep it.
     ::explicit_bzero(out.data(), out.size());
 #else
-    std::memset(out.data(), 0, out.size());
-    // No explicit_bzero here, so deny the optimizer the premise it needs to
-    // drop the store: the "memory" clobber says an unseen party may read or
+    // Everything else, macOS included -- it has no explicit_bzero, and
+    // memset_s needs __STDC_WANT_LIB_EXT1__ defined before any header pulls in
+    // <string.h>, which is too fragile to rely on. memset plus a barrier is
+    // what libsodium falls back to: deny the optimizer the premise it needs to
+    // drop the store. The "memory" clobber says an unseen party may read or
     // change these bytes, and passing the pointer as an input stops the buffer
     // itself from being reasoned about as dead.
+    std::memset(out.data(), 0, out.size());
     #if defined(__GNUC__) || defined(__clang__)
         asm volatile("" : : "r"(out.data()) : "memory");
     #else


### PR DESCRIPTION
The apple-clang CI job has been failing since the pseudo_random rewrite landed; Linux was fine, so it slipped through. Two macOS-specific breaks:

```
pseudo_random.cpp:37: error: use of undeclared identifier 'getentropy'
pseudo_random.cpp:82: error: no member named 'explicit_bzero' in the global namespace
```

## getentropy

On macOS it is declared in `<sys/random.h>`, not `<unistd.h>` — the Apple include branch had the wrong header. Split from the Emscripten branch, which keeps `<unistd.h>`. Verified on a real Mac: `getentropy` compiles from `<sys/random.h>`, fails from `<unistd.h>`.

## explicit_bzero

macOS has no `explicit_bzero`. Its standards equivalent `memset_s` needs `__STDC_WANT_LIB_EXT1__` defined before *any* header pulls in `<string.h>` — and I verified on the box that a stray earlier `<cstring>` hides the symbol, so relying on macro ordering is too fragile. macOS now uses the `memset` + compiler-barrier path the `#else` branch already had (what libsodium falls back to), which compiles cleanly under clang and is equally non-elidable in practice.

## Verification

Compiled the translation unit on a real macOS box with the **same apple-clang 21** the CI job uses — **0 errors**. Linux build unchanged (`infrastructure` target still 0 errors).