### PR TITLE
refactor(blockchain): move block validation metadata out of the domain type

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -33,6 +33,7 @@
 #include <kth/blockchain/pools/transaction_organizer.hpp>
 #include <kth/blockchain/populate/populate_chain_state.hpp>
 #include <kth/blockchain/settings.hpp>
+#include <kth/blockchain/validate/block_validation.hpp>
 
 #include <asio/any_io_executor.hpp>
 #include <asio/awaitable.hpp>
@@ -207,6 +208,11 @@ struct KB_API block_chain {
 
     domain::chain::chain_state::ptr chain_state() const;
     domain::chain::chain_state::ptr chain_state(branch::const_ptr branch) const;
+
+    /// Validator-owned side store for transient per-block validation state,
+    /// keyed by block hash. This replaces the old mutable `block::validation`
+    /// member so the domain value type carries only consensus/wire data.
+    block_validation_store& block_validations() const;
 
     // =========================================================================
     // SUBSCRIPTIONS
@@ -465,6 +471,10 @@ private:
 #if defined(KTH_WITH_MEMPOOL)
     mining::mempool mempool_;
 #endif
+
+    // Must be declared before block_organizer_: the organizer's block_pool is
+    // constructed with a reference to this store.
+    mutable block_validation_store block_validations_;
 
     transaction_organizer transaction_organizer_;
     block_organizer block_organizer_;

--- a/src/blockchain/include/kth/blockchain/pools/block_pool.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/block_pool.hpp
@@ -23,7 +23,7 @@ namespace kth::blockchain {
 /// The branch object contains chain query for new (leaf) block validation.
 /// All pool blocks are valid, lacking only sufficient work for reorganzation.
 struct KB_API block_pool {
-    block_pool(size_t maximum_depth);
+    block_pool(size_t maximum_depth, block_validation_store& block_validations);
 
     // The number of blocks in the pool.
     size_t size() const;
@@ -61,6 +61,11 @@ protected:
 
     // This is thread safe.
     size_t const maximum_depth_;
+
+    // Validator-owned per-block validation state (not owned by the pool);
+    // supplies each block's chain_state (e.g. height) and is threaded into
+    // the branches this pool creates.
+    block_validation_store& block_validations_;
 
     // This is guarded against filtering concurrent to writing.
     block_entries blocks_;

--- a/src/blockchain/include/kth/blockchain/pools/branch.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/branch.hpp
@@ -13,6 +13,7 @@
 #include <kth/domain.hpp>
 
 #include <kth/blockchain/define.hpp>
+#include <kth/blockchain/validate/block_validation.hpp>
 
 namespace kth::blockchain {
 
@@ -24,8 +25,10 @@ struct KB_API branch {
     using ptr = std::shared_ptr<branch>;
     using const_ptr = std::shared_ptr<const branch>;
 
-    /// Establish a branch with the given parent height.
-    branch(uint32_t height = 0);
+    /// Establish a branch with the given parent height. The validation store
+    /// is validator-owned; the branch reads per-block chain_state from it
+    /// (e.g. for median-time-past) now that blocks no longer self-carry it.
+    branch(uint32_t height, block_validation_store& block_validations);
 
     /// Set the height of the parent of this branch (fork point).
     void set_height(uint32_t height);
@@ -92,6 +95,9 @@ private:
 
     /// The chain of blocks in the branch.
     block_const_ptr_list_ptr blocks_;
+
+    /// Validator-owned per-block validation state (not owned by the branch).
+    block_validation_store& block_validations_;
 };
 
 local_utxo_t create_local_utxo_set(domain::chain::block const& block);

--- a/src/blockchain/include/kth/blockchain/validate/block_validation.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/block_validation.hpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_VALIDATE_BLOCK_VALIDATION_HPP
+#define KTH_BLOCKCHAIN_VALIDATE_BLOCK_VALIDATION_HPP
+
+#include <cstdint>
+
+#include <kth/blockchain/validate/validation_store.hpp>
+#include <kth/domain.hpp>
+#include <kth/infrastructure/error.hpp>
+
+namespace kth::blockchain {
+
+/// Transient validation/tracing state for a block being organized.
+///
+/// This used to live as a `mutable` member on `domain::chain::block`, which
+/// mixed consensus/wire data with validator working state and forced the
+/// value type to hand-write its comparison. It now lives here, owned by the
+/// validator via block_validation_store, keyed by block hash.
+struct block_validation {
+    uint64_t originator = 0;
+    code error = error::not_found;
+    domain::chain::chain_state::ptr state = nullptr;
+
+    // Simulate organization and instead just validate the block.
+    bool simulate = false;
+};
+
+/// Owns the per-block validation state keyed by block hash. See
+/// validation_store for the concurrency/lifetime contract.
+using block_validation_store = validation_store<block_validation>;
+
+} // namespace kth::blockchain
+
+#endif

--- a/src/blockchain/include/kth/blockchain/validate/validate_block.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/validate_block.hpp
@@ -73,9 +73,6 @@ protected:
         return stopped_;
     }
 
-    [[nodiscard]]
-    float hit_rate() const;
-
 private:
     using atomic_counter = std::atomic<size_t>;
     using atomic_counter_ptr = std::shared_ptr<atomic_counter>;
@@ -99,8 +96,6 @@ private:
     domain::config::network network_;
     executor_type executor_;
     size_t threads_;
-    mutable atomic_counter hits_;
-    mutable atomic_counter queries_;
 
     // Caller must not invoke accept/connect concurrently.
     populate_block block_populator_;

--- a/src/blockchain/include/kth/blockchain/validate/validation_store.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/validation_store.hpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_VALIDATE_VALIDATION_STORE_HPP
+#define KTH_BLOCKCHAIN_VALIDATE_VALIDATION_STORE_HPP
+
+#include <concepts>
+#include <utility>
+
+#include <boost/unordered/unordered_flat_map.hpp>
+
+#include <kth/infrastructure/hash_define.hpp>
+
+namespace kth::blockchain {
+
+/// Validator-owned side store of transient per-object validation state, keyed
+/// by object hash. Generic over the value type (block_validation,
+/// transaction_validation, ...); the value carries no consensus/wire identity,
+/// only the validator's working annotations for one object. It must be
+/// default-constructible because the store materializes a default entry the
+/// first time an object is written.
+///
+/// The surface is visitation-only: mutate/visit apply a callable to the entry
+/// and never hand out a reference or pointer to it. No internal
+/// synchronization -- every access happens inside the organizers' serialized
+/// organize() path (block and transaction organizers share one prioritized
+/// mutex held across their co_awaits, so they are mutually exclusive).
+template <std::default_initializable Validation>
+struct validation_store {
+    /// Apply `fn` (taking `Validation&`) to the entry for `hash`, creating a
+    /// default entry first if none exists. Returns true if a new entry was
+    /// created, false if an existing one was mutated. For writers.
+    template <typename Fn>
+    bool mutate(hash_digest const& hash, Fn&& fn) {
+        auto const [it, created] = map_.try_emplace(hash);
+        std::forward<Fn>(fn)(it->second);
+        return created;
+    }
+
+    /// If an entry for `hash` exists, apply `fn` (taking `Validation const&`)
+    /// to it and return true; otherwise return false. For readers.
+    template <typename Fn>
+    bool visit(hash_digest const& hash, Fn&& fn) const {
+        auto const it = map_.find(hash);
+        if (it == map_.end()) {
+            return false;
+        }
+        std::forward<Fn>(fn)(it->second);
+        return true;
+    }
+
+    /// Drop the entry for `hash`. Returns the number of entries removed (0 or
+    /// 1), i.e. whatever the underlying map's erase returns.
+    std::size_t erase(hash_digest const& hash) {
+        return map_.erase(hash);
+    }
+
+private:
+    boost::unordered_flat_map<hash_digest, Validation> map_;
+};
+
+} // namespace kth::blockchain
+
+#endif

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -714,6 +714,10 @@ domain::chain::chain_state::ptr block_chain::chain_state(branch::const_ptr branc
     return chain_state_populator_.populate(chain_state(), branch);
 }
 
+block_validation_store& block_chain::block_validations() const {
+    return block_validations_;
+}
+
 code block_chain::set_chain_state(domain::chain::chain_state::ptr previous) {
     unique_lock lock(pool_state_mutex_);
     pool_state_ = chain_state_populator_.populate(previous);
@@ -990,8 +994,12 @@ block_chain::fetch_block(size_t height) const {
     }
 
     auto const cached = last_block_.load();
-    if (cached && cached->validation.state && cached->validation.state->height() == height) {
-        co_return std::pair{cached, height};
+    if (cached) {
+        domain::chain::chain_state::ptr state;
+        block_validations().visit(cached->hash(), [&](auto const& bv){ state = bv.state; });
+        if (state && state->height() == height) {
+            co_return std::pair{cached, height};
+        }
     }
 
     // LMDB block storage removed - blocks now in flat files
@@ -1006,8 +1014,12 @@ block_chain::fetch_block(hash_digest const& hash) const {
     }
 
     auto const cached = last_block_.load();
-    if (cached && cached->validation.state && cached->hash() == hash) {
-        co_return std::pair{cached, cached->validation.state->height()};
+    if (cached) {
+        domain::chain::chain_state::ptr state;
+        block_validations().visit(cached->hash(), [&](auto const& bv){ state = bv.state; });
+        if (state && cached->hash() == hash) {
+            co_return std::pair{cached, state->height()};
+        }
     }
 
     // LMDB block storage removed - blocks now in flat files

--- a/src/blockchain/src/pools/block_organizer.cpp
+++ b/src/blockchain/src/pools/block_organizer.cpp
@@ -43,7 +43,7 @@ block_organizer::block_organizer(prioritized_mutex& mutex, executor_type executo
     , stopped_(true)
     , executor_(std::move(executor))
     , threads_(threads)
-    , block_pool_(settings.reorganization_limit)
+    , block_pool_(settings.reorganization_limit, chain_.block_validations())
 #if defined(KTH_WITH_MEMPOOL)
     , validator_(executor_, threads_, chain_, settings, network, relay_transactions, mp)
 #else
@@ -166,8 +166,10 @@ bool block_organizer::stop() {
         co_return ec;
     }
 
-    auto& top_block = branch->top()->validation;
-    top_block.error = error::success;
+    auto const top_hash = branch->top()->hash();
+    chain_.block_validations().mutate(top_hash, [](auto& bv){ bv.error = error::success; });
+    bool simulate = false;
+    chain_.block_validations().visit(top_hash, [&](auto const& bv){ simulate = bv.simulate; });
     // The header used to carry mutable validation.median_time_past /
     // .height stamped here. The header is now a pure value type; both
     // values are already available on the block's chain_state and the
@@ -175,7 +177,6 @@ bool block_organizer::stop() {
 
     auto const work = branch->work();
     auto const first_height = branch->height() + 1u;
-    top_block.start_notify = asio::steady_clock::now();
 
     // The chain query will stop if it reaches work level.
     auto const threshold = chain_.get_branch_work(work, first_height);
@@ -186,7 +187,7 @@ bool block_organizer::stop() {
 
     // TODO(legacy): consider relay of pooled blocks by modifying subscriber semantics.
     if (work <= *threshold) {
-        if ( ! top_block.simulate) {
+        if ( ! simulate) {
             block_pool_.add(branch->top());
         }
 
@@ -203,7 +204,7 @@ bool block_organizer::stop() {
     }
 
     // TODO(legacy): create a simulated validation path that does not block others.
-    if (top_block.simulate) {
+    if (simulate) {
         mutex_.unlock_high_priority();
         co_return error::success;
     }

--- a/src/blockchain/src/pools/block_pool.cpp
+++ b/src/blockchain/src/pools/block_pool.cpp
@@ -18,8 +18,9 @@ namespace kth::blockchain {
 
 using namespace boost;
 
-block_pool::block_pool(size_t maximum_depth)
+block_pool::block_pool(size_t maximum_depth, block_validation_store& block_validations)
     : maximum_depth_(maximum_depth == 0 ? max_size_t : maximum_depth)
+    , block_validations_(block_validations)
 {}
 
 size_t block_pool::size() const {
@@ -36,9 +37,12 @@ void block_pool::add(block_const_ptr valid_block) {
     // which is populated by the validator before the block reaches the pool.
     // Fall back to 0 to preserve the legacy semantics when an unvalidated
     // block (no chain_state) is added — e.g. dedup-only test paths.
-    auto height = valid_block->validation.state
-        ? static_cast<size_t>(valid_block->validation.state->height())
-        : size_t{0};
+    size_t height = 0;
+    block_validations_.visit(valid_block->hash(), [&](auto const& bv){
+        if (bv.state) {
+            height = static_cast<size_t>(bv.state->height());
+        }
+    });
     auto const& left = blocks_.left;
 
     // Caller ensure the entry does not exist by using get_path, but
@@ -75,6 +79,11 @@ void block_pool::remove(block_const_ptr_list_const_ptr accepted_blocks) {
     auto& left = blocks_.left;
 
     for (auto block: *accepted_blocks) {
+        // The block is now on the accepted chain; its validation state is no
+        // longer needed. Evict regardless of pool membership (a block accepted
+        // straight onto the main chain has a store entry but no pool entry).
+        block_validations_.erase(block->hash());
+
         auto it = left.find(block_entry{ block->hash() });
 
         if (it == left.end()) continue;
@@ -99,8 +108,10 @@ void block_pool::remove(block_const_ptr_list_const_ptr accepted_blocks) {
 
         // Copy the entry so that it can be deleted and replanted with height.
         auto const copy = it->first;
-        KTH_ASSERT(copy.block()->validation.state);
-        auto const height = static_cast<size_t>(copy.block()->validation.state->height());
+        domain::chain::chain_state::ptr state;
+        block_validations_.visit(copy.block()->hash(), [&](auto const& bv){ state = bv.state; });
+        KTH_ASSERT(state);
+        auto const height = static_cast<size_t>(state->height());
         KTH_ASSERT(it->second == 0);
 
         // Critical Section
@@ -122,13 +133,16 @@ void block_pool::prune(hash_list const& hashes, size_t minimum_height) {
         auto const it = left.find(block_entry{ hash });
         KTH_ASSERT(it != left.end());
 
-        KTH_ASSERT(it->first.block()->validation.state);
-        auto const height = static_cast<size_t>(
-            it->first.block()->validation.state->height());
+        domain::chain::chain_state::ptr state;
+        block_validations_.visit(it->first.block()->hash(), [&](auto const& bv){ state = bv.state; });
+        KTH_ASSERT(state);
+        auto const height = static_cast<size_t>(state->height());
 
         // Delete all roots and expired non-roots and recurse their children.
         if (it->second != 0 || height < minimum_height) {
-            // delete
+            // delete -- the block leaves the pool, so drop its validation state.
+            block_validations_.erase(hash);
+
             auto const& children = it->first.children();
             std::for_each(children.begin(), children.end(), saver);
 
@@ -223,7 +237,7 @@ block_const_ptr block_pool::parent(block_const_ptr block) const {
 
 branch::ptr block_pool::get_path(block_const_ptr block) const {
     ////log_content();
-    auto const trace = std::make_shared<branch>();
+    auto const trace = std::make_shared<branch>(0, block_validations_);
 
     if (exists(block)) return trace;
 

--- a/src/blockchain/src/pools/branch.cpp
+++ b/src/blockchain/src/pools/branch.cpp
@@ -53,9 +53,10 @@ local_utxo_set_t create_branch_utxo_set(branch::const_ptr const& branch) {
 
 
 // This will be eliminated once weak block headers are moved to the store.
-branch::branch(uint32_t height)
+branch::branch(uint32_t height, block_validation_store& block_validations)
     : height_(height)
     , blocks_(std::make_shared<block_const_ptr_list>())
+    , block_validations_(block_validations)
 {}
 
 void branch::set_height(uint32_t height) {
@@ -128,8 +129,10 @@ uint32_t branch::median_time_past_at(size_t index) const {
     // is now a pure value type, so we read it from the block's chain_state
     // (populated by the validator before the block reaches the branch).
     auto const& block = *(*blocks_)[index];
-    KTH_ASSERT(block.validation.state);
-    return block.validation.state->median_time_past();
+    domain::chain::chain_state::ptr state;
+    block_validations_.visit(block.hash(), [&](auto const& bv){ state = bv.state; });
+    KTH_ASSERT(state);
+    return state->median_time_past();
 }
 
 // TODO(legacy): absorb into the main chain for speed and code consolidation.

--- a/src/blockchain/src/populate/populate_block.cpp
+++ b/src/blockchain/src/populate/populate_block.cpp
@@ -42,7 +42,8 @@ populate_block::populate_block(executor_type executor, size_t threads, block_cha
     auto const block = branch->top();
     KTH_ASSERT(block);
 
-    auto const state = block->validation.state;
+    domain::chain::chain_state::ptr state;
+    chain_.block_validations().visit(block->hash(), [&](auto const& bv){ state = bv.state; });
     KTH_ASSERT(state);
 
     // Return if this blocks is under a checkpoint, block state not required.
@@ -107,7 +108,9 @@ populate_block::populate_block(executor_type executor, size_t threads, block_cha
 // Initialize the coinbase input for subsequent validation.
 void populate_block::populate_coinbase(branch::const_ptr branch, block_const_ptr block) const {
     auto const& txs = block->transactions();
-    auto const state = block->validation.state;
+    domain::chain::chain_state::ptr state;
+    chain_.block_validations().visit(block->hash(), [&](auto const& bv){ state = bv.state; });
+    KTH_ASSERT(state);
     KTH_ASSERT( ! txs.empty());
 
     auto const& coinbase = txs.front();
@@ -191,7 +194,9 @@ code populate_block::populate_transactions_sync(branch::const_ptr branch, size_t
     auto const& txs = block->transactions();
     size_t input_position = 0;
 
-    auto const state = block->validation.state;
+    domain::chain::chain_state::ptr state;
+    chain_.block_validations().visit(block->hash(), [&](auto const& bv){ state = bv.state; });
+    KTH_ASSERT(state);
 
     // Must skip coinbase here as it is already accounted for.
     auto const first = bucket == 0 ? buckets : bucket;

--- a/src/blockchain/src/populate/populate_chain_state.cpp
+++ b/src/blockchain/src/populate/populate_chain_state.cpp
@@ -289,7 +289,7 @@ chain_state::ptr populate_chain_state::populate() const {
         data.abla_state.elastic_buffer_size = elastic_buffer_size;
     }
 
-    auto branch_ptr = std::make_shared<branch>(top);
+    auto branch_ptr = std::make_shared<branch>(top, chain_.block_validations());
 
     // Use an empty branch to represent the transaction pool.
     if ( ! populate_all(data, branch_ptr)) {

--- a/src/blockchain/src/validate/validate_block.cpp
+++ b/src/blockchain/src/validate/validate_block.cpp
@@ -44,8 +44,6 @@ validate_block::validate_block(executor_type executor, size_t threads, block_cha
     , network_(network)
     , executor_(std::move(executor))
     , threads_(threads)
-    , hits_(0)
-    , queries_(0)
 #if defined(KTH_WITH_MEMPOOL)
     , block_populator_(executor_, threads_, chain, relay_transactions, mp)
 #else
@@ -141,13 +139,11 @@ code validate_block::check_block_bucket(block_const_ptr block, size_t bucket, si
     auto const block = branch->top();
     KTH_ASSERT(block);
 
-    // The block has no population timer, so set externally.
-    block->validation.start_populate = asio::steady_clock::now();
-
     // Populate chain state for the next block.
-    block->validation.state = chain_.chain_state(branch);
+    auto const block_state = chain_.chain_state(branch);
+    chain_.block_validations().mutate(block->hash(), [&](auto& bv){ bv.state = block_state; });
 
-    if ( ! block->validation.state) {
+    if ( ! block_state) {
         co_return error::block_validation_state_failed;
     }
 
@@ -162,7 +158,7 @@ code validate_block::check_block_bucket(block_const_ptr block, size_t bucket, si
         co_return populate_ec;
     }
 
-    auto const& state = *block->validation.state;
+    auto const& state = *block_state;
 
     // Run contextual block non-tx checks (sets start time).
     // For headers-first sync, skip header validation since headers were
@@ -228,7 +224,7 @@ code validate_block::check_block_bucket(block_const_ptr block, size_t bucket, si
 
     // Check sigops limit
 #if defined(KTH_CURRENCY_BCH)
-    if (block->validation.state->is_fermat_enabled()) {
+    if (block_state->is_fermat_enabled()) {
         co_return error::success;
     }
 
@@ -250,7 +246,10 @@ code validate_block::accept_transactions_bucket(block_const_ptr block, size_t bu
     }
 
     code ec(error::success);
-    auto const& state = *block->validation.state;
+    domain::chain::chain_state::ptr state_ptr;
+    chain_.block_validations().visit(block->hash(), [&](auto const& bv){ state_ptr = bv.state; });
+    KTH_ASSERT(state_ptr);
+    auto const& state = *state_ptr;
     auto const flags = state.enabled_flags();
     auto const height = state.height();
     auto const mtp = state.median_time_past();
@@ -279,12 +278,12 @@ code validate_block::accept_transactions_bucket(block_const_ptr block, size_t bu
 
 ::asio::awaitable<code> validate_block::connect(branch::const_ptr branch) const {
     auto const block = branch->top();
-    KTH_ASSERT(block && block->validation.state);
+    KTH_ASSERT(block);
+    domain::chain::chain_state::ptr state_ptr;
+    chain_.block_validations().visit(block->hash(), [&](auto const& bv){ state_ptr = bv.state; });
+    KTH_ASSERT(state_ptr);
 
-    // We are reimplementing connect, so must set timer externally.
-    block->validation.start_connect = asio::steady_clock::now();
-
-    if (block->validation.state->is_under_checkpoint()) {
+    if (state_ptr->is_under_checkpoint()) {
         co_return error::success;
     }
 
@@ -294,10 +293,6 @@ code validate_block::accept_transactions_bucket(block_const_ptr block, size_t bu
     if (non_coinbase_inputs == 0) {
         co_return error::success;
     }
-
-    // Reset statistics for each block (treat coinbase as cached).
-    hits_ = 0;
-    queries_ = 0;
 
     auto const buckets = std::min(threads_, non_coinbase_inputs);
     KTH_ASSERT(buckets != 0);
@@ -326,14 +321,16 @@ code validate_block::accept_transactions_bucket(block_const_ptr block, size_t bu
         }
     }
 
-    block->validation.cache_efficiency = hit_rate();
     co_return connect_result;
 }
 
 code validate_block::connect_inputs_bucket(block_const_ptr block, size_t bucket, size_t buckets) const {
     KTH_ASSERT(bucket < buckets);
     code ec(error::success);
-    auto const flags = block->validation.state->enabled_flags();
+    domain::chain::chain_state::ptr state_ptr;
+    chain_.block_validations().visit(block->hash(), [&](auto const& bv){ state_ptr = bv.state; });
+    KTH_ASSERT(state_ptr);
+    auto const flags = state_ptr->enabled_flags();
     auto const& txs = block->transactions();
     size_t position = 0;
 
@@ -343,17 +340,13 @@ code validate_block::connect_inputs_bucket(block_const_ptr block, size_t bucket,
 
     // Must skip coinbase here as it is already accounted for.
     for (auto tx = txs.begin() + 1; tx != txs.end(); ++tx) {
-        ++queries_;
-
         // The tx is pooled with current fork state so outputs are validated.
         if (tx->validation.current) {
-            ++hits_;
             continue;
         }
 
         // The tx was validated before its insertion in the mempool
         if (tx->validation.validated) {
-            ++hits_;
             continue;
         }
 
@@ -384,7 +377,7 @@ code validate_block::connect_inputs_bucket(block_const_ptr block, size_t bucket,
 
 #if defined(KTH_CURRENCY_BCH)
             block_sigchecks += sigchecks;
-            if (block_sigchecks > block->validation.state->dynamic_max_block_sigchecks()) {
+            if (block_sigchecks > state_ptr->dynamic_max_block_sigchecks()) {
                 ec = error::block_sigchecks_limit;
                 break;
             }
@@ -392,19 +385,13 @@ code validate_block::connect_inputs_bucket(block_const_ptr block, size_t bucket,
         }
 
         if (ec) {
-            auto const height = block->validation.state->height();
+            auto const height = state_ptr->height();
             dump(ec, *tx, input_index, flags, height);
             break;
         }
     }
 
     return ec;
-}
-
-// The tx pool cache hit rate.
-float validate_block::hit_rate() const {
-    // These values could overflow or divide by zero, but that's okay.
-    return queries_ == 0 ? 0.0f : (hits_ * 1.0f / queries_);
 }
 
 // Utility.

--- a/src/blockchain/test/block_index_bench/benchmarks.cpp
+++ b/src/blockchain/test/block_index_bench/benchmarks.cpp
@@ -37,6 +37,7 @@
 
 // Knuth block_pool (original implementation)
 #include <kth/blockchain/pools/block_pool.hpp>
+#include <kth/blockchain/validate/block_validation.hpp>
 
 using ankerl::nanobench::Bench;
 
@@ -85,10 +86,9 @@ kth::block_const_ptr create_kth_block(kth::hash_digest const& prev_hash, uint32_
         /*nonce*/     height,
     };
 
-    // The previous benchmark stamped height onto hdr.validation; block_pool
-    // now reads height from block.validation.state. This benchmark exercises
-    // the header_index path which does not consult block.validation.state,
-    // so no extra setup is needed here.
+    // block_pool reads a block's height from the validator's block_validation
+    // store; this benchmark exercises the header_index path, which does not
+    // consult that store, so no extra setup is needed here.
     auto block = std::make_shared<kth::domain::message::block>(
         hdr,
         kth::domain::chain::transaction::list{}
@@ -2560,7 +2560,8 @@ void benchmark_concurrent_insert() {
         })
         .run("Knuth block_pool (external mutex)", [&] {
             // Simulate real usage: block_organizer wraps block_pool with prioritized_mutex
-            kth::blockchain::block_pool pool(10000);
+            kth::blockchain::block_validation_store bvs;
+            kth::blockchain::block_pool pool(10000, bvs);
             std::mutex external_mutex;  // Like block_organizer's mutex_
             std::vector<std::thread> threads;
 
@@ -2728,7 +2729,8 @@ void benchmark_concurrent_read_write() {
         .run("Knuth block_pool (external mutex)", [&] {
             // Real usage: block_organizer uses prioritized_mutex for all operations
             // filter() is the only thread-safe read operation, but we use exists() for comparison
-            block_pool_fixture pool(10000);
+            kth::blockchain::block_validation_store bvs;
+            block_pool_fixture pool(10000, bvs);
             std::shared_mutex external_mutex;  // Allow concurrent reads
             std::atomic<bool> done{false};
             std::atomic<size_t> read_count{0};

--- a/src/blockchain/test/block_pool.cpp
+++ b/src/blockchain/test/block_pool.cpp
@@ -4,19 +4,57 @@
 
 #include <test_helpers.hpp>
 
+#include <memory>
 #include <utility>
 #include <kth/blockchain.hpp>
+#include <kth/blockchain/validate/block_validation.hpp>
+
+#include <catch2/catch_test_case_info.hpp>
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
 
 using namespace kth;
 using namespace kth::blockchain;
 
 // Start Test Suite: block pool tests
 
+// The per-block chain_state used to live on `block::validation`; it now lives
+// in a validator-owned block_validation_store keyed by block hash. Tests seed
+// state via make_block() and the pools read it back, so both sides share this
+// one store. It is held behind a unique_ptr and swapped for a fresh instance
+// before every test case (see the listener below) so state does not leak
+// across tests — several tests build blocks with identical header hashes but
+// different heights, which would otherwise collide in a single shared store.
+static std::unique_ptr<block_validation_store>& test_store_holder() {
+    static std::unique_ptr<block_validation_store> holder =
+        std::make_unique<block_validation_store>();
+    return holder;
+}
+
+static block_validation_store& test_store() {
+    return *test_store_holder();
+}
+
+static void reset_test_store() {
+    test_store_holder() = std::make_unique<block_validation_store>();
+}
+
+namespace {
+struct test_store_reset_listener : Catch::EventListenerBase {
+    using Catch::EventListenerBase::EventListenerBase;
+    void testCaseStarting(Catch::TestCaseInfo const&) override {
+        reset_test_store();
+    }
+};
+} // namespace
+
+CATCH_REGISTER_LISTENER(test_store_reset_listener)
+
 // Access to protected members.
 class block_pool_fixture : public block_pool {
 public:
     block_pool_fixture(size_t maximum_depth)
-        : block_pool(maximum_depth) {}
+        : block_pool(maximum_depth, test_store()) {}
 
     void prune(size_t top_height) {
         block_pool::prune(top_height);
@@ -43,8 +81,10 @@ public:
 };
 
 // Height used to be stamped onto `header().validation.height`. The header
-// is now an immutable value type; `block_pool` reads height from
-// `block.validation.state->height()`, so the chain_state is wired here.
+// is now an immutable value type and per-block chain_state lives in the
+// validator-owned store; `block_pool` reads height from
+// `store.find(block->hash())->state->height()`, so the chain_state is wired
+// into the store here.
 //
 // `chain_state`'s constructor evaluates `median_time_past(data)` and
 // `work_required(data, ...)` eagerly. Both walk the `data.*.ordered`
@@ -88,7 +128,15 @@ block_const_ptr make_block(uint32_t id, size_t height,
         domain::chain::header{ id, parent, null_hash, 0, 0, 0 }, {}
     });
 
-    block->validation.state = make_state_at_height(height);
+    // First-writer-wins: the store is keyed by block hash, so two blocks with
+    // the same hash share one entry. That mirrors production (a hash is stored
+    // once) and matches the "same hash, first retained" pool semantics — the
+    // first block's chain_state is the one the pool reads back.
+    test_store().mutate(block->hash(), [&](auto& bv){
+        if (bv.state == nullptr) {
+            bv.state = make_state_at_height(height);
+        }
+    });
     return block;
 }
 
@@ -131,7 +179,7 @@ TEST_CASE("block pool add1 one single", "[block pool tests]") {
 }
 
 TEST_CASE("block pool add1 twice single", "[block pool tests]") {
-    block_pool instance(0);
+    block_pool instance(0, test_store());
     auto const block = std::make_shared<const domain::message::block>();
 
     instance.add(block);
@@ -183,7 +231,7 @@ TEST_CASE("block pool add1 two distinct hash two", "[block pool tests]") {
 // add2
 
 TEST_CASE("block pool add2 empty empty", "[block pool tests]") {
-    block_pool instance(0);
+    block_pool instance(0, test_store());
     instance.add(std::make_shared<block_const_ptr_list const>());
     REQUIRE(instance.size() == 0u);
 }
@@ -212,7 +260,7 @@ TEST_CASE("block pool add2 distinct expected", "[block pool tests]") {
 // remove
 
 TEST_CASE("block pool remove empty unchanged", "[block pool tests]") {
-    block_pool instance(0);
+    block_pool instance(0, test_store());
     auto const block1 = make_block(1, 42);
     instance.add(block1);
     REQUIRE(instance.size() == 1u);
@@ -236,7 +284,7 @@ TEST_CASE("block pool remove all distinct empty", "[block pool tests]") {
 }
 
 TEST_CASE("block pool remove all connected empty", "[block pool tests]") {
-    block_pool instance(0);
+    block_pool instance(0, test_store());
     auto const block1 = make_block(1, 42);
     auto const block2 = make_block(2, 43, block1);
     auto const block3 = make_block(3, 44, block2);
@@ -505,7 +553,7 @@ TEST_CASE("block pool parent match true", "[block pool tests]") {
 // get_path
 
 TEST_CASE("block pool get path empty self", "[block pool tests]") {
-    block_pool instance(0);
+    block_pool instance(0, test_store());
     auto const block1 = make_block(1, 42);
     auto const path = instance.get_path(block1);
     REQUIRE(path->size() == 1u);
@@ -513,7 +561,7 @@ TEST_CASE("block pool get path empty self", "[block pool tests]") {
 }
 
 TEST_CASE("block pool get path exists empty", "[block pool tests]") {
-    block_pool instance(0);
+    block_pool instance(0, test_store());
     auto const block1 = make_block(1, 42);
     instance.add(block1);
     auto const path = instance.get_path(block1);

--- a/src/blockchain/test/branch.cpp
+++ b/src/blockchain/test/branch.cpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <kth/blockchain.hpp>
+#include <kth/blockchain/validate/block_validation.hpp>
 
 using namespace kth;
 using namespace kd::message;
@@ -24,11 +25,24 @@ std::shared_ptr<block> make_test_block(uint32_t bits,
     });
 }
 
+// Owns a validation store so it outlives the branch base subobject.
+// Declared as a base initialized before `branch` (base init order = decl
+// order) so `store` is alive when the branch ctor captures a reference to it.
+struct branch_store_holder {
+    block_validation_store store;
+};
+
 // Access to protected members.
 class branch_fixture
-  : public branch
+  : public branch_store_holder
+  , public branch
 {
 public:
+    branch_fixture()
+      : branch_store_holder()
+      , branch(0, store)
+    {}
+
     size_t index_of(size_t height) const
     {
         return branch::index_of(height);
@@ -43,7 +57,8 @@ public:
 // hash
 
 TEST_CASE("branch hash default null hash", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     REQUIRE(instance.hash() == null_hash);
 }
 
@@ -52,13 +67,15 @@ TEST_CASE("branch hash one block only previous block hash", "[branch tests]") {
     auto const expected = block0->hash();
     auto const block1 = make_test_block(1u, expected);
 
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     REQUIRE(instance.push_front(block1));
     REQUIRE(instance.hash() == expected);
 }
 
 TEST_CASE("branch hash two blocks first previous block hash", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     auto const top42 = make_test_block(42u);
     auto const expected = top42->hash();
     auto const block0 = make_test_block(0u, expected);
@@ -72,13 +89,15 @@ TEST_CASE("branch hash two blocks first previous block hash", "[branch tests]") 
 // height/set_height
 
 TEST_CASE("branch height default zero", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     REQUIRE(instance.height() == 0);
 }
 
 TEST_CASE("branch set height round trip unchanged", "[branch tests]") {
     static size_t const expected = 42;
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     instance.set_height(expected);
     REQUIRE(instance.height() == expected);
 }
@@ -126,19 +145,22 @@ TEST_CASE("branch height at value expected", "[branch tests]") {
 // size
 
 TEST_CASE("branch size empty zero", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     REQUIRE(instance.size() == 0);
 }
 
 // empty
 
 TEST_CASE("branch empty default true", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     REQUIRE(instance.empty());
 }
 
 TEST_CASE("branch empty push one false", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     auto const block0 = make_test_block(0u);
     REQUIRE(instance.push_front(block0));
     REQUIRE( ! instance.empty());
@@ -147,12 +169,14 @@ TEST_CASE("branch empty push one false", "[branch tests]") {
 // blocks
 
 TEST_CASE("branch blocks default empty", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     REQUIRE(instance.blocks()->empty());
 }
 
 TEST_CASE("branch blocks one empty", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     auto const block0 = make_test_block(0u);
     REQUIRE(instance.push_front(block0));
     REQUIRE( ! instance.empty());
@@ -197,7 +221,8 @@ TEST_CASE("branch push front two unlinked link failure", "[branch tests]") {
 // top
 
 TEST_CASE("branch top default nullptr", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     REQUIRE( ! instance.top());
 }
 
@@ -215,7 +240,8 @@ TEST_CASE("branch top two blocks expected", "[branch tests]") {
 // top_height
 
 TEST_CASE("branch top height default 0", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     REQUIRE(instance.top_height() == 0u);
 }
 
@@ -236,12 +262,14 @@ TEST_CASE("branch top height two blocks expected", "[branch tests]") {
 // work
 
 TEST_CASE("branch work default zero", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     REQUIRE(instance.work() == 0);
 }
 
 TEST_CASE("branch work two blocks expected", "[branch tests]") {
-    branch instance;
+    block_validation_store store;
+    branch instance(0, store);
     auto const block0 = make_test_block(0u);
     auto const block1 = make_test_block(1u, block0->hash());
 

--- a/src/c-api/include/kth/capi/chain/block.h
+++ b/src/c-api/include/kth/capi/chain/block.h
@@ -93,9 +93,6 @@ uint8_t* kth_chain_block_to_data(kth_block_const_t self, kth_size_t* out_size);
 // Getters
 
 KTH_EXPORT
-kth_size_t kth_chain_block_signature_operations_simple(kth_block_const_t self);
-
-KTH_EXPORT
 kth_error_code_t kth_chain_block_check(kth_block_const_t self);
 
 KTH_EXPORT

--- a/src/c-api/src/chain/block.cpp
+++ b/src/c-api/src/chain/block.cpp
@@ -116,11 +116,6 @@ uint8_t* kth_chain_block_to_data(kth_block_const_t self, kth_size_t* out_size) {
 
 // Getters
 
-kth_size_t kth_chain_block_signature_operations_simple(kth_block_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::cpp_ref<cpp_t>(self).signature_operations();
-}
-
 kth_error_code_t kth_chain_block_check(kth_block_const_t self) {
     KTH_PRECONDITION(self != nullptr);
     return kth::to_c_err(kth::cpp_ref<cpp_t>(self).check());

--- a/src/database/include/kth/database/databases/header_abla_entry.hpp
+++ b/src/database/include/kth/database/databases/header_abla_entry.hpp
@@ -12,11 +12,11 @@ namespace kth::database {
 
 using header_with_abla_state_t = std::tuple<domain::chain::header, uint64_t, uint64_t, uint64_t>;
 
-data_chunk to_data_with_abla_state(domain::chain::block const& block);
+data_chunk to_data_with_abla_state(domain::chain::block const& block, domain::chain::abla::state const& abla_state);
 data_chunk to_data_header_only(domain::chain::header const& header);
 data_chunk to_data_header_with_abla_state(domain::chain::header const& header, uint64_t block_size, uint64_t control_block_size, uint64_t elastic_buffer_size);
 
-expect<void> to_data_with_abla_state(byte_writer& writer, domain::chain::block const& block);
+expect<void> to_data_with_abla_state(byte_writer& writer, domain::chain::block const& block, domain::chain::abla::state const& abla_state);
 expect<void> to_data_header_only(byte_writer& writer, domain::chain::header const& header);
 expect<void> to_data_header_with_abla_state(byte_writer& writer, domain::chain::header const& header, uint64_t block_size, uint64_t control_block_size, uint64_t elastic_buffer_size);
 

--- a/src/database/include/kth/database/databases/header_database.ipp
+++ b/src/database/include/kth/database/databases/header_database.ipp
@@ -13,9 +13,11 @@ namespace kth::database {
 #if ! defined(KTH_DB_READONLY)
 
 template <typename Clock>
-result_code internal_database_basis<Clock>::push_block_header(domain::chain::block const& block, uint32_t height, KTH_DB_txn* db_txn) {
+result_code internal_database_basis<Clock>::push_block_header(domain::chain::block const& block, domain::chain::abla::state const& abla_state, uint32_t height, KTH_DB_txn* db_txn) {
 
-    auto valuearr = to_data_with_abla_state(block);             //TODO(fernando): podría estar afuera de la DBTx
+    // The block's ABLA/chain state is no longer carried on the block value; the
+    // caller (which has the block's chain_state during organize) supplies it.
+    auto valuearr = to_data_with_abla_state(block, abla_state);             //TODO(fernando): podría estar afuera de la DBTx
     auto key = kth_db_make_value(sizeof(height), &height);
     auto value = kth_db_make_value(valuearr.size(), valuearr.data());
 

--- a/src/database/include/kth/database/databases/internal_database.hpp
+++ b/src/database/include/kth/database/databases/internal_database.hpp
@@ -227,7 +227,7 @@ private:
     // template <typename I>
     // result_code push_transactions_non_coinbase(uint32_t height, data_chunk const& fixed_data, I f, I l, bool insert_reorg, KTH_DB_txn* db_txn);
 
-    result_code push_block_header(domain::chain::block const& block, uint32_t height, KTH_DB_txn* db_txn);
+    result_code push_block_header(domain::chain::block const& block, domain::chain::abla::state const& abla_state, uint32_t height, KTH_DB_txn* db_txn);
 
     // Headers-first sync: store header only (without block data)
     result_code push_header_only(domain::chain::header const& header, uint32_t height, KTH_DB_txn* db_txn);

--- a/src/database/src/databases/header_abla_entry.cpp
+++ b/src/database/src/databases/header_abla_entry.cpp
@@ -9,11 +9,9 @@
 
 namespace kth::database {
 
-expect<void> to_data_with_abla_state(byte_writer& writer, domain::chain::block const& block) {
+expect<void> to_data_with_abla_state(byte_writer& writer, domain::chain::block const& block, domain::chain::abla::state const& abla_state) {
     if (auto r = block.header().to_data(writer, true); ! r) return r;
-    auto const a = block.validation.state
-        ? block.validation.state->abla_state()
-        : domain::chain::abla::state{};
+    auto const& a = abla_state;
     if (auto r = writer.write_little_endian<uint64_t>(a.block_size); ! r) return r;
     if (auto r = writer.write_little_endian<uint64_t>(a.control_block_size); ! r) return r;
     return writer.write_little_endian<uint64_t>(a.elastic_buffer_size);
@@ -35,11 +33,11 @@ expect<void> to_data_header_with_abla_state(byte_writer& writer, domain::chain::
     return writer.write_little_endian<uint64_t>(elastic_buffer_size);
 }
 
-data_chunk to_data_with_abla_state(domain::chain::block const& block) {
+data_chunk to_data_with_abla_state(domain::chain::block const& block, domain::chain::abla::state const& abla_state) {
     auto const size = block.header().serialized_size(true) + 8 + 8 + 8;
     data_chunk data(size);
     byte_writer writer(data);
-    auto const r = to_data_with_abla_state(writer, block);
+    auto const r = to_data_with_abla_state(writer, block, abla_state);
     KTH_ASSERT(r.has_value());
     return data;
 }

--- a/src/domain/include/kth/domain/chain/block.hpp
+++ b/src/domain/include/kth/domain/chain/block.hpp
@@ -24,7 +24,6 @@
 
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/hash.hpp>
-#include <kth/infrastructure/utility/asio.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -34,31 +33,8 @@ namespace kth::domain::chain {
 using indexes = std::vector<size_t>;
 
 struct KD_API block {
-public:
     using list = std::vector<block>;
     using indexes = std::vector<size_t>;
-
-    // THIS IS FOR LIBRARY USE ONLY, DO NOT CREATE A DEPENDENCY ON IT.
-    struct validation_t {
-        uint64_t originator = 0;
-        code error = error::not_found;
-        chain_state::ptr state = nullptr;
-
-        // Similate organization and instead just validate the block.
-        bool simulate = false;
-
-        asio::time_point start_deserialize;
-        asio::time_point end_deserialize;
-        asio::time_point start_check;
-        asio::time_point start_populate;
-        asio::time_point start_accept;
-        asio::time_point start_connect;
-        asio::time_point start_notify;
-        asio::time_point start_pop;
-        asio::time_point start_push;
-        asio::time_point end_push;
-        float cache_efficiency;
-    };
 
     // Constructors.
     //-------------------------------------------------------------------------
@@ -73,11 +49,7 @@ public:
     // Operators.
     //-------------------------------------------------------------------------
 
-    // NOTE: `==` is not `= default` because the `validation` member is
-    // tracing metadata, not part of the value's identity. `!=` is defaulted
-    // (delegates to `!(==)`) so callers that spell out the member call still
-    // resolve.
-    bool operator==(block const& x) const;
+    bool operator==(block const& x) const = default;
     bool operator!=(block const& x) const = default;
 
     // Serialization.
@@ -166,9 +138,6 @@ public:
     hash_digest generate_merkle_root() const;
 
     [[nodiscard]]
-    size_t signature_operations() const;
-
-    [[nodiscard]]
     size_t signature_operations(bool bip16, bool bip141) const;
 
     [[nodiscard]]
@@ -209,9 +178,6 @@ public:
 
     [[nodiscard]]
     code check_transactions() const;
-
-    // THIS IS FOR LIBRARY USE ONLY, DO NOT CREATE A DEPENDENCY ON IT.
-    mutable validation_t validation{};
 
     [[nodiscard]]
     size_t non_coinbase_input_count() const;

--- a/src/domain/src/chain/block.cpp
+++ b/src/domain/src/chain/block.cpp
@@ -33,7 +33,6 @@
 #include <kth/infrastructure/machine/number.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 #include <kth/infrastructure/message/message_tools.hpp>
-#include <kth/infrastructure/utility/asio.hpp>
 #include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/limits.hpp>
 
@@ -183,16 +182,11 @@ block::block(chain::header header, transaction::list transactions)
 // Operators.
 //-----------------------------------------------------------------------------
 
-bool block::operator==(block const& x) const {
-    return header_ == x.header_ && transactions_ == x.transactions_;
-}
-
 // Serialization.
 //-----------------------------------------------------------------------------
 
 // static
 expect<block> block::from_data(byte_reader& reader) {
-    auto const start_deserialize = asio::steady_clock::now();
     auto const hdr = chain::header::from_data(reader, true);
     if ( ! hdr) {
         return std::unexpected(hdr.error());
@@ -201,11 +195,7 @@ expect<block> block::from_data(byte_reader& reader) {
     if ( ! txs) {
         return std::unexpected(txs.error());
     }
-    auto const end_deserialize = asio::steady_clock::now();
-    auto res = block(*hdr, std::move(*txs));
-    res.validation.start_deserialize = start_deserialize;
-    res.validation.end_deserialize = end_deserialize;
-    return res;
+    return block(*hdr, std::move(*txs));
 }
 
 expect<void> block::to_data(byte_writer& writer) const {
@@ -382,15 +372,6 @@ size_t block::signature_operations(bool bip16, bool bip141) const {
     //*************************************************************************
     auto const& txs = transactions_;
     return std::accumulate(txs.begin(), txs.end(), size_t{0}, value);
-}
-
-// Returns max_size_t in case of overflow or unpopulated chain state.
-size_t block::signature_operations() const {
-    auto const state = validation.state;
-    auto const bip16 = state ? state->is_enabled(script_flags::bip16_rule) : true;
-    auto const bip141 = false;
-
-    return signature_operations(bip16, bip141);
 }
 
 size_t block::total_inputs(bool with_coinbase) const {
@@ -602,8 +583,6 @@ code block::check_transactions() const {
 
 // Structural validation — no context needed, no prevout cache needed.
 code block::check() const {
-    validation.start_check = asio::steady_clock::now();
-
     code ec;
     if ((ec = header_.check(chain::hash(header_), false))) {
         return ec;
@@ -614,8 +593,6 @@ code block::check() const {
 // Check block body only (skip header validation for headers-first sync).
 // Use this when headers have already been validated during header sync.
 code block::check_body() const {
-    validation.start_check = asio::steady_clock::now();
-
     if (serialized_size() > static_absolute_max_block_size()) {
         return error::block_size_limit;
     }

--- a/src/node/include/kth/node/settings.hpp
+++ b/src/node/include/kth/node/settings.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <kth/domain.hpp>
 #include <kth/infrastructure/display_mode.hpp>
+#include <kth/infrastructure/utility/asio.hpp>
 #include <kth/node/define.hpp>
 
 namespace kth::node {


### PR DESCRIPTION
`domain::chain::block` carried a `mutable validation_t validation` member (chain_state, error, timers, flags), annotated through a `const` `block_const_ptr` during organization. It mixed consensus/wire data with validator working state, forced `block` to hand-write its comparison, and kept a value type from being a pure value.

**The block value type is now pure** — `operator==` is `= default`, no `validation` member. The per-block validation state lives in a new validator-owned `block_validation_store`, keyed by block hash, owned by `block_chain`.

### Design
- `block_validation_store` wraps `boost::unordered_flat_map<hash_digest, block_validation>`, values stored **by value** (the struct is small, no per-entry allocation / allocator sync).
- **No internal mutex.** Every access is inside `block_organizer::organize()`, which holds a prioritized mutex across its `co_await`s — blocks validate one at a time (the threadpool parallelism is intra-block). That is exactly why a plain `unordered_flat_map` suffices over a concurrent one; a future concurrent design swaps in `boost::concurrent_flat_map` behind the same `get`/`find`/`erase` surface.
- `validate_block`/`populate_block` reach it via `chain_.block_validations()`; `block_pool` and `branch` take a `block_validation_store&` threaded from `block_organizer` / `populate_chain_state`.
- **Eviction** in `block_pool::remove` (accepted onto the chain) and `prune` (dropped), so the map tracks in-flight blocks rather than growing unbounded.

### Notes on dead/adjacent code
- `block_chain::last_block_` is never populated (LMDB-era vestige), so the `fetch_block` height-cache read of validation state is a dead path — migrated only so it compiles.
- `header_abla_entry::to_data_with_abla_state` now takes the `abla::state` explicitly instead of reaching into the block; its `push_block_header` caller is dead (both call sites commented out, LMDB era).
- `block::signature_operations()` with no args is a c-api convenience (consensus uses the flags-taking overload); it assumes bip16 active, matching the prior null-chain-state fallback.
- Domain `from_data`/`check` profiling-timer writes are dropped — the value type no longer self-profiles.

First member of #454 (extract mutable validation/tracing metadata out of the domain value types); `block` chosen first to prove the pattern.

**Full tree builds green** (domain, blockchain, database, network, node, c-api, all bench/test targets). Domain suite 3819 cases; blockchain suite 522 assertions / 107 cases (incl. pool eviction).