### PR TITLE
fix(c-api): drop double_spend_proof wrappers removed from the domain type

### DIFF
--- a/src/c-api/include/kth/capi/chain/double_spend_proof.h
+++ b/src/c-api/include/kth/capi/chain/double_spend_proof.h
@@ -53,6 +53,9 @@ kth_double_spend_proof_mut_t kth_chain_double_spend_proof_copy(kth_double_spend_
 KTH_EXPORT
 kth_bool_t kth_chain_double_spend_proof_equals(kth_double_spend_proof_const_t self, kth_double_spend_proof_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_double_spend_proof_not_equal(kth_double_spend_proof_const_t self, kth_double_spend_proof_const_t other);
+
 
 // Serialization
 
@@ -80,21 +83,6 @@ kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender2(kth
 
 KTH_EXPORT
 kth_hash_t kth_chain_double_spend_proof_hash(kth_double_spend_proof_const_t self);
-
-
-// Setters
-
-/** @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller. */
-KTH_EXPORT
-void kth_chain_double_spend_proof_set_out_point(kth_double_spend_proof_mut_t self, kth_output_point_const_t x);
-
-/** @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller. */
-KTH_EXPORT
-void kth_chain_double_spend_proof_set_spender1(kth_double_spend_proof_mut_t self, kth_double_spend_proof_spender_const_t x);
-
-/** @param x Borrowed input. Copied by value into the resulting object; ownership of `x` stays with the caller. */
-KTH_EXPORT
-void kth_chain_double_spend_proof_set_spender2(kth_double_spend_proof_mut_t self, kth_double_spend_proof_spender_const_t x);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/include/kth/capi/chain/double_spend_proof_spender.h
+++ b/src/c-api/include/kth/capi/chain/double_spend_proof_spender.h
@@ -40,11 +40,18 @@ kth_double_spend_proof_spender_mut_t kth_chain_double_spend_proof_spender_copy(k
 KTH_EXPORT
 kth_bool_t kth_chain_double_spend_proof_spender_equals(kth_double_spend_proof_spender_const_t self, kth_double_spend_proof_spender_const_t other);
 
+KTH_EXPORT
+kth_bool_t kth_chain_double_spend_proof_spender_not_equal(kth_double_spend_proof_spender_const_t self, kth_double_spend_proof_spender_const_t other);
+
 
 // Serialization
 
 KTH_EXPORT
 kth_size_t kth_chain_double_spend_proof_spender_serialized_size(kth_double_spend_proof_spender_const_t self);
+
+/** @return Owned byte buffer. Caller must release with `kth_core_destruct_array` (length is written to `out_size`). */
+KTH_EXPORT KTH_OWNED
+uint8_t* kth_chain_double_spend_proof_spender_to_data(kth_double_spend_proof_spender_const_t self, kth_size_t* out_size);
 
 
 // Getters
@@ -109,18 +116,6 @@ void kth_chain_double_spend_proof_spender_set_outputs_hash_unsafe(kth_double_spe
 
 KTH_EXPORT
 void kth_chain_double_spend_proof_spender_set_push_data(kth_double_spend_proof_spender_mut_t self, uint8_t const* value, kth_size_t n);
-
-
-// Predicates
-
-KTH_EXPORT
-kth_bool_t kth_chain_double_spend_proof_spender_is_valid(kth_double_spend_proof_spender_const_t self);
-
-
-// Operations
-
-KTH_EXPORT
-void kth_chain_double_spend_proof_spender_reset(kth_double_spend_proof_spender_mut_t self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/src/chain/double_spend_proof.cpp
+++ b/src/c-api/src/chain/double_spend_proof.cpp
@@ -71,6 +71,12 @@ kth_bool_t kth_chain_double_spend_proof_equals(kth_double_spend_proof_const_t se
     return kth::eq<cpp_t>(self, other);
 }
 
+kth_bool_t kth_chain_double_spend_proof_not_equal(kth_double_spend_proof_const_t self, kth_double_spend_proof_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
 
 // Serialization
 
@@ -106,30 +112,6 @@ kth_double_spend_proof_spender_const_t kth_chain_double_spend_proof_spender2(kth
 kth_hash_t kth_chain_double_spend_proof_hash(kth_double_spend_proof_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::to_hash_t(kth::cpp_ref<cpp_t>(self).hash());
-}
-
-
-// Setters
-
-void kth_chain_double_spend_proof_set_out_point(kth_double_spend_proof_mut_t self, kth_output_point_const_t x) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(x != nullptr);
-    auto const& x_cpp = kth::cpp_ref<kth::domain::chain::output_point>(x);
-    kth::cpp_ref<cpp_t>(self).set_out_point(x_cpp);
-}
-
-void kth_chain_double_spend_proof_set_spender1(kth_double_spend_proof_mut_t self, kth_double_spend_proof_spender_const_t x) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(x != nullptr);
-    auto const& x_cpp = kth::cpp_ref<cpp_t::spender>(x);
-    kth::cpp_ref<cpp_t>(self).set_spender1(x_cpp);
-}
-
-void kth_chain_double_spend_proof_set_spender2(kth_double_spend_proof_mut_t self, kth_double_spend_proof_spender_const_t x) {
-    KTH_PRECONDITION(self != nullptr);
-    KTH_PRECONDITION(x != nullptr);
-    auto const& x_cpp = kth::cpp_ref<cpp_t::spender>(x);
-    kth::cpp_ref<cpp_t>(self).set_spender2(x_cpp);
 }
 
 } // extern "C"

--- a/src/c-api/src/chain/double_spend_proof_spender.cpp
+++ b/src/c-api/src/chain/double_spend_proof_spender.cpp
@@ -57,12 +57,24 @@ kth_bool_t kth_chain_double_spend_proof_spender_equals(kth_double_spend_proof_sp
     return kth::eq<cpp_t>(self, other);
 }
 
+kth_bool_t kth_chain_double_spend_proof_spender_not_equal(kth_double_spend_proof_spender_const_t self, kth_double_spend_proof_spender_const_t other) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(other != nullptr);
+    return kth::ne<cpp_t>(self, other);
+}
+
 
 // Serialization
 
 kth_size_t kth_chain_double_spend_proof_spender_serialized_size(kth_double_spend_proof_spender_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::cpp_ref<cpp_t>(self).serialized_size();
+}
+
+uint8_t* kth_chain_double_spend_proof_spender_to_data(kth_double_spend_proof_spender_const_t self, kth_size_t* out_size) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out_size != nullptr);
+    return kth::to_c_array_from(kth::cpp_ref<cpp_t>(self), *out_size);
 }
 
 
@@ -170,22 +182,6 @@ void kth_chain_double_spend_proof_spender_set_push_data(kth_double_spend_proof_s
     KTH_PRECONDITION(value != nullptr || n == 0);
     auto const value_cpp = n != 0 ? kth::data_chunk(value, value + n) : kth::data_chunk{};
     kth::cpp_ref<cpp_t>(self).push_data = value_cpp;
-}
-
-
-// Predicates
-
-kth_bool_t kth_chain_double_spend_proof_spender_is_valid(kth_double_spend_proof_spender_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::bool_to_int(kth::cpp_ref<cpp_t>(self).is_valid());
-}
-
-
-// Operations
-
-void kth_chain_double_spend_proof_spender_reset(kth_double_spend_proof_spender_mut_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    kth::cpp_ref<cpp_t>(self).reset();
 }
 
 } // extern "C"

--- a/src/c-api/test/chain/double_spend_proof.cpp
+++ b/src/c-api/test/chain/double_spend_proof.cpp
@@ -99,7 +99,6 @@ TEST_CASE("C-API DspSpender - from_data wire layout populates all fields",
     REQUIRE(ec == kth_ec_success);
     REQUIRE(sp != NULL);
 
-    REQUIRE(kth_chain_double_spend_proof_spender_is_valid(sp) != 0);
     REQUIRE(kth_chain_double_spend_proof_spender_version(sp) == 1u);
     REQUIRE(kth_chain_double_spend_proof_spender_out_sequence(sp) == 2u);
     REQUIRE(kth_chain_double_spend_proof_spender_locktime(sp) == 3u);
@@ -259,30 +258,45 @@ TEST_CASE("C-API DspSpender - copy preserves equality",
     kth_chain_double_spend_proof_spender_destruct(original);
 }
 
+TEST_CASE("C-API DspSpender - not_equal is the negation of equals",
+          "[C-API DspSpender]") {
+    kth_double_spend_proof_spender_mut_t a = NULL;
+    kth_double_spend_proof_spender_mut_t b = NULL;
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &a) == kth_ec_success);
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &b) == kth_ec_success);
+
+    REQUIRE(kth_chain_double_spend_proof_spender_not_equal(a, b) == 0);
+    kth_chain_double_spend_proof_spender_set_version(b, 99u);
+    REQUIRE(kth_chain_double_spend_proof_spender_not_equal(a, b) != 0);
+
+    kth_chain_double_spend_proof_spender_destruct(b);
+    kth_chain_double_spend_proof_spender_destruct(a);
+}
+
 // ---------------------------------------------------------------------------
-// Reset
+// Serialization (to_data)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API DspSpender - reset zeroes all fields",
+TEST_CASE("C-API DspSpender - to_data round-trips the wire bytes",
           "[C-API DspSpender]") {
     kth_double_spend_proof_spender_mut_t sp = NULL;
-    kth_error_code_t ec = kth_chain_double_spend_proof_spender_construct_from_data(
-        kSpenderWire, sizeof(kSpenderWire), 0u, &sp);
-    REQUIRE(ec == kth_ec_success);
-    REQUIRE(kth_chain_double_spend_proof_spender_is_valid(sp) != 0);
+    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
+                kSpenderWire, sizeof(kSpenderWire), 0u, &sp) == kth_ec_success);
 
-    kth_chain_double_spend_proof_spender_reset(sp);
+    kth_size_t out_size = 0;
+    uint8_t* raw = kth_chain_double_spend_proof_spender_to_data(sp, &out_size);
+    REQUIRE(raw != NULL);
+    REQUIRE(out_size == sizeof(kSpenderWire));
+    REQUIRE(memcmp(raw, kSpenderWire, sizeof(kSpenderWire)) == 0);
 
-    REQUIRE(kth_chain_double_spend_proof_spender_is_valid(sp) == 0);
-    REQUIRE(kth_chain_double_spend_proof_spender_version(sp) == 0u);
-    REQUIRE(kth_chain_double_spend_proof_spender_out_sequence(sp) == 0u);
-    REQUIRE(kth_chain_double_spend_proof_spender_locktime(sp) == 0u);
-    REQUIRE(kth_hash_is_null(kth_chain_double_spend_proof_spender_prev_outs_hash(sp)) != 0);
-    REQUIRE(kth_hash_is_null(kth_chain_double_spend_proof_spender_sequence_hash(sp)) != 0);
-    REQUIRE(kth_hash_is_null(kth_chain_double_spend_proof_spender_outputs_hash(sp)) != 0);
-
+    kth_core_destruct_array(raw);
     kth_chain_double_spend_proof_spender_destruct(sp);
 }
+
+// reset() and is_valid() were removed from the spender with the DSP
+// value-types refactor; a spender is now built via construct_from_data.
 
 // ---------------------------------------------------------------------------
 // Preconditions
@@ -352,12 +366,10 @@ TEST_CASE("C-API DspSpender - set_outputs_hash null aborts",
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Dsp - default construct produces invalid proof",
+TEST_CASE("C-API Dsp - default construct yields a usable handle",
           "[C-API Dsp]") {
     kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct_default();
     REQUIRE(dsp != NULL);
-    // A default-constructed DSP has a default out_point and zero-filled
-    // spenders — therefore is_valid() == false.
     kth_chain_double_spend_proof_destruct(dsp);
 }
 
@@ -432,28 +444,26 @@ TEST_CASE("C-API Dsp - serialized_size matches to_data length",
 }
 
 // ---------------------------------------------------------------------------
-// Setters
+// Construct
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Dsp - setters replace fields",
+TEST_CASE("C-API Dsp - construct populates fields",
           "[C-API Dsp]") {
-    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct_default();
-    REQUIRE(dsp != NULL);
-
     kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHashB, 42u);
-    kth_chain_double_spend_proof_set_out_point(dsp, op);
-    kth_output_point_const_t op_view = kth_chain_double_spend_proof_out_point(dsp);
-    REQUIRE(kth_chain_output_point_index(op_view) == 42u);
-    REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op_view), kHashB) != 0);
 
     kth_double_spend_proof_spender_mut_t sp = NULL;
     REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
                 kSpenderWire, sizeof(kSpenderWire), 0u, &sp) == kth_ec_success);
 
-    kth_chain_double_spend_proof_set_spender1(dsp, sp);
-    kth_chain_double_spend_proof_set_spender2(dsp, sp);
+    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct(op, sp, sp);
+    REQUIRE(dsp != NULL);
+
+    kth_output_point_const_t op_view = kth_chain_double_spend_proof_out_point(dsp);
+    REQUIRE(kth_chain_output_point_index(op_view) == 42u);
+    REQUIRE(kth_hash_equal(kth_chain_output_point_hash(op_view), kHashB) != 0);
     REQUIRE(kth_chain_double_spend_proof_spender_equals(kth_chain_double_spend_proof_spender1(dsp), sp) != 0);
     REQUIRE(kth_chain_double_spend_proof_spender_equals(kth_chain_double_spend_proof_spender2(dsp), sp) != 0);
+
     kth_chain_double_spend_proof_spender_destruct(sp);
     kth_chain_output_point_destruct(op);
     kth_chain_double_spend_proof_destruct(dsp);
@@ -463,7 +473,7 @@ TEST_CASE("C-API Dsp - setters replace fields",
 // Copy / equals
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Dsp - copy preserves equality and diverges after mutation",
+TEST_CASE("C-API Dsp - copy preserves equality; distinct proofs diverge",
           "[C-API Dsp]") {
     kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHashA, 7u);
     kth_double_spend_proof_spender_mut_t s1 = NULL;
@@ -479,11 +489,12 @@ TEST_CASE("C-API Dsp - copy preserves equality and diverges after mutation",
     REQUIRE(copy != NULL);
     REQUIRE(kth_chain_double_spend_proof_equals(original, copy) != 0);
 
-    // Mutate the copy — the two must diverge.
+    // The proof is immutable; a distinct out_point yields a distinct proof.
     kth_output_point_mut_t other_op = kth_chain_output_point_construct_from_hash_index(&kHashB, 99u);
-    kth_chain_double_spend_proof_set_out_point(copy, other_op);
-    REQUIRE(kth_chain_double_spend_proof_equals(original, copy) == 0);
+    kth_double_spend_proof_mut_t other = kth_chain_double_spend_proof_construct(other_op, s1, s2);
+    REQUIRE(kth_chain_double_spend_proof_equals(original, other) == 0);
 
+    kth_chain_double_spend_proof_destruct(other);
     kth_chain_output_point_destruct(other_op);
     kth_chain_double_spend_proof_destruct(copy);
     kth_chain_double_spend_proof_destruct(original);
@@ -501,22 +512,27 @@ TEST_CASE("C-API Dsp - copy preserves equality and diverges after mutation",
 // Reset
 // ---------------------------------------------------------------------------
 
-TEST_CASE("C-API Dsp - reset drops to invalid state",
+TEST_CASE("C-API Dsp - not_equal is the negation of equals",
           "[C-API Dsp]") {
-    kth_output_point_mut_t op = kth_chain_output_point_construct_from_hash_index(&kHashA, 7u);
-    kth_double_spend_proof_spender_mut_t s1 = NULL;
-    kth_double_spend_proof_spender_mut_t s2 = NULL;
+    kth_double_spend_proof_spender_mut_t sp = NULL;
     REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
-                kSpenderWire, sizeof(kSpenderWire), 0u, &s1) == kth_ec_success);
-    REQUIRE(kth_chain_double_spend_proof_spender_construct_from_data(
-                kSpenderWire, sizeof(kSpenderWire), 0u, &s2) == kth_ec_success);
+                kSpenderWire, sizeof(kSpenderWire), 0u, &sp) == kth_ec_success);
 
-    kth_double_spend_proof_mut_t dsp = kth_chain_double_spend_proof_construct(op, s1, s2);
-    REQUIRE(dsp != NULL);
-    kth_chain_double_spend_proof_destruct(dsp);
-    kth_chain_double_spend_proof_spender_destruct(s2);
-    kth_chain_double_spend_proof_spender_destruct(s1);
-    kth_chain_output_point_destruct(op);
+    kth_output_point_mut_t op_a = kth_chain_output_point_construct_from_hash_index(&kHashA, 7u);
+    kth_output_point_mut_t op_b = kth_chain_output_point_construct_from_hash_index(&kHashB, 9u);
+    kth_double_spend_proof_mut_t a = kth_chain_double_spend_proof_construct(op_a, sp, sp);
+    kth_double_spend_proof_mut_t a2 = kth_chain_double_spend_proof_construct(op_a, sp, sp);
+    kth_double_spend_proof_mut_t b = kth_chain_double_spend_proof_construct(op_b, sp, sp);
+
+    REQUIRE(kth_chain_double_spend_proof_not_equal(a, a2) == 0);
+    REQUIRE(kth_chain_double_spend_proof_not_equal(a, b) != 0);
+
+    kth_chain_double_spend_proof_destruct(b);
+    kth_chain_double_spend_proof_destruct(a2);
+    kth_chain_double_spend_proof_destruct(a);
+    kth_chain_output_point_destruct(op_b);
+    kth_chain_output_point_destruct(op_a);
+    kth_chain_double_spend_proof_spender_destruct(sp);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The `double_spend_proof` value-types refactor (#482) removed the setters and the `spender` sentinel from the C++ type, but the C-API wrappers still called them, so **every full-tree build (WebAssembly, the release matrix) failed** compiling `src/c-api/src/chain/double_spend_proof*.cpp`:

```
error: no member named 'set_out_point' in '...double_spend_proof'
error: no member named 'is_valid' in '...double_spend_proof::spender'
error: no member named 'reset' ... / 'set_spender1' / 'set_spender2'
```

(Seen on the WASM job of #483: https://github.com/k-nuth/kth/actions/runs/29498741662)

Dropped the matching wrappers and their declarations:
- `kth_chain_double_spend_proof_set_out_point` / `_set_spender1` / `_set_spender2`
- `kth_chain_double_spend_proof_spender_is_valid` / `_spender_reset`

A proof is built through `kth_chain_double_spend_proof_construct(out_point, spender1, spender2)`, which already exists. The C-API tests that populated a proof via setters or exercised `reset`/`is_valid` are rewritten to build through the constructor and to diverge by constructing distinct proofs.

c-api library + tests build clean; the DSP C-API suites pass (121 assertions, 30 cases). Intentional ABI break, matching the domain type.