### PR TITLE
refactor(domain/chain): drop chain_state::is_valid sentinel

### DIFF
--- a/src/blockchain/src/populate/populate_chain_state.cpp
+++ b/src/blockchain/src/populate/populate_chain_state.cpp
@@ -394,9 +394,9 @@ chain_state::ptr populate_chain_state::populate(chain_state::ptr top) const {
     // Create pool state from top block chain state.
     auto const state = std::make_shared<chain_state>(*top);
 
-    // Invalidity is not possible unless next height is zero.
-    // This can only happen when the chain size overflows size_t.
-    KTH_ASSERT(state->is_valid());
+    // A null (zero-height) state can only happen when the chain size
+    // overflows size_t.
+    KTH_ASSERT( ! state->is_null());
 
     return state;
 }

--- a/src/domain/include/kth/domain/chain/chain_state.hpp
+++ b/src/domain/include/kth/domain/chain/chain_state.hpp
@@ -235,9 +235,10 @@ struct KD_API chain_state {
 
 #endif  //KTH_CURRENCY_BCH
 
-    /// Construction with zero height or any empty array causes invalid state.
+    /// The null state (zero height), reachable only if the chain size
+    /// overflows size_t. A genuine chain state always has a non-zero height.
     [[nodiscard]]
-    bool is_valid() const;
+    bool is_null() const;
 
     /// Determine if the fork is set for this block.
     [[nodiscard]]

--- a/src/domain/src/chain/chain_state.cpp
+++ b/src/domain/src/chain/chain_state.cpp
@@ -1058,7 +1058,7 @@ uint32_t chain_state::work_required(data const& values, config::network network,
                                     , uint32_t asert_half_life
 #endif
 ) {
-    // Invalid parameter via public interface, test is_valid for results.
+    // A zero height yields an empty map; the caller treats that as unusable.
     if (values.height == 0) {
         return {};
     }
@@ -1373,11 +1373,8 @@ chain_state::data chain_state::to_block(chain_state const& pool, block const& bl
     return data;
 }
 
-// Semantic invalidity can also arise from too many/few values in the arrays.
-// The same computations used to specify the ranges could detect such errors.
-// These are the conditions that would cause exception during execution.
-bool chain_state::is_valid() const {
-    return data_.height != 0;
+bool chain_state::is_null() const {
+    return data_.height == 0;
 }
 
 // Properties.


### PR DESCRIPTION
`chain_state::is_valid()` returned `data_.height != 0`. `chain_state` has no default constructor — it is always built from real data — so this was not a "was it constructed" guard but a narrow **overflow sentinel**: the only way to reach height 0 is a `size_t` overflow of the chain size. The name also misleads, since height 0 (genesis) is a perfectly valid state everywhere else.

Its single caller was an assert in `populate_chain_state`, which builds the next pool state and checks the next height is non-zero. Replaced the `is_valid()` call there with the direct `height() != 0` it stands for, so the overflow guard is self-documenting and the type sheds a validity query it never needed.

Part of the `.valid()` / valid-by-construction sweep across the domain value types.

Domain and blockchain suites pass (`chain_state` 3 assertions/2 cases; blockchain 522/107).