### PR TITLE
refactor(domain/message): drop double_spend_proof sentinels and setters

### DIFF
--- a/src/domain/include/kth/domain/message/double_spend_proof.hpp
+++ b/src/domain/include/kth/domain/message/double_spend_proof.hpp
@@ -5,19 +5,13 @@
 #ifndef KTH_DOMAIN_MESSAGE_double_spend_proof_HPP
 #define KTH_DOMAIN_MESSAGE_double_spend_proof_HPP
 
-#include <istream>
-
 #include <kth/domain/chain/output_point.hpp>
+#include <kth/domain/concepts.hpp>
 #include <kth/domain/constants.hpp>
 #include <kth/domain/define.hpp>
-// #include <kth/domain/message/block.hpp>
-// #include <kth/domain/message/prefilled_transaction.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
-
-
-#include <kth/domain/concepts.hpp>
 
 namespace kth::domain::message {
 
@@ -35,26 +29,6 @@ struct KD_API double_spend_proof {
         hash_digest sequence_hash = null_hash;
         hash_digest outputs_hash = null_hash;
         data_chunk push_data;
-
-        [[nodiscard]]
-        bool is_valid() const {
-            return version != 0 ||
-                   out_sequence != 0 ||
-                   locktime != 0 ||
-                   prev_outs_hash != null_hash ||
-                   sequence_hash != null_hash ||
-                   outputs_hash != null_hash;
-        }
-
-        void reset() {
-            version = 0;
-            out_sequence = 0;
-            locktime = 0;
-            prev_outs_hash = null_hash;
-            sequence_hash = null_hash;
-            outputs_hash = null_hash;
-            push_data.clear();
-        }
 
         [[nodiscard]]
         friend bool operator==(spender const&, spender const&) = default;
@@ -93,15 +67,12 @@ struct KD_API double_spend_proof {
 
     [[nodiscard]]
     chain::output_point const& out_point() const;
-    void set_out_point(chain::output_point const& x);
 
     [[nodiscard]]
     spender const& spender1() const;
-    void set_spender1(spender const& x);
 
     [[nodiscard]]
     spender const& spender2() const;
-    void set_spender2(spender const& x);
 
     static
     expect<double_spend_proof> from_data(byte_reader& reader, uint32_t /*version*/);

--- a/src/domain/src/message/double_spend_proof.cpp
+++ b/src/domain/src/message/double_spend_proof.cpp
@@ -106,26 +106,14 @@ chain::output_point const& double_spend_proof::out_point() const {
     return out_point_;
 }
 
-void double_spend_proof::set_out_point(chain::output_point const& x) {
-    out_point_ = x;
-}
-
 [[nodiscard]]
 double_spend_proof::spender const& double_spend_proof::spender1() const {
     return spender1_;
 }
 
-void double_spend_proof::set_spender1(double_spend_proof::spender const& x) {
-    spender1_ = x;
-}
-
 [[nodiscard]]
 double_spend_proof::spender const& double_spend_proof::spender2() const {
     return spender2_;
-}
-
-void double_spend_proof::set_spender2(double_spend_proof::spender const& x) {
-    spender2_ = x;
 }
 
 hash_digest hash(double_spend_proof const& x) {

--- a/src/domain/test/message/double_spend_proof.cpp
+++ b/src/domain/test/message/double_spend_proof.cpp
@@ -47,21 +47,8 @@ static chain::output_point make_out_point() {
 // Lifecycle / predicates
 // ---------------------------------------------------------------------------
 
-TEST_CASE("double_spend_proof::spender default construct is invalid", "[double_spend_proof::spender]") {
+TEST_CASE("double_spend_proof::spender default construct zeroes all fields", "[double_spend_proof::spender]") {
     message::double_spend_proof::spender s;
-    REQUIRE(s.version == 0u);
-    REQUIRE(s.out_sequence == 0u);
-    REQUIRE(s.locktime == 0u);
-    REQUIRE(s.prev_outs_hash == null_hash);
-    REQUIRE(s.sequence_hash == null_hash);
-    REQUIRE(s.outputs_hash == null_hash);
-    REQUIRE(s.push_data.empty());
-}
-
-TEST_CASE("double_spend_proof::spender reset zeroes all fields", "[double_spend_proof::spender]") {
-    auto s = make_spender();
-    s.push_data = data_chunk{1, 2, 3};
-    s.reset();
     REQUIRE(s.version == 0u);
     REQUIRE(s.out_sequence == 0u);
     REQUIRE(s.locktime == 0u);
@@ -163,47 +150,23 @@ TEST_CASE("double_spend_proof three-arg construct preserves fields", "[double_sp
     REQUIRE(dsp.spender2() == s2);
 }
 
-// `double_spend_proof::is_valid()` was removed with the value-types
-// refactor — the outer DSP is now valid-by-construction. Validity of
-// the inner `spender` sub-object stays covered by the spender tests.
-
-// `reset()` was removed along with `is_valid()`: DSP is now an
-// immutable value type built via a full ctor.
-
-// ---------------------------------------------------------------------------
-// Setters
-// ---------------------------------------------------------------------------
-
-TEST_CASE("double_spend_proof setters replace fields", "[double_spend_proof]") {
-    message::double_spend_proof dsp;
-
-    auto const op = make_out_point();
-    dsp.set_out_point(op);
-    REQUIRE(dsp.out_point() == op);
-
-    auto const s1 = make_spender(1);
-    dsp.set_spender1(s1);
-    REQUIRE(dsp.spender1() == s1);
-
-    auto const s2 = make_spender(2);
-    dsp.set_spender2(s2);
-    REQUIRE(dsp.spender2() == s2);
-}
+// A double_spend_proof is immutable and valid-by-construction: it exposes
+// no is_valid()/reset()/setters, only the full constructor and from_data.
 
 // ---------------------------------------------------------------------------
 // Equality
 // ---------------------------------------------------------------------------
 
-TEST_CASE("double_spend_proof equality reflexive and diverges under mutation", "[double_spend_proof]") {
+TEST_CASE("double_spend_proof equality reflexive and diverges by spender", "[double_spend_proof]") {
     message::double_spend_proof a(make_out_point(), make_spender(1), make_spender(2));
     message::double_spend_proof b(make_out_point(), make_spender(1), make_spender(2));
 
     REQUIRE(a == b);
     REQUIRE( ! (a != b));
 
-    b.set_spender1(make_spender(99));
-    REQUIRE(a != b);
-    REQUIRE( ! (a == b));
+    message::double_spend_proof c(make_out_point(), make_spender(99), make_spender(2));
+    REQUIRE(a != c);
+    REQUIRE( ! (a == c));
 }
 
 // ---------------------------------------------------------------------------
@@ -244,13 +207,10 @@ TEST_CASE("double_spend_proof hash is deterministic", "[double_spend_proof]") {
     REQUIRE(message::hash(dsp) == h1);
 }
 
-TEST_CASE("double_spend_proof hash changes under mutation", "[double_spend_proof]") {
-    message::double_spend_proof dsp(make_out_point(), make_spender(1), make_spender(2));
-    auto const h1 = dsp.hash();
-
-    dsp.set_spender1(make_spender(99));
-    auto const h2 = dsp.hash();
-    REQUIRE(h1 != h2);
+TEST_CASE("double_spend_proof hash changes with spender", "[double_spend_proof]") {
+    message::double_spend_proof const dsp(make_out_point(), make_spender(1), make_spender(2));
+    message::double_spend_proof const other(make_out_point(), make_spender(99), make_spender(2));
+    REQUIRE(dsp.hash() != other.hash());
 }
 
 TEST_CASE("double_spend_proof hash differs between distinct proofs", "[double_spend_proof]") {


### PR DESCRIPTION
`double_spend_proof` and its inner `spender` are message value types with no syntactic invariant — `from_data` reads fixed-width fields and is the only thing that can fail. They still carried the old vestigial surface:

- `spender::is_valid()` — an all-zero sentinel (*"is this a default-built empty spender?"*), no production caller.
- `spender::reset()` — zeroed every field, the sentinel's companion.
- `double_spend_proof::set_out_point` / `set_spender1` / `set_spender2` — mutated a default-constructed proof into shape; only tests used them.

All removed. A proof is now built through its full constructor (as `from_data` already does) and is immutable — no setters to break the object mid-assembly, nothing to query for "validity" because construction is the only gate.

Tests updated to build proofs via the constructor and to diverge equality/hash by constructing distinct proofs rather than mutating one. Header include list tidied.

Part of the `.valid()` / valid-by-construction sweep across the domain value types.

Domain build green; `double_spend_proof` suite passes (33 assertions, 14 cases). The C-API wrappers that referenced the removed members are updated in the pending bulk C-API pass.