### PR TITLE
fix(blockchain/bench): use boost::atomic_shared_ptr for the COW block pool

### DIFF
--- a/src/blockchain/bench/block_pool/benchmarks.cpp
+++ b/src/blockchain/bench/block_pool/benchmarks.cpp
@@ -38,6 +38,9 @@
 #include <boost/bimap.hpp>
 #include <boost/bimap/multiset_of.hpp>
 #include <boost/bimap/unordered_set_of.hpp>
+#include <boost/smart_ptr/atomic_shared_ptr.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
+#include <boost/smart_ptr/shared_ptr.hpp>
 #include <boost/unordered/concurrent_flat_map.hpp>
 #include <boost/unordered/unordered_flat_map.hpp>
 
@@ -200,13 +203,13 @@ class cow_pool {
 public:
     using store = boost::unordered_flat_map<hash_digest, value, hash_hasher>;
 
-    cow_pool() : blocks_(std::make_shared<store const>()) {}
+    cow_pool() : blocks_(boost::make_shared<store const>()) {}
 
     size_t size() const { return snapshot()->size(); }
 
     void add(hash_digest const& hash, size_t height) {
         std::lock_guard lock(write_mutex_);
-        auto next = std::make_shared<store>(*snapshot());
+        auto next = boost::make_shared<store>(*snapshot());
         next->emplace(hash, value{std::make_shared<int>(1), height, {}});
         blocks_.store(std::move(next));
     }
@@ -217,7 +220,7 @@ public:
 
     void remove(std::vector<hash_digest> const& hashes) {
         std::lock_guard lock(write_mutex_);
-        auto next = std::make_shared<store>(*snapshot());
+        auto next = boost::make_shared<store>(*snapshot());
         for (auto const& h : hashes) {
             next->erase(h);
         }
@@ -243,9 +246,12 @@ public:
     }
 
 private:
-    std::shared_ptr<store const> snapshot() const { return blocks_.load(); }
+    boost::shared_ptr<store const> snapshot() const { return blocks_.load(); }
 
-    std::atomic<std::shared_ptr<store const>> blocks_;
+    // std::atomic<std::shared_ptr<>> is not portable: libc++ (Apple clang)
+    // has no such specialisation and static_asserts on the primary template.
+    // boost::atomic_shared_ptr gives the same lock-free snapshot everywhere.
+    boost::atomic_shared_ptr<store const> blocks_;
     std::mutex write_mutex_;   // serialises writers against each other only
 };
 


### PR DESCRIPTION
The block_pool store benchmark's copy-on-write variant held its snapshot in a `std::atomic<std::shared_ptr<store const>>`. libstdc++ provides that specialisation, but **libc++ (Apple clang) does not** — it falls back to the primary `std::atomic` template, whose `static_assert` requires a trivially-copyable `T`, so the macOS build failed:

```
static assertion failed ... std::atomic<T> requires that 'T' be a trivially copyable type
```

(Seen on the macOS job: https://github.com/k-nuth/kth/actions/runs/29493060871)

Switched the COW pool to `boost::atomic_shared_ptr<store const>` (with `boost::shared_ptr` / `boost::make_shared` for the store). Same lock-free snapshot load/store on every toolchain, header-only boost the target already links.

**Verified on the failing platform** via `ssh mac`: the `atomic_shared_ptr` snapshot pattern compiles and runs under Apple clang 21 / libc++ with `-std=c++23`; the benchmark also builds clean on Linux (GCC).