### PR TITLE
refactor(domain/message): addrv2_entry is valid-by-construction

### DIFF
--- a/src/c-api/include/kth/capi/error.h
+++ b/src/c-api/include/kth/capi/error.h
@@ -242,6 +242,7 @@ typedef enum kth_error_code {
     kth_ec_script_not_push_only,
     kth_ec_script_invalid_size,
     kth_ec_invalid_address_count,
+    kth_ec_invalid_address,
     kth_ec_bad_inventory_count,
     kth_ec_invalid_headers_count,
     kth_ec_version_too_low,

--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -587,6 +587,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/math/stealth.cpp
 
         test/message/address.cpp
+        test/message/addrv2.cpp
         test/message/alert.cpp
         test/message/alert_payload.cpp
         test/message/block.cpp

--- a/src/domain/include/kth/domain/message/addrv2.hpp
+++ b/src/domain/include/kth/domain/message/addrv2.hpp
@@ -30,20 +30,22 @@ enum class bip155_network : uint8_t {
 
 /// BIP155 address entry
 struct KD_API addrv2_entry {
-    uint32_t time{0};
-    uint64_t services{0};
-    bip155_network network{bip155_network::ipv4};
-    data_chunk addr;  // Variable length based on network type
-    uint16_t port{0};
+    /// Fails with error::invalid_address when the network id is unknown or the
+    /// address length does not match it (BIP155 fixes one length per network).
+    static
+    expect<addrv2_entry> create(uint32_t time, uint64_t services,
+        bip155_network network, data_chunk addr, uint16_t port);
 
     [[nodiscard]]
     friend bool operator==(addrv2_entry const&, addrv2_entry const&) = default;
 
-    /// Check if this entry is valid
-    [[nodiscard]]
-    bool is_valid() const;
+    [[nodiscard]] uint32_t time() const;
+    [[nodiscard]] uint64_t services() const;
+    [[nodiscard]] bip155_network network() const;
+    [[nodiscard]] data_chunk const& addr() const;
+    [[nodiscard]] uint16_t port() const;
 
-    /// Get the expected address size for a given network
+    /// The address length BIP155 fixes for a network id, or 0 if unknown.
     static
     size_t expected_addr_size(bip155_network net);
 
@@ -51,9 +53,19 @@ struct KD_API addrv2_entry {
     [[nodiscard]]
     std::optional<infrastructure::message::network_address> to_network_address() const;
 
-    /// Create from network_address
+    /// Create from network_address. IPv4/IPv6 always yield a valid entry.
     static
     addrv2_entry from_network_address(infrastructure::message::network_address const& addr);
+
+private:
+    addrv2_entry(uint32_t time, uint64_t services, bip155_network network,
+        data_chunk addr, uint16_t port);
+
+    uint32_t time_;
+    uint64_t services_;
+    bip155_network network_;
+    data_chunk addr_;
+    uint16_t port_;
 };
 
 /// BIP155: addrv2 message.

--- a/src/domain/src/message/addrv2.cpp
+++ b/src/domain/src/message/addrv2.cpp
@@ -20,12 +20,45 @@ constexpr size_t ADDR_CJDNS_SIZE = 16;
 // addrv2_entry implementation
 //-----------------------------------------------------------------------------
 
-bool addrv2_entry::is_valid() const {
-    auto const expected_size = expected_addr_size(network);
-    if (expected_size == 0) {
-        return false;  // Unknown network type
+addrv2_entry::addrv2_entry(uint32_t time, uint64_t services,
+    bip155_network network, data_chunk addr, uint16_t port)
+    : time_(time)
+    , services_(services)
+    , network_(network)
+    , addr_(std::move(addr))
+    , port_(port)
+{}
+
+// static
+expect<addrv2_entry> addrv2_entry::create(uint32_t time, uint64_t services,
+    bip155_network network, data_chunk addr, uint16_t port) {
+    // BIP155 fixes one address length per network; an unknown id or a length
+    // that does not match it cannot describe a real address.
+    auto const expected = expected_addr_size(network);
+    if (expected == 0 || addr.size() != expected) {
+        return std::unexpected(error::invalid_address);
     }
-    return addr.size() == expected_size;
+    return addrv2_entry(time, services, network, std::move(addr), port);
+}
+
+uint32_t addrv2_entry::time() const {
+    return time_;
+}
+
+uint64_t addrv2_entry::services() const {
+    return services_;
+}
+
+bip155_network addrv2_entry::network() const {
+    return network_;
+}
+
+data_chunk const& addrv2_entry::addr() const {
+    return addr_;
+}
+
+uint16_t addrv2_entry::port() const {
+    return port_;
 }
 
 // static
@@ -49,47 +82,26 @@ size_t addrv2_entry::expected_addr_size(bip155_network net) {
 }
 
 std::optional<infrastructure::message::network_address> addrv2_entry::to_network_address() const {
-    infrastructure::message::network_address result;
+    infrastructure::message::ip_address ip{};
 
-    if (network == bip155_network::ipv4 && addr.size() == ADDR_IPV4_SIZE) {
-        // IPv4: stored as 4 bytes, convert to IPv4-mapped IPv6 format
-        // ::ffff:a.b.c.d format: 10 bytes of 0, 2 bytes of 0xff, then 4 bytes of IPv4
-        infrastructure::message::ip_address ip{};
-        std::fill(ip.begin(), ip.begin() + 10, 0x00);
+    if (network_ == bip155_network::ipv4 && addr_.size() == ADDR_IPV4_SIZE) {
+        // IPv4 is carried as 4 bytes; widen to the IPv4-mapped IPv6 form
+        // ::ffff:a.b.c.d -- 10 zero bytes, 0xff 0xff, then the 4 IPv4 bytes.
         ip[10] = 0xff;
         ip[11] = 0xff;
-        std::copy(addr.begin(), addr.end(), ip.begin() + 12);
-
-        result.set_ip(ip);
-        result.set_port(port);
-        result.set_services(services);
-        result.set_timestamp(time);
-        return result;
+        std::copy(addr_.begin(), addr_.end(), ip.begin() + 12);
+    } else if (network_ == bip155_network::ipv6 && addr_.size() == ADDR_IPV6_SIZE) {
+        std::copy(addr_.begin(), addr_.end(), ip.begin());
+    } else {
+        // Tor, I2P and CJDNS have no legacy network_address representation.
+        return std::nullopt;
     }
 
-    if (network == bip155_network::ipv6 && addr.size() == ADDR_IPV6_SIZE) {
-        // IPv6: direct copy
-        infrastructure::message::ip_address ip{};
-        std::copy(addr.begin(), addr.end(), ip.begin());
-
-        result.set_ip(ip);
-        result.set_port(port);
-        result.set_services(services);
-        result.set_timestamp(time);
-        return result;
-    }
-
-    // Other network types (Tor, I2P, CJDNS) not supported for legacy conversion
-    return std::nullopt;
+    return infrastructure::message::network_address(time_, services_, ip, port_);
 }
 
 // static
 addrv2_entry addrv2_entry::from_network_address(infrastructure::message::network_address const& addr) {
-    addrv2_entry entry;
-    entry.time = addr.timestamp();
-    entry.services = addr.services();
-    entry.port = addr.port();
-
     auto const& ip = addr.ip();
 
     // Check if it's an IPv4-mapped IPv6 address (::ffff:x.x.x.x)
@@ -103,15 +115,13 @@ addrv2_entry addrv2_entry::from_network_address(infrastructure::message::network
     }
     is_ipv4_mapped = is_ipv4_mapped && ip[10] == 0xff && ip[11] == 0xff;
 
-    if (is_ipv4_mapped) {
-        entry.network = bip155_network::ipv4;
-        entry.addr.assign(ip.begin() + 12, ip.end());
-    } else {
-        entry.network = bip155_network::ipv6;
-        entry.addr.assign(ip.begin(), ip.end());
-    }
+    auto const network = is_ipv4_mapped ? bip155_network::ipv4 : bip155_network::ipv6;
+    data_chunk bytes(is_ipv4_mapped ? ip.begin() + 12 : ip.begin(), ip.end());
 
-    return entry;
+    // IPv4 is 4 bytes, IPv6 is 16 -- each matches its network, so create never
+    // fails here.
+    return create(addr.timestamp(), addr.services(), network,
+        std::move(bytes), addr.port()).value();
 }
 
 // addrv2 implementation
@@ -170,28 +180,24 @@ expect<addrv2> addrv2::from_data(byte_reader& reader, uint32_t version) {
     addresses.reserve(*count);
 
     for (size_t i = 0; i < *count; ++i) {
-        addrv2_entry entry;
-
         // time: uint32
         auto time = reader.read_little_endian<uint32_t>();
         if (!time) {
             return std::unexpected(time.error());
         }
-        entry.time = *time;
 
         // services: compactsize
         auto services = reader.read_size_little_endian();
         if (!services) {
             return std::unexpected(services.error());
         }
-        entry.services = *services;
 
         // network: uint8
-        auto network = reader.read_byte();
-        if (!network) {
-            return std::unexpected(network.error());
+        auto network_byte = reader.read_byte();
+        if (!network_byte) {
+            return std::unexpected(network_byte.error());
         }
-        entry.network = static_cast<bip155_network>(*network);
+        auto const network = static_cast<bip155_network>(*network_byte);
 
         // addr_len: compactsize
         auto addr_len = reader.read_size_little_endian();
@@ -208,23 +214,30 @@ expect<addrv2> addrv2::from_data(byte_reader& reader, uint32_t version) {
         if (!addr_bytes) {
             return std::unexpected(addr_bytes.error());
         }
-        entry.addr.assign(addr_bytes->begin(), addr_bytes->end());
 
         // port: uint16 big-endian
         auto port = reader.read_big_endian<uint16_t>();
         if (!port) {
             return std::unexpected(port.error());
         }
-        entry.port = *port;
 
-        // Validate expected address size for known networks
-        auto const expected_size = addrv2_entry::expected_addr_size(entry.network);
-        if (expected_size > 0 && entry.addr.size() != expected_size) {
-            // Skip invalid entries but continue parsing
+        // BIP155: an unknown network id may be a future type. Drop it and keep
+        // parsing (its bytes are already consumed) rather than fail, so a peer
+        // can still relay the entries we do understand.
+        if (addrv2_entry::expected_addr_size(network) == 0) {
             continue;
         }
 
-        addresses.push_back(std::move(entry));
+        // A known network with the wrong length is a malformed message, not a
+        // droppable entry. create() rejects it, and we reject the whole addrv2
+        // -- matching BCHN.
+        auto entry = addrv2_entry::create(*time, *services, network,
+            data_chunk(addr_bytes->begin(), addr_bytes->end()), *port);
+        if (!entry) {
+            return std::unexpected(entry.error());
+        }
+
+        addresses.push_back(std::move(*entry));
     }
 
     return create(std::move(addresses));
@@ -238,10 +251,10 @@ size_t addrv2::serialized_size(uint32_t /*version*/) const {
 
     for (auto const& entry : addresses_) {
         size += 4;  // time
-        size += infrastructure::message::variable_uint_size(entry.services);
+        size += infrastructure::message::variable_uint_size(entry.services());
         size += 1;  // network
-        size += infrastructure::message::variable_uint_size(entry.addr.size());
-        size += entry.addr.size();
+        size += infrastructure::message::variable_uint_size(entry.addr().size());
+        size += entry.addr().size();
         size += 2;  // port
     }
 
@@ -252,12 +265,12 @@ expect<void> addrv2::to_data(byte_writer& writer, uint32_t version) const {
         if (auto r = writer.write_variable_little_endian(addresses_.size()); ! r) return r;
 
         for (auto const& entry : addresses_) {
-            if (auto r = writer.write_little_endian<uint32_t>(entry.time); ! r) return r;
-            if (auto r = writer.write_variable_little_endian(entry.services); ! r) return r;
-            if (auto r = writer.write_byte(static_cast<uint8_t>(entry.network)); ! r) return r;
-            if (auto r = writer.write_variable_little_endian(entry.addr.size()); ! r) return r;
-            if (auto r = writer.write_bytes(entry.addr); ! r) return r;
-            if (auto r = writer.write_big_endian<uint16_t>(entry.port); ! r) return r;
+            if (auto r = writer.write_little_endian<uint32_t>(entry.time()); ! r) return r;
+            if (auto r = writer.write_variable_little_endian(entry.services()); ! r) return r;
+            if (auto r = writer.write_byte(static_cast<uint8_t>(entry.network())); ! r) return r;
+            if (auto r = writer.write_variable_little_endian(entry.addr().size()); ! r) return r;
+            if (auto r = writer.write_bytes(entry.addr()); ! r) return r;
+            if (auto r = writer.write_big_endian<uint16_t>(entry.port()); ! r) return r;
         }
         return {};
 }

--- a/src/domain/test/message/addrv2.cpp
+++ b/src/domain/test/message/addrv2.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <kth/domain/message/addrv2.hpp>
+#include <kth/domain/message/version.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+
+using namespace kth;
+using namespace kd;
+using namespace kd::message;
+
+namespace {
+
+// One addrv2 entry on the wire: time(4) services(varint) net(1) addr_len(varint)
+// addr(len) port(2 BE). Helper builds one with a single-byte varint length.
+data_chunk entry_bytes(uint32_t time, uint8_t services, uint8_t net,
+    data_chunk const& addr, uint16_t port) {
+    data_chunk out;
+    out.push_back(uint8_t(time));
+    out.push_back(uint8_t(time >> 8));
+    out.push_back(uint8_t(time >> 16));
+    out.push_back(uint8_t(time >> 24));
+    out.push_back(services);
+    out.push_back(net);
+    out.push_back(uint8_t(addr.size()));       // addr_len (< 253, so one byte)
+    out.insert(out.end(), addr.begin(), addr.end());
+    out.push_back(uint8_t(port >> 8));          // port is big-endian
+    out.push_back(uint8_t(port));
+    return out;
+}
+
+data_chunk one_entry_message(data_chunk const& entry) {
+    data_chunk out{0x01};                        // count = 1
+    out.insert(out.end(), entry.begin(), entry.end());
+    return out;
+}
+
+data_chunk const ipv6(16, 0x11);
+
+} // namespace
+
+// Start Test Suite: addrv2 tests
+
+TEST_CASE("addrv2_entry create accepts a known network at its size", "[addrv2]") {
+    auto const entry = addrv2_entry::create(1234u, 1u, bip155_network::ipv6, ipv6, 8333u);
+    REQUIRE(entry);
+    REQUIRE(entry->network() == bip155_network::ipv6);
+    REQUIRE(entry->addr() == ipv6);
+    REQUIRE(entry->port() == 8333u);
+}
+
+TEST_CASE("addrv2_entry create rejects an unknown network", "[addrv2]") {
+    auto const net = static_cast<bip155_network>(0x07);   // beyond cjdns=6
+    auto const entry = addrv2_entry::create(1u, 0u, net, data_chunk(16, 0x00), 0u);
+    REQUIRE( ! entry);
+    REQUIRE(entry.error() == error::invalid_address);
+}
+
+TEST_CASE("addrv2_entry create rejects a known network at the wrong size", "[addrv2]") {
+    // ipv6 must be 16 bytes; hand it 15.
+    auto const entry = addrv2_entry::create(1u, 0u, bip155_network::ipv6, data_chunk(15, 0x00), 0u);
+    REQUIRE( ! entry);
+    REQUIRE(entry.error() == error::invalid_address);
+}
+
+TEST_CASE("addrv2_entry from_network_address round-trips through create", "[addrv2]") {
+    infrastructure::message::ip_address ip{};
+    std::copy(ipv6.begin(), ipv6.end(), ip.begin());
+    infrastructure::message::network_address const addr(1234u, 1u, ip, 8333u);
+
+    auto const entry = addrv2_entry::from_network_address(addr);
+    REQUIRE(entry.network() == bip155_network::ipv6);
+    REQUIRE(entry.addr() == ipv6);
+    REQUIRE(entry.port() == 8333u);
+}
+
+TEST_CASE("addrv2 from_data keeps a well-formed entry", "[addrv2]") {
+    auto const raw = one_entry_message(
+        entry_bytes(1234u, 1u, uint8_t(bip155_network::ipv6), ipv6, 8333u));
+    byte_reader reader(raw);
+    auto const result = addrv2::from_data(reader, version::level::maximum);
+    REQUIRE(result);
+    REQUIRE(result->addresses().size() == 1u);
+}
+
+TEST_CASE("addrv2 from_data drops an unknown-network entry but keeps parsing", "[addrv2]") {
+    // BIP155: an unknown network id (maybe a future type) is silently dropped,
+    // and the entries we understand are still returned -- matching BCHN.
+    data_chunk raw{0x02};                        // two entries
+    auto const unknown = entry_bytes(1u, 0u, 0x07, data_chunk(20, 0xaa), 0u);
+    auto const known = entry_bytes(1234u, 1u, uint8_t(bip155_network::ipv6), ipv6, 8333u);
+    raw.insert(raw.end(), unknown.begin(), unknown.end());
+    raw.insert(raw.end(), known.begin(), known.end());
+
+    byte_reader reader(raw);
+    auto const result = addrv2::from_data(reader, version::level::maximum);
+    REQUIRE(result);
+    REQUIRE(result->addresses().size() == 1u);   // the unknown one is gone
+    REQUIRE(result->addresses()[0].network() == bip155_network::ipv6);
+}
+
+TEST_CASE("addrv2 from_data rejects the whole message on a bad known-network size", "[addrv2]") {
+    // A known network (ipv6) with the wrong length is malformed. BCHN rejects
+    // the entire message rather than skipping the entry.
+    auto const bad = entry_bytes(1u, 0u, uint8_t(bip155_network::ipv6), data_chunk(15, 0x00), 0u);
+    auto const raw = one_entry_message(bad);
+    byte_reader reader(raw);
+    auto const result = addrv2::from_data(reader, version::level::maximum);
+    REQUIRE( ! result);
+    REQUIRE(result.error() == error::invalid_address);
+}
+
+// End Test Suite

--- a/src/infrastructure/include/kth/infrastructure/error.hpp
+++ b/src/infrastructure/include/kth/infrastructure/error.hpp
@@ -273,6 +273,7 @@ enum error_code_t {
     script_not_push_only,
     script_invalid_size,
     invalid_address_count,
+    invalid_address,
     bad_inventory_count,
     invalid_headers_count,
     version_too_low,

--- a/src/infrastructure/src/error.cpp
+++ b/src/infrastructure/src/error.cpp
@@ -261,6 +261,28 @@ std::string error_category_impl::message(int ev) const noexcept {
         { error::read_past_end_of_buffer, "read past end of buffer" },
         { error::skip_past_end_of_buffer, "skip past end of buffer" },
         { error::write_past_end_of_buffer, "write past end of buffer" },
+        { error::invalid_size, "invalid size" },
+        { error::invalid_script_type, "invalid script type" },
+        { error::script_not_push_only, "script is not push-only" },
+        { error::script_invalid_size, "invalid script size" },
+        { error::invalid_address_count, "invalid address count" },
+        { error::invalid_address, "invalid address" },
+        { error::bad_inventory_count, "invalid inventory count" },
+        { error::invalid_headers_count, "invalid headers count" },
+        { error::version_too_low, "version too low" },
+        { error::version_too_new, "version too new" },
+        { error::invalid_compact_block, "invalid compact block" },
+        { error::unsupported_version, "unsupported version" },
+        { error::invalid_filter_add, "invalid filter add" },
+        { error::invalid_filter_load, "invalid filter load" },
+        { error::bad_merkle_block_count, "invalid merkle block count" },
+        { error::illegal_value, "illegal value" },
+
+        // Database cache
+        { error::height_not_found, "height not found" },
+        { error::hash_not_found, "hash not found" },
+        { error::empty_cache, "empty cache" },
+        { error::utxo_not_found, "utxo not found" },
     };
 
     auto const message = messages.find(ev);


### PR DESCRIPTION
`addrv2_entry` was the last group-F type left from #478 — an aggregate with five public fields whose `is_valid()` checked a real BIP155 invariant (the address length must match the network id; an unknown id is invalid), but nothing enforced it at construction. The field-by-field builders could assemble an entry no peer would accept, and `to_data` would serialize it.

## The refactor

- Private constructor + `create(...)` returning `expect<>`, validating "known network **and** length matches it".
- Fields private with const accessors; no setters.
- `is_valid()` dropped.
- `from_network_address` always builds a valid IPv4/IPv6 entry, so it routes through `create().value()`.

## Fixes two `from_data` deviations from BCHN

Cross-checked against `CNetAddr::SetNetFromBIP155Network`, which was the authoritative answer for the invariant:

| case | BCHN | our `from_data` (before) |
|---|---|---|
| known network, right length | keep | keep ✅ |
| **unknown network id** | **drop, keep parsing** | **kept it** ❌ |
| **known network, wrong length** | **reject whole message** | skipped the entry |

BCHN on the unknown case: *"Don't throw on addresses with unknown network ids (maybe from the future). Instead silently drop them and have the unserialization code consume subsequent ones."* We were keeping them — relaying entries we don't understand as if valid. `from_data` now drops them.

For a known network at the wrong length, BCHN rejects the entire message rather than skipping the entry; `from_data` now returns `error::invalid_address` and rejects.

## Also

- Adds `error::invalid_address`; the C-API error enum is regenerated to match (same as #478 did for `invalid_headers_count`).
- Adds the first **unit tests** for addrv2 — the `create()` invariant (accept at size, reject unknown network, reject wrong size) and both `from_data` behaviours above. The existing `addrv2_bchn_comparison` executable is a separate target, gated on the BCHN sources being in-tree.

## Testing

Full build green across every target; domain (3821 cases), network (98) and C-API (734) suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a distinct error code for invalid address errors, enabling clearer error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->