### PR TITLE
build: add mempool_backend conan flag (cfm|parlay) propagated to code

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -59,6 +59,7 @@ class KthRecipe(KnuthConanFileV2):
         "march_id": ["ANY"],
         "march_strategy": ["download_if_possible", "optimized", "download_or_fail"],
         "currency": ['BCH', 'BTC', 'LTC'],
+        "mempool_backend": ['cfm', 'parlay'],
         "verbose": [True, False],
         "consensus": [True, False],
         "db": ['dynamic'],
@@ -103,6 +104,7 @@ class KthRecipe(KnuthConanFileV2):
         "console": False,
         "march_strategy": "download_if_possible",
         "currency": "BCH",
+        "mempool_backend": "cfm",
         "verbose": False,
         "consensus": True,
         "db": "dynamic",
@@ -326,6 +328,7 @@ class KthRecipe(KnuthConanFileV2):
         # Secp256k1 -------------------------------------------- (END)
 
         tc.variables["CURRENCY"] = self.options.currency
+        tc.variables["KTH_MEMPOOL_BACKEND"] = self.options.mempool_backend
 
         # Header index capacity based on compilation year
         header_capacity = _calculate_header_capacity(datetime.now().year)
@@ -363,6 +366,9 @@ class KthRecipe(KnuthConanFileV2):
 
         # Define currency macro based on option
         currency_define = f"KTH_CURRENCY_{self.options.currency}"
+
+        # Define mempool-backend macro based on option (cfm | parlay)
+        mempool_backend_define = f"KTH_MEMPOOL_BACKEND_{str(self.options.mempool_backend).upper()}"
 
         # Define STATIC macros when building static libraries
         static_defines = []
@@ -468,7 +474,7 @@ class KthRecipe(KnuthConanFileV2):
         self.cpp_info.components["blockchain"].libs = ["blockchain"]
         self.cpp_info.components["blockchain"].names["cmake_find_package"] = "blockchain"
         self.cpp_info.components["blockchain"].names["cmake_find_package_multi"] = "blockchain"
-        self.cpp_info.components["blockchain"].defines = [currency_define] + static_defines
+        self.cpp_info.components["blockchain"].defines = [currency_define, mempool_backend_define] + static_defines
         # Blockchain depends on database and optionally consensus
         blockchain_requires = ["database"]
         if self.options.consensus:
@@ -488,7 +494,7 @@ class KthRecipe(KnuthConanFileV2):
         self.cpp_info.components["node"].libs = ["node"]
         self.cpp_info.components["node"].names["cmake_find_package"] = "node"
         self.cpp_info.components["node"].names["cmake_find_package_multi"] = "node"
-        self.cpp_info.components["node"].defines = [currency_define] + static_defines
+        self.cpp_info.components["node"].defines = [currency_define, mempool_backend_define] + static_defines
         # Node depends on blockchain and optionally network (if not Emscripten).
         # ftxui is consumed by the node-exe TUI dashboard (executable, not a
         # library component); listing it here keeps Conan 2's strict
@@ -508,7 +514,7 @@ class KthRecipe(KnuthConanFileV2):
                 self.cpp_info.components["node-exe"].libs = node_exe_libs
                 self.cpp_info.components["node-exe"].names["cmake_find_package"] = "node-exe"
                 self.cpp_info.components["node-exe"].names["cmake_find_package_multi"] = "node-exe"
-                self.cpp_info.components["node-exe"].defines = [currency_define] + static_defines
+                self.cpp_info.components["node-exe"].defines = [currency_define, mempool_backend_define] + static_defines
                 self.cpp_info.components["node-exe"].requires = ["node"]
         except:
             # If collect_libs fails or node-exe is not built, skip it
@@ -522,7 +528,7 @@ class KthRecipe(KnuthConanFileV2):
                 self.cpp_info.components["c-api"].libs = c_api_libs
                 self.cpp_info.components["c-api"].names["cmake_find_package"] = "c-api"
                 self.cpp_info.components["c-api"].names["cmake_find_package_multi"] = "c-api"
-                self.cpp_info.components["c-api"].defines = [currency_define] + static_defines
+                self.cpp_info.components["c-api"].defines = [currency_define, mempool_backend_define] + static_defines
                 self.cpp_info.components["c-api"].requires = ["node"]
         except:
             # If collect_libs fails or c-api is not built, skip it

--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -50,6 +50,21 @@ endif()
 
 message(STATUS "Knuth: Cryptocurrency: ${CURRENCY}")
 
+# Mempool backing map: cfm (boost::concurrent_flat_map) | parlay (ParlayHash).
+# Selects the mempool's concurrent hashmap implementation at compile time so the
+# two can be A/B measured on a running node.
+set(KTH_MEMPOOL_BACKEND "cfm" CACHE STRING "Mempool backing map (cfm|parlay).")
+
+if (${KTH_MEMPOOL_BACKEND} STREQUAL "cfm")
+  add_definitions(-DKTH_MEMPOOL_BACKEND_CFM)
+elseif (${KTH_MEMPOOL_BACKEND} STREQUAL "parlay")
+  add_definitions(-DKTH_MEMPOOL_BACKEND_PARLAY)
+else()
+  message(FATAL_ERROR "Invalid mempool backend: ${KTH_MEMPOOL_BACKEND} (expected cfm|parlay)")
+endif()
+
+message(STATUS "Knuth: Mempool backend: ${KTH_MEMPOOL_BACKEND}")
+
 # Header index capacity (number of headers for static array allocation)
 # Default: 1,179,648 headers (~2030, aligned to 2^16)
 if(NOT DEFINED KTH_HEADER_INDEX_CAPACITY)
@@ -205,6 +220,7 @@ set(kth_headers
   include/kth/blockchain/validate/validate_input.hpp
   include/kth/blockchain/validate/validate_transaction.hpp
   include/kth/blockchain/pools/block_entry.hpp
+  include/kth/blockchain/pools/mempool_config.hpp
   include/kth/blockchain/pools/mempool_transaction_summary.hpp
   include/kth/blockchain/pools/block_organizer.hpp
   include/kth/blockchain/pools/branch.hpp

--- a/src/blockchain/include/kth/blockchain/pools/mempool_config.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool_config.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_POOLS_MEMPOOL_CONFIG_HPP
+#define KTH_BLOCKCHAIN_POOLS_MEMPOOL_CONFIG_HPP
+
+// Selects the mempool's concurrent-hashmap backend at compile time. Exactly one
+// of KTH_MEMPOOL_BACKEND_CFM / KTH_MEMPOOL_BACKEND_PARLAY is defined, driven by
+// the conan option `mempool_backend` -> CMake `KTH_MEMPOOL_BACKEND` (see the
+// blockchain CMakeLists). The two backends exist so they can be A/B measured on
+// a running node.
+//
+//   cfm    -> boost::concurrent_flat_map  (default)
+//   parlay -> ParlayHash
+
+#if defined(KTH_MEMPOOL_BACKEND_CFM) && defined(KTH_MEMPOOL_BACKEND_PARLAY)
+    #error "Both KTH_MEMPOOL_BACKEND_CFM and KTH_MEMPOOL_BACKEND_PARLAY are defined; pick exactly one."
+#elif ! defined(KTH_MEMPOOL_BACKEND_CFM) && ! defined(KTH_MEMPOOL_BACKEND_PARLAY)
+    #error "No mempool backend defined. Set the conan option mempool_backend=cfm|parlay (propagates to -DKTH_MEMPOOL_BACKEND_*)."
+#endif
+
+namespace kth::blockchain {
+
+enum class mempool_backend {
+    cfm,
+    parlay
+};
+
+#if defined(KTH_MEMPOOL_BACKEND_PARLAY)
+inline constexpr mempool_backend active_mempool_backend = mempool_backend::parlay;
+inline constexpr char const* mempool_backend_name = "parlay";
+#else
+inline constexpr mempool_backend active_mempool_backend = mempool_backend::cfm;
+inline constexpr char const* mempool_backend_name = "cfm";
+#endif
+
+} // namespace kth::blockchain
+
+#endif // KTH_BLOCKCHAIN_POOLS_MEMPOOL_CONFIG_HPP

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -20,6 +20,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include <kth/blockchain/pools/mempool_config.hpp>
 #include <kth/blockchain/populate/populate_chain_state.hpp>
 #include <kth/blockchain/settings.hpp>
 #include <kth/database.hpp>
@@ -121,6 +122,7 @@ block_chain::block_chain(blockchain::settings const& chain_settings,
     , block_organizer_(validation_mutex_, priority_pool_.get_executor(), priority_pool_.size(), priority_pool_, *this, chain_settings, network, relay_transactions)
 {
     spdlog::debug("[blockchain] block_chain constructor completed successfully");
+    spdlog::info("[blockchain] Mempool backend: {}", mempool_backend_name);
 }
 
 block_chain::~block_chain() {


### PR DESCRIPTION
Foundation for the new mempool: a compile-time selector for the concurrent-hashmap backend, so the two candidates (`boost::concurrent_flat_map` and ParlayHash) can be **A/B measured on a running node** rather than only in a synthetic bench.

- conan option `mempool_backend` = `cfm` | `parlay` (default `cfm`) → `KTH_MEMPOOL_BACKEND` (CMake) → `-DKTH_MEMPOOL_BACKEND_{CFM,PARLAY}` on the blockchain/node/node-exe/c-api components. Mirrors the existing `currency` → `KTH_CURRENCY_*` pattern exactly.
- New `pools/mempool_config.hpp` resolves the backend (`enum mempool_backend`, `active_mempool_backend`, `mempool_backend_name`) and `#error`-guards against neither/both defined (verified in all 4 macro states).
- `block_chain` includes it — so the `#error` fires if the define fails to propagate, compile-verifying the whole chain — and logs `Mempool backend: <name>` at startup.

No backend implementation yet; the default `cfm` build is unchanged. Part of #491.

Verified: full-tree conan build green (default cfm), CMake reports `Knuth: Mempool backend: cfm`, integration test package links.