### PR TITLE
refactor(blockchain): move transaction validation metadata out of the domain type

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -34,6 +34,7 @@
 #include <kth/blockchain/populate/populate_chain_state.hpp>
 #include <kth/blockchain/settings.hpp>
 #include <kth/blockchain/validate/block_validation.hpp>
+#include <kth/blockchain/validate/transaction_validation.hpp>
 
 #include <asio/any_io_executor.hpp>
 #include <asio/awaitable.hpp>
@@ -213,6 +214,11 @@ struct KB_API block_chain {
     /// keyed by block hash. This replaces the old mutable `block::validation`
     /// member so the domain value type carries only consensus/wire data.
     block_validation_store& block_validations() const;
+
+    /// Validator-owned side store for transient per-transaction validation
+    /// state, keyed by transaction hash. Replaces the old mutable
+    /// `transaction::validation` member.
+    transaction_validation_store& transaction_validations() const;
 
     // =========================================================================
     // SUBSCRIPTIONS
@@ -475,6 +481,7 @@ private:
     // Must be declared before block_organizer_: the organizer's block_pool is
     // constructed with a reference to this store.
     mutable block_validation_store block_validations_;
+    mutable transaction_validation_store transaction_validations_;
 
     transaction_organizer transaction_organizer_;
     block_organizer block_organizer_;

--- a/src/blockchain/include/kth/blockchain/mining/mempool_v2.hpp
+++ b/src/blockchain/include/kth/blockchain/mining/mempool_v2.hpp
@@ -39,7 +39,7 @@ node make_node(domain::chain::transaction const& tx) {
 #endif
                                   , tx.to_data(true, KTH_WITNESS_DEFAULT)
                                   , tx.fees()
-                                  , tx.signature_operations()
+                                  , tx.signature_operations(true /*bip16*/, false /*bip141*/)  // BCH: P2SH always active, no segwit.
                                   , tx.outputs().size())
                         );
 }

--- a/src/blockchain/include/kth/blockchain/mining/transaction_element.1.hpp
+++ b/src/blockchain/include/kth/blockchain/mining/transaction_element.1.hpp
@@ -24,7 +24,7 @@ public:
 #endif
         , raw_(transaction_.to_data(true, KTH_WITNESS_DEFAULT))
         , fee_(transaction_.fees())
-        , sigops_(transaction_.signature_operations()) {}
+        , sigops_(transaction_.signature_operations(true /*bip16*/, false /*bip141*/)) {}  // BCH: P2SH always active, no segwit.
 
     transaction_element(domain::chain::transaction&& tx)
         : transaction_(std::move(tx))
@@ -34,7 +34,7 @@ public:
 #endif
         , raw_(transaction_.to_data(true, KTH_WITNESS_DEFAULT))
         , fee_(transaction_.fees())
-        , sigops_(transaction_.signature_operations()) {}
+        , sigops_(transaction_.signature_operations(true /*bip16*/, false /*bip141*/)) {}  // BCH: P2SH always active, no segwit.
 
     domain::chain::transaction const& transaction() const {
         return transaction_;

--- a/src/blockchain/include/kth/blockchain/pools/transaction_entry.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/transaction_entry.hpp
@@ -26,7 +26,9 @@ struct KB_API transaction_entry {
     /// Construct an entry for the pool.
     /// Never store an invalid transaction in the pool except for the cases of:
     /// double spend and input invalid due to forks change (sentinel forks).
-    transaction_entry(transaction_const_ptr tx);
+    /// `flags` are the enabled fork flags for the next block (previously read
+    /// from the tx's now-removed `validation.state`); the caller supplies them.
+    transaction_entry(transaction_const_ptr tx, domain::script_flags_t flags);
 
     /// Use this construction only as a search key.
     transaction_entry(hash_digest const& hash);

--- a/src/blockchain/include/kth/blockchain/validate/transaction_validation.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/transaction_validation.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2025 Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_VALIDATE_TRANSACTION_VALIDATION_HPP
+#define KTH_BLOCKCHAIN_VALIDATE_TRANSACTION_VALIDATION_HPP
+
+#include <kth/blockchain/validate/validation_store.hpp>
+#include <kth/domain.hpp>
+
+namespace kth::blockchain {
+
+/// Transient validation state for a transaction being validated (mempool or
+/// inside a block). This used to live as a `mutable` member on
+/// domain::chain::transaction, mixing consensus/wire data with validator
+/// working state; it now lives here, owned by the validator, keyed by tx hash.
+struct transaction_validation {
+    domain::chain::chain_state::ptr state = nullptr;
+
+    // The transaction is an unspent duplicate (BIP30).
+    bool duplicate = false;
+
+    // The unconfirmed tx is validated at the block's current fork state.
+    bool current = false;
+
+    // Simulate organization and instead just validate the transaction.
+    bool simulate = false;
+
+    // The transaction was validated before its insertion in the mempool.
+    bool validated = false;
+};
+
+/// Owns the per-transaction validation state keyed by transaction hash. See
+/// validation_store for the surface and the lifetime/concurrency contract.
+using transaction_validation_store = validation_store<transaction_validation>;
+
+} // namespace kth::blockchain
+
+#endif

--- a/src/blockchain/include/kth/blockchain/validate/validate_transaction.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/validate_transaction.hpp
@@ -55,7 +55,7 @@ protected:
     }
 
 private:
-    code connect_inputs_sync(transaction_const_ptr tx, size_t bucket, size_t buckets) const;
+    code connect_inputs_sync(transaction_const_ptr tx, domain::script_flags_t flags, size_t bucket, size_t buckets) const;
 
     // These are thread safe.
     std::atomic<bool> stopped_;

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -718,6 +718,10 @@ block_validation_store& block_chain::block_validations() const {
     return block_validations_;
 }
 
+transaction_validation_store& block_chain::transaction_validations() const {
+    return transaction_validations_;
+}
+
 code block_chain::set_chain_state(domain::chain::chain_state::ptr previous) {
     unique_lock lock(pool_state_mutex_);
     pool_state_ = chain_state_populator_.populate(previous);

--- a/src/blockchain/src/pools/block_organizer.cpp
+++ b/src/blockchain/src/pools/block_organizer.cpp
@@ -139,16 +139,32 @@ bool block_organizer::stop() {
         co_return error::orphan_block;
     }
 
+    // The transaction_validation_store holds only in-flight validation scratch:
+    // a block's txs get entries (populated during accept below) that are dead
+    // once the block leaves this organize() call, whatever the outcome. Erasing
+    // runs under the high-priority validation mutex held across this whole
+    // coroutine (the only writer of the store), so it is race-free. If an erased
+    // block is later reorganized in, the populator recreates the entries it
+    // needs (a missing entry only forces harmless re-validation, never a wrong
+    // result). This is the primary fix for the per-block-tx IBD leak.
+    auto const erase_block_tx_validations = [this](block_const_ptr const& blk) {
+        for (auto const& tx : blk->transactions()) {
+            chain_.transaction_validations().erase(tx.hash());
+        }
+    };
+
     // Checks that are dependent on chain state and prevouts.
     // For headers-first sync, use accept_body() to skip header validation.
     ec = co_await validator_.accept(branch, headers_pre_validated);
 
     if (stopped()) {
+        erase_block_tx_validations(branch->top());
         mutex_.unlock_high_priority();
         co_return error::service_stopped;
     }
 
     if (ec) {
+        erase_block_tx_validations(branch->top());
         mutex_.unlock_high_priority();
         co_return ec;
     }
@@ -157,14 +173,23 @@ bool block_organizer::stop() {
     ec = co_await validator_.connect(branch);
 
     if (stopped()) {
+        erase_block_tx_validations(branch->top());
         mutex_.unlock_high_priority();
         co_return error::service_stopped;
     }
 
     if (ec) {
+        erase_block_tx_validations(branch->top());
         mutex_.unlock_high_priority();
         co_return ec;
     }
+
+    // Validation of branch->top() is complete; nothing below reads this block's
+    // tx-validation entries again (organize_mempool reads only the incoming tx
+    // hashes and writes fresh entries for outgoing/re-added txs). Drop them here
+    // so the store never accumulates across accepted/pooled blocks. Every mined
+    // mempool tx is cleaned by this same erase when its block is accepted.
+    erase_block_tx_validations(branch->top());
 
     auto const top_hash = branch->top()->hash();
     chain_.block_validations().mutate(top_hash, [](auto& bv){ bv.error = error::success; });
@@ -407,7 +432,9 @@ void block_organizer::organize_mempool(branch::const_ptr branch, block_const_ptr
                         });
 
                         if ( ! double_spend) {
-                            tx.validation.state = chain_.chain_state();
+                            // Serial reorg re-add path (under the validation
+                            // mutex): safe to write the non-concurrent store.
+                            chain_.transaction_validations().mutate(tx.hash(), [this](auto& tv){ tv.state = chain_.chain_state(); });
                             populate_transaction_inputs(branch, tx.inputs(), branch_utxo);
                             mempool_.add(tx);       //TODO(fernando): add bulk
                         }

--- a/src/blockchain/src/pools/transaction_entry.cpp
+++ b/src/blockchain/src/pools/transaction_entry.cpp
@@ -23,13 +23,14 @@ uint32_t cap(size_t value) {
     return domain_constrain<uint32_t>(value);
 }
 
-// TODO(legacy): implement size, sigops, and fees caching on domain::chain::transaction.
-// This requires the full population of transaction.validation metadata.
-transaction_entry::transaction_entry(transaction_const_ptr tx)
+// This entry IS the cache for a transaction's size, sigops and fees; the
+// domain::chain::transaction value type deliberately holds no such state
+// (validation metadata now lives in the validator, not on the value type).
+transaction_entry::transaction_entry(transaction_const_ptr tx, script_flags_t flags)
     : size_(cap(tx->serialized_size(domain::message::version::level::canonical)))
-    , sigops_(cap(tx->signature_operations()))
+    , sigops_(cap(tx->signature_operations(true /*bip16*/, false /*bip141*/)))  // BCH: P2SH always active, no segwit.
     , fees_(tx->fees())
-    , flags_(tx->validation.state->enabled_flags())
+    , flags_(flags)
     , hash_(tx->hash())
     , marked_(false)
 {}

--- a/src/blockchain/src/pools/transaction_organizer.cpp
+++ b/src/blockchain/src/pools/transaction_organizer.cpp
@@ -100,26 +100,38 @@ bool transaction_organizer::stop() {
     }
 
     // Checks that are dependent on chain state and prevouts.
+    // NOTE: this path (c-api single-tx validate) runs lock-free, so the store
+    // entry that validator_.accept creates is written off the validation mutex.
+    // That is safe only because this path is not run concurrently with block or
+    // mempool organization (same pre-existing assumption as the accept-time
+    // insert). Erase on every exit after the entry was created so the store does
+    // not accumulate one entry per validated tx (idempotent if none was made).
     ec = co_await validator_.accept(tx);
 
     if (stopped()) {
+        chain_.transaction_validations().erase(tx->hash());
         co_return error::service_stopped;
     }
 
     if (ec) {
+        chain_.transaction_validations().erase(tx->hash());
         co_return ec;
     }
 
     if (tx->fees() < price(tx)) {
+        chain_.transaction_validations().erase(tx->hash());
         co_return error::insufficient_fee;
     }
 
     if (tx->is_dusty(settings_.minimum_output_satoshis)) {
+        chain_.transaction_validations().erase(tx->hash());
         co_return error::dusty_transaction;
     }
 
     // Checks that include script validation.
     ec = co_await validator_.connect(tx);
+
+    chain_.transaction_validations().erase(tx->hash());
 
     if (stopped()) {
         co_return error::service_stopped;
@@ -180,25 +192,39 @@ bool transaction_organizer::stop() {
         co_return ec;
     }
 
+    // The tx-validation store entry created during validator_.accept below is
+    // in-flight validation scratch: nothing reads it once this coroutine
+    // returns (a mempool tx that is later mined has its entry recreated by the
+    // block populator, and mempool eviction — including mempool_v2's internal
+    // has_room_for drop — never needs it). So erase it on every exit after it
+    // was created. All erases run under the low-priority validation mutex.
+    auto const erase_tx_validation = [this, tx] {
+        chain_.transaction_validations().erase(tx->hash());
+    };
+
     // Checks that are dependent on chain state and prevouts.
     ec = co_await validator_.accept(tx);
 
     if (stopped()) {
+        erase_tx_validation();
         mutex_.unlock_low_priority();
         co_return error::service_stopped;
     }
 
     if (ec) {
+        erase_tx_validation();
         mutex_.unlock_low_priority();
         co_return ec;
     }
 
     if (tx->fees() < price(tx)) {
+        erase_tx_validation();
         mutex_.unlock_low_priority();
         co_return error::insufficient_fee;
     }
 
     if (tx->is_dusty(settings_.minimum_output_satoshis)) {
+        erase_tx_validation();
         mutex_.unlock_low_priority();
         co_return error::dusty_transaction;
     }
@@ -207,17 +233,25 @@ bool transaction_organizer::stop() {
     ec = co_await validator_.connect(tx);
 
     if (stopped()) {
+        erase_tx_validation();
         mutex_.unlock_low_priority();
         co_return error::service_stopped;
     }
 
     if (ec) {
+        erase_tx_validation();
         mutex_.unlock_low_priority();
         co_return ec;
     }
 
     // TODO: create a simulated validation path that does not block others.
-    if (tx->validation.simulate) {
+    bool simulate = false;
+    chain_.transaction_validations().visit(tx->hash(), [&](auto const& tv){ simulate = tv.simulate; });
+
+    // Last read of the store entry; safe to drop it now for every path below.
+    erase_tx_validation();
+
+    if (simulate) {
         mutex_.unlock_low_priority();
         co_return error::success;
     }
@@ -324,7 +358,8 @@ uint64_t transaction_organizer::price(transaction_const_ptr tx) const {
     // TODO: this is a second pass on size and sigops, implement cache.
     // This at least prevents uncached calls when zero fee is configured.
     auto byte = byte_fee > 0 ? byte_fee * tx->serialized_size(true) : 0;
-    auto sigop = sigop_fee > 0 ? sigop_fee * tx->signature_operations() : 0;
+    // BCH: P2SH always active, no segwit.
+    auto sigop = sigop_fee > 0 ? sigop_fee * tx->signature_operations(true /*bip16*/, false /*bip141*/) : 0;
 
     // Require at least one satoshi per tx if there are any fees configured.
     return std::max(uint64_t(1), uint64_t(byte + sigop));

--- a/src/blockchain/src/populate/populate_base.cpp
+++ b/src/blockchain/src/populate/populate_base.cpp
@@ -26,23 +26,22 @@ populate_base::populate_base(executor_type executor, size_t threads, block_chain
 {}
 
 // This is the only necessary file system read in block/tx validation.
+// Must be called serially: it writes the tx's entry in the validator-owned
+// transaction_validation_store (non-concurrent).
 void populate_base::populate_duplicate(size_t branch_height, domain::chain::transaction const& tx, bool require_confirmed) const {
     //Knuth: We are not validating tx duplication
-    tx.validation.duplicate = false;
+    chain_.transaction_validations().mutate(tx.hash(), [](auto& tv){ tv.duplicate = false; });
 }
 
+// Must be called serially: it writes the tx's entry in the validator-owned
+// transaction_validation_store (non-concurrent).
 void populate_base::populate_pooled(domain::chain::transaction const& tx, uint32_t height) const {
-    tx.validation.pooled = false;
-    tx.validation.current = false;
+    bool current = false;
     auto const result = chain_.get_transaction_position(tx.hash(), false);
-    if ( ! result) {
-        return;
+    if (result && result->second == position_max) {
+        current = (result->first == height);
     }
-    if (result->second != position_max) {
-        return;
-    }
-    tx.validation.pooled = true;
-    tx.validation.current = (result->first == height);
+    chain_.transaction_validations().mutate(tx.hash(), [&](auto& tv){ tv.current = current; });
 }
 
 // Unspent outputs are cached by the store. If the cache is large enough this

--- a/src/blockchain/src/populate/populate_block.cpp
+++ b/src/blockchain/src/populate/populate_block.cpp
@@ -70,6 +70,32 @@ populate_block::populate_block(executor_type executor, size_t threads, block_cha
     auto validated_txs = mempool_.get_validated_txs_high();
 #endif
 
+    //-------------------------------------------------------------------------
+    // Serial pre-pass: all tx.validation flag writes.
+    //
+    // The transaction_validation_store is not concurrent, so every write to a
+    // transaction's validation entry (pooled/current/validated) must happen
+    // here, before the parallel buckets are dispatched. The buckets below only
+    // touch per-input output_point (prevout) validation, which is race-free.
+    // These flags are fully determined by mempool membership, known up front,
+    // so setting them serially is equivalent to the old per-bucket writes.
+    //-------------------------------------------------------------------------
+    {
+        auto const& txs = block->transactions();
+        // Skip the coinbase (index 0); it is handled by populate_coinbase.
+        for (size_t i = 1; i < txs.size(); ++i) {
+            auto const& tx = txs[i];
+            if (relay_transactions_) {
+                populate_base::populate_pooled(tx, state->height());
+            }
+#if defined(KTH_WITH_MEMPOOL)
+            if (validated_txs.find(tx.hash()) != validated_txs.end()) {
+                chain_.transaction_validations().mutate(tx.hash(), [](auto& tv){ tv.validated = true; });
+            }
+#endif
+        }
+    }
+
     // Use a channel to collect results from parallel tasks
     using result_channel = ::asio::experimental::concurrent_channel<void(std::error_code, code)>;
     auto channel = std::make_shared<result_channel>(executor_, buckets);
@@ -194,38 +220,11 @@ code populate_block::populate_transactions_sync(branch::const_ptr branch, size_t
     auto const& txs = block->transactions();
     size_t input_position = 0;
 
-    domain::chain::chain_state::ptr state;
-    chain_.block_validations().visit(block->hash(), [&](auto const& bv){ state = bv.state; });
-    KTH_ASSERT(state);
-
-    // Must skip coinbase here as it is already accounted for.
-    auto const first = bucket == 0 ? buckets : bucket;
-
-    for (auto position = first; position < txs.size(); position = ceiling_add(position, buckets)) {
-        auto const& tx = txs[position];
-
-        //---------------------------------------------------------------------
-        // This prevents output validation and full tx deposit respectively.
-        // The tradeoff is a read per tx that may not be cached. This is
-        // bypassed by checkpoints. This will be optimized using the tx pool.
-        // Until that time this is a material population performance hit.
-        // However the hit is necessary in preventing store tx duplication
-        // unless tx relay is disabled. In that case duplication is unlikely.
-        //---------------------------------------------------------------------
-
-        if (relay_transactions_) {
-            populate_base::populate_pooled(tx, state->height());
-        }
-
-        //*********************************************************************
-        // CONSENSUS: Satoshi implemented allow collisions in Nov 2015. This is
-        // a network upgrade that destroys unspent outputs in case of hash collision.
-        //*********************************************************************
-        //Knuth: we are not validating tx duplicates.
-        // if ( ! collide) {
-        //     populate_base::populate_duplicate(branch->height(), tx, true);
-        // }
-    }
+    // Note: the tx.validation flag writes (pooled/current/validated) that used
+    // to live here were hoisted to a serial pre-pass in populate(), because the
+    // transaction_validation_store is not concurrent. This parallel path only
+    // populates per-input prevout (output_point) validation, which is race-free
+    // across buckets.
 
     size_t first_height = branch_height + 1u;
     size_t chain_top;
@@ -240,7 +239,6 @@ code populate_block::populate_transactions_sync(branch::const_ptr branch, size_t
             auto const& inputs = tx->inputs();
             populate_transaction_inputs(branch, inputs, bucket, buckets, input_position, branch_utxo, first_height, chain_top, reorg_subset);
         } else {
-            tx->validation.validated = true;
             auto const& tx_cached = it->second.second;
             for (size_t i = 0; i < tx_cached.inputs().size(); ++i) {
                 tx->inputs()[i].previous_output().validation = tx_cached.inputs()[i].previous_output().validation;

--- a/src/blockchain/src/populate/populate_transaction.cpp
+++ b/src/blockchain/src/populate/populate_transaction.cpp
@@ -40,12 +40,13 @@ populate_transaction::populate_transaction(executor_type executor, size_t thread
 #endif
 
 ::asio::awaitable<code> populate_transaction::populate(transaction_const_ptr tx) const {
-    auto const state = tx->validation.state;
+    domain::chain::chain_state::ptr state;
+    chain_.transaction_validations().visit(tx->hash(), [&](auto const& tv){ state = tv.state; });
     KTH_ASSERT(state);
 
     // Chain state is for the next block, so always > 0.
-    KTH_ASSERT(tx->validation.state->height() > 0);
-    auto const chain_height = tx->validation.state->height() - 1u;
+    KTH_ASSERT(state->height() > 0);
+    auto const chain_height = state->height() - 1u;
 
     //*************************************************************************
     // CONSENSUS:
@@ -59,7 +60,9 @@ populate_transaction::populate_transaction(executor_type executor, size_t thread
 
     // Because txs include no proof of work we much short circuit here.
     // Otherwise a peer can flood us with repeat transactions to validate.
-    if (tx->validation.duplicate) {
+    bool duplicate = false;
+    chain_.transaction_validations().visit(tx->hash(), [&](auto const& tv){ duplicate = tv.duplicate; });
+    if (duplicate) {
         co_return error::unspent_duplicate;
     }
 

--- a/src/blockchain/src/validate/validate_block.cpp
+++ b/src/blockchain/src/validate/validate_block.cpp
@@ -261,10 +261,15 @@ code validate_block::accept_transactions_bucket(block_const_ptr block, size_t bu
     auto const count = txs.size();
 
     // Run contextual tx non-script checks (not in tx order).
+    // Reads of the transaction_validation_store here are const and race-free:
+    // all writes to it were done in the serial populate pre-pass.
     for (auto tx = bucket; tx < count && !ec; tx = ceiling_add(tx, buckets)) {
         auto const& transaction = txs[tx];
-        if ( ! transaction.validation.validated) {
-            ec = transaction.accept(flags, height, mtp, max_sigops, under_checkpoint, false /*transaction_pool*/);
+        bool validated = false;
+        bool duplicate = false;
+        chain_.transaction_validations().visit(transaction.hash(), [&](auto const& tv){ validated = tv.validated; duplicate = tv.duplicate; });
+        if ( ! validated) {
+            ec = transaction.accept(flags, height, mtp, max_sigops, under_checkpoint, false /*transaction_pool*/, duplicate);
         }
         *sigops += transaction.signature_operations(bip16, bip141);
     }
@@ -340,13 +345,17 @@ code validate_block::connect_inputs_bucket(block_const_ptr block, size_t bucket,
 
     // Must skip coinbase here as it is already accounted for.
     for (auto tx = txs.begin() + 1; tx != txs.end(); ++tx) {
+        bool current = false;
+        bool validated = false;
+        chain_.transaction_validations().visit(tx->hash(), [&](auto const& tv){ current = tv.current; validated = tv.validated; });
+
         // The tx is pooled with current fork state so outputs are validated.
-        if (tx->validation.current) {
+        if (current) {
             continue;
         }
 
         // The tx was validated before its insertion in the mempool
-        if (tx->validation.validated) {
+        if (validated) {
             continue;
         }
 

--- a/src/blockchain/src/validate/validate_transaction.cpp
+++ b/src/blockchain/src/validate/validate_transaction.cpp
@@ -28,6 +28,7 @@ namespace kth::blockchain {
 using namespace kd::chain;
 using namespace kd::machine;
 using namespace std::placeholders;
+using kd::script_flags_t;
 
 #define NAME "validate_transaction"
 
@@ -83,10 +84,15 @@ void validate_transaction::stop()
 
 ::asio::awaitable<code> validate_transaction::accept(transaction_const_ptr tx) const {
     // Populate chain state of the next block (tx pool).
-    tx->validation.state = chain_.chain_state();
-
-    if ( ! tx->validation.state) {
-        co_return error::transaction_validation_state_failed;
+    // NOTE: on the transaction_validate (c-api single-tx validate) path this
+    // store write happens off the organizer mutex, but the tx is private to
+    // the caller so no other worker touches this hash concurrently.
+    {
+        auto const state = chain_.chain_state();
+        chain_.transaction_validations().mutate(tx->hash(), [&](auto& tv){ tv.state = state; });
+        if ( ! state) {
+            co_return error::transaction_validation_state_failed;
+        }
     }
 
     auto const populate_ec = co_await transaction_populator_.populate(tx);
@@ -99,8 +105,11 @@ void validate_transaction::stop()
         co_return populate_ec;
     }
 
-    KTH_ASSERT(tx->validation.state);
-    auto const& state = *tx->validation.state;
+    domain::chain::chain_state::ptr state_ptr;
+    bool duplicate = false;
+    chain_.transaction_validations().visit(tx->hash(), [&](auto const& tv){ state_ptr = tv.state; duplicate = tv.duplicate; });
+    KTH_ASSERT(state_ptr);
+    auto const& state = *state_ptr;
 
     // Run contextual tx checks.
     co_return tx->accept(
@@ -111,7 +120,8 @@ void validate_transaction::stop()
             ? state.dynamic_max_block_sigops()
             : static_max_block_sigops(state.network()),
         state.is_under_checkpoint(),
-        true /*transaction_pool*/
+        true /*transaction_pool*/,
+        duplicate
     );
 }
 
@@ -120,7 +130,10 @@ void validate_transaction::stop()
 // These checks require chain state, block state and perform script validation.
 
 ::asio::awaitable<code> validate_transaction::connect(transaction_const_ptr tx) const {
-    KTH_ASSERT(tx->validation.state);
+    domain::chain::chain_state::ptr state_ptr;
+    chain_.transaction_validations().visit(tx->hash(), [&](auto const& tv){ state_ptr = tv.state; });
+    KTH_ASSERT(state_ptr);
+    auto const flags = state_ptr->enabled_flags();
     auto const total_inputs = tx->inputs().size();
 
     // Return if there are no inputs to validate (will fail later).
@@ -137,8 +150,8 @@ void validate_transaction::stop()
 
     // Launch parallel tasks
     for (size_t bucket = 0; bucket < buckets; ++bucket) {
-        ::asio::post(executor_, [this, tx, bucket, buckets, channel]() {
-            auto result = connect_inputs_sync(tx, bucket, buckets);
+        ::asio::post(executor_, [this, tx, flags, bucket, buckets, channel]() {
+            auto result = connect_inputs_sync(tx, flags, bucket, buckets);
             channel->try_send(std::error_code{}, result);
         });
     }
@@ -159,14 +172,13 @@ void validate_transaction::stop()
     co_return final_result;
 }
 
-code validate_transaction::connect_inputs_sync(transaction_const_ptr tx, size_t bucket, size_t buckets) const {
+code validate_transaction::connect_inputs_sync(transaction_const_ptr tx, script_flags_t flags, size_t bucket, size_t buckets) const {
     KTH_ASSERT(bucket < buckets);
 
 #if defined(KTH_CURRENCY_BCH)
     size_t tx_sigchecks = 0;
 #endif
 
-    auto const flags = tx->validation.state->enabled_flags();
     auto const& inputs = tx->inputs();
 
     for (auto input_index = bucket; input_index < inputs.size(); input_index = ceiling_add(input_index, buckets)) {

--- a/src/blockchain/test/mempool_tests.cpp
+++ b/src/blockchain/test/mempool_tests.cpp
@@ -20,35 +20,19 @@ hash_digest hash_one   {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 hash_digest hash_two   {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2};
 hash_digest hash_three {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3};
 
-static chain_state::data get_data() {
-    chain_state::data value;
-    value.height = 1;
-    value.bits = { 0, { 0 } };
-    value.version = { 1, { 0 } };
-    value.timestamp = { 0, 0, { 0 } };
-    return value;
-}
-
-void add_state(transaction& tx) {
-    tx.validation.state = std::make_shared<chain_state>(
-#if defined(KTH_CURRENCY_BCH)
-        chain_state{ get_data(), {}, 0, 0, 0 });
-#else
-        chain_state{ get_data(), {}, 0 });
-#endif //KTH_CURRENCY_BCH
-}
+// The tx.validation.state member was removed; the mempool does not read per-tx
+// chain state, so the old add_state()/get_data() helpers are gone. Sigops are
+// counted with BIP16 assumed active (see transaction::signature_operations()).
 
 transaction get_tx(std::string const& hex) {
     auto const data = decode_base16(hex);
     auto tx = transaction::factory_from_data(*data);
-    add_state(tx);
     return tx;
 }
 
 transaction get_tx_from_mempool(mining::mempool const& mp, std::unordered_map<domain::chain::point, domain::chain::output> const& internal_utxo, std::string const& hex) {
     auto const data = decode_base16(hex);
     auto tx = transaction::factory_from_data(*data);
-    add_state(tx);
 
     for (auto& i : tx.inputs()) {
         auto o = mp.get_utxo(i.previous_output());
@@ -226,17 +210,14 @@ TEST_CASE("[mempool] chained transactions") {
 TEST_CASE("[mempool] replace TX Candidate for a better one") {
 
     transaction coinbase0 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{17, script{}}}};
-    add_state(coinbase0);
     REQUIRE(coinbase0.is_valid());
     REQUIRE(coinbase0.is_coinbase());
 
     transaction coinbase1 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{34, script{}}}};
-    add_state(coinbase1);
     REQUIRE(coinbase1.is_valid());
     REQUIRE(coinbase1.is_coinbase());
 
     transaction spender0 {1, 1, {input{output_point{coinbase0.hash(), 0}, script{}, 1}}, {output{10, script{}}}};
-    add_state(spender0);
     spender0.inputs()[0].previous_output().validation.cache = coinbase0.outputs()[0];
     spender0.inputs()[0].previous_output().validation.from_mempool = false;
 
@@ -244,7 +225,6 @@ TEST_CASE("[mempool] replace TX Candidate for a better one") {
     REQUIRE(spender0.fees() == 7);
 
     transaction spender1 {1, 1, {input{output_point{coinbase1.hash(), 0}, script{}, 1}}, {output{10, script{}}}};
-    add_state(spender1);
     spender1.inputs()[0].previous_output().validation.cache = coinbase1.outputs()[0];
     spender1.inputs()[0].previous_output().validation.from_mempool = false;
 
@@ -275,17 +255,14 @@ TEST_CASE("[mempool] replace TX Candidate for a better one") {
 TEST_CASE("[mempool] Try to insert a Low Benefit Transaction") {
 
     transaction coinbase0 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{17, script{}}}};
-    add_state(coinbase0);
     REQUIRE(coinbase0.is_valid());
     REQUIRE(coinbase0.is_coinbase());
 
     transaction coinbase1 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{34, script{}}}};
-    add_state(coinbase1);
     REQUIRE(coinbase1.is_valid());
     REQUIRE(coinbase1.is_coinbase());
 
     transaction spender0 {1, 1, {input{output_point{coinbase0.hash(), 0}, script{}, 1}}, {output{10, script{}}}};
-    add_state(spender0);
     spender0.inputs()[0].previous_output().validation.cache = coinbase0.outputs()[0];
     spender0.inputs()[0].previous_output().validation.from_mempool = false;
 
@@ -293,7 +270,6 @@ TEST_CASE("[mempool] Try to insert a Low Benefit Transaction") {
     REQUIRE(spender0.fees() == 7);
 
     transaction spender1 {1, 1, {input{output_point{coinbase1.hash(), 0}, script{}, 1}}, {output{33, script{}}}};
-    add_state(spender1);
     spender1.inputs()[0].previous_output().validation.cache = coinbase1.outputs()[0];
     spender1.inputs()[0].previous_output().validation.from_mempool = false;
 
@@ -330,33 +306,28 @@ TEST_CASE("[mempool] Try to insert a Low Benefit Transaction") {
 TEST_CASE("[mempool] Dependencies 0") {
 
     transaction coinbase0 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{50, script{}}}};
-    add_state(coinbase0);
     REQUIRE(coinbase0.is_valid());
     REQUIRE(coinbase0.is_coinbase());
 
     transaction a {1, 1, {input{output_point{coinbase0.hash(), 0}, script{}, 1}}, {output{40, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = coinbase0.outputs()[0];
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 10);
 
     transaction b {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{31, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
     REQUIRE(b.fees() == 9);
 
     transaction c {1, 1, {input{output_point{b.hash(), 0}, script{}, 1}}, {output{23, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = b.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
     REQUIRE(c.fees() == 8);
 
     transaction d {1, 1, {input{output_point{c.hash(), 0}, script{}, 1}}, {output{16, script{}}}};
-    add_state(d);
     d.inputs()[0].previous_output().validation.cache = c.outputs()[0];
     d.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(d.is_valid());
@@ -396,33 +367,28 @@ TEST_CASE("[mempool] Dependencies 0") {
 TEST_CASE("[mempool] Dependencies 1") {
 
     transaction coinbase0 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{50, script{}}}};
-    add_state(coinbase0);
     REQUIRE(coinbase0.is_valid());
     REQUIRE(coinbase0.is_coinbase());
 
     transaction a {1, 1, {input{output_point{coinbase0.hash(), 0}, script{}, 1}}, {output{43, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = coinbase0.outputs()[0];
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 7);
 
     transaction b {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{35, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
     REQUIRE(b.fees() == 8);
 
     transaction c {1, 1, {input{output_point{b.hash(), 0}, script{}, 1}}, {output{26, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = b.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
     REQUIRE(c.fees() == 9);
 
     transaction d {1, 1, {input{output_point{c.hash(), 0}, script{}, 1}}, {output{16, script{}}}};
-    add_state(d);
     d.inputs()[0].previous_output().validation.cache = c.outputs()[0];
     d.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(d.is_valid());
@@ -464,33 +430,28 @@ TEST_CASE("[mempool] Dependencies 1") {
 TEST_CASE("[mempool] Dependencies 2") {
 
     transaction coinbase0 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{50, script{}}}};
-    add_state(coinbase0);
     REQUIRE(coinbase0.is_valid());
     REQUIRE(coinbase0.is_coinbase());
 
     transaction a {1, 1, {input{output_point{coinbase0.hash(), 0}, script{}, 1}}, {output{43, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = coinbase0.outputs()[0];
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 7);
 
     transaction b {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{35, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
     REQUIRE(b.fees() == 8);
 
     transaction c {1, 1, {input{output_point{b.hash(), 0}, script{}, 1}}, {output{26, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = b.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
     REQUIRE(c.fees() == 9);
 
     transaction d {1, 1, {input{output_point{c.hash(), 0}, script{}, 1}}, {output{16, script{}}}};
-    add_state(d);
     d.inputs()[0].previous_output().validation.cache = c.outputs()[0];
     d.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(d.is_valid());
@@ -515,7 +476,6 @@ TEST_CASE("[mempool] Dependencies 2") {
     }
 
     transaction e {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{15, script{}}}};
-    add_state(e);
     e.inputs()[0].previous_output().validation.cache = output{26, script{}};
     e.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(e.is_valid());
@@ -554,19 +514,16 @@ TEST_CASE("[mempool] Dependencies 2") {
 TEST_CASE("[mempool] Dependencies 3") {
 
     transaction coinbase0 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{50, script{}}}};
-    add_state(coinbase0);
     REQUIRE(coinbase0.is_valid());
     REQUIRE(coinbase0.is_coinbase());
 
     transaction a {1, 1, {input{output_point{coinbase0.hash(), 0}, script{}, 1}}, {output{43, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = coinbase0.outputs()[0];
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 7);
 
     transaction b {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{35, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
@@ -588,7 +545,6 @@ TEST_CASE("[mempool] Dependencies 3") {
     }
 
     transaction z {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{19, script{}}}};
-    add_state(z);
     z.inputs()[0].previous_output().validation.cache = output{26, script{}};
     z.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(z.is_valid());
@@ -607,7 +563,6 @@ TEST_CASE("[mempool] Dependencies 3") {
     }
 
     transaction c {1, 1, {input{output_point{b.hash(), 0}, script{}, 1}}, {output{34, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = b.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
@@ -638,21 +593,18 @@ TEST_CASE("[mempool] Dependencies 3") {
 TEST_CASE("[mempool] Dependencies 4") {
 
     transaction x {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{48, script{}}}};
-    add_state(x);
     x.inputs()[0].previous_output().validation.cache = output{50, script{}};
     x.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(x.is_valid());
     REQUIRE(x.fees() == 2);
 
     transaction y {1, 1, {input{output_point{hash_one, 0}, script{}, 1}}, {output{49, script{}}}};
-    add_state(y);
     y.inputs()[0].previous_output().validation.cache = output{50, script{}};
     y.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(y.is_valid());
     REQUIRE(y.fees() == 1);
 
     transaction z {1, 1, {input{output_point{hash_two, 0}, script{}, 1}}, {output{47, script{}}}};
-    add_state(z);
     z.inputs()[0].previous_output().validation.cache = output{50, script{}};
     z.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(z.is_valid());
@@ -677,14 +629,12 @@ TEST_CASE("[mempool] Dependencies 4") {
 
 
     transaction a {1, 1, {input{output_point{hash_three, 0}, script{}, 1}}, {output{50, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = output{50, script{}};
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 0);
 
     transaction b {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{50, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
@@ -712,7 +662,6 @@ TEST_CASE("[mempool] Dependencies 4") {
 
 
     transaction c {1, 1, {input{output_point{b.hash(), 0}, script{}, 1}}, {output{40, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = b.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
@@ -755,21 +704,18 @@ TEST_CASE("[mempool] Dependencies 4") {
 TEST_CASE("[mempool] Dependencies 4b") {
 
     transaction x {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{48, script{}}}};
-    add_state(x);
     x.inputs()[0].previous_output().validation.cache = output{50, script{}};
     x.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(x.is_valid());
     REQUIRE(x.fees() == 2);
 
     transaction y {1, 1, {input{output_point{x.hash(), 0}, script{}, 1}}, {output{47, script{}}}};
-    add_state(y);
     y.inputs()[0].previous_output().validation.cache = x.outputs()[0];
     y.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(y.is_valid());
     REQUIRE(y.fees() == 1);
 
     transaction z {1, 1, {input{output_point{y.hash(), 0}, script{}, 1}}, {output{44, script{}}}};
-    add_state(z);
     z.inputs()[0].previous_output().validation.cache = y.outputs()[0];
     z.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(z.is_valid());
@@ -797,14 +743,12 @@ TEST_CASE("[mempool] Dependencies 4b") {
 
 
     transaction a {1, 1, {input{output_point{hash_one, 0}, script{}, 1}}, {output{50, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = output{50, script{}};
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 0);
 
     transaction b {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{50, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
@@ -833,7 +777,6 @@ TEST_CASE("[mempool] Dependencies 4b") {
     // }
 
     transaction c {1, 1, {input{output_point{b.hash(), 0}, script{}, 1}}, {output{40, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = b.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
@@ -878,21 +821,18 @@ TEST_CASE("[mempool] Dependencies 4b") {
 TEST_CASE("[mempool] Dependencies 5") {
 
     transaction a {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{40, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = output{50, script{}};
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 10);
 
     transaction b {1, 1, {input{output_point{hash_one, 0}, script{}, 1}}, {output{41, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = output{50, script{}};
     b.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(b.is_valid());
     REQUIRE(b.fees() == 9);
 
     transaction c {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{39, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
@@ -940,21 +880,18 @@ TEST_CASE("[mempool] Dependencies 5") {
 TEST_CASE("[mempool] Dependencies 6") {
 
     transaction a {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{40, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = output{50, script{}};
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 10);
 
     transaction b {1, 1, {input{output_point{hash_one, 0}, script{}, 1}}, {output{41, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = output{50, script{}};
     b.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(b.is_valid());
     REQUIRE(b.fees() == 9);
 
     transaction c {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{39, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
@@ -1003,7 +940,6 @@ TEST_CASE("[mempool] Dependencies 7 - what_to_insert") {
     transaction a {1, 1, { input{output_point{null_hash, 0}, script{}, 1} },
                          { output{40, script{}}, output{30, script{}} }
                   };
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = output{90, script{}};
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
@@ -1016,7 +952,6 @@ TEST_CASE("[mempool] Dependencies 7 - what_to_insert") {
     transaction b {1, 1, { input{output_point{a.hash(), 0}, script{}, 1} },
                          {output{30, script{}}}
                   };
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
@@ -1029,7 +964,6 @@ TEST_CASE("[mempool] Dependencies 7 - what_to_insert") {
     transaction c {1, 1, { input{output_point{a.hash(), 1}, script{}, 1} },
                          { output{20, script{}} }
                   };
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = a.outputs()[1];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
@@ -1043,7 +977,6 @@ TEST_CASE("[mempool] Dependencies 7 - what_to_insert") {
                            input{output_point{c.hash(), 0}, script{}, 1} },
                          { output{20, script{}} }
                   };
-    add_state(d);
     d.inputs()[0].previous_output().validation.cache = b.outputs()[0];
     d.inputs()[0].previous_output().validation.from_mempool = true;
     d.inputs()[1].previous_output().validation.cache = c.outputs()[0];
@@ -1098,21 +1031,18 @@ TEST_CASE("[mempool] Dependencies 7 - what_to_insert") {
 TEST_CASE("[mempool] Double Spend Mempool") {
 
     transaction a {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{40, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = output{50, script{}};
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 10);
 
     transaction b {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{31, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
     REQUIRE(b.fees() == 9);
 
     transaction c {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{30, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
@@ -1136,14 +1066,12 @@ TEST_CASE("[mempool] Double Spend Mempool") {
 TEST_CASE("[mempool] Double Spend Blockchain") {
 
     transaction a {1, 1, {input{output_point{hash_one, 0}, script{}, 1}}, {output{40, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = output{50, script{}};
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 10);
 
     transaction b {1, 1, {input{output_point{hash_one, 0}, script{}, 1}}, {output{41, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = output{50, script{}};
     b.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(b.is_valid());
@@ -1209,21 +1137,18 @@ D       C
 
 TEST_CASE("[mempool] Remove Transactions 0") {
     transaction x {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{48, script{}}}};
-    add_state(x);
     x.inputs()[0].previous_output().validation.cache = output{50, script{}};
     x.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(x.is_valid());
     REQUIRE(x.fees() == 2);
 
     transaction y {1, 1, {input{output_point{hash_one, 0}, script{}, 1}}, {output{49, script{}}}};
-    add_state(y);
     y.inputs()[0].previous_output().validation.cache = output{50, script{}};
     y.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(y.is_valid());
     REQUIRE(y.fees() == 1);
 
     transaction z {1, 1, {input{output_point{hash_two, 0}, script{}, 1}}, {output{47, script{}}}};
-    add_state(z);
     z.inputs()[0].previous_output().validation.cache = output{50, script{}};
     z.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(z.is_valid());
@@ -1264,21 +1189,18 @@ TEST_CASE("[mempool] Remove Transactions 0") {
 
 TEST_CASE("[mempool] Remove Transactions 1") {
     transaction x {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{48, script{}}}};
-    add_state(x);
     x.inputs()[0].previous_output().validation.cache = output{50, script{}};
     x.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(x.is_valid());
     REQUIRE(x.fees() == 2);
 
     transaction y {1, 1, {input{output_point{hash_one, 0}, script{}, 1}}, {output{49, script{}}}};
-    add_state(y);
     y.inputs()[0].previous_output().validation.cache = output{50, script{}};
     y.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(y.is_valid());
     REQUIRE(y.fees() == 1);
 
     transaction z {1, 1, {input{output_point{hash_two, 0}, script{}, 1}}, {output{47, script{}}}};
-    add_state(z);
     z.inputs()[0].previous_output().validation.cache = output{50, script{}};
     z.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(z.is_valid());
@@ -1318,21 +1240,18 @@ TEST_CASE("[mempool] Remove Transactions 1") {
 
 TEST_CASE("[mempool] Remove Transactions 2") {
     transaction x {1, 1, {input{output_point{null_hash, 0}, script{}, 1}}, {output{48, script{}}}};
-    add_state(x);
     x.inputs()[0].previous_output().validation.cache = output{50, script{}};
     x.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(x.is_valid());
     REQUIRE(x.fees() == 2);
 
     transaction y {1, 1, {input{output_point{hash_one, 0}, script{}, 1}}, {output{49, script{}}}};
-    add_state(y);
     y.inputs()[0].previous_output().validation.cache = output{50, script{}};
     y.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(y.is_valid());
     REQUIRE(y.fees() == 1);
 
     transaction z {1, 1, {input{output_point{y.hash(), 0}, script{}, 1}}, {output{47, script{}}}};
-    add_state(z);
     z.inputs()[0].previous_output().validation.cache = y.outputs()[0];
     z.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(z.is_valid());
@@ -1356,7 +1275,6 @@ TEST_CASE("[mempool] Remove Transactions 2") {
 
 
     transaction w {1, 1, {input{output_point{y.hash(), 0}, script{}, 1}}, {output{46, script{}}}};
-    add_state(w);
     w.inputs()[0].previous_output().validation.cache = y.outputs()[0];
     w.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(w.is_valid());
@@ -2490,33 +2408,28 @@ TEST_CASE("[mempool] testnet case 3") {
 TEST_CASE("[mempool] GetBlockTemplate CTOR/LTOR") {
 
     transaction coinbase0 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{50, script{}}}};
-    add_state(coinbase0);
     REQUIRE(coinbase0.is_valid());
     REQUIRE(coinbase0.is_coinbase());
 
     transaction a {1, 1, {input{output_point{coinbase0.hash(), 0}, script{}, 1}}, {output{40, script{}}}};
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = coinbase0.outputs()[0];
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 10);
 
     transaction b {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{15, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
     REQUIRE(b.fees() == 25);
 
     transaction c {1, 1, {input{output_point{b.hash(), 0}, script{}, 1}}, {output{14, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = b.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
     REQUIRE(c.fees() == 1);
 
     transaction d {1, 1, {input{output_point{c.hash(), 0}, script{}, 1}}, {output{7, script{}}}};
-    add_state(d);
     d.inputs()[0].previous_output().validation.cache = c.outputs()[0];
     d.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(d.is_valid());
@@ -2991,33 +2904,28 @@ TEST_CASE("[mempool] GetBlockTemplate CTOR/LTOR 2 - testnet case 2") {
 TEST_CASE("[mempool] GetBlockTemplate CTOR/LTOR 3 - Dependencies graph") {
 
     transaction coinbase0 {1, 1, {input{output_point{null_hash, point::null_index}, script{}, 1}}, {output{50, script{}}}};
-    add_state(coinbase0);
     REQUIRE(coinbase0.is_valid());
     REQUIRE(coinbase0.is_coinbase());
 
     transaction a {1, 1, {input{output_point{coinbase0.hash(), 0}, script{}, 1}}, { output{25, script{}}, output{15, script{}}} };
-    add_state(a);
     a.inputs()[0].previous_output().validation.cache = coinbase0.outputs()[0];
     a.inputs()[0].previous_output().validation.from_mempool = false;
     REQUIRE(a.is_valid());
     REQUIRE(a.fees() == 10);
 
     transaction b {1, 1, {input{output_point{a.hash(), 0}, script{}, 1}}, {output{10, script{}}, output{14, script{}}}};
-    add_state(b);
     b.inputs()[0].previous_output().validation.cache = a.outputs()[0];
     b.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(b.is_valid());
     REQUIRE(b.fees() == 1);
 
     transaction c {1, 1, {input{output_point{b.hash(), 0}, script{}, 1}}, {output{2, script{}}}};
-    add_state(c);
     c.inputs()[0].previous_output().validation.cache = b.outputs()[0];
     c.inputs()[0].previous_output().validation.from_mempool = true;
     REQUIRE(c.is_valid());
     REQUIRE(c.fees() == 8);
 
     transaction d {1, 1, {input{output_point{b.hash(), 1}, script{}, 1} ,input{output_point{c.hash(), 0}, script{}, 1}}, {output{11, script{}}}};
-    add_state(d);
     d.inputs()[0].previous_output().validation.cache = b.outputs()[1];
     d.inputs()[0].previous_output().validation.from_mempool = true;
     d.inputs()[1].previous_output().validation.cache = c.outputs()[0];
@@ -3026,7 +2934,6 @@ TEST_CASE("[mempool] GetBlockTemplate CTOR/LTOR 3 - Dependencies graph") {
     REQUIRE(d.fees() == 5);
 
     transaction e {1, 1, { input{output_point{a.hash(), 1}, script{}, 1}, input{output_point{d.hash(), 0}, script{}, 1}}, {output{1, script{}}}};
-    add_state(e);
     e.inputs()[0].previous_output().validation.cache = a.outputs()[1];
     e.inputs()[0].previous_output().validation.from_mempool = true;
     e.inputs()[1].previous_output().validation.cache = d.outputs()[0];

--- a/src/blockchain/test/transaction_entry.cpp
+++ b/src/blockchain/test/transaction_entry.cpp
@@ -31,29 +31,35 @@ chain_state::data data() {
 
 static
 transaction_const_ptr make_tx() {
-    auto const tx = std::make_shared<const domain::message::transaction>();
-    tx->validation.state = std::make_shared<chain_state>(
+    return std::make_shared<const domain::message::transaction>();
+}
+
+// The transaction_entry ctor used to read the enabled fork flags off the tx's
+// `validation.state`; that member was removed, so the flags are supplied by the
+// caller. This mirrors the old testnet4 chain_state so `flags()` stays non-zero.
+static
+domain::script_flags_t test_flags() {
+    auto const state = std::make_shared<chain_state>(
 #if defined(KTH_CURRENCY_BCH)
         chain_state {
-            data(), 
-            0, 
-            {}, 
-            domain::config::network::testnet4, 
-            domain::chain::chain_state::assert_anchor_block_info_t{}, 
-            0, 
+            data(),
+            0,
+            {},
+            domain::config::network::testnet4,
+            domain::chain::chain_state::assert_anchor_block_info_t{},
+            0,
             abla::config{},
             kth::cantor_t(0)
         });
 #else
         chain_state {data(), 0, {}});
 #endif //KTH_CURRENCY_BCH
-
-    return tx;
+    return state->enabled_flags();
 }
 
 static
 transaction_entry::ptr make_instance() {
-    return std::make_shared<transaction_entry>(transaction_entry(make_tx()));
+    return std::make_shared<transaction_entry>(transaction_entry(make_tx(), test_flags()));
 }
 
 // TODO: add populated tx and test property values.
@@ -61,7 +67,7 @@ transaction_entry::ptr make_instance() {
 // construct1/tx
 
 TEST_CASE("transaction entry construct1 default tx expected values", "[transaction entry tests]") {
-    transaction_entry const instance(make_tx());
+    transaction_entry const instance(make_tx(), test_flags());
     REQUIRE(instance.is_anchor());
     REQUIRE(instance.fees() == 0);
     // flags() pulls from chain_state::enabled_flags(); on testnet4 every
@@ -94,14 +100,14 @@ TEST_CASE("transaction entry construct1 default block hash expected values", "[t
 // is_anchor
 
 TEST_CASE("transaction entry is anchor parents false", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     auto const parent = make_instance();
     instance.add_parent(parent);
     REQUIRE( ! instance.is_anchor());
 }
 
 TEST_CASE("transaction entry is anchor children true", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     auto const child = make_instance();
     instance.add_child(child);
     REQUIRE(instance.is_anchor());
@@ -110,13 +116,13 @@ TEST_CASE("transaction entry is anchor children true", "[transaction entry tests
 // mark
 
 TEST_CASE("transaction entry mark true expected", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     instance.mark(true);
     REQUIRE(instance.is_marked());
 }
 
 TEST_CASE("transaction entry mark true false expected", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     instance.mark(true);
     instance.mark(false);
     REQUIRE( ! instance.is_marked());
@@ -125,12 +131,12 @@ TEST_CASE("transaction entry mark true false expected", "[transaction entry test
 // is_marked
 
 TEST_CASE("transaction entry mark default false", "[transaction entry tests]") {
-    transaction_entry const instance(make_tx());
+    transaction_entry const instance(make_tx(), test_flags());
     REQUIRE( ! instance.is_marked());
 }
 
 TEST_CASE("transaction entry is marked true true", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     instance.mark(true);
     REQUIRE(instance.is_marked());
 }
@@ -138,7 +144,7 @@ TEST_CASE("transaction entry is marked true true", "[transaction entry tests]") 
 // add_parent
 
 TEST_CASE("transaction entry add parent one expected parents", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     auto const parent = make_instance();
     instance.add_parent(parent);
     REQUIRE(instance.parents().size() == 1u);
@@ -148,7 +154,7 @@ TEST_CASE("transaction entry add parent one expected parents", "[transaction ent
 // add_child
 
 TEST_CASE("transaction entry add child one expected children", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     auto const child = make_instance();
     instance.add_child(child);
     REQUIRE(instance.children().size() == 1u);
@@ -158,14 +164,14 @@ TEST_CASE("transaction entry add child one expected children", "[transaction ent
 // remove_child
 
 TEST_CASE("transaction entry remove child not found empty", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     auto const child = make_instance();
     instance.remove_child(child);
     REQUIRE(instance.children().empty());
 }
 
 TEST_CASE("transaction entry remove child only found empty", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     auto const child = make_instance();
     instance.add_child(child);
     REQUIRE(instance.children().size() == 1u);
@@ -174,7 +180,7 @@ TEST_CASE("transaction entry remove child only found empty", "[transaction entry
 }
 
 TEST_CASE("transaction entry remove child one of two expected one remains", "[transaction entry tests]") {
-    transaction_entry instance(make_tx());
+    transaction_entry instance(make_tx(), test_flags());
     auto const child1 = make_instance();
     auto const child2 = make_instance();
     instance.add_child(child1);

--- a/src/c-api/include/kth/capi/chain/transaction.h
+++ b/src/c-api/include/kth/capi/chain/transaction.h
@@ -123,12 +123,6 @@ uint64_t kth_chain_transaction_total_input_value(kth_transaction_const_t self);
 KTH_EXPORT
 uint64_t kth_chain_transaction_total_output_value(kth_transaction_const_t self);
 
-KTH_EXPORT
-kth_size_t kth_chain_transaction_signature_operations_simple(kth_transaction_const_t self);
-
-KTH_EXPORT
-kth_error_code_t kth_chain_transaction_connect_simple(kth_transaction_const_t self);
-
 
 // Predicates
 
@@ -190,7 +184,7 @@ KTH_EXPORT
 kth_size_t kth_chain_transaction_min_tx_size(kth_transaction_const_t self, kth_script_flags_t flags);
 
 KTH_EXPORT
-kth_error_code_t kth_chain_transaction_accept(kth_transaction_const_t self, kth_script_flags_t flags, kth_size_t height, uint32_t median_time_past, kth_size_t max_sigops, kth_bool_t is_under_checkpoint, kth_bool_t transaction_pool);
+kth_error_code_t kth_chain_transaction_accept(kth_transaction_const_t self, kth_script_flags_t flags, kth_size_t height, uint32_t median_time_past, kth_size_t max_sigops, kth_bool_t is_under_checkpoint, kth_bool_t transaction_pool, kth_bool_t duplicate);
 
 KTH_EXPORT
 kth_error_code_t kth_chain_transaction_connect(kth_transaction_const_t self, kth_chain_state_const_t state);

--- a/src/c-api/src/chain/chain_other.cpp
+++ b/src/c-api/src/chain/chain_other.cpp
@@ -183,9 +183,11 @@ void kth_chain_transaction_validate_sequential(kth_chain_t chain, void* ctx, kth
     if (handler == nullptr) return;
 
     auto tx_cpp = tx_shared(tx);
-    tx_cpp->validation.simulate = true;
 
     auto& bc = safe_chain(chain);
+    // `simulate` moved off the transaction value type into the validator's
+    // per-tx store; set it there before organizing.
+    bc.transaction_validations().mutate(tx_cpp->hash(), [](auto& tv){ tv.simulate = true; });
     ::asio::co_spawn(bc.executor(), [&bc, tx_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
         auto ec = co_await bc.organize(tx_cpp);
         if (ec) {

--- a/src/c-api/src/chain/transaction.cpp
+++ b/src/c-api/src/chain/transaction.cpp
@@ -174,16 +174,6 @@ uint64_t kth_chain_transaction_total_output_value(kth_transaction_const_t self) 
     return kth::cpp_ref<cpp_t>(self).total_output_value();
 }
 
-kth_size_t kth_chain_transaction_signature_operations_simple(kth_transaction_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::cpp_ref<cpp_t>(self).signature_operations();
-}
-
-kth_error_code_t kth_chain_transaction_connect_simple(kth_transaction_const_t self) {
-    KTH_PRECONDITION(self != nullptr);
-    return kth::to_c_err(kth::cpp_ref<cpp_t>(self).connect());
-}
-
 
 // Predicates
 
@@ -289,13 +279,14 @@ kth_size_t kth_chain_transaction_min_tx_size(kth_transaction_const_t self, kth_s
     return kth::cpp_ref<cpp_t>(self).min_tx_size(flags);
 }
 
-kth_error_code_t kth_chain_transaction_accept(kth_transaction_const_t self, kth_script_flags_t flags, kth_size_t height, uint32_t median_time_past, kth_size_t max_sigops, kth_bool_t is_under_checkpoint, kth_bool_t transaction_pool) {
+kth_error_code_t kth_chain_transaction_accept(kth_transaction_const_t self, kth_script_flags_t flags, kth_size_t height, uint32_t median_time_past, kth_size_t max_sigops, kth_bool_t is_under_checkpoint, kth_bool_t transaction_pool, kth_bool_t duplicate) {
     KTH_PRECONDITION(self != nullptr);
     auto const height_cpp = kth::sz(height);
     auto const max_sigops_cpp = kth::sz(max_sigops);
     auto const is_under_checkpoint_cpp = kth::int_to_bool(is_under_checkpoint);
     auto const transaction_pool_cpp = kth::int_to_bool(transaction_pool);
-    return kth::to_c_err(kth::cpp_ref<cpp_t>(self).accept(flags, height_cpp, median_time_past, max_sigops_cpp, is_under_checkpoint_cpp, transaction_pool_cpp));
+    auto const duplicate_cpp = kth::int_to_bool(duplicate);
+    return kth::to_c_err(kth::cpp_ref<cpp_t>(self).accept(flags, height_cpp, median_time_past, max_sigops_cpp, is_under_checkpoint_cpp, transaction_pool_cpp, duplicate_cpp));
 }
 
 kth_error_code_t kth_chain_transaction_connect(kth_transaction_const_t self, kth_chain_state_const_t state) {

--- a/src/domain/include/kth/domain/chain/transaction.hpp
+++ b/src/domain/include/kth/domain/chain/transaction.hpp
@@ -77,28 +77,6 @@ struct KD_API transaction {
     using outs = output::list;
     using list = std::vector<transaction>;
 
-    // THIS IS FOR LIBRARY USE ONLY, DO NOT CREATE A DEPENDENCY ON IT.
-    struct validation_t {
-        uint64_t originator = 0;
-        code error = error::not_found;
-        chain_state::ptr state = nullptr;
-
-        // The transaction is an unspent duplicate.
-        bool duplicate = false;
-
-        // The unconfirmed tx exists in the store.
-        bool pooled = false;
-
-        // The unconfirmed tx is validated at the block's current fork state.
-        bool current = false;
-
-        // Similate organization and instead just validate the transaction.
-        bool simulate = false;
-
-        // The transaction was validated before its insertion in the mempool.
-        bool validated = false;
-    };
-
     // Constructors.
     //-----------------------------------------------------------------------------
 
@@ -123,11 +101,7 @@ struct KD_API transaction {
     // Operators.
     //-----------------------------------------------------------------------------
 
-    // NOTE: `==` is not `= default` because the `validation` member is
-    // tracing metadata, not part of the value's identity. `!=` is defaulted
-    // (delegates to `!(==)`) so callers that spell out the member call still
-    // resolve.
-    bool operator==(transaction const& x) const;
+    bool operator==(transaction const& x) const = default;
     bool operator!=(transaction const& x) const = default;
 
     // Serialization.
@@ -197,9 +171,6 @@ struct KD_API transaction {
     uint64_t total_output_value() const;
 
     [[nodiscard]]
-    size_t signature_operations() const;
-
-    [[nodiscard]]
     size_t signature_operations(bool bip16, bool bip141) const;
 
     [[nodiscard]]
@@ -255,11 +226,9 @@ struct KD_API transaction {
         uint32_t median_time_past,
         size_t max_sigops,
         bool is_under_checkpoint,
-        bool transaction_pool
+        bool transaction_pool,
+        bool duplicate
     ) const;
-
-    [[nodiscard]]
-    code connect() const;
 
     [[nodiscard]]
     code connect(chain_state const& state) const;
@@ -279,9 +248,6 @@ struct KD_API transaction {
     /// passed flags only on the scriptPubKey side.
     [[nodiscard]]
     bool is_standard(script_flags_t flags) const;
-
-    // THIS IS FOR LIBRARY USE ONLY, DO NOT CREATE A DEPENDENCY ON IT.
-    mutable validation_t validation{};
 
 private:
     [[nodiscard]]

--- a/src/domain/src/chain/transaction.cpp
+++ b/src/domain/src/chain/transaction.cpp
@@ -69,13 +69,6 @@ bool transaction::is_null() const {
 // Operators.
 //-----------------------------------------------------------------------------
 
-bool transaction::operator==(transaction const& x) const {
-    return version_ == x.version_
-        && locktime_ == x.locktime_
-        && inputs_ == x.inputs_
-        && outputs_ == x.outputs_;
-}
-
 // Serialization.
 //-----------------------------------------------------------------------------
 
@@ -279,13 +272,6 @@ size_t transaction::signature_operations(bool bip16, bool bip141) const {
            std::accumulate(outputs_.begin(), outputs_.end(), size_t{0}, out);
 }
 
-size_t transaction::signature_operations() const {
-    auto const state = validation.state;
-    auto const bip16 = state ? state->is_enabled(kth::domain::machine::script_flags::bip16_rule) : true;
-    auto const bip141 = false;
-    return signature_operations(bip16, bip141);
-}
-
 bool transaction::is_missing_previous_outputs() const {
     auto const missing = [](input const& input) {
         auto const& prevout = input.previous_output();
@@ -442,7 +428,8 @@ code transaction::accept(
     uint32_t median_time_past,
     size_t max_sigops,
     bool is_under_checkpoint,
-    bool transaction_pool
+    bool transaction_pool,
+    bool duplicate
 ) const {
     auto const is_enabled = [](script_flags_t active, auto flag) {
         return script::is_enabled(active, flag);
@@ -474,7 +461,7 @@ code transaction::accept(
         return error::transaction_non_final;
     }
 
-    if (bip30 && ! revert_bip30 && validation.duplicate) {
+    if (bip30 && ! revert_bip30 && duplicate) {
         return error::unspent_duplicate;
     }
 
@@ -551,11 +538,6 @@ code transaction::connect_input(chain_state const& state, size_t input_index) co
     auto const index32 = uint32_t(input_index);
 
     return verify(*this, index32, flags);
-}
-
-code transaction::connect() const {
-    auto const state = validation.state;
-    return state ? connect(*state) : error::operation_failed;
 }
 
 code transaction::connect(chain_state const& state) const {

--- a/src/domain/test/chain/vmb_tests.hpp
+++ b/src/domain/test/chain/vmb_tests.hpp
@@ -91,7 +91,7 @@ void run_vmb_test(vmb_test_case const& test) {
         // Use large height/mtp so sequence locks and finality checks don't reject valid transactions.
         ec = tx.accept(test.flags, 1'000'000 /*height*/, 1'700'000'000 /*median_time_past*/,
                        0 /*max_sigops*/, false /*is_under_checkpoint*/,
-                       false /*transaction_pool*/);
+                       false /*transaction_pool*/, false /*duplicate*/);
     }
 
     // Script verification for the specified input.


### PR DESCRIPTION
Second member of #454, **stacked on the block::validation extraction PR** (base is that branch, not master — will retarget to master once the parent merges). Same move for `chain::transaction`.

The value type is now pure (`operator==` defaulted, no `validation` member); the transient per-transaction validation state lives in a new validator-owned `transaction_validation_store`, keyed by tx hash, owned by `block_chain`.

### Store: plain `unordered_flat_map`, NOT concurrent
The intra-block parallelism (populate buckets) is **incidental, not essential** — the essential parallel work (`populate_transaction_inputs`) only touches `output_point`/prevout validation, never `tx.validation`. So the `tx.validation` flag writes (`pooled`/`current`/`validated`), fully determined by mempool membership known up front, are **hoisted to a serial pre-pass** in `populate_block::populate` before the parallel dispatch. After that the store is touched only serially (block + mempool organize share one prioritized mutex), so a plain flat map suffices — and the hoist removes the old redundant N-bucket `.validated` write.

### Eviction: erase-always
No transaction retains a store entry past the `organize()`/`transaction_validate()` call that validated it. `block_organizer` erases a block's tx entries after `connect` (covers the IBD leak and every mined mempool tx — the single external mempool-removal path); `transaction_organizer` erases a candidate's entry on every post-accept exit. A later re-validation of the same hash recreates only what it needs — **a missing entry forces harmless re-validation, never an incorrect skip**. `mempool_v2`'s internal low-benefit eviction has no callback, which erase-always moots.

### Dead fields dropped
`originator` and `error` (never read/written on a tx) and `pooled` (write-only). `duplicate` kept (feeds a BIP30-gated read, effectively always false today) — `transaction::accept` now takes it as a parameter. The no-arg `connect()`/`signature_operations()` domain fallbacks (which read `validation.state`) are gone; the transaction C-API is regenerated to match, and the c-api sequential-validate path writes `simulate` into the store.

Full tree builds green; domain (3819 cases), blockchain (522 assertions / 107 cases), and the transaction C-API suite (148/19) pass.