### PR TITLE
vendor: add ParlayHash (third_party/parlayhash, pinned 081408ba)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -153,7 +153,7 @@ class KthRecipe(KnuthConanFileV2):
     # The bloom is consumed from `${CMAKE_SOURCE_DIR}/data/utxo_bloom.dat`
     # when present (CI / git-checkout builds embed it); source-tarball
     # rebuilds gracefully fall back to no-embed (slower IBD, still correct).
-    exports_sources = "src/*", "include/*", "CMakeLists.txt", "cmake/*", "ci_utils/cmake/*"
+    exports_sources = "src/*", "include/*", "CMakeLists.txt", "cmake/*", "ci_utils/cmake/*", "third_party/*"
 
 
     @property

--- a/third_party/parlayhash/CMakeLists.txt
+++ b/third_party/parlayhash/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2016-present Knuth Project developers.
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Header-only, vendored ParlayHash (see README.md for the pinned commit).
+# Exposed as an INTERFACE target; the include directory is marked SYSTEM so the
+# library's deprecation warnings do not surface in the Knuth build.
+
+add_library(parlayhash INTERFACE)
+add_library(parlayhash::parlayhash ALIAS parlayhash)
+
+target_include_directories(parlayhash SYSTEM INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+target_compile_features(parlayhash INTERFACE cxx_std_23)

--- a/third_party/parlayhash/LICENSE
+++ b/third_party/parlayhash/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 cmuparlay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/parlayhash/README.md
+++ b/third_party/parlayhash/README.md
@@ -1,0 +1,44 @@
+# ParlayHash (vendored)
+
+A header-only concurrent hash map from CMU (<https://github.com/cmuparlay/parlayhash>).
+
+Vendored here — not pulled via Conan — because there is no reliable Conan
+package for it. It is one of the two candidate backends for the Knuth mempool's
+concurrent map (the other is `boost::concurrent_flat_map`); the mempool selects
+between them at compile time via the `mempool_backend` Conan option
+(`cfm` | `parlay`).
+
+## Pinned upstream version
+
+- Repository: <https://github.com/cmuparlay/parlayhash>
+- Commit: `081408ba6111ce78b5add9129f8d902fa2fea58f`
+- Date: 2025-08-19 ("added unit tests, fixed some interface bugs")
+- License: MIT (© 2023 cmuparlay) — see `LICENSE`, compatible with Knuth's MIT.
+
+## What is included
+
+Only the subtree needed by `parlay_hash/unordered_map.h`:
+
+- `include/parlay_hash/` — the map itself (`unordered_map.h`, `parlay_hash.h`,
+  `bigatomic.h`, `parallel.h`, `unordered_set.h`).
+- `include/parlay/` — the parallel-primitives headers it transitively includes
+  (`bigatomic.h` pulls `parlay/primitives.h` unconditionally).
+- `include/utils/` — epoch-based reclamation and locks.
+
+Excluded from upstream: `include/old_parlay_hash/` (superseded) and a handful of
+editor scratch/autosave files (`#*#`, `foo.h`, `s.h`).
+
+## Usage notes
+
+- Use without defining `USE_PARLAY`: `parlay_hash/parallel.h` then provides a
+  serial fallback and the Parlay task scheduler is not linked. Plain
+  `std::thread` needs no thread registration.
+- Build with `-DNDEBUG` in production; otherwise `utils/epoch.h` enables
+  guard-byte checks.
+- The headers are included as SYSTEM headers so their deprecation warnings do
+  not pollute the Knuth build.
+
+## Updating
+
+Re-copy the three subtrees from the pinned commit, delete the excluded files,
+and update the commit hash above.

--- a/third_party/parlayhash/include/parlay/.#hash_table.h
+++ b/third_party/parlayhash/include/parlay/.#hash_table.h
@@ -1,0 +1,1 @@
+guyb@aware.aladdin.cs.cmu.edu.136086:1550966469

--- a/third_party/parlayhash/include/parlay/alloc.h
+++ b/third_party/parlayhash/include/parlay/alloc.h
@@ -1,0 +1,288 @@
+#ifndef PARLAY_ALLOC_H
+#define PARLAY_ALLOC_H
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "type_traits.h"  // IWYU pragma: keep
+#include "utilities.h"
+
+#include "internal/block_allocator.h"
+#include "internal/memory_size.h"
+#include "internal/pool_allocator.h"
+
+// IWYU pragma: no_forward_declare is_trivially_relocatable
+
+namespace parlay {
+
+// ----------------------------------------------------------------------------
+//                            internal pool allocator
+//
+// allocates pools of blocks with powers of two sizes. Used internally to provide
+// allocation for the container allocator, parlay::allocator<T>; and for the free
+// functions, parlay::p_malloc and parlay::p_free.
+// ----------------------------------------------------------------------------
+
+namespace internal {
+
+// The size of the largest pool used by the memory allocator
+inline const size_t default_allocator_max_pool_size = getMemorySize() / 64;
+
+// these are bucket sizes used by the default allocator. They are powers
+// of two starting at 16 and going until SystemMemory / 64.
+//
+// Note that them being powers of two is very important for correctness
+// of the high-level allocators defined here!
+//  - being powers of two means that if a block is suitably aligned for an object
+//    of type T, the next block is guaranteed to also be suitably aligned for T
+//  - p_malloc optimizes its header by only storing log(size) of the allocation,
+//    which works because that is enough information to know which pool it came from
+//
+inline std::vector<size_t> default_allocator_sizes() {
+  size_t log_min_size = 4;
+  size_t log_max_size = log2_up(default_allocator_max_pool_size);
+
+  std::vector<size_t> sizes;
+  for (size_t i = log_min_size; i <= log_max_size; i++)
+    sizes.push_back(size_t{1} << i);
+  return sizes;
+}
+
+extern inline pool_allocator& get_default_allocator() {
+  static pool_allocator default_allocator(default_allocator_sizes());
+  return default_allocator;
+}
+
+// pair of total currently used space, and total unused space the allocator has in reserve
+inline std::pair<size_t,size_t> memory_usage() {
+  return get_default_allocator().stats();
+}
+
+inline void memory_clear() {
+  return get_default_allocator().clear();
+}
+
+}  // namespace internal
+
+// ----------------------------------------------------------------------------
+//  Free allocation functions
+//
+//  Allocates headered blocks so the user doesn't need to remember the size
+// ----------------------------------------------------------------------------
+
+namespace internal {
+
+// Header used by p_malloc. Stores the requested size of the buffer and
+// the offset of the underlying buffer that we need to free later.
+struct p_malloc_header {
+  uint64_t log_size : 8;   // We can store the log of the size because the default
+  uint64_t offset : 48;    // allocator uses only powers of two pool sizes
+};
+static_assert(sizeof(p_malloc_header) <= 8);
+
+// Minimum size of the padding for p_malloc. For large allocations, uses a larger
+// padding to guarantee at least 64-byte alignment. Needs to be at least sizeof(size_t).
+inline size_t alloc_padding_size(size_t n) {  // in bytes
+  return  (n >= 1024) ? 64 : (n & 15) ? 8 : (n & 63) ? 16 : 64;
+}
+
+}  // namespace internal
+
+// GCC doesn't like placement new into the offset buffer
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wplacement-new"
+#endif
+
+// Allocate size bytes of uninitialized storage. Optionally ask for an
+// aligned buffer of memory with the given alignment.
+//
+// By default, the alignment is at least alignof(std::max_align_t), and may
+// be larger for larger size allocations.
+inline void* p_malloc(size_t size, size_t align = alignof(std::max_align_t)) {
+  assert(align > 0 && (align & (align - 1)) == 0 && "Requested alignment must be a power of two");
+
+  // allocates and tags with a header that contains the size and offset
+  size_t pad_size = std::max<size_t>(internal::alloc_padding_size(size), align);
+  void* buffer = internal::get_default_allocator().allocate(size + pad_size);
+  void* offset_buffer = static_cast<void*>(static_cast<std::byte*>(buffer) + sizeof(internal::p_malloc_header));
+  size_t space = size + pad_size - sizeof(internal::p_malloc_header);
+  void* new_buffer = std::align(pad_size, size, offset_buffer, space);
+  assert(new_buffer != nullptr && new_buffer == offset_buffer);
+  size_t offset = (static_cast<std::byte*>(new_buffer) - static_cast<std::byte*>(buffer));
+  assert(offset == (size + pad_size) - space);
+  new (static_cast<std::byte*>(new_buffer) - sizeof(internal::p_malloc_header))
+      internal::p_malloc_header{log2_up(size + pad_size), offset};
+  return static_cast<void*>(new_buffer);
+}
+
+// Free a block of memory obtained by p_malloc
+inline void p_free(void* ptr) {
+  // reads the header to determine the offset and size, then frees
+  auto h = *from_bytes<internal::p_malloc_header>(static_cast<std::byte*>(ptr) - sizeof(internal::p_malloc_header));
+  if (h.log_size > 48u || h.offset > 1ull << 48) {
+    std::cerr << "corrupted header in p_free\n";
+    std::abort();
+  }
+  auto buffer = static_cast<void*>(static_cast<std::byte*>(ptr) - h.offset);
+  internal::get_default_allocator().deallocate(buffer, size_t{1} << size_t(h.log_size));
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+// ----------------------------------------------------------------------------
+//                            Container allocator
+// ----------------------------------------------------------------------------
+
+// A general purpose container allocator for arrays of type T.
+//
+// Matches the c++ Allocator specification (minimally)
+// https://en.cppreference.com/w/cpp/named_req/Allocator
+// Can therefore be used for STL containers, e.g.:
+//    std::vector<int, parlay::allocator<int>>
+//
+template <typename T>
+struct allocator {
+  using value_type = T;
+  T* allocate(size_t n) {
+    // Use headerless blocks straight from the pool if the alignment is suitable,
+    // otherwise fall back to manually-aligned headered blocks from p_malloc
+    if constexpr (alignof(T) > internal::pool_allocator::max_alignment) {
+      return static_cast<T*>(p_malloc(n * sizeof(T), alignof(T)));
+    }
+    else {
+      // Should be suitably aligned for alignments up to pool_allocator::max_alignment
+      void* buffer = internal::get_default_allocator().allocate(n * sizeof(T));
+      assert(reinterpret_cast<uintptr_t>(buffer) % alignof(T) == 0);
+      return static_cast<T*>(buffer);
+    }
+  }
+  void deallocate(T* ptr, [[maybe_unused]] size_t n) {
+    assert(reinterpret_cast<uintptr_t>(ptr) % alignof(T) == 0);
+    if constexpr (alignof(T) > internal::pool_allocator::max_alignment) {
+      p_free(static_cast<void*>(ptr));
+    }
+    else {
+      internal::get_default_allocator().deallocate(static_cast<void*>(ptr), n * sizeof(T));
+    }
+  }
+
+  constexpr allocator() { internal::get_default_allocator(); };
+  template <class U> /* implicit */ constexpr allocator(const allocator<U>&) noexcept { }
+};
+
+template<typename T>
+struct is_trivially_relocatable<allocator<T>> : std::true_type {};
+
+template <class T, class U>
+bool operator==(const allocator<T>&, const allocator<U>&) { return true; }
+template <class T, class U>
+bool operator!=(const allocator<T>&, const allocator<U>&) { return false; }
+
+
+// ----------------------------------------------------------------------------
+// Static allocator for single items of a given type, e.g.
+//   using long_allocator = type_allocator<long>;
+//   long* foo = long_allocator::alloc();
+//   new (foo) long{23};
+//   long_allocator::free(foo);
+//
+// Uses block allocator internally, and is headerless
+// ----------------------------------------------------------------------------
+
+namespace internal {
+template<size_t Size, size_t Align>
+extern inline block_allocator& get_block_allocator() {
+  static block_allocator a(Size, Align);
+  return a;
+}
+}
+
+// A static allocator for allocating storage for single objects of a fixed
+// type. Much more efficient than using p_malloc or parlay::allocator for
+// individual objects.
+//
+// Can be used to allocate raw uninitialized storage via alloc()/free(ptr),
+// or to perform combined allocation and construction with create(args...)
+// followed by destroy(ptr) to destroy and deallocate.
+//
+// alloc() -> T*         : returns uninitialized storage for an object of type T
+// free(T*)              : deallocates storage obtained by alloc
+//
+// create(args...) -> T* : allocates storage for and constructs a T using args...
+// destroy(T*)           : destroys and deallocates a T obtained from create(...)
+//
+// All members are static, so it is not required to create an instance of
+// type_allocator<T> to use it.
+//
+template <typename T>
+class type_allocator {
+
+  static internal::block_allocator& get_allocator() {
+    return internal::get_block_allocator<sizeof(T), alignof(T)>();
+  }
+
+public:
+
+  // Allocate uninitialized storage appropriate for storing an object of type T
+  static T* alloc() {
+    void* buffer = get_allocator().alloc();
+    assert(reinterpret_cast<uintptr_t>(buffer) % alignof(T) == 0);
+    return static_cast<T*>(buffer);
+  }
+
+  // Free storage obtained by alloc()
+  static void free(T* ptr) {
+    assert(ptr != nullptr);
+    assert(reinterpret_cast<uintptr_t>(ptr) % alignof(T) == 0);
+    get_allocator().free(static_cast<void*>(ptr));
+  }
+
+  // Allocate storage for and then construct an object of type T using args...
+  template<typename... Args>
+  static T* create(Args... args) {
+    static_assert(std::is_constructible_v<T, Args...>);
+    return new (alloc()) T(std::forward<Args>(args)...);
+  }
+
+  // Destroy an object obtained by create(...) and deallocate its storage
+  static void destroy(T* ptr) {
+    assert(ptr != nullptr);
+    ptr->~T();
+    free(ptr);
+  }
+
+  // for backward compatibility -----------------------------------------------
+  static constexpr inline size_t default_alloc_size = 0;
+  static constexpr inline bool initialized = true;
+
+  template <typename ... Args>
+  static T* allocate(Args... args) { return create(std::forward<Args>(args)...); }
+  static void retire(T* ptr) { destroy(ptr); }
+  static void init(size_t, size_t) {};
+  static void init() {};
+  static void reserve([[maybe_unused]] size_t n = default_alloc_size) { }
+  static void finish() { get_allocator().clear(); }
+  static size_t block_size () { return get_allocator().get_block_size(); }
+  static size_t num_allocated_blocks() { return get_allocator().num_allocated_blocks(); }
+  static size_t num_used_blocks() { return get_allocator().num_used_blocks(); }
+  static size_t num_used_bytes() { return num_used_blocks() * block_size(); }
+  static void print_stats() { get_allocator().print_stats(); }
+};
+
+
+}  // namespace parlay
+
+#endif  // PARLAY_ALLOC_H

--- a/third_party/parlayhash/include/parlay/delayed.h
+++ b/third_party/parlayhash/include/parlay/delayed.h
@@ -1,0 +1,103 @@
+
+#ifndef PARLAY_DELAYED_H_
+#define PARLAY_DELAYED_H_
+
+#include <cstddef>
+
+#include <tuple>
+#include <type_traits>                      // IWYU pragma: keep
+#include <utility>
+
+#include "internal/delayed/filter.h"        // IWYU pragma: export
+#include "internal/delayed/filter_op.h"     // IWYU pragma: export
+#include "internal/delayed/flatten.h"       // IWYU pragma: export
+#include "internal/delayed/map.h"           // IWYU pragma: export
+#include "internal/delayed/scan.h"          // IWYU pragma: export
+#include "internal/delayed/terminal.h"      // IWYU pragma: export
+#include "internal/delayed/zip.h"           // IWYU pragma: export
+
+#include "internal/sequence_ops.h"
+
+#include "delayed_sequence.h"
+#include "range.h"
+#include "type_traits.h"
+
+namespace parlay {
+namespace delayed {
+
+// Import all first-class delayed operations
+
+using ::parlay::internal::delayed::to_sequence;
+using ::parlay::internal::delayed::reduce;
+using ::parlay::internal::delayed::map;
+using ::parlay::internal::delayed::flatten;
+using ::parlay::internal::delayed::zip;
+using ::parlay::internal::delayed::scan;
+using ::parlay::internal::delayed::scan_inclusive;
+using ::parlay::internal::delayed::filter;
+using ::parlay::internal::delayed::filter_op;
+using ::parlay::internal::delayed::map_maybe;
+using ::parlay::internal::delayed::for_each;
+using ::parlay::internal::delayed::apply;
+
+// Delayed tabulate
+
+template<typename UnaryFunction>
+auto tabulate(size_t n, UnaryFunction f) {
+  return parlay::internal::delayed_tabulate(n, std::move(f));
+}
+
+// Composite delayed operations
+
+template<typename Integral_>
+auto iota(Integral_ n) {
+  static_assert(std::is_integral_v<Integral_>);
+  return delayed_seq<Integral_>(n, [](size_t i) -> Integral_ { return i; });
+}
+
+template<typename Range_>
+auto enumerate(Range_&& r) {
+  static_assert(is_block_iterable_range_v<Range_>);
+  return ::parlay::internal::delayed::zip(::parlay::delayed::iota(parlay::size(r)), std::forward<Range_>(r));
+}
+
+template<typename NaryOperator, typename... Ranges_>
+auto zip_with(NaryOperator f, Ranges_&&... rs) {
+  static_assert((is_block_iterable_range_v<Ranges_> && ...));
+  static_assert(std::is_invocable_v<NaryOperator, range_reference_type_t<Ranges_>...>);
+  return ::parlay::internal::delayed::map(
+    ::parlay::internal::delayed::zip(std::forward<Ranges_>(rs)...),
+    [f = std::move(f)](auto&& t) { return std::apply(f, std::forward<decltype(t)>(t)); }
+  );
+}
+
+template<size_t N, typename Range_>
+auto elements_view(Range_&& r) {
+  static_assert(is_block_iterable_range_v<Range_>);
+  static_assert(N < std::tuple_size_v<range_value_type_t<Range_>>);
+  using return_type = maybe_decay_t<!std::is_reference_v<range_reference_type_t<Range_>>,
+        decltype(std::get<N>(std::declval<range_reference_type_t<Range_>>()))>;
+  return ::parlay::internal::delayed::map(std::forward<Range_>(r),
+    [](auto&& x) -> return_type { return std::get<N>(std::forward<decltype(x)>(x)); });
+}
+
+// Given a range of pair-like objects (e.g. pairs or tuples of size two),
+// returns a delayed view of the first elements of the pairs
+template<typename Range_>
+auto keys_view(Range_&& r) {
+  static_assert(is_block_iterable_range_v<Range_>);
+  return elements_view<0>(std::forward<Range_>(r));
+}
+
+// Given a range of pair-like objects (e.g. pairs or tuples of size two),
+// returns a delayed view of the second elements of the pairs
+template<typename Range_>
+auto values_view(Range_&& r) {
+  static_assert(is_block_iterable_range_v<Range_>);
+  return elements_view<1>(std::forward<Range_>(r));
+}
+
+}
+}
+
+#endif  // PARLAY_DELAYED_H_

--- a/third_party/parlayhash/include/parlay/delayed_sequence.h
+++ b/third_party/parlayhash/include/parlay/delayed_sequence.h
@@ -1,0 +1,328 @@
+// Delayed sequences are random access iterator ranges
+// that generate their elements on demand. Their memory
+// requirement is therefore at most that of the function
+// object that generates the range. Unlike most common
+// iterators, dereferencing them can possibly result in
+// a prvalue (temporary) rather than a reference.
+//
+// A delayed sequence is defined by a maximum index and a
+// function object. The recommended way to construct
+// a delayed sequence is by using the delayed_tabulate
+// function. Example:
+//
+// auto s = parlay::delayed_tabulate(1000,
+//            [](size_t i) { return i*i; });
+//
+// By default, the reference type of the delayed sequence
+// is the return type of the function F and the value type
+// is std::remove_cv_t<std::remove_reference_t<reference>>.
+// These can be customized by providing template arguments
+// to delayed_tabulate.
+//
+
+#ifndef PARLAY_DELAYED_SEQUENCE_H_
+#define PARLAY_DELAYED_SEQUENCE_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+#include "utilities.h"
+
+namespace parlay {
+
+template<typename T, typename V, typename F>
+class delayed_sequence;
+
+// Factory function that can infer the type of the function
+//
+// Deprecated. Prefer to use delayed_tabulate instead.
+template <typename T, typename F>
+delayed_sequence<T, std::remove_cv_t<std::remove_reference_t<T>>, F> delayed_seq (size_t, F);
+
+// A delayed sequence is an iterator range that generates its
+// elements on demand.
+//
+// T is the reference_type of the sequence, i.e. the type returned
+// by the delayed sequence. V is the value_type of the sequence.
+// Often, these are the same, e.g., when the delayed sequence
+// returns a prvalue (temporary). They should differ if the
+// delayed sequence is going to return a reference, or a type
+// with reference-semantics (e.g., a tuple of references), in
+// which case value_type should be a type with corresponding value
+// semantics.
+//
+template<typename T, typename V, typename F>
+class delayed_sequence {
+  static_assert(std::is_invocable_r_v<T, const F&, size_t>);
+
+ public:
+  
+  // Types exposed by standard containers (although
+  // delayed_sequence is not itself a container).
+  //
+  // Note that, counterintuitively, reference is not necessarily
+  // a reference type, but rather, it refers to the type returned
+  // by dereferencing the iterator. For a delayed sequence, this
+  // could be a value type since elements are generated on demand.
+  using value_type = V;
+  using reference = T;
+  using const_reference = std::add_const_t<T>;
+  class iterator;
+  using const_iterator = iterator;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = reverse_iterator;
+  using difference_type = std::ptrdiff_t;
+  using size_type = size_t;
+ 
+  // ------------------------------------------------
+  //    Internal iterator for a delayed sequence
+  // ------------------------------------------------
+  class iterator {
+   public:
+
+    // Iterator traits
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = V;
+    using difference_type = std::ptrdiff_t;
+    using pointer = typename std::add_pointer<T>::type;
+    using reference = T;
+
+    friend class delayed_sequence<T, V, F>;
+
+    // ----- Requirements for vanilla iterator ----
+
+    // Copy constructor and copy assignment
+    iterator(const iterator& other) = default;
+    iterator& operator=(const iterator&) = default;
+
+    // Destructor
+    ~iterator() = default;
+
+    // Forward iteration
+    iterator& operator++() {
+      assert(index < parent->last);
+      index++;
+      return *this;
+    }
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4267) // conversion from 'size_t' to *, possible loss of data
+#endif
+
+    // Dereference
+    T operator*() const { return parent->f(index); }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+    // ---- Requirements for input iterator ----
+
+    iterator operator++(int) {
+      assert(index < parent->last);
+      auto tmp = *this;
+      index++;
+      return tmp;
+    }
+
+    bool operator==(const iterator& other) const {
+      return index == other.index;
+    }
+
+    bool operator!=(const iterator& other) const {
+      return index != other.index;
+    }
+
+    // ---- Requirements for forward iterator ----
+
+    // Value-initialized (default constructed) iterators should
+    // compare equal, but should not be dereferenced or incremented
+    iterator() : parent(nullptr), index(0) {}
+
+    // ---- Requirements for bidirectional iterator ----
+
+    iterator& operator--() {
+      assert(index > parent->first);
+      index--;
+      return *this;
+    }
+
+    iterator operator--(int) {
+      assert(index > parent->first);
+      auto tmp = *this;
+      index--;
+      return tmp;
+    }
+
+    // ---- Requirements for random access iterator ----
+
+    bool operator<(const iterator& other) const {
+      return index < other.index;
+    }
+
+    bool operator>(const iterator& other) const {
+      return index > other.index;
+    }
+
+    bool operator<=(const iterator& other) const {
+      return index <= other.index;
+    }
+
+    bool operator>=(const iterator& other) const {
+      return index >= other.index;
+    }
+
+    iterator& operator+=(size_t delta) {
+      assert(index + delta <= parent->last);
+      index += delta;
+      return *this;
+    }
+
+    iterator operator+(size_t delta) const {
+      assert(index + delta <= parent->last);
+      return iterator(parent, index + delta);
+    }
+
+    iterator& operator-=(size_t delta) {
+      assert(index - delta >= parent->first);
+      index -= delta;
+      return *this;
+    }
+
+    iterator operator-(size_t delta) const {
+      assert(index - delta >= parent->first);
+      return iterator(parent, index - delta);
+    }
+
+    std::ptrdiff_t operator-(const iterator& other) const {
+      return static_cast<std::ptrdiff_t>(index)
+        - static_cast<std::ptrdiff_t>(other.index);
+    }
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4267) // conversion from 'size_t' to *, possible loss of data
+#endif
+
+    T operator[](size_t i) const { return parent->f(index + i); }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+   private:
+
+    iterator(const delayed_sequence* _parent, size_t _index)
+      : parent(_parent), index(_index) { }
+   
+    const delayed_sequence<T, V, F>* parent;
+    size_t index;
+  };
+  
+  // ----------- Constructors and Factories ---------------
+
+  static auto constant(size_t n, T value) {
+    return delayed_seq<T>(n,
+      [val = std::move(value)](size_t) { return val; });
+  }
+
+  delayed_sequence(size_t n, F _f)
+    : first(0), last(n), f(std::move(_f)) { }
+
+  delayed_sequence(size_t _first, size_t _last, F _f)
+    : first(_first), last(_last), f(std::move(_f)) { }
+    
+  // Default copy & move, constructor and assignment
+  delayed_sequence(const delayed_sequence<T, V, F>&) = default;
+  delayed_sequence(delayed_sequence<T, V, F>&&) = default;                          // NOLINT: A default move constructor is noexcept whenever possible
+  delayed_sequence<T, V, F>& operator=(const delayed_sequence<T, V, F>&) = default;
+  delayed_sequence<T, V, F>& operator=(delayed_sequence<T, V, F>&&) = default;      // NOLINT: A default move assignment is noexcept whenever possible
+
+  // ---------------- Iterator Pairs --------------------
+
+  iterator begin() const { return iterator(this, first); }
+  iterator end() const { return iterator(this, last); }
+
+  const_iterator cbegin() const { return begin(); }
+  const_iterator cend() const { return end(); }
+  
+  reverse_iterator rbegin() const { return std::make_reverse_iterator(end()); }
+  reverse_iterator rend() const { return std::make_reverse_iterator(begin()); }
+  
+  const_reverse_iterator crbegin() const { return rbegin(); }
+  const_reverse_iterator crend() const { return rend(); }
+  
+  // ---------------- Other operations --------------------
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4267) // conversion from 'size_t' to *, possible loss of data
+#endif
+
+  // Subscript access
+  T operator[](size_t i) const { return f(i); }
+
+  // Subscript access with bounds checking
+  T at(size_t i) const {
+    if (i < first || i >= last) {
+      throw_exception_or_terminate<std::out_of_range>("Delayed sequence access out of range at " + std::to_string(i) +
+                                                      "for a sequence with bounds [" + std::to_string(first) + ", " +
+                                                      std::to_string(last) + ")");
+    }
+    return f(i);
+  }
+
+  // Return the first element
+  T front() const {
+    assert(!empty());
+    return f(first);
+  }
+
+  // Return the last element
+  T back() const {
+    assert(!empty());
+    return f(last-1);
+  }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+  // Size
+  [[nodiscard]] size_t size() const {
+    assert(first <= last);
+    return last - first;
+  }
+  
+  // Is empty?
+  [[nodiscard]] bool empty() const {
+    return size() == 0;
+  }
+  
+  // Swap this with another delayed sequence
+  void swap(delayed_sequence<T, V, F>& other) {
+    std::swap(*this, other);
+  }
+  
+ private:
+  size_t first, last;
+  copyable_function_wrapper<F> f;
+};
+
+// Factory function that can infer the type of the function
+//
+// Deprecated. Prefer to use delayed_tabulate instead.
+template <typename T, typename F>
+delayed_sequence<T, std::remove_cv_t<std::remove_reference_t<T>>, F> delayed_seq (size_t n, F f) {
+  return delayed_sequence<T, std::remove_cv_t<std::remove_reference_t<T>>, F>(n, std::move(f));
+}
+
+}  // namespace parlay
+
+#endif  // PARLAY_DELAYED_SEQUENCE_H_

--- a/third_party/parlayhash/include/parlay/hash_table.h
+++ b/third_party/parlayhash/include/parlay/hash_table.h
@@ -1,0 +1,301 @@
+
+#ifndef PARLAY_HASH_TABLE_H_
+#define PARLAY_HASH_TABLE_H_
+
+#include <cstddef>
+
+#include <atomic>
+#include <iostream>
+
+#include "delayed_sequence.h"
+#include "parallel.h"
+#include "sequence.h"
+#include "slice.h"
+#include "utilities.h"
+#include "primitives.h"
+
+
+namespace parlay {
+
+// A "history independent" hash table that supports insertion, and searching
+// It is described in the paper
+//   Julian Shun and Guy E. Blelloch
+//   Phase-concurrent hash tables for determinism
+//   SPAA 2014: 96-107
+// Insertions can happen in parallel
+// Searches can happen in parallel
+// Deletion can happen in parallel
+// but insertions cannot happen in parallel with searches or deletions
+// and searches cannot happen in parallel with deletions
+// i.e. each of the three types of operations have to happen in phase
+template <class HASH>
+class hashtable {
+ private:
+  using eType = typename HASH::eType;
+  using kType = typename HASH::kType;
+  size_t m;
+  eType empty;
+  HASH hashStruct;
+  sequence<eType> TA;
+  using index = size_t;
+
+  static void clear(eType* A, size_t n, eType v) {
+    auto f = [&](size_t i) { assign_uninitialized(A[i], v); };
+    parallel_for(0, n, f, granularity(n));
+  }
+
+  struct notEmptyF {
+    eType e;
+    notEmptyF(eType _e) : e(_e) {}
+    int operator()(eType a) { return e != a; }
+  };
+
+  index hashToRange(index h) { return static_cast<index>(static_cast<size_t>(h) % m); }
+  index firstIndex(kType v) { return hashToRange(hashStruct.hash(v)); }
+  index incrementIndex(index h) { return (h + 1 == m) ? 0 : h + 1; }
+  index decrementIndex(index h) { return (h == 0) ? m - 1 : h - 1; }
+  bool lessIndex(index a, index b) {
+    return (a < b) ? (2 * (b - a) < m) : (2 * (a - b) > m);
+  }
+  bool lessEqIndex(index a, index b) { return a == b || lessIndex(a, b); }
+
+ public:
+  // Size is the maximum number of values the hash table will hold.
+  // Overfilling the table could put it into an infinite loop.
+  hashtable(size_t size, HASH hashF, double load = 1.5)
+    : m(100 + static_cast<size_t>(load * static_cast<double>(size))),
+      empty(hashF.empty()),
+      hashStruct(hashF),
+      TA(sequence<eType>(m, empty)) {
+  }
+
+  ~hashtable() { };
+
+  // prioritized linear probing
+  //   a new key will bump an existing key up if it has a higher priority
+  //   an equal key will replace an old key if replaceQ(new,old) is true
+  // returns 0 if not inserted (i.e. equal and replaceQ false) and 1 otherwise
+  bool insert(eType v) {
+    index i = firstIndex(hashStruct.getKey(v));
+    while (true) {
+      eType c = TA[i];
+      if (c == empty) {
+        if (hashStruct.cas(&TA[i], c, v)) return true;
+      } else {
+        int cmp = hashStruct.cmp(hashStruct.getKey(v), hashStruct.getKey(c));
+        if (cmp == 0) {
+          if (!hashStruct.replaceQ(v, c))
+            return false;
+          else if (hashStruct.cas(&TA[i], c, v))
+            return true;
+        } else if (cmp < 0)
+          i = incrementIndex(i);
+        else if (hashStruct.cas(&TA[i], c, v)) {
+          v = c;
+          i = incrementIndex(i);
+        }
+      }
+    }
+  }
+
+  // prioritized linear probing
+  //   a new key will bump an existing key up if it has a higher priority
+  //   an equal key will replace an old key if replaceQ(new,old) is true
+  // returns 0 if not inserted (i.e. equal and replaceQ false) and 1 otherwise
+  bool update(eType v) {
+    index i = firstIndex(hashStruct.getKey(v));
+    while (true) {
+      eType c = TA[i];
+      if (c == empty) {
+        if (hashStruct.cas(&TA[i], c, v)) return true;
+      } else {
+        int cmp = hashStruct.cmp(hashStruct.getKey(v), hashStruct.getKey(c));
+        if (cmp == 0) {
+          if (!hashStruct.replaceQ(v, c))
+            return false;
+          else {
+            eType new_val = hashStruct.update(c, v);
+            if (hashStruct.cas(&TA[i], c, new_val)) return true;
+          }
+        } else if (cmp < 0)
+          i = incrementIndex(i);
+        else if (hashStruct.cas(&TA[i], c, v)) {
+          v = c;
+          i = incrementIndex(i);
+        }
+      }
+    }
+  }
+
+  bool deleteVal(kType v) {
+    index i = firstIndex(v);
+    int cmp;
+
+    // find first element less than or equal to v in priority order
+    index j = i;
+    eType c = TA[j];
+
+    if (c == empty) return true;
+
+    // find first location with priority less or equal to v's priority
+    while ((cmp = (c == empty) ? 1 : hashStruct.cmp(v, hashStruct.getKey(c))) <
+           0) {
+      j = incrementIndex(j);
+      c = TA[j];
+    }
+    while (true) {
+      // Invariants:
+      //   v is the key that needs to be deleted
+      //   j is our current index into TA
+      //   if v appears in TA, then at least one copy must appear at or before j
+      //   c = TA[j] at some previous time (could now be changed)
+      //   i = h(v)
+      //   cmp = compare v to key of c (positive if greater, 0 equal, negative
+      //   less)
+      if (cmp != 0) {
+        // v does not match key of c, need to move down one and exit if
+        // moving before h(v)
+        if (j == i) return true;
+        j = decrementIndex(j);
+        c = TA[j];
+        cmp = (c == empty) ? 1 : hashStruct.cmp(v, hashStruct.getKey(c));
+      } else {  // found v at location j (at least at some prior time)
+
+        // Find next available element to fill location j.
+        // This is a little tricky since we need to skip over elements for
+        // which the hash index is greater than j, and need to account for
+        // things being moved downwards by others as we search.
+        // Makes use of the fact that values in a cell can only decrease
+        // during a delete phase as elements are moved from the right to left.
+        index jj = incrementIndex(j);
+        eType x = TA[jj];
+        while (x != empty && lessIndex(j, firstIndex(hashStruct.getKey(x)))) {
+          jj = incrementIndex(jj);
+          x = TA[jj];
+        }
+        index jjj = decrementIndex(jj);
+        while (jjj != j) {
+          eType y = TA[jjj];
+          if (y == empty || !lessIndex(j, firstIndex(hashStruct.getKey(y)))) {
+            x = y;
+            jj = jjj;
+          }
+          jjj = decrementIndex(jjj);
+        }
+
+        // try to copy the the replacement element into j
+        if (hashStruct.cas(&TA[j], c, x)) {
+          // swap was successful
+          // if the replacement element was empty, we are done
+          if (x == empty) return true;
+
+          // Otherwise there are now two copies of the replacement element x
+          // delete one copy (probably the original) by starting to look at jj.
+          // Note that others can come along in the meantime and delete
+          // one or both of them, but that is fine.
+          v = hashStruct.getKey(x);
+          j = jj;
+          i = firstIndex(v);
+        }
+        c = TA[j];
+        cmp = (c == empty) ? 1 : hashStruct.cmp(v, hashStruct.getKey(c));
+      }
+    }
+  }
+
+  // Returns the value if an equal value is found in the table
+  // otherwise returns the "empty" element.
+  // due to prioritization, can quit early if v is greater than cell
+  eType find(kType v) {
+    index h = firstIndex(v);
+    eType c = TA[h];
+    while (true) {
+      if (c == empty) return empty;
+      int cmp = hashStruct.cmp(v, hashStruct.getKey(c));
+      if (cmp >= 0) {
+        if (cmp > 0)
+          return empty;
+        else
+          return c;
+      }
+      h = incrementIndex(h);
+      c = TA[h];
+    }
+  }
+
+  // returns the number of entries
+  size_t count() {
+    auto is_full = [&](size_t i) -> size_t { return (TA[i] == empty) ? 0 : 1; };
+    return internal::reduce(delayed_seq<size_t>(m, is_full), addm<size_t>());
+  }
+
+  // returns all the current entries compacted into a sequence
+  sequence<eType> entries() {
+    return filter(make_slice(TA),
+                  [&] (eType v) { return v != empty; });
+  }
+
+  index findIndex(kType v) {
+    index h = firstIndex(v);
+    eType c = TA[h];
+    while (true) {
+      if (c == empty) return -1;
+      int cmp = hashStruct.cmp(v, hashStruct.getKey(c));
+      if (cmp >= 0) {
+        if (cmp > 0)
+          return -1;
+        else
+          return h;
+      }
+      h = incrementIndex(h);
+      c = TA[h];
+    }
+  }
+
+  sequence<index> get_index() {
+    auto is_full = [&](const size_t i) -> int {
+      if (TA[i] != empty)
+        return 1;
+      else
+        return 0;
+    };
+    auto x = sequence<index>::from_function(m, is_full);
+    internal::scan_inplace(make_slice(x), addm<index>());
+    return x;
+  }
+
+  // prints the current entries along with the index they are stored at
+  void print() {
+    std::cout << "vals = ";
+    for (size_t i = 0; i < m; i++)
+      if (TA[i] != empty) std::cout << i << ":" << TA[i] << ",";
+    std::cout << std::endl;
+  }
+};
+
+// Example for hashing numeric values.
+// T must be some integer type
+template <class T>
+struct hash_numeric {
+  using eType = T;
+  using kType = T;
+  eType empty() { return -1; }
+  kType getKey(eType v) { return v; }
+  size_t hash(kType v) { return static_cast<size_t>(hash64(v)); }
+  int cmp(kType v, kType b) { return (v > b) ? 1 : ((v == b) ? 0 : -1); }
+  bool replaceQ(eType, eType) { return 0; }
+  eType update(eType v, eType) { return v; }
+  bool cas(eType* p, eType o, eType n) {
+    // TODO: Make this use atomics properly. This is a quick
+    // fix to get around the fact that the hashtable does
+    // not use atomics. This will break for types that
+    // do not inline perfectly inside a std::atomic (i.e.,
+    // any type that the standard library chooses to lock)
+    return std::atomic_compare_exchange_strong_explicit(
+      reinterpret_cast<std::atomic<eType>*>(p), &o, n, std::memory_order_relaxed, std::memory_order_relaxed);
+  }
+};
+
+}  // namespace parlay
+
+#endif  // PARLAY_HASH_TABLE_H

--- a/third_party/parlayhash/include/parlay/internal/atomic_wait.h
+++ b/third_party/parlayhash/include/parlay/internal/atomic_wait.h
@@ -1,0 +1,425 @@
+// modified from https://raw.githubusercontent.com/ogiroux/atomic_wait/master/include/atomic_wait
+/*
+
+Copyright (c) 2019, NVIDIA Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+/*
+
+This file introduces std::atomic_wait, atomic_notify_one, atomic_notify_all.
+
+It has these strategies implemented:
+ * Contention table. Used to optimize futex notify, or to hold CVs. Disable with __NO_TABLE.
+ * Futex. Supported on Linux and Windows. For performance requires a table on Linux. Disable with __NO_FUTEX.
+ * Condition variables. Supported on Linux and Mac. Requires table to function. Disable with __NO_CONDVAR.
+ * Timed back-off. Supported on everything. Disable with __NO_SLEEP.
+ * Spinlock. Supported on everything. Force with __NO_IDENT. Note: performance is too terrible to use.
+
+You can also compare to pure spinning at algorithm level with __NO_WAIT.
+
+The strategy is chosen this way, by platform:
+ * Linux: default to futex (with table), fallback to futex (no table) -> CVs -> timed backoff -> spin.
+ * Mac: default to CVs (table), fallback to timed backoff -> spin.
+ * Windows: default to futex (no table), fallback to timed backoff -> spin.
+ * CUDA: default to timed backoff, fallback to spin. (This is not all checked in in this tree.)
+ * Unidentified platform: default to spin.
+
+*/
+
+//#define __NO_TABLE
+//#define __NO_FUTEX
+//#define __NO_CONDVAR
+//#define __NO_SLEEP
+//#define __NO_IDENT
+
+// To benchmark against spinning
+//#define __NO_SPIN
+//#define __NO_WAIT
+
+#ifndef PARLAY_INTERNAL_ATOMIC_WAIT_H_
+#define PARLAY_INTERNAL_ATOMIC_WAIT_H_
+
+#include "../type_traits.h"
+
+#ifndef __cpp_lib_atomic_wait
+
+#include <cstdint>
+#include <climits>
+#include <cassert>
+#include <type_traits>
+
+#if defined(__NO_IDENT)
+
+    #include <thread>
+    #include <chrono>
+
+    #define __ABI
+    #define __YIELD() std::this_thread::yield()
+    #define __SLEEP(x) std::this_thread::sleep_for(std::chrono::microseconds(x))
+    #define __YIELD_PROCESSOR()
+
+#else
+
+#if defined(__CUSTD__)
+    #define __NO_FUTEX
+    #define __NO_CONDVAR
+    #ifndef __CUDACC__
+        #define __host__
+        #define __device__
+    #endif
+    #define __ABI __host__ __device__
+#else
+    #define __ABI
+#endif
+
+#if defined(__APPLE__) || defined(__linux__)
+
+    #include <unistd.h>
+    #include <sched.h>
+    #define __YIELD() sched_yield()
+    #define __SLEEP(x) usleep(x)
+
+    #if defined(__aarch64__)
+        #  define __YIELD_PROCESSOR() asm volatile ("yield" ::: "memory")
+    #elif defined(__x86_64__)
+        # define __YIELD_PROCESSOR() asm volatile ("pause" ::: "memory")
+    #elif defined (__powerpc__)
+        # define __YIELD_PROCESSOR() asm volatile ("or 27,27,27" ::: "memory")
+    #endif
+#endif
+
+#if defined(__linux__) && !defined(__NO_FUTEX)
+
+    #if !defined(__NO_TABLE)
+        #define __TABLE
+    #endif
+
+    #include <ctime>
+    #include <unistd.h>
+    #include <linux/futex.h>
+    #include <sys/syscall.h>
+
+    #define __FUTEX
+    #define __FUTEX_TIMED
+    #define __type_used_directly(_T) (std::is_same<typename std::remove_const< \
+            typename std::remove_volatile<_Tp>::type>::type, __futex_preferred_t>::value)
+    using __futex_preferred_t = std::int32_t;
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __do_direct_wait(_Tp const* ptr, _Tp val, void const* timeout) {
+        syscall(SYS_futex, ptr, FUTEX_WAIT_PRIVATE, val, timeout, 0, 0);
+    }
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __do_direct_wake(_Tp const* ptr, bool all) {
+        syscall(SYS_futex, ptr, FUTEX_WAKE_PRIVATE, all ? INT_MAX : 1, 0, 0, 0);
+    }
+
+#elif defined(_WIN32) && !defined(__CUSTD__)
+
+    #define __NO_CONDVAR
+    #define __NO_TABLE
+
+
+    #ifndef NOMINMAX
+    #define PARLAY_DEFINED_NOMINMAX
+    #define NOMINMAX
+    #endif
+    #include <Windows.h>
+    #ifdef PARLAY_DEFINED_NOMINMAX
+    #undef NOMINMAX
+    #endif
+
+    #define __YIELD() Sleep(0)
+    #define __SLEEP(x) Sleep(x)
+    #define __YIELD_PROCESSOR() YieldProcessor()
+
+    #include <intrin.h>
+    template <class _Tp>
+    auto __atomic_load_n(_Tp const* a, int) -> typename std::remove_reference<decltype(*a)>::type {
+        auto const t = *a;
+        _ReadWriteBarrier();
+        return t;
+    }
+    #define __builtin_expect(e, v) (e)
+
+    #if defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN8) && !defined(__NO_FUTEX)
+
+        #define __FUTEX
+        #define __type_used_directly(_T) (sizeof(_T) <= 8)
+        using __futex_preferred_t = std::int64_t;
+        template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+        void __do_direct_wait(_Tp const* ptr, _Tp val, void const*) {
+            WaitOnAddress((PVOID)ptr, (PVOID)&val, sizeof(_Tp), INFINITE);
+        }
+        template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+        void __do_direct_wake(_Tp const* ptr, bool all) {
+            if (all)
+                WakeByAddressAll((PVOID)ptr);
+            else
+                WakeByAddressSingle((PVOID)ptr);
+        }
+
+    #endif
+#endif // _WIN32
+
+#if !defined(__FUTEX) && !defined(__NO_CONDVAR)
+
+    #if defined(__NO_TABLE)
+        #warning "Condvars always generate a table (ignoring __NO_TABLE)."
+    #endif
+    #include <pthread.h>
+    #define __CONDVAR
+    #define __TABLE
+#endif
+
+#endif // __NO_IDENT
+
+#ifdef __TABLE
+    struct alignas(64) contended_t {
+    #if defined(__FUTEX)
+        int                     waiters = 0;
+        __futex_preferred_t     version = 0;
+    #elif defined(__CONDVAR)
+        int                     credit = 0;
+        pthread_mutex_t         mutex = PTHREAD_MUTEX_INITIALIZER;
+        pthread_cond_t          condvar = PTHREAD_COND_INITIALIZER;
+    #else
+        #error ""
+    #endif
+    };
+    contended_t * __contention(volatile void const * p);
+#else
+    template <class _Tp>
+    __ABI void __cxx_atomic_try_wait_slow_fallback(_Tp const* ptr, _Tp val, int order) {
+    #ifndef __NO_SLEEP
+        long history = 10;
+        do {
+            __SLEEP(history >> 2);
+            history += history >> 2;
+            if (history > (1 << 10))
+                history = 1 << 10;
+        } while (__atomic_load_n(ptr, order) == val);
+    #else
+        __YIELD();
+    #endif
+    }
+#endif // __TABLE
+
+#if defined(__CONDVAR)
+
+    template <class _Tp>
+    void __cxx_atomic_notify_all(volatile _Tp const* ptr) {
+        auto * const c = __contention(ptr);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        if(__builtin_expect(0 == __atomic_load_n(&c->credit, __ATOMIC_RELAXED), 1))
+            return;
+        if(0 != __atomic_exchange_n(&c->credit, 0, __ATOMIC_RELAXED)) {
+            pthread_mutex_lock(&c->mutex);
+            pthread_mutex_unlock(&c->mutex);
+            pthread_cond_broadcast(&c->condvar);
+        }
+    }
+    template <class _Tp>
+    void __cxx_atomic_notify_one(volatile _Tp const* ptr) {
+        __cxx_atomic_notify_all(ptr);
+    }
+    template <class _Tp>
+    void __cxx_atomic_try_wait_slow(volatile _Tp const* ptr, _Tp const val, int order) {
+        auto * const c = __contention(ptr);
+        pthread_mutex_lock(&c->mutex);
+        __atomic_store_n(&c->credit, 1, __ATOMIC_RELAXED);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        if (val == __atomic_load_n(ptr, order))
+            pthread_cond_wait(&c->condvar, &c->mutex);
+        pthread_mutex_unlock(&c->mutex);
+    }
+
+#elif defined(__FUTEX)
+
+        template <class _Tp, typename std::enable_if<!__type_used_directly(_Tp), int>::type = 1>
+        void __cxx_atomic_notify_all(_Tp const* ptr) {
+    #if defined(__TABLE)
+            auto * const c = __contention(ptr);
+            __atomic_fetch_add(&c->version, 1, __ATOMIC_RELAXED);
+            __atomic_thread_fence(__ATOMIC_SEQ_CST);
+            if (0 != __atomic_exchange_n(&c->waiters, 0, __ATOMIC_RELAXED))
+                __do_direct_wake(&c->version, true);
+    #endif
+        }
+        template <class _Tp, typename std::enable_if<!__type_used_directly(_Tp), int>::type = 1>
+        void __cxx_atomic_notify_one(_Tp const* ptr) {
+            __cxx_atomic_notify_all(ptr);
+        }
+        template <class _Tp, typename std::enable_if<!__type_used_directly(_Tp), int>::type = 1>
+        void __cxx_atomic_try_wait_slow(_Tp const* ptr, _Tp const val, int order) {
+    #if defined(__TABLE)
+            auto * const c = __contention(ptr);
+            __atomic_store_n(&c->waiters, 1, __ATOMIC_RELAXED);
+            __atomic_thread_fence(__ATOMIC_SEQ_CST);
+            auto const version = __atomic_load_n(&c->version, __ATOMIC_RELAXED);
+            if (__builtin_expect(val != __atomic_load_n(ptr, order), 1))
+                return;
+        #ifdef __FUTEX_TIMED
+            constexpr timespec timeout = { 2, 0 }; // Hedge on rare 'int version' aliasing.
+            __do_direct_wait(&c->version, version, &timeout);
+        #else
+            __do_direct_wait(&c->version, version, nullptr);
+        #endif
+    #else
+        __cxx_atomic_try_wait_slow_fallback(ptr, val, order);
+    #endif // __TABLE
+        }
+
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __cxx_atomic_try_wait_slow(_Tp const* ptr, _Tp val, [[maybe_unused]] int order) {
+    #ifdef __TABLE
+        auto * const c = __contention(ptr);
+        __atomic_fetch_add(&c->waiters, 1, __ATOMIC_RELAXED);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    #endif
+        __do_direct_wait(ptr, val, nullptr);
+    #ifdef __TABLE
+        __atomic_fetch_sub(&c->waiters, 1, __ATOMIC_RELAXED);
+    #endif
+    }
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __cxx_atomic_notify_all(_Tp const* ptr) {
+    #ifdef __TABLE
+        auto * const c = __contention(ptr);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        if (0 != __atomic_load_n(&c->waiters, __ATOMIC_RELAXED))
+    #endif
+            __do_direct_wake(ptr, true);
+    }
+    template <class _Tp, typename std::enable_if<__type_used_directly(_Tp), int>::type = 1>
+    void __cxx_atomic_notify_one(_Tp const* ptr) {
+    #ifdef __TABLE
+        auto * const c = __contention(ptr);
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        if (0 != __atomic_load_n(&c->waiters, __ATOMIC_RELAXED))
+    #endif
+            __do_direct_wake(ptr, false);
+    }
+
+#else // __FUTEX || __CONDVAR
+
+    template <class _Tp>
+    __ABI void __cxx_atomic_try_wait_slow(_Tp const* ptr, _Tp val, int order) {
+        __cxx_atomic_try_wait_slow_fallback(ptr, val, order);
+    }
+    template <class _Tp>
+    __ABI void __cxx_atomic_notify_one(_Tp const* ptr) { }
+    template <class _Tp>
+    __ABI void __cxx_atomic_notify_all(_Tp const* ptr) { }
+
+#endif // __FUTEX || __CONDVAR
+
+template <class _Tp>
+__ABI void __cxx_atomic_wait(_Tp const* ptr, _Tp const val, int order) {
+#ifndef __NO_SPIN
+    if(__builtin_expect(__atomic_load_n(ptr, order) != val,1))
+        return;
+    for(int i = 0; i < 16; ++i) {
+        if(__atomic_load_n(ptr, order) != val)
+            return;
+        if(i < 12)
+            __YIELD_PROCESSOR();
+        else
+            __YIELD();
+    }
+#endif
+    while(val == __atomic_load_n(ptr, order))
+#ifndef __NO_WAIT
+        __cxx_atomic_try_wait_slow(ptr, val, order)
+#endif
+        ;
+}
+
+#include <atomic>
+
+namespace parlay {
+
+    // Note:  We use parlay::type_identity_t here to force a non-deduced context for _Tp. We
+    // can't use typename std::atomic<_Tp>::value_type as the C++20 standard does, because
+    // value_type is not a member of std::atomic in older compiler version (it was added in
+    // a defect report, P0558R1, but doesn't appear to have been retroactively fixed).
+
+    template <class _Tp>
+    __ABI void atomic_wait_explicit(const std::atomic<_Tp>* a, parlay::type_identity_t<_Tp> val, std::memory_order order) {
+        __cxx_atomic_wait((const _Tp*)a, val, (int)order);                        // cppcheck-suppress cstyleCast
+    }
+    template <class _Tp>
+    __ABI void atomic_wait(const std::atomic<_Tp>* a, parlay::type_identity_t<_Tp> val) {
+        __cxx_atomic_wait((const _Tp*)a, val, (int)std::memory_order_seq_cst);    // cppcheck-suppress cstyleCast
+    }
+    template <class _Tp>
+    __ABI void atomic_notify_one(std::atomic<_Tp>* a) {
+        __cxx_atomic_notify_one((const _Tp*)a);                                   // cppcheck-suppress cstyleCast
+    }
+    template <class _Tp>
+    __ABI void atomic_notify_all(std::atomic<_Tp>* a) {
+        __cxx_atomic_notify_all((const _Tp*)a);                                   // cppcheck-suppress cstyleCast
+    }
+
+}
+
+// modified from https://raw.githubusercontent.com/ogiroux/atomic_wait/master/lib/source.cpp
+
+#ifdef __TABLE
+
+extern inline contended_t * __contention(volatile void const * p) {
+    static contended_t contention[256];
+    return contention + ((uintptr_t)p & 255);
+}
+
+#endif //__TABLE
+
+#else // !__cpp_lib_atomic_wait
+
+#include <atomic>
+
+namespace parlay {
+
+    template <class _Tp>
+    void atomic_wait_explicit(const std::atomic<_Tp>* a, parlay::type_identity_t<_Tp> val, std::memory_order order) {
+        std::atomic_wait_explicit(a, val, order);
+    }
+
+    template <class _Tp>
+    void atomic_wait(const std::atomic<_Tp>* a, parlay::type_identity_t<_Tp> val) {
+        std::atomic_wait(a, val);
+    }
+
+    template <class _Tp>
+    void atomic_notify_one(std::atomic<_Tp>* a) {
+        std::atomic_notify_one(a);
+    }
+
+    template <class _Tp>
+    void atomic_notify_all(std::atomic<_Tp>* a) {
+        std::atomic_notify_all(a);
+    }
+
+}
+
+#endif // !__cpp_lib_atomic_wait
+
+#endif //PARLAY_INTERNAL_ATOMIC_WAIT_H_

--- a/third_party/parlayhash/include/parlay/internal/binary_search.h
+++ b/third_party/parlayhash/include/parlay/internal/binary_search.h
@@ -1,0 +1,62 @@
+
+#ifndef PARLAY_BINARY_SEARCH_H_
+#define PARLAY_BINARY_SEARCH_H_
+
+#include <cstddef>
+
+namespace parlay {
+namespace internal {
+  
+// the following parameter can be tuned
+constexpr const size_t _binary_search_base = 16;
+
+template <typename Seq, typename F>
+size_t linear_search(Seq const &I, typename Seq::value_type const &v,
+                     const F &less) {
+  for (size_t i = 0; i < I.size(); i++)
+    if (!less(I[i], v)) return i;
+  return I.size();
+}
+
+// return index to first key greater or equal to v
+template <typename Seq, typename F>
+size_t binary_search(Seq const &I, typename Seq::value_type const &v,
+                     const F &less) {
+  size_t start = 0;
+  size_t end = I.size();
+  while (end - start > _binary_search_base) {
+    size_t mid = (end + start) / 2;
+    if (!less(I[mid], v))
+      end = mid;
+    else
+      start = mid + 1;
+  }
+  return start + linear_search(make_slice(I).cut(start, end), v, less);
+}
+
+template <typename Seq, typename F>
+size_t linear_search(Seq const &I, const F &less) {
+  for (size_t i = 0; i < I.size(); i++)
+    if (!less(I[i])) return i;
+  return I.size();
+}
+
+// return index to first key where less is false
+template <typename Seq, typename F>
+size_t binary_search(Seq const &I, const F &less) {
+  size_t start = 0;
+  size_t end = I.size();
+  while (end - start > _binary_search_base) {
+    size_t mid = (end + start) / 2;
+    if (!less(I[mid]))
+      end = mid;
+    else
+      start = mid + 1;
+  }
+  return start + linear_search(make_slice(I).cut(start, end), less);
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_BINARY_SEARCH_H_

--- a/third_party/parlayhash/include/parlay/internal/block_allocator.h
+++ b/third_party/parlayhash/include/parlay/internal/block_allocator.h
@@ -1,0 +1,233 @@
+// A concurrent allocator for blocks of a fixed size
+//
+// Keeps a local pool per thread, and grabs list_length elements from a
+// global pool if empty, and returns list_length elements to the global
+// pool when local pool=2*list_length.
+//
+// Keeps track of number of allocated elements. Much more efficient
+// than a general purpose allocator.
+//
+// Not generally intended for users. Users should use "type_allocator"
+// which is a convenient wrapper around block_allocator that helps
+// to manage memory for a specific type
+
+#ifndef PARLAY_INTERNAL_BLOCK_ALLOCATOR_H_
+#define PARLAY_INTERNAL_BLOCK_ALLOCATOR_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <new>
+#include <optional>
+
+#include "../utilities.h"
+#include "../thread_specific.h"
+
+#include "concurrency/hazptr_stack.h"
+
+#include "memory_size.h"
+
+// IWYU pragma: no_include <array>
+// IWYU pragma: no_include <vector>
+
+namespace parlay {
+namespace internal {
+
+struct block_allocator {
+ private:
+
+  static inline constexpr size_t default_list_bytes = (1 << 18) - 64;  // in bytes
+  static inline constexpr size_t min_alignment = 128;  // for cache line padding
+
+  struct block {
+    block* next;
+  };
+
+  struct alignas(128) local_list {
+    size_t sz;
+    block* head;
+    block* mid;
+    local_list() : sz(0), head(nullptr), mid(nullptr) {};
+  };
+
+  hazptr_stack<std::byte*> allocated_buffers;
+  hazptr_stack<block*> global_stack;
+  ThreadSpecific<local_list> my_local_list;
+
+  size_t block_size;
+  std::align_val_t block_align;
+  size_t list_length;
+  size_t max_blocks;
+  std::atomic<size_t> blocks_allocated;
+
+  block* get_block(std::byte* buffer, size_t i) const {
+    // Since block is an aggregate type, it has implicit lifetime, so the following code
+    // is defined behaviour in C++20 even if we haven't yet called a constructor of block.
+    // It is still UB prior to C++20, but this is hard to avoid without losing performance.
+    return from_bytes<block>(buffer + i * block_size);
+  }
+
+ public:
+  block_allocator(const block_allocator&) = delete;
+  block_allocator(block_allocator&&) = delete;
+  block_allocator& operator=(const block_allocator&) = delete;
+  block_allocator& operator=(block_allocator&&) = delete;
+
+  size_t get_block_size() const { return block_size; }
+  size_t num_allocated_blocks() const { return blocks_allocated.load(); }
+
+  // Allocate a new list of list_length elements
+
+  auto initialize_list(std::byte* buffer) const -> block* {
+    for (size_t i=0; i < list_length - 1; i++) {
+      new (buffer + i * block_size) block{get_block(buffer, i+1)};
+    }
+    new (buffer + (list_length - 1) * block_size) block{nullptr};
+    return get_block(buffer, 0);
+  }
+
+  size_t num_used_blocks() {
+    size_t free_blocks = global_stack.size()*list_length;
+    my_local_list.for_each([&](auto&& list) {
+      free_blocks += list.sz;
+    });
+    return blocks_allocated.load() - free_blocks;
+  }
+
+  auto allocate_blocks(size_t num_blocks) -> std::byte* {
+    auto buffer = static_cast<std::byte*>(::operator new(num_blocks * block_size, block_align));
+    assert(buffer != nullptr);
+
+    blocks_allocated.fetch_add(num_blocks);
+    assert(blocks_allocated.load() <= max_blocks);
+
+    allocated_buffers.push(buffer); // keep track so can free later
+    return buffer;
+  }
+
+  // Either grab a list from the global pool, or if there is none
+  // then allocate a new list
+  auto get_list() -> block* {
+    std::optional<block*> rem = global_stack.pop();
+    if (rem) return *rem;
+    std::byte* buffer = allocate_blocks(list_length);
+    return initialize_list(buffer);
+  }
+
+  // Allocate n elements across however many lists are needed (rounded up)
+  [[deprecated]] void reserve(size_t) { }
+
+  void print_stats() {
+    size_t used = num_used_blocks();
+    size_t allocated = num_allocated_blocks();
+    size_t sz = get_block_size();
+    std::cout << "Used: " << used << ", allocated: " << allocated
+	      << ", block size: " << sz
+	      << ", bytes: " << sz*allocated << "\n";
+  }
+
+  explicit block_allocator(size_t block_size_,
+    size_t block_align_ = alignof(std::max_align_t),
+    [[maybe_unused]] size_t reserved_blocks = 0,
+    size_t list_length_ = 0,
+    size_t max_blocks_ = 0) :
+      my_local_list(),                                                               // Each block needs to be at least
+      block_size(std::max<size_t>(block_size_, sizeof(block))),    // <------------- // large enough to hold the struct
+      block_align(std::align_val_t{std::max<size_t>(block_align_, min_alignment)}),  // representing a free block.
+      list_length(list_length_ == 0 ? (default_list_bytes + block_size + 1) / block_size : list_length_),
+      max_blocks(max_blocks_ == 0 ? (3 * getMemorySize() / block_size) / 4 : max_blocks_),
+      blocks_allocated(0) {
+
+  }
+
+  // Clears all memory ever allocated by this allocator. All allocated blocks
+  // must be returned before calling this function.
+  //
+  // This operation is not safe to perform concurrently with any other operation
+  //
+  // Returns false if there exists blocks that haven't been returned, in which case
+  // the operation fails and nothing is cleared. Returns true if no lingering
+  // blocks were not freed, in which case the operation is successful
+  bool clear() {
+    if (num_used_blocks() > 0) {
+      return false;
+    }
+    else {
+      // clear lists
+      my_local_list.for_each([](auto&& list) {
+        list.sz = 0;
+      });
+
+      // throw away all allocated memory
+      std::optional<std::byte*> x;
+      while ((x = allocated_buffers.pop())) ::operator delete(*x, block_align);
+      global_stack.clear();
+      blocks_allocated.store(0);
+      return true;
+    }
+  }
+
+  ~block_allocator() {
+    [[maybe_unused]] auto cleared = clear();
+#if !defined(NDEBUG) && !defined(PARLAY_ALLOC_ALLOW_LEAK)
+    if (!cleared) {
+      std::cerr << "There are un-freed blocks obtained from block_allocator. If this is intentional you may"
+                        "suppress this messsage with -DPARLAY_ALLOC_ALLOW_LEAK\n";
+    }
+#endif
+  }
+
+  void free(void* ptr) {
+
+    if (my_local_list->sz == list_length+1) {
+      my_local_list->mid = my_local_list->head;
+    } else if (my_local_list->sz == 2*list_length) {
+      global_stack.push(my_local_list->mid->next);
+      my_local_list->mid->next = nullptr;
+      my_local_list->sz = list_length;
+    }
+
+    auto new_node = new (ptr) block{my_local_list->head};
+    my_local_list->head = new_node;
+    my_local_list->sz++;
+  }
+
+  inline void* alloc() {
+    if (my_local_list->sz == 0)  {
+      auto new_list = get_list();
+
+      // !! Critical problem !! If this task got stolen during get_list(), the
+      // running thread may have changed, so we can't assume we are looking at
+      // the same local list, so we have to double-check the (possibly different)
+      // local list of the (possibly changed) thread
+
+      if (my_local_list->sz == 0) {
+        my_local_list->head = new_list;
+        my_local_list->sz = list_length;
+      }
+      else {
+        // Looks like the task got stolen and the new thread already had a
+        // non-empty local list, so we can push the new one into the global
+        // pool for someone else to use in the future
+        global_stack.push(new_list);
+      }
+    }
+
+    block* p = my_local_list->head;
+    my_local_list->head = my_local_list->head->next;
+    my_local_list->sz--;
+
+    // Note: block is trivial, so it is legal to not call its destructor
+    // before returning it and allowing its storage to be reused
+    return static_cast<void*>(p);
+  }
+
+};
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_BLOCK_ALLOCATOR_H_

--- a/third_party/parlayhash/include/parlay/internal/block_delayed.h
+++ b/third_party/parlayhash/include/parlay/internal/block_delayed.h
@@ -1,0 +1,316 @@
+#ifndef PARLAY_INTERNAL_BLOCK_DELAYED_H_
+#define PARLAY_INTERNAL_BLOCK_DELAYED_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <algorithm>
+#include <iterator>
+#include <new>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "../delayed_sequence.h"
+#include "../monoid.h"
+#include "../parallel.h"
+#include "../sequence.h"
+#include "../slice.h"
+
+#include "get_time.h"
+#include "sequence_ops.h"
+#include "stream_delayed.h"
+
+namespace parlay {
+namespace block_delayed {
+
+static size_t _block_size = 2000;
+
+// takes nested forward iterators and flattens them into a single forward iterator
+// The value_type of the outer iterator must be a range type
+// containing value_type and iterator types, and supporting begin(), and end().
+// Used both in block_delayed_sequence to get a single iterator that goes
+// through all blocks, and in flatten, to get a range over multiple blocks.
+template <typename out_iter_t>
+struct flatten_iterator {
+  using in_range_t = typename std::iterator_traits<out_iter_t>::value_type;
+  using in_iter_t = typename in_range_t::iterator;
+  using value_type = typename in_range_t::value_type;
+  in_iter_t in_iter;
+  out_iter_t out_iter;
+  flatten_iterator& operator++() {
+    //std::cout << (*out_iter).end() - (*out_iter).begin() << std::endl;
+    ++in_iter;
+    while (in_iter == (*out_iter).end()) {// if at end of inner range
+      //std::cout << "moving to next outer" << std::endl;
+      ++out_iter;                      // move to next outer
+      in_iter = (*out_iter).begin();   // and set inner to start
+    }
+    return *this;
+  }
+  value_type operator*() const {return *in_iter;}
+  flatten_iterator(in_iter_t in_iter, out_iter_t out_iter) :
+      in_iter(in_iter), out_iter(out_iter) {
+    //std::cout << "in flatten init: " << (*out_iter).end() - (*out_iter).begin() << std::endl;
+  }
+  flatten_iterator(out_iter_t out_iter) :
+      in_iter((*out_iter).begin()), out_iter(out_iter) {}
+};
+
+template <typename IDS>
+struct block_delayed_sequence {
+  using value_type = typename parlay::sequence<IDS>::value_type;
+  using seq_iter = typename parlay::sequence<IDS>::iterator;
+  using range_type = stream_delayed::forward_delayed_sequence<flatten_iterator<seq_iter>>;
+  using iterator = typename range_type::iterator;
+
+
+  size_t size() const {return rng.end()-rng.begin();}
+  iterator begin() {return rng.end();}
+  iterator end() {return rng.begin();}
+  block_delayed_sequence(parlay::sequence<IDS> sub_ranges_, size_t n)
+      : sub_ranges(std::move(sub_ranges_)),
+        rng(stream_delayed::forward_delayed_sequence(flatten_iterator(sub_ranges.begin()),n)) {}
+
+  parlay::sequence<IDS> sub_ranges; // to iterate over each block
+  range_type rng;  // to iterate over the whole sequence
+};
+
+static inline std::pair<size_t,size_t> num_blocks_and_size(size_t n) {
+  return std::pair((n==0) ? 0 : 1ul + ((n)-1ul) / (_block_size),
+                   _block_size);
+}
+
+// helpers to check if a type is a delayed sequence
+template <typename>
+struct is_delayed_base : std::false_type {};
+template <typename IDS>
+struct is_delayed_base<block_delayed_sequence<IDS>> : std::true_type {};
+template <typename T, typename V, typename F>
+struct is_delayed_base<parlay::delayed_sequence<T,V,F>> : std::true_type {};
+template<typename T>
+struct is_delayed : is_delayed_base<std::remove_cv_t<T>> {};
+
+
+template <typename Seq>
+auto make_iterators(Seq const &S) {
+  size_t n = S.end()-S.begin();
+  auto [num_blocks, block_size] = num_blocks_and_size(n);
+  return internal::tabulate(num_blocks, [&, bs = block_size] (size_t i) {
+    size_t start = i * bs;
+    size_t end = (std::min)(start + bs, n);
+    return parlay::make_slice(S).cut(start,end);
+  }, 1);
+}
+
+// this is only needed to satisfy the overloading rules (same as above but without const)
+template <typename Seq>
+auto make_out_iterators(Seq &S) {
+  size_t n = S.end()-S.begin();
+  auto [num_blocks, block_size] = num_blocks_and_size(n);
+  return internal::tabulate(num_blocks, [&, bs = block_size] (size_t i) {
+    size_t start = i * bs;
+    size_t end = (std::min)(start + bs, n);
+    return parlay::make_slice(S).cut(start,end);
+  }, 1);
+}
+
+template <typename IDS>
+auto make_iterators(block_delayed_sequence<IDS> const &A) {
+  return A.sub_ranges;
+}
+
+// ***************************
+// User functions below here
+// ***************************
+
+template <typename Seq, typename Monoid>
+auto scan_(Seq const &S, Monoid const &m, bool inclusive) {
+  using T = typename Seq::value_type;
+  auto iters = make_iterators(S);
+  size_t num_blocks = iters.size();
+  sequence<T> offsets;
+  T total = m.identity;
+  // if only one block and inclusive then can skip first phase
+  if (!(num_blocks == 1 && inclusive)) {
+    auto sums = internal::map(iters, [&] (auto iter) {
+      return stream_delayed::reduce(m.f, m.identity, iter);});
+    std::tie(offsets, total) = internal::scan(sums, m);
+  } else offsets = sequence<T>(1, m.identity);
+  auto iters2 = internal::tabulate(num_blocks, [&] (size_t i) {
+    return stream_delayed::scan(m.f, offsets[i], iters[i], inclusive);}, 1);
+  assert(!(iters2.empty()));
+  auto bls = block_delayed_sequence(std::move(iters2), S.size());
+  return std::pair(std::move(bls), inclusive ? m.identity : total);
+}
+
+// does not work if input is parlay-delayed for some reason
+template <typename Seq, typename Monoid>
+auto scan(Seq const &S, Monoid const &m) {
+  return scan_(S, m, false);}
+
+// does not work if input is parlay-delayed for some reason
+template <typename Seq, typename Monoid>
+auto scan_inclusive(Seq const &S, Monoid const &m) {
+  return scan_(S, m, true).first;}
+
+template <typename IDS, typename Monoid>
+auto reduce(block_delayed_sequence<IDS> const &A, Monoid const &m) {
+  auto sums = internal::map(A.sub_ranges, [&] (auto iter) {
+    return stream_delayed::reduce(m.f, m.identity, iter);});
+  return internal::reduce(sums, m);
+}
+
+template <typename Seq1, typename Seq2>
+auto zip(Seq1 const &S1, Seq2 const &S2) {
+  size_t n = S1.size();
+  auto iters1 = make_iterators(S1);
+  auto iters2 = make_iterators(S2);
+  auto results = internal::tabulate(iters1.size(), [&] (size_t i) {
+    return stream_delayed::zip(iters1[i], iters2[i]);}, 1);
+  return block_delayed_sequence(std::move(results), n);
+}
+
+template <typename Seq1, typename Seq2, typename F>
+auto zip_with(Seq1 const &S1, Seq2 const &S2, F const &f) {
+  auto iters1 = make_iterators(S1);
+  auto iters2 = make_iterators(S2);
+  auto results = internal::tabulate(iters1.size(), [&] (size_t i) {
+    return stream_delayed::zip_with(iters1[i], iters2[i], f);}, 1);
+  return block_delayed_sequence(std::move(results),S1.size());
+}
+
+template <typename IDS, typename F>
+void apply(block_delayed_sequence<IDS> const &A, F const &f) {
+  auto I = A.sub_ranges;
+  parlay::parallel_for(0, I.size(), [&] (size_t i) {
+    stream_delayed::apply(I[i], f);}, 1);
+}
+
+template <typename Seq1, typename Seq2, typename F>
+void zip_apply(Seq1 const &s1, Seq2 const &s2, F const &f) {
+  auto iters1 = make_iterators(s1);
+  auto iters2 = make_iterators(s2);
+  parlay::parallel_for(0, iters1.size(), [&] (size_t i) {
+    stream_delayed::zip_apply(iters1[i], iters2[i], f);}, 1);
+}
+
+template <typename IDS, typename F>
+auto map(block_delayed_sequence<IDS> const &A, F const &f) {
+  auto I = A.sub_ranges;
+  auto results = internal::tabulate(I.size(), [&] (size_t i) {
+    return stream_delayed::map(I[i], f);
+  },1);
+  return block_delayed_sequence(std::move(results), A.size());
+}
+
+template <typename Seq, typename F,
+	  typename std::enable_if_t<!is_delayed<Seq>::value, int> = 0>
+auto map(Seq const &A, F const &f) {
+  return internal::map(A, f);
+}
+
+template <typename Seq,
+    typename std::enable_if_t<is_delayed<Seq>::value, int> = 0>
+auto force(Seq A) {
+  size_t n = A.size();
+  using T = decltype(*(A.begin()));
+  auto idx = parlay::delayed_seq<size_t>(n, [] (size_t i) {return i;});
+  auto r = parlay::sequence<T>::uninitialized(n);
+  auto f = [&] (size_t i, T a) {new (&r[i]) T(a);};
+  block_delayed::zip_apply(idx, A, f);
+  return r;
+}
+
+// force is the identity if not a delayed sequence
+template <typename Seq,
+    typename std::enable_if_t<!is_delayed<Seq>::value, int> = 0>
+auto force(Seq &A) {return A;}
+
+template<typename Seq>
+auto flatten(Seq &seq) {
+  using out_iter_t = typename Seq::iterator;
+  using in_iter_t = typename Seq::value_type::iterator;
+  //using T = typename Seq::value_type::value_type;
+  auto sizes = internal::map(seq, [] (auto const& s) -> size_t {
+    return s.size();});
+  auto res = internal::scan(sizes, parlay::plus<size_t>());
+  auto offsets = res.first;
+  auto n = res.second;
+  auto [num_blocks, block_size] = num_blocks_and_size(n);
+  auto results = internal::tabulate(num_blocks, [&, block_size=block_size] (size_t i) {
+    size_t start = i * block_size;
+    size_t len = std::min(block_size, n - start);
+    size_t j = (std::upper_bound(offsets.begin(),offsets.end(),start)
+                - offsets.begin() - 1);
+    out_iter_t out_iter = seq.begin()+j;
+    in_iter_t in_iter = (*out_iter).begin() + (start - offsets[j]);
+    return stream_delayed::forward_delayed_sequence(flatten_iterator(in_iter, out_iter), len);
+  }, 1);
+  return block_delayed_sequence(std::move(results), n);
+}
+
+// Allocates a small temp sequence per block, and then copies them
+// into a smaller block sequenc of just copied elements, and finally into the result.
+// This involves an extra copy but works well if the temp block is reused
+// across blocks since it will be in the cache.   It can save significant memory.
+template <typename Seq, typename F, typename G>
+auto filter_map(Seq A, F const &f, G const &g) {
+  internal::timer t("new filter", false);
+  using T = decltype(g(*(A.begin())));
+  auto iters = make_iterators(A);
+  auto num_blocks = iters.size();
+  if (num_blocks == 1)
+    return stream_delayed::filter_map(iters[0], f, g);
+  auto seqs = internal::tabulate(num_blocks, [&] (size_t i) -> parlay::sequence<T> {
+    return stream_delayed::filter_map(iters[i], f, g);}, 1);
+  t.next("tabulate");
+  auto sizes = internal::map(seqs, [&] (parlay::sequence<T> const& x) {
+    return x.size();});
+  auto [r, total]  = internal::scan(sizes, parlay::plus<size_t>());
+  parlay::sequence<T> out = parlay::sequence<T>::uninitialized(total);
+  parlay::parallel_for(0, num_blocks, [&, ri = r.begin(), oi = out.begin()] (size_t i) {
+    for (size_t j = 0; j < sizes[i]; j++)
+      oi[ri[i]+j] = seqs[i][j];
+  }, 1);
+  t.next("parallel for");
+  return out;
+}
+
+template <typename Seq, typename F>
+auto filter(Seq const &A, F const &f) {
+  return block_delayed::filter_map(A, f, [] (auto x) {return x;});
+}
+
+template <typename Seq, typename F, typename G>
+auto filter_op(Seq A, F const &f, G const &g) {
+  internal::timer t("new filter", false);
+  using T = decltype(g(*(A.begin())));
+  auto iters = make_iterators(A);
+  auto num_blocks = iters.size();
+  //if (num_blocks == 1)
+  //  return stream_delayed::filter_map(iters[0], f, g);
+  auto seqs = internal::tabulate(num_blocks, [&] (size_t i) -> parlay::sequence<T> {
+    return stream_delayed::filter_map(iters[i], f, g);}, 1);
+  t.next("tabulate");
+  auto y = flatten(seqs);
+  //std::cout << "filter_op: " << A.size() << ", " << y.size() << std::endl;
+  return std::pair(std::move(y), std::move(seqs));
+}
+
+template <typename Seq, typename F>
+auto filter_op2(Seq A, F const &f) {
+  using T = typename std::remove_reference<decltype(f(*(A.begin())).value())>::type;
+  auto iters = make_iterators(A);
+  auto num_blocks = iters.size();
+  auto seqs = internal::tabulate(num_blocks, [&] (size_t i) -> parlay::sequence<T> {
+      return stream_delayed::filter_op(iters[i], f);}, 1);
+  auto y = flatten(seqs);
+  return std::pair(std::move(y), std::move(seqs));
+}
+
+}  // namespace block_delayed
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_BLOCK_DELAYED_H_

--- a/third_party/parlayhash/include/parlay/internal/bucket_sort.h
+++ b/third_party/parlayhash/include/parlay/internal/bucket_sort.h
@@ -1,0 +1,176 @@
+
+#ifndef PARLAY_BUCKET_SORT_H_
+#define PARLAY_BUCKET_SORT_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <limits>
+
+#include "merge_sort.h"
+#include "quicksort.h"
+
+#include "uninitialized_sequence.h"
+
+#include "../parallel.h"
+#include "../relocation.h"
+#include "../sequence.h"
+#include "../slice.h"
+#include "../utilities.h"
+
+namespace parlay {
+namespace internal {
+
+template <typename InIterator, typename OutIterator, typename KT>
+void radix_step_(slice<InIterator, InIterator> A,
+                 slice<OutIterator, OutIterator> B,
+                 KT* keys,
+                 size_t* counts,
+                 size_t m) {
+  size_t n = A.size();
+  for (size_t i = 0; i < m; i++) counts[i] = 0;
+  for (size_t j = 0; j < n; j++) {
+    size_t k = keys[j];
+    counts[k]++;
+  }
+
+  size_t s = 0;
+  for (size_t i = 0; i < m; i++) {
+    s += counts[i];
+    counts[i] = s;
+  }
+
+  for (size_t j = n; j > 0; j--) {
+    auto x = --counts[keys[j-1]];
+    uninitialized_relocate(&B[x], &A[j-1]);
+  }
+}
+
+// Given the sequence In[l, r), write to Out, the values of
+// In arranged in a balanced tree. Values are indexed using
+// the standard implicit tree ordering (a la binary heaps)
+//
+//                      root (i)
+//                    /          \                       |
+//              left (2i+1)   right(2i+2)
+//
+// i.e. the root of the tree is at index 0, and the left
+// and right children of the node at index i are at indices
+// 2i+1 and 2i+2 respectively.
+//
+// Template parameters: assignment_tag: one of copy_assign_tag,
+// move_assign_tag, uninitialized_copy_tag, uninitialized_move_tag,
+// or unintialized_relocate_tag. Specifies the mode by which
+// values are relocated from In to Out.
+template <typename assignment_tag, typename InIterator, typename OutIterator>
+void to_balanced_tree(InIterator In,
+                      OutIterator Out,
+                      size_t root,
+                      size_t l,
+                      size_t r) {
+  size_t n = r - l;
+  size_t m = l + n / 2;
+  assign_dispatch(Out[root], In[m], assignment_tag());
+  if (n == 1) return;
+  to_balanced_tree<assignment_tag>(In, Out, 2 * root + 1, l, m);
+  to_balanced_tree<assignment_tag>(In, Out, 2 * root + 2, m + 1, r);
+}
+
+// returns true if all equal
+// TODO: Can we avoid the indirection of having to refer to
+// the pivots via their indices? Copying the elements is
+// bad because it doesn't work non-copyable types, but
+// there should be some middle ground.
+template <typename Iterator, typename BinaryOp>
+bool get_buckets(slice<Iterator, Iterator> A,
+                 unsigned char* buckets,
+                 BinaryOp f,
+                 size_t rounds) {
+  size_t n = A.size();
+  size_t num_buckets = (size_t{1} << rounds);
+  size_t over_sample = 1 + n / (num_buckets * 400);
+  size_t sample_set_size = num_buckets * over_sample;
+  size_t num_pivots = num_buckets - 1;
+  
+  auto sample_set = sequence<size_t>::from_function(sample_set_size,
+    [&](size_t i) { return static_cast<size_t>(hash64(i) % n); });
+
+  // sort the samples
+  quicksort(sample_set.begin(), sample_set_size, [&](size_t i, size_t j) {
+    return f(A[i], A[j]); });
+
+  auto pivots = sequence<size_t>::from_function(
+      num_pivots, [&](size_t i) { return sample_set[over_sample * (i + 1)]; });
+
+  if (!f(A[pivots[0]], A[pivots[num_pivots - 1]])) return true;
+
+  auto pivot_tree = sample_set.begin();
+  to_balanced_tree<copy_assign_tag>(pivots.begin(), pivot_tree, 0, 0, num_pivots);
+
+  for (size_t i = 0; i < n; i++) {
+    size_t j = 0;
+    for (size_t k = 0; k < rounds; k++) j = 1 + 2 * j + !f(A[i], A[pivot_tree[j]]);
+    assert(j - num_pivots <= (std::numeric_limits<unsigned char>::max)());
+    buckets[i] = static_cast<unsigned char>(j - num_pivots);
+  }
+  return false;
+}
+
+template <typename InIterator, typename OutIterator, typename BinaryOp>
+void base_sort(slice<InIterator, InIterator> in,
+               slice<OutIterator, OutIterator> out,
+               BinaryOp f,
+               bool stable,
+               bool inplace) {
+  if (stable) {
+    merge_sort_(in, out, f, inplace);
+  }
+  else {
+    quicksort(in.begin(), in.size(), f);
+    if (!inplace) {
+      uninitialized_relocate_n(out.begin(), in.begin(), in.size());
+    }
+  }
+}
+
+template <typename InIterator, typename OutIterator, typename BinaryOp>
+void bucket_sort_r(slice<InIterator, InIterator> in,
+                   slice<OutIterator, OutIterator> out,
+                   BinaryOp f,
+                   bool stable,
+                   bool inplace) {
+  size_t n = in.size();
+  size_t bits = 4;
+  size_t num_buckets = size_t{1} << bits;
+  if (n < num_buckets * 32) {
+    base_sort(in, out, f, stable, inplace);
+  } else {
+    auto counts = sequence<size_t>::uninitialized(num_buckets);
+    auto bucketsm = sequence<unsigned char>::uninitialized(n);
+    unsigned char* buckets = bucketsm.begin();
+    if (get_buckets(in, buckets, f, bits)) {
+      base_sort(in, out, f, stable, inplace);
+    } else {
+      radix_step_(in, out, buckets, counts.data(), num_buckets);
+      auto loop = [&] (size_t j) {
+        size_t start = counts[j];
+        size_t end = (j == num_buckets - 1) ? n : counts[j + 1];
+        bucket_sort_r(out.cut(start, end), in.cut(start, end), f, stable, !inplace);
+      };
+      parallel_for(0, num_buckets, loop, 4);
+    }
+  }
+}
+
+template <typename Iterator, typename BinaryOp>
+void bucket_sort(slice<Iterator, Iterator> in, BinaryOp f, bool stable = false) {
+  using T = typename slice<Iterator, Iterator>::value_type;
+  size_t n = in.size();
+  auto tmp = uninitialized_sequence<T>(n);
+  bucket_sort_r(make_slice(in), make_slice(tmp), f, stable, true);
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_BUCKET_SORT_H_

--- a/third_party/parlayhash/include/parlay/internal/collect_reduce.h
+++ b/third_party/parlayhash/include/parlay/internal/collect_reduce.h
@@ -1,0 +1,349 @@
+#ifndef PARLAY_COLLECT_REDUCE_H_
+#define PARLAY_COLLECT_REDUCE_H_
+
+#include <cassert>
+#include <cstdio>
+
+#include <algorithm>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "../parallel.h"
+#include "../sequence.h"
+#include "../slice.h"
+#include "../utilities.h"
+
+#include "counting_sort.h"
+#include "sequence_ops.h"
+#include "integer_sort.h"
+#include "uninitialized_sequence.h"
+#include "get_time.h"
+
+namespace parlay {
+namespace internal {
+
+// the following parameters can be tuned
+constexpr const size_t CR_SEQ_THRESHOLD = 8192;
+
+// Sequential version of collect_reduce
+// The helper must supply an init() function to initialize a bucket,
+// a get_key(.) function to extrat a key from an element of A,
+// a get_val(.) function to extract a value from an element of A, and
+// a update(.,.) function to add in a new value into a bucket.
+// all keys must be less than num_buckets.
+template <typename Seq, class Helper>
+auto seq_collect_reduce(Seq const &A, Helper const &helper, size_t num_buckets) {
+  using result_type = decltype(helper.init());
+  sequence<result_type> Out(num_buckets, helper.init());
+  for (size_t j = 0; j < A.size(); j++) {
+    size_t k = helper.get_key(A[j]);
+    assert(k < num_buckets);
+    helper.update(Out[k], helper.get_val(A[j]));
+  }
+  return Out;
+}
+
+// This is for few buckets (e.g. less than 2^16)
+template <typename Seq, typename Helper>
+auto collect_reduce_few(Seq const &A, Helper const &helper, size_t num_buckets) {
+  using result_type = decltype(helper.init());
+  size_t n = A.size();
+
+  size_t num_threads = num_workers();
+  size_t num_blocks_ = (std::min)(4 * num_threads, n / num_buckets / 64) + 1;
+  size_t block_size = ((n - 1) / num_blocks_) + 1;
+  size_t num_blocks = (1 + ((n)-1) / (block_size));
+
+  // if insufficient parallelism, do sequentially
+  if (n < CR_SEQ_THRESHOLD || num_blocks == 1 || num_threads == 1)
+    return seq_collect_reduce(A, helper, num_buckets);
+
+  // partial results for each block
+  sequence<sequence<result_type>> Out(num_blocks);
+  sliced_for(n, block_size, [&](size_t i, size_t start, size_t end) {
+    Out[i] = seq_collect_reduce(make_slice(A).cut(start, end),
+                                helper, num_buckets);
+  });
+
+  // comibine partial results into total result
+  return tabulate(num_buckets, [&](size_t i) {
+    result_type o_val = helper.init();
+    for (size_t j = 0; j < num_blocks; j++)
+      helper.update(o_val, Out[j][i]);
+    return o_val; }, 1);
+}
+
+// The idea is to return a hash function that maps any items
+// that appear many times into their own bucket.
+// Otherwise items can end up in the same bucket.
+// E is the type of element
+// HashEq must contain
+//    a key_type
+//    a hash function : key_type -> size_t
+//    an equality function : key_type x key_type -> bool
+template <typename HashEq>
+struct get_bucket {
+  using in_type = typename HashEq::in_type;
+  using key_type = typename HashEq::key_type;
+  using KI = std::pair<key_type, int>;
+  sequence<KI> hash_table;
+  size_t table_mask;
+  size_t bucket_mask;
+  size_t heavy_hitters;
+  const HashEq hasheq;
+
+  // creates a structure from a sequence of elements
+  // bits is the number of bits that will be returned by the hash function
+  // items that appear many times will be mapped individually into the earliest buckets
+  // heavy_hitters will indicate how many of these there are
+  template <typename Seq>
+  get_bucket(Seq const &A, HashEq const &hasheq, size_t bits) : hasheq(hasheq) {
+    size_t n = A.size();
+    size_t num_buckets = size_t{1} << bits;
+    int copy_cutoff = 5; // number of copies in sample to be considered a heavy hitter
+    size_t num_samples = num_buckets;
+    size_t table_size = 4 * num_samples;
+    table_mask = table_size - 1;
+    bucket_mask = num_buckets - 1;
+
+    auto hash_table_count = sequence<KI>(table_size, std::make_pair(key_type(), -1));
+
+    // insert sample into hash table with one less than the
+    // count of how many times appears (since it starts with -1)
+    for (size_t i = 0; i < num_samples; i++) {
+      const auto& a = A[hash64(i) % n];
+      const auto& s = hasheq.get_key(a);
+      size_t idx = hasheq.hash(s) & table_mask;
+      while (1) {
+        if (hash_table_count[idx].second == -1) {
+          hash_table_count[idx] = std::make_pair(s, 0);
+          break;
+        } else if (hasheq.equal(hash_table_count[idx].first, s)) {
+          hash_table_count[idx].second += 1;
+          break;
+        } else
+          idx = (idx + 1) & table_mask;
+      }
+    }
+
+    // add to the hash table if at least copy_cutoff copies appear in sample
+    // give added items consecutive numbers.
+    heavy_hitters = 0;
+    hash_table = sequence<KI>(table_size, std::make_pair(key_type(), -1));
+    for (size_t i = 0; i < table_size; i++) {
+      if (hash_table_count[i].second + 2 > copy_cutoff) {
+        key_type key = hash_table_count[i].first;
+        size_t idx = hasheq.hash(key) & table_mask;
+        if (hash_table[idx].second == -1)
+          hash_table[idx] = std::make_pair(key, heavy_hitters++);
+      }
+    }
+  }
+
+  // the hash function.
+  // uses chosen bucket from preprocessing if key appears many times (heavy)
+  // otherwise uses one of the remaining buckets
+  size_t operator()(in_type const &v) const {
+    //key_type& key = ;
+    auto hash_val = hasheq.hash(hasheq.get_key(v));
+    if (heavy_hitters > 0) {
+      auto &h = hash_table[hash_val & table_mask];
+      if (h.second != -1 && hasheq.equal(h.first, hasheq.get_key(v))) return h.second;
+      hash_val = hash_val & bucket_mask;
+      if ((hash_val & bucket_mask) < heavy_hitters)
+        return hash_val % (bucket_mask+1-heavy_hitters) + heavy_hitters;
+      return hash_val & bucket_mask;
+    }
+    return hash_val & bucket_mask;
+  }
+};
+
+template <typename Seq, class Helper>
+auto collect_reduce(Seq const &A, Helper const &helper, size_t num_buckets) {
+  timer t("collect reduce", false);
+  using T = typename Seq::value_type;
+  size_t n = A.size();
+  //using val_type = typename Helper::val_type;
+  using result_type = decltype(helper.init());
+
+  // #bits is selected so each block fits into L3 cache
+  //   assuming an L3 cache of size 1M per thread
+  // the counting sort uses 2 x input size due to copy
+  size_t cache_per_thread = 1000000;
+  size_t bits = std::max<size_t>(
+      log2_up(1 + (2 * (size_t) sizeof(T) * n) / cache_per_thread), 4);
+  size_t num_blocks = size_t{1} << bits;
+
+  if (num_buckets <= 4 * num_blocks || n < CR_SEQ_THRESHOLD)
+    return collect_reduce_few(A, helper, num_buckets);
+
+  // Shift is to align cache lines.
+  constexpr size_t shift = 8 / sizeof(T);
+
+  // Returns a map (hash) from key to block.
+  // Keys with many elements (big) have their own block while
+  // others share a block.
+  // Keys that share low 4 bits get same block unless big.
+  // This is to avoid false sharing.
+  struct hasheq {
+    Helper helper;
+    using in_type = T;
+    using key_type = typename Helper::key_type;
+    static size_t hash(key_type const &a) {
+      return hash64_2((a+shift) & ~((size_t)15)); }
+    static bool equal(key_type const& a, key_type const& b) { return a == b; }
+    key_type get_key(const in_type &v) const {return helper.get_key(v);}
+  };
+  get_bucket<hasheq> gb(A, hasheq{helper}, bits);
+
+  sequence<T> B = sequence<T>::uninitialized(n);
+  auto Tmp = uninitialized_sequence<T>(n);
+
+  // first partition into blocks based on hash using a counting sort
+  sequence<size_t> block_offsets;
+  block_offsets = integer_sort_<std::false_type, uninitialized_copy_tag>(
+      make_slice(A), make_slice(B), make_slice(Tmp), gb, bits, num_blocks);
+  t.next("sort");
+
+  // results
+  sequence<result_type> sums_s(num_buckets, helper.init());
+  auto sums = sums_s.begin();
+
+  // now process each block in parallel
+  parallel_for(0, num_blocks, [&] (size_t i) {
+    auto slice = B.cut(block_offsets[i], block_offsets[i + 1]);
+
+    if (i < gb.heavy_hitters) // heavy hitters with all equal keys
+      helper.combine(sums[helper.get_key(slice[0])], slice);
+    else { // shared blocks
+      for (size_t j = 0; j < slice.size(); j++) {
+        size_t k = helper.get_key(slice[j]);
+        assert(k < num_buckets);
+        helper.update(sums[k], helper.get_val(slice[j]));
+      }
+    }
+  });
+  t.next("into tables");
+  return sums_s;
+}
+
+template <typename assignment_tag, typename Slice, typename Helper>
+auto seq_collect_reduce_sparse(Slice A, Helper const &helper) {
+  size_t table_size = 3 * A.size() / 2;
+  //using in_type = typename Helper::in_type;
+  using key_type = typename Helper::key_type;
+  using result_type = typename Helper::result_type;
+
+  size_t count=0;
+  uninitialized_sequence<result_type> table_s (table_size);
+  sequence<bool> flags_s(table_size, false);
+  auto table = table_s.begin();
+  auto flags = flags_s.begin();
+
+  // hash into buckets
+  for (size_t j = 0; j < A.size(); j++) {
+    const auto& aj = A[j];
+    const auto& key = helper.get_key(aj);
+    size_t k = ((size_t) helper.hash(key)) % table_size;
+    while (flags[k] && !helper.equal(helper.get_key(table[k]), key))
+      k = (k + 1 == table_size) ? 0 : k + 1;
+    if (flags[k]) {
+      helper.update(table[k], A[j]);
+      // if relocating input need to destruct key
+      if constexpr (std::is_same<assignment_tag,uninitialized_relocate_tag>::value)
+        helper.get_key(A[j]).~key_type();
+    } else {
+      flags[k] = true;
+      count++;
+      helper.init(table[k], A[j]);
+      assign_dispatch(helper.get_key(table[k]),
+                      helper.get_key(A[j]),
+                      assignment_tag());
+    }
+    // if relocating input need to destruct value
+    if constexpr (std::is_same<assignment_tag,uninitialized_relocate_tag>::value)
+      helper.destruct_val(A[j]);
+  }
+
+  // pack non-empty entries of table into result sequence
+  auto r_s = sequence<result_type>::uninitialized(count);
+  auto r = r_s.begin();
+  size_t j = 0;
+  for (size_t i = 0; i < table_size; i++)
+    if (flags[i]) uninitialized_relocate(&r[j++], &table[i]);
+  assert(j == count);
+  return r_s;
+}
+
+// this one is for more buckets than the length of A (i.e. sparse)
+//  A is a sequence of key-value pairs
+//  monoid has fields m.identity and m.f (a binary associative function)
+template <typename assignment_tag, typename Slice, typename Helper>
+auto collect_reduce_sparse_(Slice A, Helper const &helper) {
+  timer t("collect reduce sparse", false);
+  using in_type = std::remove_const_t<typename Helper::in_type>;
+  size_t n = A.size();
+
+  if (n < 10000) return seq_collect_reduce_sparse<assignment_tag>(A, helper);
+
+  // #bits is selected so each block fits into L3 cache
+  //   assuming an L3 cache of size 1M per thread
+  // the counting sort uses 2 x input size due to copy
+  size_t cache_per_thread = 1000000;
+  size_t bits = log2_up(static_cast<size_t>(
+      1 + (1.2 * 2 * sizeof(in_type) * static_cast<double>(n)) / static_cast<double>(cache_per_thread)));
+  bits = std::max<size_t>(bits, 4);
+  size_t num_buckets = (1 << bits);
+
+  // Returns a map (hash) from key to bucket.
+  // Keys with many elements (heavy) have their own bucket while
+  // others share a bucket.
+  auto gb = get_bucket<Helper>(A, helper, bits);
+
+  // first bucket based on hash using an integer sort
+  uninitialized_sequence<in_type> B(n);
+  auto keys = delayed_tabulate(n, [&] (size_t i) {return gb(A[i]);});
+  auto bucket_offsets =
+      count_sort<assignment_tag>(make_slice(A), make_slice(B),
+                                 make_slice(keys), num_buckets).first;
+  t.next("integer sort");
+  // all buckets up to heavy_cutoff have a single key in them
+  size_t heavy_cutoff = gb.heavy_hitters;
+
+  // now in parallel process each bucket sequentially, returning a sequence
+  // of the results within that bucket
+  // Note that all elements of B need to be destructed within this code
+  // since no destructor will be called on B after it.
+  auto tables = tabulate(num_buckets, [&] (size_t i) {
+    auto block = make_slice(B).cut(bucket_offsets[i], bucket_offsets[i+1]);
+    if (i < heavy_cutoff) {
+      auto a = sequence(1,helper.reduce(block));
+      if constexpr (!std::is_trivially_destructible_v<in_type>)
+        parallel_for(0, block.size(), [&] (size_t i) {block[i].~in_type();}, 1000);
+      return a;
+    } else return seq_collect_reduce_sparse<uninitialized_relocate_tag>(block, helper);
+  }, 1);
+  t.next("block hash");
+
+  // flatten the results
+  return flatten(std::move(tables));
+}
+
+template <typename T, typename Helper>
+auto collect_reduce_sparse(sequence<T> &&A, Helper const &helper) {
+  auto r = collect_reduce_sparse_<uninitialized_relocate_tag>(make_slice(A), helper);
+  clear_relocated(A);
+  return r;
+}
+
+template <typename Range, typename Helper>
+auto collect_reduce_sparse(Range const &A, Helper const &helper) {
+  return collect_reduce_sparse_<uninitialized_copy_tag>(make_slice(A), helper);
+}
+
+} // namespace internal
+
+}  // namespace parlay
+
+#endif  // PARLAY_COLLECT_REDUCE_H_

--- a/third_party/parlayhash/include/parlay/internal/concurrency/acquire_retire.h
+++ b/third_party/parlayhash/include/parlay/internal/concurrency/acquire_retire.h
@@ -1,0 +1,171 @@
+
+#ifndef PARLAY_INTERNAL_CONCURRENCY_ACQUIRE_RETIRE_H
+#define PARLAY_INTERNAL_CONCURRENCY_ACQUIRE_RETIRE_H
+
+#include <cassert>
+#include <cstddef>
+
+#include <algorithm>      // IWYU pragma: keep
+#include <atomic>
+#include <memory>
+#include <type_traits>    // IWYU pragma: keep
+#include <unordered_set>
+#include <utility>        // IWYU pragma: keep
+
+#include "../../portability.h"
+#include "../../thread_specific.h"
+
+// IWYU pragma: no_forward_declare parlay::padded
+
+namespace parlay {
+namespace internal {
+
+// intrusive_acquire_retire works on types T that expose a T* via
+// the ADL findable free functions intrusive_get_next(ptr) & intrusive_set_next(ptr)
+template<typename T, typename Deleter = std::default_delete<T>, size_t delay = 1>
+class intrusive_acquire_retire {
+
+  struct RetiredList {
+
+    constexpr RetiredList() noexcept = default;
+
+    ~RetiredList() {
+      assert(size == 0 && "RetiredLists must be emptied via cleanup() before destruction.");
+    }
+
+    void push(T* p) noexcept {
+      intrusive_set_next(p, std::exchange(head, p));
+      size++;
+    }
+
+    [[nodiscard]] std::size_t get_size() const noexcept {
+      return size;
+    }
+
+    template<typename F>
+    void cleanup(F&& is_protected, Deleter& destroy) {
+
+      while (head && !is_protected(head)) {
+        T* old = std::exchange(head, intrusive_get_next(head));
+        destroy(old);
+        size--;
+      }
+
+      if (head) {
+        T* prev = head;
+        T* current = intrusive_get_next(head);
+        while (current) {
+          if (!is_protected(current)) {
+            auto next = intrusive_get_next(current);
+            intrusive_set_next(prev, next);
+            destroy(current);
+            current = next;
+            size--;
+          }
+          else {
+            prev = std::exchange(current, intrusive_get_next(current));
+          }
+        }
+      }
+    }
+
+   private:
+    T* head = nullptr;
+    std::size_t size = 0;
+  };
+
+ public:
+  explicit intrusive_acquire_retire(Deleter deleter_ = {}) :
+      data(), deleter(std::move(deleter_)) {}
+
+  template<typename U>
+  U acquire(const std::atomic<U>& p) {
+    static_assert(std::is_convertible_v<U, T*>, "acquire must read from a type that is convertible to T*");
+    std::atomic<T*>& slot = data->announcement;
+    U result;
+    do {
+      result = p.load(std::memory_order_seq_cst);
+      PARLAY_PREFETCH(result, 0, 0);
+      slot.store(static_cast<T*>(result), std::memory_order_seq_cst);
+    } while (p.load(std::memory_order_seq_cst) != result);
+    return result;
+  }
+
+  void release() {
+    data->announcement.store(nullptr);
+  }
+
+  template<typename U>
+  void retire(U p) {
+    static_assert(std::is_convertible_v<U, T*>, "retire must take a type that is convertible to T*");
+    data->retired.push(static_cast<T*>(p));
+    work_toward_ejects();
+  }
+
+  // Perform any remaining deferred destruction. Need to be very careful
+  // about additional objects being queued for deferred destruction by
+  // an object that was just destructed.
+  ~intrusive_acquire_retire() {
+    // Not a data race since no thread should be accessing the intrusive_acquire_retire
+    // instance while its destructor is being run.  That would be a race from the user.
+    data.for_each([](auto& td) {
+      td.in_progress = true;
+    });
+
+    // Perform cleanup in a loop in case deleting a retired value causes
+    // something else to get retired (e.g., cleaning up a linked list)
+    bool retired = true;
+    while (retired) {
+      retired = false;
+      data.for_each([&](auto&& local_data) {
+        if (local_data.retired.get_size() > 0) {
+          retired = true;
+          local_data.retired.cleanup([](auto&&) { return false; }, deleter);
+        }
+      });
+    }
+  }
+
+ private:
+  // Apply the function f to every currently announced value
+  template<typename F>
+  void scan_slots(F &&f) {
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    data.for_each([&](auto&& local_data) {
+      auto x = local_data.announcement.load(std::memory_order_seq_cst);
+      if (x != nullptr) f(x);
+    });
+  }
+
+  void work_toward_ejects(size_t work = 1) {
+    data->amortized_work += work;
+    auto threshold = std::max<size_t>(30, delay * num_thread_ids());  // Always attempt at least 30 ejects
+    while (!(data->in_progress) && data->amortized_work >= threshold) {
+      data->amortized_work = 0;
+      if (data->retired.get_size() == 0) break;  // nothing to collect
+      data->in_progress = true;
+
+      std::unordered_set<T*> announced;
+      scan_slots([&](T* reserved) { announced.insert(reserved); });
+      data->retired.cleanup([&](T* p) { return announced.count(p) != 0; }, deleter);
+
+      data->in_progress = false;
+    }
+  }
+
+  struct ThreadData {
+    std::atomic<T*> announcement{nullptr};
+    bool in_progress{false};                    // cppcheck-suppress unusedStructMember
+    size_t amortized_work{0};                   // cppcheck-suppress unusedStructMember
+    RetiredList retired{};
+  };
+
+  ThreadSpecific<ThreadData> data;
+  PARLAY_NO_UNIQUE_ADDR Deleter deleter;
+};
+
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_CONCURRENCY_ACQUIRE_RETIRE_H

--- a/third_party/parlayhash/include/parlay/internal/concurrency/hazptr_stack.h
+++ b/third_party/parlayhash/include/parlay/internal/concurrency/hazptr_stack.h
@@ -1,0 +1,132 @@
+
+#ifndef PARLAY_INTERNAL_CONCURRENCY_HAZPTR_STACK_H
+#define PARLAY_INTERNAL_CONCURRENCY_HAZPTR_STACK_H
+
+#include <cstddef>
+
+#include <atomic>
+#include <optional>
+#include <utility>  // IWYU pragma: keep
+
+#include "acquire_retire.h"
+
+namespace parlay {
+namespace internal {
+
+// A minimal, low-level, linearizable, lock-free concurrent
+// stack that uses hazard-pointers for garbage collection.
+//
+// The stack keeps track of its current length
+//
+// Template parameters:
+//  T:  The type of the element stored in the stack
+template<typename T>
+class hazptr_stack {
+
+  struct Node {
+    T t;
+    Node* next;
+    size_t length;
+
+    // Allow the intrusive garbage collector to use the node's own next pointer
+    // instead of having to allocate its own memory to store the retired nodes
+    friend Node* intrusive_get_next(Node* node) {
+      return node->next;
+    }
+
+    friend void intrusive_set_next(Node* node, Node* next_) {
+      node->next = next_;
+    }
+
+    explicit Node(T t_) noexcept(std::is_nothrow_move_constructible_v<T>)
+      : t(std::move(t_)), next(nullptr), length(1) { }
+  };
+
+ public:
+  hazptr_stack() : head(nullptr) {
+    // Touch the hazard pointer instance to force its initialization
+    // before this object, since it must outlive this object. Without
+    // this line, the hazard pointer instance might be destroyed before
+    // the stack, in which case subsequent uses of the stack may try
+    // to use the hazard pointer instance after it has been destroyed!
+    hazptr_instance();
+  }
+
+  // Insert the object t at the top of the stack
+  //
+  // This operation is safe to perform concurrently with other operations
+  void push(T t) {
+    auto p = new Node(std::move(t));
+    do {
+      auto h = hazptr_instance().acquire(head);
+      p->next = h;
+      p->length = h ? h->length + 1 : 1;
+    } while (!head.compare_exchange_weak(p->next, p));
+    hazptr_instance().release();
+  }
+
+  // Remove and return the object at the top of the stack. If the stack
+  // is empty, returns an empty optional<T>.
+  //
+  // This operation is safe to perform concurrently with other operations
+  std::optional<T> pop() {
+    Node* p;
+    do {
+      p = hazptr_instance().acquire(head);
+      if (p == nullptr) return {};
+    } while (!head.compare_exchange_weak(p, p->next));
+    auto val = std::make_optional(std::move(p->t));
+    hazptr_instance().retire(p);
+    hazptr_instance().release();
+    return val;
+  }
+
+  // Return the current size of the stack
+  [[nodiscard]] size_t size() const noexcept {
+    auto p = hazptr_instance().acquire(head);
+    auto result = p ? p->length : 0;
+    hazptr_instance().release();
+    return result;
+  }
+
+  // Returns true if the stack is currently empty
+  [[nodiscard]] bool empty() const noexcept {
+    return head.load() == nullptr;
+  }
+
+  ~hazptr_stack() {
+    // More efficient than clear since we can assume there are
+    // no concurrent accesses and hence we don't need to use
+    // pop, which acquires hazard pointers and uses a CAS loop
+    Node* p = head.load();
+    Node* prev = nullptr;
+    while (p) {
+      prev = p;
+      p = p->next;
+      delete prev;
+    }
+  }
+
+  // Empties the stack
+  //
+  // Can be safely invoked concurrently with other operations, though it
+  // is possible that this operation can be stalled indefinitely if other
+  // threads continue to push onto the stack forever, then this thread
+  // will just keep popping and never manage to empty it.
+  void clear() {
+    while (pop()) { }
+  }
+
+ private:
+  std::atomic<Node*> head;
+
+  static intrusive_acquire_retire<Node>& hazptr_instance() {
+    static intrusive_acquire_retire<Node> instance;
+    return instance;
+  }
+};
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_CONCURRENCY_HAZPTR_STACK_H

--- a/third_party/parlayhash/include/parlay/internal/counting_sort.h
+++ b/third_party/parlayhash/include/parlay/internal/counting_sort.h
@@ -1,0 +1,330 @@
+
+#ifndef PARLAY_COUNTING_SORT_H_
+#define PARLAY_COUNTING_SORT_H_
+
+#include <cassert>
+
+#include <cstddef>
+#include <cstdint>
+#include <algorithm>
+#include <iterator>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+#include "sequence_ops.h"
+#include "uninitialized_sequence.h"
+
+#include "../monoid.h"
+#include "../parallel.h"
+#include "../relocation.h"
+#include "../sequence.h"
+#include "../slice.h"
+#include "../utilities.h"
+
+
+namespace parlay {
+namespace internal {
+
+// the following parameters can be tuned
+constexpr const size_t SEQ_THRESHOLD = 8192;
+constexpr const size_t BUCKET_FACTOR = 32;
+constexpr const size_t LOW_BUCKET_FACTOR = 16;
+
+// count number in each bucket
+template <typename InSeq, typename CountIterator, typename KeySeq>
+void seq_count_(InSeq In, KeySeq Keys, CountIterator counts, size_t num_buckets) {
+  using s_size_t = typename std::iterator_traits<CountIterator>::value_type;
+  size_t n = In.size();
+  // use local counts to avoid false sharing
+  auto local_counts = sequence<s_size_t>(num_buckets);
+  for (size_t j = 0; j < n; j++) {
+    size_t k = Keys[j];
+    assert(k < num_buckets);
+    local_counts[k]++;
+  }
+  for (size_t i = 0; i < num_buckets; i++) counts[i] = local_counts[i];
+}
+
+// write to destination, where offsets give start of each bucket
+template <typename assignment_tag, typename InSeq, typename OffsetIterator, typename KeySeq>
+void seq_write_(InSeq In, KeySeq Keys, OffsetIterator offsets, size_t num_buckets) {
+  // copy to local offsets to avoid false sharing
+  using oi = typename std::iterator_traits<OffsetIterator>::value_type;
+  auto local_offsets = sequence<oi>::uninitialized(num_buckets);
+  for (size_t i = 0; i < num_buckets; i++) local_offsets[i] = offsets[i];
+  for (size_t j = 0; j < In.size(); j++) {
+    oi k = local_offsets[Keys[j]]++;
+    // needs to be made portable
+    #if defined(__GNUC__) || defined(__clang__)
+    if constexpr (is_contiguous_iterator_v<oi>)
+       __builtin_prefetch (((char*) k) + 64);
+    #endif
+    assign_dispatch(*k, In[j], assignment_tag());
+  }
+}
+
+// write to destination, where offsets give end of each bucket
+template <typename assignment_tag, typename InSeq, typename OutIterator, typename OffsetIterator, typename KeySeq>
+void seq_write_down_(InSeq In, OutIterator Out, KeySeq Keys,
+                     OffsetIterator offsets, size_t) {  // num_buckets) {
+  for (std::ptrdiff_t j = In.size() - 1; j >= 0; j--) {
+    auto k = --offsets[Keys[j]];
+    assign_dispatch(Out[k], In[j], assignment_tag());
+  }
+}
+
+// Sequential counting sort internal
+template <typename assignment_tag, typename InS, typename OutS, typename CountIterator, typename KeyS>
+void seq_count_sort_(InS In, OutS Out, KeyS Keys, CountIterator counts,
+                     size_t num_buckets) {
+  // count size of each bucket
+  seq_count_(In, Keys, counts, num_buckets);
+
+  // generate offsets for buckets
+  size_t s = 0;
+  for (size_t i = 0; i < num_buckets; i++) {
+    s += counts[i];
+    counts[i] = s;
+  }
+
+  // send to destination
+  seq_write_down_<assignment_tag>(In, Out.begin(), Keys, counts, num_buckets);
+}
+
+// Sequential counting sort
+template <typename assignment_tag, typename InIterator, typename OutIterator, typename KeyIterator>
+sequence<size_t> seq_count_sort(slice<InIterator, InIterator> In,
+                                slice<OutIterator, OutIterator> Out,
+                                slice<KeyIterator, KeyIterator> Keys,
+                                size_t num_buckets) {
+  auto counts = sequence<size_t>::uninitialized(num_buckets + 1);
+  seq_count_sort_<assignment_tag>(In, Out, Keys, counts.begin(), num_buckets);
+  counts[num_buckets] = In.size();
+  return counts;
+}
+
+// Parallel internal counting sort specialized to type for bucket counts
+// returns counts, and a flag
+// If skip_if_in_one and returned flag is true, then the Input was alread
+// sorted, and it has not been moved to the output.
+//
+// Values are transferred from In to Out as per the type of assignment_tag.
+// E.g. If assignment_tag is parlay::copy_assign_tag, values are copied,
+// if it is parlay::uninitialized_move_tag, they are moved assuming that
+// Out is uninitialized, etc.
+template <typename assignment_tag, typename s_size_t, typename InIterator, typename OutIterator, typename KeyIterator>
+std::pair<sequence<size_t>, bool> count_sort_(slice<InIterator, InIterator> In,
+                                              slice<OutIterator, OutIterator> Out,
+                                              slice<KeyIterator, KeyIterator> Keys,
+                                              size_t num_buckets,
+                                              float parallelism = 1.0,
+                                              bool skip_if_in_one = false) {
+  using T = typename slice<InIterator, InIterator>::value_type;
+  size_t n = In.size();
+  size_t num_threads = num_workers();
+  bool is_nested = parallelism < .5;
+
+  // pick number of blocks for sufficient parallelism but to make sure
+  // cost on counts is not to high (i.e. bucket upper).
+  // size_t par_lower = 1 + static_cast<size_t>(round(num_threads * parallelism * 9));
+  // size_t size_lower = 1;  // + n * sizeof(T) / 2000000;
+  // size_t bucket_upper =
+  //     1 + n * sizeof(T) / (4 * num_buckets * sizeof(s_size_t));
+  // size_t num_blocks = (std::min)(bucket_upper, (std::max)(par_lower, size_lower));
+  size_t num_blocks = 1 + n * sizeof(T) / std::max<size_t>(num_buckets * 500, 5000);
+  
+  // if insufficient parallelism, sort sequentially
+  if (n < SEQ_THRESHOLD || num_blocks == 1 || num_threads == 1) {
+    return std::make_pair(
+      seq_count_sort<assignment_tag>(In, Out, Keys, num_buckets),
+      false);
+  }
+
+  size_t block_size = ((n - 1) / num_blocks) + 1;
+  size_t m = num_blocks * num_buckets;
+
+  auto counts = sequence<s_size_t>::uninitialized(m);
+
+  // sort each block
+  parallel_for(0, num_blocks,
+               [&](size_t i) {
+                 size_t start = (std::min)(i * block_size, n);
+                 size_t end = (std::min)(start + block_size, n);
+                 seq_count_(In.cut(start, end), make_slice(Keys).cut(start, end),
+                            counts.begin() + i * num_buckets, num_buckets);
+               },
+               1, is_nested);
+
+  auto bucket_offsets = sequence<size_t>::uninitialized(num_buckets + 1);
+  parallel_for(0, num_buckets,
+               [&](size_t i) {
+                 size_t v = 0;
+                 for (size_t j = 0; j < num_blocks; j++)
+                   v += counts[j * num_buckets + i];
+                 bucket_offsets[i] = v;
+               },
+               1 + 1024 / num_blocks);
+  bucket_offsets[num_buckets] = 0;
+
+  // if all in one bucket, then no need to sort
+  size_t num_non_zero = 0;
+  for (size_t i = 0; i < num_buckets; i++)
+    num_non_zero += (bucket_offsets[i] > 0);
+  [[maybe_unused]] size_t total = scan_inplace(make_slice(bucket_offsets), plus<size_t>());
+  if (skip_if_in_one && num_non_zero == 1) {
+    return std::make_pair(std::move(bucket_offsets), true);
+  }
+
+  assert(total == n);
+
+  auto dest_offsets = sequence<OutIterator>::uninitialized(num_blocks * num_buckets);
+  parallel_for(0, num_buckets,
+               [&](size_t i) {
+		 auto v = bucket_offsets[i] + Out.begin();
+                 for (size_t j = 0; j < num_blocks; j++) {
+                   dest_offsets[j * num_buckets + i] = v;
+                   v += counts[j * num_buckets + i];
+                 }
+               },
+               1 + 1024 / num_blocks);
+  
+  parallel_for(0, num_blocks,
+               [&](size_t i) {
+                 size_t start = (std::min)(i * block_size, n);
+                 size_t end = (std::min)(start + block_size, n);
+                 seq_write_<assignment_tag>(In.cut(start, end), Keys.cut(start, end),
+					    dest_offsets.begin() + i * num_buckets,
+					    num_buckets);
+               },
+               1, is_nested);
+
+  return std::make_pair(std::move(bucket_offsets), false);
+}
+
+template <typename InIterator, typename KeyIterator>
+auto group_by_small_int(slice<InIterator, InIterator> In,
+			slice<KeyIterator, KeyIterator> Keys,
+			size_t num_buckets) {
+  using T = typename slice<InIterator, InIterator>::value_type;
+  size_t n = In.size();
+  using s_size_t = size_t;
+
+  size_t num_blocks = 1 + n * sizeof(T) / std::max<size_t>(num_buckets * 500, 5000);
+  size_t block_size = ((n - 1) / num_blocks) + 1;
+  size_t m = num_blocks * num_buckets;
+
+  if (num_buckets == 2) {
+    sequence<size_t> Sums(num_blocks);
+    sliced_for(n, block_size, [&](size_t i, size_t s, size_t e) {
+	size_t c = 0;
+	for (size_t j = s; j < e; j++) c += (Keys[j] == 0);
+	Sums[i] = c; });
+    size_t m = scan_inplace(make_slice(Sums), plus<size_t>());
+    auto r0 = sequence<T>::uninitialized(m);
+    auto r1 = sequence<T>::uninitialized(n-m);
+    sliced_for(n, block_size, [&](size_t i, size_t s, size_t e) {
+	size_t c0 = Sums[i];
+	size_t c1 = s - c0;
+	for (size_t j = s; j < e; j++) {
+	  if (Keys[j] == 0)
+	    assign_uninitialized(r0[c0++], In[j]);
+	  else
+	    assign_uninitialized(r1[c1++], In[j]);
+	}});
+    return parlay::sequence<sequence<T>>{std::move(r0), std::move(r1)};
+  }
+
+  auto counts = sequence<s_size_t>::uninitialized(m);
+
+  // sort each block
+  parallel_for(0, num_blocks,
+               [&](size_t i) {
+                 size_t start = (std::min)(i * block_size, n);
+                 size_t end = (std::min)(start + block_size, n);
+                 seq_count_(In.cut(start, end), make_slice(Keys).cut(start, end),
+                            counts.begin() + i * num_buckets, num_buckets);
+               },
+               1);
+
+  auto total_counts = sequence<size_t>::uninitialized(num_buckets);
+  parallel_for(0, num_buckets, [&](size_t i) {
+    size_t v = 0;
+    for (size_t j = 0; j < num_blocks; j++)
+      v += counts[j * num_buckets + i];
+    total_counts[i] = v;
+  }, 1 + 1024 / num_blocks);
+  //total_counts[num_buckets] = 0;
+
+  auto dest_offsets = sequence<T*>::uninitialized(num_blocks * num_buckets);
+  auto results = map(total_counts, [](size_t cnt) { return sequence<T>::uninitialized(cnt); });
+
+  parallel_for(0, num_buckets, [&](size_t i) {
+    auto v = results[i].begin();
+    for (size_t j = 0; j < num_blocks; j++) {
+      dest_offsets[j * num_buckets + i] = v;
+      v += counts[j * num_buckets + i];
+    }
+  }, 1 + 1024 / num_blocks);
+
+  parallel_for(0, num_blocks, [&] (size_t i) {
+    size_t start = (std::min)(i * block_size, n);
+    size_t end = (std::min)(start + block_size, n);
+    seq_write_<uninitialized_copy_tag>(In.cut(start, end), Keys.cut(start, end),
+         dest_offsets.begin() + i * num_buckets,
+         num_buckets);
+  }, 1);
+
+  return results;
+}
+
+// If skip_if_in_one and returned flag is true, then the Input was alread
+// sorted, and it has not been moved to the output.
+//
+// Values are transferred from In to Out as per the type of assignment_tag.
+// E.g. If assignment_tag is parlay::copy_assign_tag, values are copied,
+// if it is parlay::uninitialized_move_tag, they are moved assuming that
+// Out is uninitialized, etc. assignment_tag can be uninitialized_relocate_tag,
+// in which case the inputs are destructively moved, leaving the input
+// as uninitialized memory that must not be destroyed.
+template <typename assignment_tag, typename InIterator, typename OutIterator, typename KeyIterator>
+auto count_sort(slice<InIterator, InIterator> In,
+                slice<OutIterator, OutIterator> Out,
+                slice<KeyIterator, KeyIterator> Keys,
+                size_t num_buckets,
+                float parallelism = 1.0,
+                bool skip_if_in_one = false) {
+  size_t n = In.size();
+  assert(n == Out.size());
+  assert(n == Keys.size());
+
+  size_t max32 = static_cast<size_t>((std::numeric_limits<uint32_t>::max)());
+  if (n < max32 && num_buckets < max32)
+    // use 4-byte counters when larger ones not needed
+    return count_sort_<assignment_tag, uint32_t>(In, Out, Keys, num_buckets, parallelism,
+                                 skip_if_in_one);
+  return count_sort_<assignment_tag, size_t>(In, Out, Keys, num_buckets, parallelism,
+                             skip_if_in_one);
+}
+
+template <typename InIterator, typename KeyS>
+auto count_sort(slice<InIterator, InIterator> In, KeyS const& Keys, size_t num_buckets) {
+  using value_type = typename slice<InIterator, InIterator>::value_type;
+  auto Out = sequence<value_type>::uninitialized(In.size());
+  auto a = count_sort<uninitialized_copy_tag>(In, make_slice(Out), make_slice(Keys), num_buckets);
+  return std::make_pair(std::move(Out), std::move(a.first));
+}
+
+template <typename InIterator, typename KeyS>
+auto count_sort_inplace(slice<InIterator, InIterator> In, KeyS const& Keys, size_t num_buckets) {
+  using value_type = typename slice<InIterator, InIterator>::value_type;
+  auto Tmp = uninitialized_sequence<value_type>(In.size());
+  auto a = count_sort<uninitialized_relocate_tag>(In, make_slice(Tmp), make_slice(Keys), num_buckets);
+  uninitialized_relocate_n(In.begin(), Tmp.begin(), In.size());
+  return a.first;
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_COUNTING_SORT_H_

--- a/third_party/parlayhash/include/parlay/internal/debug_uninitialized.h
+++ b/third_party/parlayhash/include/parlay/internal/debug_uninitialized.h
@@ -1,0 +1,143 @@
+#ifndef PARLAY_INTERNAL_DEBUG_UNINITIALIZED_H_
+#define PARLAY_INTERNAL_DEBUG_UNINITIALIZED_H_
+
+#include <type_traits>
+
+namespace parlay {
+namespace internal {
+
+// A simple type to help look for uninitialized memory bugs.
+// UninitializedTracker is essentially an integer type, but
+// also tracks whether it is currently in an initialized
+// or uninitialized state.
+//
+// Attempting to assign to an uninitialized state will
+// trigger an assertion failure. Attempting to copy or
+// move an uninitialized object will also cause failure.
+//
+// This code will technically invoke undefined behaviour
+// at some point, since we set the initialized flag to
+// false in the destructor for the sole purpose of
+// checking whether it is indeed false the next time
+// someone comes along and wants to do an uninitialized
+// in place construction at that memory location.
+//
+// Some compilers or debugging tools might therefore not
+// work correctly with this class. Defining the initialized
+// flag as volatile seems to prevent compilers from optimizing
+// it out, and therefore leaves its value in memory after
+// the object is destroyed, but this can not be guaranteed.
+//
+// For correctness, this type should only ever be used
+// if its memory is allocated inside a parlay::sequence
+// or parlay::uninitialized_sequence since they know how
+// to set the initialized/uninitialized flag
+struct UninitializedTracker {
+
+  UninitializedTracker() : x(0), initialized(true) {}
+
+  // cppcheck-suppress noExplicitConstructor
+  /* implicit */ UninitializedTracker(int _x) : x(_x), initialized(true) {}
+
+  UninitializedTracker(const UninitializedTracker &other) {
+    assert(other.initialized && "Attempting to copy an uninitialized object!");
+    x = other.x;
+    initialized = true;
+  }
+
+  UninitializedTracker &operator=(const UninitializedTracker &other) {
+    assert(initialized && "Attempting to assign to an uninitialized object!");
+    assert(other.initialized && "Copy assigning an uninitialized object!");
+    x = other.x;
+    return *this;
+  }
+
+  ~UninitializedTracker() {
+    assert(initialized && "Destructor called on uninitialized object!");
+    initialized = false;
+  }
+
+  bool operator==(const UninitializedTracker& other) const {
+    assert(initialized && "Trying to compare an uninitialized object!");
+    assert(other.initialized && "Trying to compare against an uninitialized object!");
+    return x == other.x;
+  }
+
+  bool operator<(const UninitializedTracker& other) const {
+    assert(initialized && "Trying to compare an uninitialized object!");
+    assert(other.initialized && "Trying to compare against an uninitialized object!");
+    return x < other.x;
+  }
+
+  void swap(UninitializedTracker& other) {
+    assert(initialized && "Trying to swap uninitialized object!");
+    assert(other.initialized && "Trying to swap with an uninitialized object!");
+    std::swap(x, other.x);
+  }
+
+  friend void swap(parlay::internal::UninitializedTracker& a, parlay::internal::UninitializedTracker& b) {
+    a.swap(b);
+  }
+
+  int x;
+  volatile bool initialized;   // Volatile required to prevent optimizing out the store in the destructor
+};
+
+}  // namespace internal
+}  // namespace parlay
+
+
+// Macros for testing initialized/uninitializedness
+
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+
+// Checks that the given UninitializedTracker object is uninitialized
+//
+// Usage:
+//   PARLAY_ASSERT_UNINITIALIZED(x)
+// Result:
+//   Terminates the program if the expression (x) refers to an object of
+//   type UninitializedTracker such that (x).initialized is true, i.e.
+//   the object is in an initialized state
+//
+// Note: This macro should only ever be used on memory that was allocated
+// by a parlay::sequence or a parlay::uninitialized_sequence, since they
+// are required to appropriately flag all newly allocated memory as being
+// uninitialized. False positives will occur if this macro is invoked on
+// memory that is not managed by one of these containers.
+#define PARLAY_ASSERT_UNINITIALIZED(x)                                                       \
+do {                                                                                         \
+  using PARLAY_AU_T = std::remove_cv_t<std::remove_reference_t<decltype(x)>>;                \
+  if constexpr (std::is_same_v<PARLAY_AU_T, ::parlay::internal::UninitializedTracker>) {     \
+    assert(!((x).initialized) && "Memory required to be uninitialized is initialized!");     \
+  }                                                                                          \
+} while (0)
+
+// Checks that the given UninitializedTracker object is initialized
+//
+// Usage:
+//   PARLAY_ASSERT_INITIALIZED(x)
+// Result:
+//   Terminates the program if the expression (x) refers to an object of
+//   type UninitializedTracker such that (x).initialized is false, i.e.
+//   the object is in an uninitialized state
+//
+// Note: This macro should only ever be used on memory that was allocated
+// by a parlay::sequence or a parlay::uninitialized_sequence, since they
+// are required to appropriately flag all newly allocated memory as being
+// uninitialized. False positives will occur if this macro is invoked on
+// memory that is not managed by one of these containers.
+#define PARLAY_ASSERT_INITIALIZED(x)                                                         \
+do {                                                                                         \
+  using PARLAY_AI_T = std::remove_cv_t<std::remove_reference_t<decltype(x)>>;                \
+  if constexpr (std::is_same_v<PARLAY_AI_T, ::parlay::internal::UninitializedTracker>) {     \
+    assert((x).initialized && "Memory required to be initialized is uninitialized!");        \
+  }                                                                                          \
+} while (0)
+
+#else
+#define PARLAY_ASSERT_UNINITIALIZED(x)
+#define PARLAY_ASSERT_INITIALIZED(x)
+#endif  // PARLAY_DEBUG_UNINITIALIZED
+
+#endif  // PARLAY_INTERNAL_DEBUG_UNINITIALIZED_H_

--- a/third_party/parlayhash/include/parlay/internal/delayed/common.h
+++ b/third_party/parlayhash/include/parlay/internal/delayed/common.h
@@ -1,0 +1,228 @@
+#ifndef PARLAY_INTERNAL_DELAYED_COMMON_H
+#define PARLAY_INTERNAL_DELAYED_COMMON_H
+
+#include <cstddef>
+
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <type_traits>
+
+#include "../../range.h"
+
+namespace parlay {
+namespace internal {
+namespace delayed {
+
+//  --------------------- Useful concept traits -----------------------
+
+// Defines the member value true if, given a Range type Range_, and a unary operator
+// UnaryOperator_ to be applied to each element of the range, the operator can be
+// applied to the range even when it is const-qualified
+//
+// This trait is used to selectively disable const overloads of member functions
+// (e.g., begin and end) when it would be ill-formed to attempt to transform
+// the range when it is const.
+template<typename Range_, typename UnaryOperator_, typename = std::void_t<>>
+struct is_range_const_transformable : std::false_type {};
+
+template<typename Range_, typename UnaryOperator_>
+struct is_range_const_transformable<Range_, UnaryOperator_, std::void_t<
+  std::enable_if_t< is_range_v<std::add_const_t<std::remove_reference_t<Range_>>> >,
+  std::enable_if_t< std::is_invocable_v<const UnaryOperator_&, range_reference_type_t<std::add_const_t<std::remove_reference_t<Range_>>>> >
+>> : std::true_type {};
+
+// True if, given a Range type Range_, and a unary operator UnaryOperator_ to be
+// applied to each element of the range, the operator can be applied to the range
+// even when it is const-qualified
+template<typename UV, typename UO>
+static inline constexpr bool is_range_const_transformable_v = is_range_const_transformable<UV,UO>::value;
+
+// Defines the member value true if the given type implements get_begin_block(size_t)
+template<typename T, typename = std::void_t<>>
+struct has_begin_block : public std::false_type {};
+
+template<typename T>
+struct has_begin_block<T, std::void_t<
+  decltype( std::declval<T&>().get_begin_block(std::declval<size_t>()) )
+>> : public std::true_type {};
+
+// True if the given type implements get_begin_block(size_t)
+template<typename T>
+inline constexpr bool has_begin_block_v = has_begin_block<T>::value;
+
+// Helper functional that dereferences an indirectly readable object
+// (iterator/pointer/optional/etc) passed to it
+struct dereference {
+  template<typename IndirectlyReadable>
+  decltype(auto) operator()(IndirectlyReadable&& it) const { return *std::forward<IndirectlyReadable>(it); }
+};
+
+// ----------------------------------------------------------------------------
+//                        Block-iterable range parameters
+// ----------------------------------------------------------------------------
+
+// Default block size to use for block-iterable sequences
+static constexpr size_t block_size = 2000;
+
+inline constexpr size_t num_blocks_from_size(size_t n) {
+  return (n == 0) ? 0 : (1 + (n - 1) / block_size);
+}
+
+// ----------------------------------------------------------------------------
+//              Block-iterable interface for random-access ranges
+// ----------------------------------------------------------------------------
+
+template<typename Range,
+         std::enable_if_t<is_random_access_range_v<Range>, int> = 0>
+size_t num_blocks(Range&& r) {
+  auto n = parlay::size(r);
+  return num_blocks_from_size(n);
+}
+
+template<typename Range,
+         std::enable_if_t<is_random_access_range_v<Range>, int> = 0>
+auto begin_block(Range&& r, size_t i) {
+  size_t n = parlay::size(r);
+
+  // Note: For the interface requirements of a block-iterable sequence,
+  // we require begin_block(n_blocks) to be valid and point to the end
+  // iterator of the sequence, since this means that we always satisfy
+  // end_block(r, i) == begin_block(r, i+1).
+  size_t start = (std::min)(i * block_size, n);
+  return std::begin(r) + start;
+}
+
+template<typename Range,
+         std::enable_if_t<is_random_access_range_v<Range>, int> = 0>
+auto end_block(Range&& r, size_t i) {
+  size_t n = parlay::size(r);
+
+  size_t end = (std::min)((i+1) * block_size, n);
+  return std::begin(r) + end;
+}
+
+// ----------------------------------------------------------------------------
+//            Block-iterable interface for non-random-access ranges
+// ----------------------------------------------------------------------------
+
+template<typename Range,
+         std::enable_if_t<!is_random_access_range_v<Range> && is_block_iterable_range_v<Range>, int> = 0>
+size_t num_blocks(Range&& r) {
+  return r.get_num_blocks();
+}
+
+template<typename Range,
+         std::enable_if_t<!is_random_access_range_v<Range> && is_block_iterable_range_v<Range>, int> = 0>
+auto begin_block(Range&& r, size_t i) {
+  return r.get_begin_block(i);
+}
+
+template<typename Range,
+         std::enable_if_t<!is_random_access_range_v<Range> && is_block_iterable_range_v<Range>, int> = 0>
+auto end_block(Range&& r, size_t i) {
+  return r.get_end_block(i);
+}
+
+// ----------------------------------------------------------------------------
+//                          Base class for BID views
+// ----------------------------------------------------------------------------
+
+// Given a view over which we want to perform a delayed operation, we either
+// want to store a reference to it, or a copy. If the input view is provided
+// as an lvalue reference, we will keep a reference, but we will do so inside
+// a reference wrapper to ensure that it is copy-assignable.
+//
+// If the input view is a prvalue or rvalue reference, we take ownership of it
+// and keep it as a value member.
+template<typename T>
+using view_storage_type = std::conditional_t<std::is_lvalue_reference_v<T>,
+                            std::reference_wrapper<std::remove_reference_t<T>>,
+                                                   std::remove_reference_t<T>>;
+
+template<typename UnderlyingView>
+struct block_iterable_view_base_data {
+  explicit block_iterable_view_base_data(UnderlyingView&& v) : view_m(static_cast<UnderlyingView&&>(v)) { }
+
+  UnderlyingView& base_view() { return view_m; }
+  const UnderlyingView& base_view() const { return view_m; }
+
+ private:
+  view_storage_type<UnderlyingView> view_m;
+};
+
+template<>
+struct block_iterable_view_base_data<void> { };
+
+// This base class helps to implement block-iterable delayed views.
+//
+// The parent class must implement get_begin_block(size_t), which, given an index i,
+// returns an iterator to the beginning of block i, and get_num_blocks(), which returns
+// the number of blocks in the range. Note, importantly, that begin_begin_block(n)
+// for n = get_num_blocks() should be valid and return an end iterator for the range.
+//
+// The base class will take care of implementing:
+//
+//  Method            |  Equivalent to
+//  ----------------------------------------------------------
+//  get_end_block(i)  |  get_begin_block(i+1)
+//  begin()           |  get_begin_block(0)
+//  end()             |  get_begin_block(get_num_blocks())
+//
+// If the parent class implements a const overload of get_begin_block, then const
+// overloads of these methods will also be present. Else, they will be disabled.
+//
+// The base class also helps to store the base view. If the underlying (base) view is
+// a reference type, then it is wrapped in a reference_wrapper so that the parent
+// view type is still copy-assignable. If the underlying view is not a reference type,
+// then it is just stored as a value member.
+//
+// If the underlying view is void, then no extra data member is stored. This is useful
+// if the view is actually going to move/copy the underlying data and store it itself.
+//
+// Template arguments:
+//  UnderlyingView: the type of the underlying view that is being transformed
+//  Parent: the type of the parent view class (CRTP)
+template<typename UnderlyingView, typename Parent>
+struct block_iterable_view_base : public block_iterable_view_base_data<UnderlyingView> {
+ public:
+
+  // Returns an interator pointing to the end of block i
+  auto get_end_block(size_t i) { return parent()->get_begin_block(i+1); }
+
+  // Returns an interator pointing to the end of block i
+  template<typename P = const Parent, std::enable_if_t<has_begin_block_v<P>, int> = 0>
+  auto get_end_block(size_t i) const { return parent()->get_begin_block(i+1); }
+
+  // Returns an iterator pointing to the first element of the range
+  auto begin() { return parent()->get_begin_block(0); }
+
+  // Returns an iterator pointing to the first element of the range
+  template<typename P = const Parent, std::enable_if_t<has_begin_block_v<P>, int> = 0>
+  auto begin() const { return parent()->get_begin_block(0); }
+
+  // Returns an iterator pointing to the end of the range
+  auto end() { return parent()->get_begin_block(parent()->get_num_blocks()); }
+
+  // Returns an iterator pointing to the end of the range
+  template<typename P = const Parent, std::enable_if_t<has_begin_block_v<P>, int> = 0>
+  auto end() const { return parent()->get_begin_block(parent()->get_num_blocks()); }
+
+ protected:
+  block_iterable_view_base() = default;
+
+  template<typename UV>
+  explicit block_iterable_view_base(UV&& v, int)
+    : block_iterable_view_base_data<UnderlyingView>(std::forward<UV>(v)) { }
+
+ private:
+  Parent* parent() { return static_cast<Parent*>(this); }
+  const Parent* parent() const { return static_cast<const Parent*>(this); }
+};
+
+
+}  // namespace delayed
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_DELAYED_COMMON_H

--- a/third_party/parlayhash/include/parlay/internal/delayed/filter.h
+++ b/third_party/parlayhash/include/parlay/internal/delayed/filter.h
@@ -1,0 +1,122 @@
+#ifndef PARLAY_INTERNAL_DELAYED_FILTER_H_
+#define PARLAY_INTERNAL_DELAYED_FILTER_H_
+
+#include <cstddef>
+#include <utility>
+
+#include "../../range.h"
+#include "../../relocation.h"
+#include "../../sequence.h"
+#include "../../utilities.h"
+
+#include "../sequence_ops.h"
+#include "../uninitialized_sequence.h"
+
+#include "common.h"
+#include "flatten.h"
+#include "map.h"
+
+namespace parlay {
+namespace internal {
+namespace delayed {
+
+template<typename UnderlyingView, typename UnaryPredicate>
+struct block_delayed_filter_t :
+    public block_iterable_view_base<UnderlyingView, block_delayed_filter_t<UnderlyingView, UnaryPredicate>> {
+
+ private:
+  using base = block_iterable_view_base<UnderlyingView, block_delayed_filter_t<UnderlyingView, UnaryPredicate>>;
+  using base::base_view;
+
+  static_assert(is_block_iterable_range_v<UnderlyingView>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPredicate, range_reference_type_t<UnderlyingView>>);
+
+  using block_type = sequence<range_iterator_type_t<UnderlyingView>>;
+  using block_result_type = sequence<block_type>;
+  using flattener_type = block_delayed_flatten_t<block_result_type>;
+  using mapper_type = block_delayed_map_t<flattener_type, dereference>;
+
+ public:
+  using value_type = range_value_type_t<UnderlyingView>;
+  using reference = range_reference_type_t<UnderlyingView>;
+
+  template<typename UV>
+  block_delayed_filter_t(UV&& v, UnaryPredicate p_) : base(std::forward<UV>(v), 0), p(std::move(p_)),
+      result(flattener_type{filter_blocks(base_view(), p), 0}, dereference{}) { }
+
+  // The default copy constructor is not viable because it might copy dangling iterators
+  block_delayed_filter_t(const block_delayed_filter_t& other) : base(other), p(other.p),
+    result(flattener_type{filter_blocks(base_view(), p), 0}, dereference{}) { }
+
+  block_delayed_filter_t(block_delayed_filter_t&&) noexcept(
+    std::is_nothrow_move_constructible_v<base>                                      &&
+    std::is_nothrow_move_constructible_v<copyable_function_wrapper<UnaryPredicate>> &&
+    std::is_nothrow_move_constructible_v<mapper_type>) = default;
+
+  friend void swap(block_delayed_filter_t& first, block_delayed_filter_t& second) {
+    using std::swap;
+    swap(first.base_view(), second.base_view());
+    swap(first.result, second.result);
+    swap(first.p, second.p);
+  }
+
+  block_delayed_filter_t& operator=(block_delayed_filter_t other) {
+    swap(*this, other);
+    return *this;
+  }
+
+  // Returns the number of elements in the filtered range
+  [[nodiscard]] size_t size() const { return result.size(); }
+
+  // Returns the number of blocks in the filtered range
+  auto get_num_blocks() const { return result.get_num_blocks(); }
+
+  // Return an iterator pointing to the beginning of block i
+  auto get_begin_block(size_t i) { return result.get_begin_block(i); }
+
+  // Return an iterator pointing to the beginning of block i
+  auto get_begin_block(size_t i) const { return result.get_begin_block(i); }
+
+ private:
+  template<typename UV, typename UP>
+  auto filter_blocks(UV&& v, UP&& p) {
+    size_t temp_size = (std::min<size_t>)(parlay::size(v), block_size);
+    return parlay::internal::tabulate(num_blocks(v), [&](size_t i) {
+      return filter_block(begin_block(v, i), end_block(v, i), p, temp_size);
+    });
+  }
+
+  template<typename It, typename UP>
+  auto filter_block(It first, It last, UP&& p, size_t size) {
+    parlay::internal::uninitialized_sequence<It> temp(size);
+    size_t n = 0;
+    for (; first != last; ++first) {
+      if (p(*first)) {
+        assign_uninitialized(temp[n++], first);
+      }
+    }
+    auto res = sequence<It>::uninitialized(n);
+    uninitialized_relocate_n(res.begin(), temp.begin(), n);
+    return res;
+  }
+
+  copyable_function_wrapper<UnaryPredicate> p;
+  mapper_type result;
+};
+
+// Given a range v and a predicate p on the reference type of v,
+// returns a delayed range that references the elements of v for
+// which p returns true.
+template<typename UnderlyingView, typename UnaryPredicate>
+auto filter(UnderlyingView&& v, UnaryPredicate p) {
+  static_assert(is_block_iterable_range_v<UnderlyingView>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPredicate, range_reference_type_t<UnderlyingView>>);
+  return block_delayed_filter_t<UnderlyingView, UnaryPredicate>(
+      std::forward<UnderlyingView>(v), std::move(p));
+}
+
+}  // namespace delayed
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_DELAYED_FILTER_H_

--- a/third_party/parlayhash/include/parlay/internal/delayed/filter_op.h
+++ b/third_party/parlayhash/include/parlay/internal/delayed/filter_op.h
@@ -1,0 +1,122 @@
+#ifndef PARLAY_INTERNAL_DELAYED_FILTER_OP_H_
+#define PARLAY_INTERNAL_DELAYED_FILTER_OP_H_
+
+#include <cstddef>
+
+#include <type_traits>
+#include <utility>
+
+#include "../../range.h"
+#include "../../relocation.h"
+#include "../../sequence.h"
+#include "../../utilities.h"
+
+#include "../sequence_ops.h"
+#include "../uninitialized_sequence.h"
+
+#include "common.h"
+#include "flatten.h"
+
+namespace parlay {
+namespace internal {
+namespace delayed {
+
+template<typename UnderlyingView, typename UnaryOperator>
+struct block_delayed_filter_op_t :
+    public block_iterable_view_base<UnderlyingView, block_delayed_filter_op_t<UnderlyingView, UnaryOperator>> {
+
+ private:
+  using base = block_iterable_view_base<UnderlyingView, block_delayed_filter_op_t<UnderlyingView, UnaryOperator>>;
+  using base::base_view;
+
+  static_assert(is_block_iterable_range_v<UnderlyingView>);
+  static_assert(std::is_invocable_v<UnaryOperator, range_reference_type_t<UnderlyingView>>);
+
+  using optional_type = std::invoke_result_t<UnaryOperator, range_reference_type_t<UnderlyingView>>;
+  static_assert(is_optional_v<optional_type>);
+  using result_type = typename optional_type::value_type;
+  static_assert(std::is_move_constructible_v<result_type>);
+
+  using block_type = sequence<result_type>;
+  using block_result_type = sequence<block_type>;
+  using flattener_type = block_delayed_flatten_t<block_result_type>;
+
+ public:
+  using value_type = result_type;
+  using reference = const result_type&;
+
+  template<typename UV, typename UP>
+  block_delayed_filter_op_t(UV&& v, UP&& p) : base(std::forward<UV>(v), 0),
+      result(filter_blocks(base_view(), std::forward<UP>(p)), 0) {
+
+  }
+
+  // Returns the number of elements in the resulting range
+  [[nodiscard]] size_t size() const { return result.size(); }
+
+  // Returns the number of blocks in the resulting range
+  auto get_num_blocks() const { return result.get_num_blocks(); }
+
+  // Return an iterator pointing to the beginning of block i
+  auto get_begin_block(size_t i) { return result.get_begin_block(i); }
+
+  // Return an iterator pointing to the beginning of block i
+  auto get_begin_block(size_t i) const { return result.get_begin_block(i); }
+
+ private:
+  template<typename UV, typename UP>
+  auto filter_blocks(UV&& v, UP&& p) {
+    size_t temp_size = (std::min<size_t>)(parlay::size(v), block_size);
+    return parlay::internal::tabulate(num_blocks(v), [&](size_t i) {
+      // Note: For some reason, inlining this code results in a performance
+      // decrease!! Calling a separate function here is 2% faster (on GCC 9)
+      return filter_block(begin_block(v,i), end_block(v,i), p, temp_size);
+    });
+  }
+
+  template<typename It, typename UP>
+  auto filter_block(It first, It last, UP&& p, size_t size) {
+    parlay::internal::uninitialized_sequence<result_type> temp(size);
+    size_t n = 0;
+    for (; first != last; ++first) {
+      auto opt = p(*first);
+      if (opt.has_value()) {
+        assign_uninitialized(temp[n++], std::move(*opt));
+      }
+    }
+    auto res = sequence<result_type>::uninitialized(n);
+    uninitialized_relocate_n(res.begin(), temp.begin(), n);
+    return res;
+  }
+
+  flattener_type result;
+};
+
+// Given a range v and a function p on the reference type of v
+// that returns std::optional<T> for some type T, returns a
+// delayed range consisting of the values held by the optionals
+// produced by p on the values of v such that the optional is
+// not empty.
+template<typename UnderlyingView, typename UnaryOperator>
+auto filter_op(UnderlyingView&& v, UnaryOperator&& p) {
+  static_assert(is_block_iterable_range_v<UnderlyingView>);
+  static_assert(std::is_invocable_v<UnaryOperator, range_reference_type_t<UnderlyingView>>);
+  return block_delayed_filter_op_t<UnderlyingView, UnaryOperator>(
+      std::forward<UnderlyingView>(v), std::forward<UnaryOperator>(p));
+}
+
+// Given a range v and a function p on the reference type of v
+// that returns std::optional<T> for some type T, returns a
+// delayed range consisting of the values held by the optionals
+// produced by p on the values of v such that the optional is
+// not empty.
+template<typename UnderlyingView, typename UnaryOperator>
+auto map_maybe(UnderlyingView&& v, UnaryOperator&& p) {
+  return filter_op(std::forward<UnderlyingView>(v), std::forward<UnaryOperator>(p));
+}
+
+}  // namespace delayed
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_DELAYED_FILTER_OP_H_

--- a/third_party/parlayhash/include/parlay/internal/delayed/flatten.h
+++ b/third_party/parlayhash/include/parlay/internal/delayed/flatten.h
@@ -1,0 +1,296 @@
+#ifndef PARLAY_INTERNAL_DELAYED_FLATTEN_H_
+#define PARLAY_INTERNAL_DELAYED_FLATTEN_H_
+
+#include <cstddef>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+#include "../../monoid.h"
+#include "../../parallel.h"
+#include "../../range.h"
+#include "../../sequence.h"
+#include "../../slice.h"
+#include "../../type_traits.h"
+#include "../../utilities.h"
+
+#include "../sequence_ops.h"
+
+#include "common.h"
+#include "map.h"
+#include "terminal.h"
+
+namespace parlay {
+namespace internal {
+namespace delayed {
+
+template<typename UnderlyingView>
+struct block_delayed_flatten_t :
+    public block_iterable_view_base<UnderlyingView, block_delayed_flatten_t<UnderlyingView>> {
+
+ private:
+  static_assert(is_block_iterable_range_v<UnderlyingView>);
+  static_assert(is_forward_range_v<range_reference_type_t<UnderlyingView>>);
+  static_assert(std::is_reference_v<range_reference_type_t<UnderlyingView>>);
+
+  using base = block_iterable_view_base<UnderlyingView, block_delayed_flatten_t<UnderlyingView>>;
+  using base::base_view;
+
+  using outer_iterator_type = range_iterator_type_t<UnderlyingView>;
+  using inner_iterator_type = range_iterator_type_t<range_reference_type_t<UnderlyingView>>;
+
+ public:
+  using reference = range_reference_type_t<range_reference_type_t<UnderlyingView>>;
+  using value_type = range_value_type_t<range_reference_type_t<UnderlyingView>>;
+
+  template<typename UV>
+  block_delayed_flatten_t(UV&& v, int) : base(std::forward<UV>(v), 0) {
+    //                            ^
+    // Extra int parameter is used to ensure that this template doesn't
+    // accidentally take over the job of the copy constructor.
+    initialize_iterators();
+  }
+
+  // The default copy constructor is not viable because it might copy dangling iterators
+  block_delayed_flatten_t(const block_delayed_flatten_t& other) : base(other) {
+    initialize_iterators();
+  }
+
+  block_delayed_flatten_t(block_delayed_flatten_t&&) noexcept(
+    std::is_nothrow_move_constructible_v<base>                          &&
+    std::is_nothrow_move_constructible_v<sequence<outer_iterator_type>> &&
+    std::is_nothrow_move_constructible_v<sequence<inner_iterator_type>>) = default;
+
+  friend void swap(block_delayed_flatten_t& first, block_delayed_flatten_t& second) {
+    using std::swap;
+    swap(first.base_view(), second.base_view());
+    swap(first.n_blocks, second.n_blocks);
+    swap(first.n_elements, second.n_elements);
+    swap(first.outer_starts, second.outer_starts);
+    swap(first.inner_starts, second.inner_starts);
+  }
+
+  block_delayed_flatten_t& operator=(block_delayed_flatten_t other) {
+    swap(*this, other);
+    return *this;
+  }
+
+  template<bool Const>
+  struct iterator_t {
+   private:
+    using parent_type = maybe_const_t<Const, block_delayed_flatten_t<UnderlyingView>>;
+    using base_view_type = maybe_const_t<Const, std::remove_reference_t<UnderlyingView>>;
+    using outer_iterator_type = range_iterator_type_t<base_view_type>;
+    using inner_iterator_type = range_iterator_type_t<range_reference_type_t<base_view_type>>;
+
+    static_assert(std::is_same_v<inner_iterator_type,
+                                 range_iterator_type_t<decltype(*std::declval<outer_iterator_type&>())>>);
+
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using reference = range_reference_type_t<range_reference_type_t<base_view_type>>;
+    using value_type = range_value_type_t<range_reference_type_t<base_view_type>>;;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+
+    decltype(auto) operator*() const { return *inner_it; }
+
+    iterator_t& operator++() {
+      ++inner_it;
+
+      while (inner_it == std::end(*outer_it)) {          // while loop instead of if in case of empty inner sequences
+        if (++outer_it == end_base) {
+          inner_it = {};
+          return *this;
+        }
+        inner_it = std::begin(*outer_it);
+      }
+      return *this;
+    }
+
+    iterator_t operator++(int) { auto tmp = *this; ++(*this); return tmp; }
+
+    friend bool operator==(const iterator_t& x, const iterator_t& y) {
+      return x.outer_it == y.outer_it && x.inner_it == y.inner_it;
+    }
+
+    friend bool operator!=(const iterator_t& x, const iterator_t& y) {
+      return x.outer_it != y.outer_it || x.inner_it != y.inner_it;
+    }
+
+    // Conversion from non-const iterator to const iterator
+    /* implicit */ iterator_t(const iterator_t<false>& other)
+        : outer_it(other.outer_it), inner_it(other.inner_it), end_base(other.end_base) {}
+
+    iterator_t() : outer_it{}, inner_it{}, end_base{} {}
+
+   private:
+    friend parent_type;
+
+    iterator_t(outer_iterator_type outer_it_, inner_iterator_type inner_it_, outer_iterator_type end_base_)
+        : outer_it(std::move(outer_it_)), inner_it(std::move(inner_it_)), end_base(end_base_) {}
+
+    outer_iterator_type outer_it;
+    inner_iterator_type inner_it;
+    outer_iterator_type end_base;
+  };
+
+  using iterator = iterator_t<false>;
+  using const_iterator = iterator_t<true>;
+
+  // Returns the number of elements in the flattened range
+  [[nodiscard]] size_t size() const { return n_elements; }
+
+  // Returns the number of blocks in the flattened range
+  auto get_num_blocks() const { return n_blocks; }
+
+  // Return an iterator pointing to the beginning of block i
+  auto get_begin_block(size_t i) { return iterator(outer_starts[i], inner_starts[i], std::end(base_view())); }
+
+  // Return an iterator pointing to the beginning of block i
+  template<typename UV = const std::remove_reference_t<UnderlyingView>, std::enable_if_t<is_range_v<UV>, int> = 0>
+  auto get_begin_block(size_t i) const { return const_iterator(outer_starts[i], inner_starts[i], std::end(base_view())); }
+
+ private:
+  void initialize_iterators() {
+    // Compute "input offsets", which are, for each element in the input (outer)
+    // sequence, the position of its first element in the output sequence
+    auto offsets = parlay::internal::delayed::to_sequence(
+        parlay::internal::delayed::map(base_view(), [](auto&& r) -> size_t { return parlay::size(r); }));
+    n_elements = parlay::internal::scan_inplace(make_slice(offsets), plus<size_t>{});
+
+    n_blocks = num_blocks_from_size(n_elements);
+    outer_starts = sequence<outer_iterator_type>::uninitialized(n_blocks+1);
+    inner_starts = sequence<inner_iterator_type>::uninitialized(n_blocks+1);
+
+    // The random-access version of the algorithm can just binary
+    // search the offsets for each block which is very cheap
+    if constexpr (is_random_access_range_v<UnderlyingView>) {
+      parlay::parallel_for(0, n_blocks, [&](size_t i) {
+        size_t start = i * block_size;
+        auto j = std::distance(std::begin(offsets),
+                               std::upper_bound(std::begin(offsets), std::end(offsets), start)) - 1;
+        auto external_it = std::begin(base_view()) + j;
+        auto internal_it = std::begin(*external_it);
+        std::advance(internal_it, (start - offsets[j]));
+        assign_uninitialized(outer_starts[i], external_it);
+        assign_uninitialized(inner_starts[i], internal_it);
+      });
+    }
+
+    // The block-iterable version of the algorithm can not binary search the offsets,
+    // so instead it linearly searches them within each block. To be efficient, it
+    // does not do a new linear search for each element since this could take up to
+    // quadratic work, but instead it can start from where the previous search ended
+    else if (n_elements > 0) {
+
+      // Compute "output block offsets", which are, for each block in the output sequence,
+      // the index of the element in the input sequence that contains the block's first element
+      auto out_block_offsets = parlay::internal::tabulate(n_blocks, [&](size_t i) -> size_t {
+        size_t start = i * block_size;
+        return std::distance(std::begin(offsets),
+                             std::upper_bound(std::begin(offsets), std::end(offsets), start)) - 1;
+      });
+
+      // For each block in the input sequence, iterate it (sequentially since we have to), and
+      // find the locations at which the blocks of the output sequence begin.
+      parallel_for(0, num_blocks(base_view()), [&](size_t i) {
+        size_t block_start = i * block_size, block_end = (std::min)((i + 1) * block_size, offsets.size());
+        size_t out_block_id = std::distance(std::begin(out_block_offsets),
+                                            std::lower_bound(std::begin(out_block_offsets), std::end(out_block_offsets), block_start));
+
+        size_t outer_idx = out_block_offsets[out_block_id];
+        if (outer_idx < block_end) {
+          auto outer_it = begin_block(base_view(), i);
+          std::advance(outer_it, outer_idx - block_start);
+
+          auto outer_end = end_block(base_view(), i);
+          for (; outer_it != outer_end && out_block_id < out_block_offsets.size() &&
+                 out_block_offsets[out_block_id] < block_end; ++outer_it, ++outer_idx) {
+            for (; out_block_id < out_block_offsets.size() && out_block_offsets[out_block_id] == outer_idx;
+                 ++out_block_id) {
+              auto inner_it = std::begin(*outer_it);
+              std::advance(inner_it, out_block_id * block_size - offsets[outer_idx]);
+              assign_uninitialized(outer_starts[out_block_id], outer_it);
+              assign_uninitialized(inner_starts[out_block_id], inner_it);
+            }
+          }
+        }
+      });
+    }
+
+    // Sentinel for the end iterator. The inner sentinel is value-initialized, which
+    // is safe because it will never be compared against any other iterator unless
+    // outer_it = end(base_view()), in which case, the other is also value-initialized
+    assign_uninitialized(outer_starts[n_blocks], std::end(base_view()));
+    assign_uninitialized(inner_starts[n_blocks], {});
+  }
+
+  size_t n_blocks, n_elements;
+  sequence<outer_iterator_type> outer_starts;
+  sequence<inner_iterator_type> inner_starts;
+};
+
+// If we want to flatten a range of temporaries, we can not use the previous
+// algorithms because they keeps references into the ranges, which will dangle.
+//
+// This version of flatten therefore just eagerly copies the sequence and
+// then wraps it around the reference version of flatten.
+template<typename UnderlyingView>
+struct block_delayed_flatten_copy_t : public block_iterable_view_base<void, block_delayed_flatten_copy_t<UnderlyingView>> {
+ private:
+  using base = block_iterable_view_base<void, block_delayed_flatten_copy_t<UnderlyingView>>;
+
+  using inner_sequence_type = range_value_type_t<UnderlyingView>;
+  using flattener_type = block_delayed_flatten_t<sequence<inner_sequence_type>&>;
+
+ public:
+  using value_type = range_value_type_t<range_value_type_t<UnderlyingView>>;
+  using reference = range_reference_type_t<range_value_type_t<UnderlyingView>>;
+
+  using iterator = typename flattener_type::iterator;
+  using const_iterator = typename flattener_type::const_iterator;
+
+  template<typename UV>
+  block_delayed_flatten_copy_t(UV&& v, int) : base(),
+      data(parlay::internal::delayed::to_sequence(std::forward<UV>(v))), result(data, 0) {
+
+  }
+
+  // Returns the number of elements in the flattened range
+  [[nodiscard]] size_t size() const { return result.size(); }
+
+  // Returns the number of blocks
+  auto get_num_blocks() const { return result.get_num_blocks(); }
+
+  // Return an iterator pointing to the beginning of block i
+  auto get_begin_block(size_t i) { return result.get_begin_block(i); }
+
+  // Return an iterator pointing to the beginning of block i
+  template<typename UV = const std::remove_reference_t<UnderlyingView>, std::enable_if_t<is_range_v<UV>, int> = 0>
+  auto get_begin_block(size_t i) const { return result.get_begin_block(i); }
+
+ private:
+  sequence<inner_sequence_type> data;
+  flattener_type result;
+};
+
+template<typename UnderlyingView,
+    std::enable_if_t<std::is_reference_v<range_reference_type_t<UnderlyingView>>, int> = 0>
+auto flatten(UnderlyingView&& v) {
+  return block_delayed_flatten_t<UnderlyingView>(std::forward<UnderlyingView>(v), 0);
+}
+
+template<typename UnderlyingView,
+    std::enable_if_t<!std::is_reference_v<range_reference_type_t<UnderlyingView>>, int> = 0>
+auto flatten(UnderlyingView&& v) {
+  return block_delayed_flatten_copy_t<UnderlyingView>(std::forward<UnderlyingView>(v), 0);
+}
+
+}  // namespace delayed
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_DELAYED_FLATTEN_H_

--- a/third_party/parlayhash/include/parlay/internal/delayed/map.h
+++ b/third_party/parlayhash/include/parlay/internal/delayed/map.h
@@ -1,0 +1,118 @@
+#ifndef PARLAY_INTERNAL_DELAYED_MAP_H_
+#define PARLAY_INTERNAL_DELAYED_MAP_H_
+
+#include <cstddef>
+
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+#include "../../range.h"
+#include "../../type_traits.h"
+#include "../../utilities.h"
+
+#include "../sequence_ops.h"
+
+#include "common.h"
+
+namespace parlay {
+namespace internal {
+namespace delayed {
+
+template<typename UnderlyingView, typename UnaryOperator>
+struct block_delayed_map_t :
+    public block_iterable_view_base<UnderlyingView, block_delayed_map_t<UnderlyingView, UnaryOperator>> {
+
+ private:
+  using base = block_iterable_view_base<UnderlyingView, block_delayed_map_t>;
+  using base::base_view;
+
+  static_assert(is_block_iterable_range_v<UnderlyingView>);
+  static_assert(!std::is_reference_v<UnaryOperator>);
+  static_assert(std::is_invocable_v<UnaryOperator&, range_reference_type_t<UnderlyingView>>);
+
+ public:
+
+  using reference = std::invoke_result_t<UnaryOperator&, range_reference_type_t<UnderlyingView>>;
+  using value_type = std::remove_cv_t<std::remove_reference_t<reference>>;
+
+  template<typename UV>
+  block_delayed_map_t(UV&& v, UnaryOperator f) : base(std::forward<UV>(v), 0), op(std::move(f)) {}
+
+  template<bool Const>
+  struct iterator_t {
+   private:
+    using parent_type = maybe_const_t<Const, block_delayed_map_t>;
+    using base_view_type = maybe_const_t<Const, std::remove_reference_t<UnderlyingView>>;
+    using base_iterator_type = range_iterator_type_t<base_view_type>;
+    using f_type = maybe_const_t<Const, UnaryOperator>;
+
+   public:
+    static_assert(std::is_invocable_v<f_type&, range_reference_type_t<base_view_type>>);
+    using iterator_category = std::forward_iterator_tag;
+    using reference = std::invoke_result_t<UnaryOperator, range_reference_type_t<base_view_type>>;
+    using value_type = std::remove_cv_t<std::remove_reference_t<reference>>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+
+    decltype(auto) operator*() const { return (*op)(*it); }
+
+    iterator_t& operator++() { ++it; return *this; }
+    iterator_t operator++(int) { auto tmp = *this; ++(*this); return tmp; }
+
+    friend bool operator==(const iterator_t& x, const iterator_t& y) { return x.it == y.it; }
+    friend bool operator!=(const iterator_t& x, const iterator_t& y) { return x.it != y.it; }
+
+    // Conversion from non-const iterator to const iterator
+    /* implicit */ iterator_t(const iterator_t<false>& other) : it(other.it), op(other.op) {}
+
+    iterator_t() : it{}, op(nullptr) {}
+
+   private:
+    friend parent_type;
+
+    iterator_t(base_iterator_type it_, f_type* op_) : it(std::move(it_)), op(op_) {}
+
+    base_iterator_type it;
+    f_type* op;
+  };
+
+  using iterator = iterator_t<false>;
+  using const_iterator = iterator_t<true>;
+
+  // Returns the number of elements in the range
+  [[nodiscard]] size_t size() const { return base_view().size(); }
+
+  // Returns the number of blocks in the range
+  auto get_num_blocks() const { return num_blocks(base_view()); }
+
+  // Return an iterator pointing to the beginning of block i
+  auto get_begin_block(size_t i) { return iterator(begin_block(base_view(), i), op.get()); }
+
+  // Return an iterator pointing to the beginning of block i
+  template<typename UV = UnderlyingView, std::enable_if_t<is_range_const_transformable_v<UV, UnaryOperator>, int> = 0>
+  auto get_begin_block(size_t i) const { return const_iterator(begin_block(base_view(), i), op.get()); }
+
+ private:
+  copyable_function_wrapper<UnaryOperator> op;
+};
+
+template<typename UnderlyingView, typename UnaryOperator,
+    std::enable_if_t<is_random_access_range_v<UnderlyingView>, int> = 0>
+auto map(UnderlyingView&& v, UnaryOperator f) {
+  return parlay::internal::delayed_map(std::forward<UnderlyingView>(v), std::move(f));
+}
+
+template<typename UnderlyingView, typename UnaryOperator,
+    std::enable_if_t<!is_random_access_range_v<UnderlyingView> &&
+                      is_block_iterable_range_v<UnderlyingView>, int> = 0>
+auto map(UnderlyingView&& v, UnaryOperator f) {
+  return parlay::internal::delayed::block_delayed_map_t<UnderlyingView, UnaryOperator>
+      (std::forward<UnderlyingView>(v), std::move(f));
+}
+
+}  // namespace delayed
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_DELAYED_MAP_H_

--- a/third_party/parlayhash/include/parlay/internal/delayed/scan.h
+++ b/third_party/parlayhash/include/parlay/internal/delayed/scan.h
@@ -1,0 +1,191 @@
+
+#ifndef PARLAY_INTERNAL_DELAYED_SCAN_H
+#define PARLAY_INTERNAL_DELAYED_SCAN_H
+
+#include <cstddef>
+
+#include <iterator>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include "common.h"
+
+#include "../sequence_ops.h"
+
+#include "../../monoid.h"
+#include "../../parallel.h"
+#include "../../range.h"
+#include "../../sequence.h"
+#include "../../slice.h"
+#include "../../type_traits.h"
+#include "../../utilities.h"
+
+namespace parlay {
+namespace internal {
+namespace delayed {
+
+template<typename UnderlyingView, bool Inclusive, typename BinaryOperator, typename T>
+struct block_delayed_scan_t :
+    public block_iterable_view_base<UnderlyingView, block_delayed_scan_t<UnderlyingView, Inclusive, BinaryOperator, T>> {
+
+ private:
+  using base = block_iterable_view_base<UnderlyingView, block_delayed_scan_t<UnderlyingView, Inclusive, BinaryOperator, T>>;
+  using base::base_view;
+
+  using base_ref_type = range_reference_type_t<UnderlyingView>;
+
+ public:
+  using reference = T;
+  using value_type = T;
+
+  static_assert(std::is_move_constructible_v<T>);
+  static_assert(is_binary_operator_for_v<BinaryOperator, T, base_ref_type>);
+
+  template<typename UV>
+  block_delayed_scan_t(UV&& v, BinaryOperator f, T identity)
+      : base(std::forward<UV>(v), 0), total(identity), op(std::move(f)) {
+
+    size_t n_blocks = num_blocks(base_view());
+
+    if (!(n_blocks == 1 && Inclusive)) {
+      block_sums = parlay::internal::tabulate(n_blocks+1, [&](size_t i) {
+        T result = identity;
+        if (i == n_blocks) return result;
+        auto it = begin_block(base_view(), i), last = end_block(base_view(), i);
+        for (; it != last; ++it) {
+          result = op(std::move(result), *it);
+        }
+        return result;
+      });
+      total = parlay::internal::scan_inplace(make_slice(block_sums), parlay::make_monoid(*(op.get()), identity));
+    }
+    else {
+      block_sums = sequence<T>(1, identity);
+    }
+
+    // If inclusive, each block needs to initially include its first value
+    if constexpr (Inclusive) {
+      parallel_for(0, n_blocks, [&](size_t i) {
+        block_sums[i] = op(std::move(block_sums[i]), *begin_block(base_view(), i));
+      });
+    }
+  }
+
+  template<bool Const>
+  struct iterator_t {
+   private:
+    using parent_type = maybe_const_t<Const, block_delayed_scan_t<UnderlyingView, Inclusive, BinaryOperator, T>>;
+    using parent_ptr = std::add_pointer_t<parent_type>;
+    using base_view_type = maybe_const_t<Const, std::remove_reference_t<UnderlyingView>>;
+    using base_iterator_type = range_iterator_type_t<base_view_type>;
+
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using reference = T;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+
+    T operator*() const { return value; }
+
+    iterator_t& operator++() {
+      if constexpr (Inclusive) {
+        if (++it != std::end(parent->base_view())) {
+          value = (parent->op)(std::move(value), *it);
+        }
+      }
+      else {
+        value = (parent->op)(std::move(value), *it);
+        ++it;
+      }
+      return *this;
+    }
+    iterator_t operator++(int) { auto tmp = *this; ++(*this); return tmp; }
+
+    friend bool operator==(const iterator_t& x, const iterator_t& y) { return x.it == y.it; }
+    friend bool operator!=(const iterator_t& x, const iterator_t& y) { return x.it != y.it; }
+
+    // Conversion from non-const iterator to const iterator
+    /* implicit */ iterator_t(const iterator_t<false>& other)
+        : value(other.value), it(other.it), parent(other.parent) {}
+
+    iterator_t() : value{}, it{}, parent(nullptr) {}
+
+   private:
+    friend parent_type;
+
+    iterator_t(T value_, base_iterator_type it_, parent_ptr parent_)
+        : value(std::move(value_)), it(std::move(it_)), parent(parent_) {}
+
+    T value;
+    base_iterator_type it;
+    parent_ptr parent;
+  };
+
+  using iterator = iterator_t<false>;
+  using const_iterator = iterator_t<true>;
+
+  // Returns the total sum of the range
+  template<typename U = T, typename = std::enable_if_t<!Inclusive, U>>
+  auto get_total() const { return total; }
+
+  // Returns the number of elements in the range
+  [[nodiscard]] size_t size() const { return base_view().size(); }
+
+  // Returns the number of blocks in the range
+  auto get_num_blocks() const { return num_blocks(base_view()); }
+
+  // Return an iterator pointing to the beginning of block i
+  auto get_begin_block(size_t i) { return iterator(block_sums[i], begin_block(base_view(), i), this); }
+
+  // Return an iterator pointing to the beginning of block i
+  template<typename UV = const std::remove_reference_t<UnderlyingView>, std::enable_if_t<is_range_v<UV>, int> = 0>
+  auto get_begin_block(size_t i) const { return const_iterator(block_sums[i], begin_block(base_view(), i), this); }
+
+ private:
+  T total;
+  sequence<T> block_sums;
+  copyable_function_wrapper<BinaryOperator> op;
+};
+
+template<typename T, typename UnderlyingView, typename BinaryOperator>
+auto scan(UnderlyingView&& v, BinaryOperator f, T identity) {
+  auto s = block_delayed_scan_t<UnderlyingView, false, BinaryOperator, T>
+      (std::forward<UnderlyingView>(v), std::move(f), std::move(identity));
+  return std::make_pair(std::move(s), s.get_total());
+}
+
+template<typename UnderlyingView, typename Monoid>
+auto scan(UnderlyingView&& v, Monoid m) {
+  auto identity = m.identity;
+  return scan(std::forward<UnderlyingView>(v), std::move(m), std::move(identity));
+}
+
+template<typename UnderlyingView>
+auto scan(UnderlyingView&& v) {
+  return scan(std::forward<UnderlyingView>(v), std::plus<>{}, range_value_type_t<UnderlyingView>{});
+}
+
+template<typename T, typename UnderlyingView, typename BinaryOperator>
+auto scan_inclusive(UnderlyingView&& v, BinaryOperator f, T identity) {
+  return block_delayed_scan_t<UnderlyingView, true, BinaryOperator, T>
+      (std::forward<UnderlyingView>(v), std::move(f), std::move(identity));
+}
+
+template<typename UnderlyingView, typename Monoid>
+auto scan_inclusive(UnderlyingView&& v, Monoid m) {
+  auto identity = m.identity;
+  return scan_inclusive(std::forward<UnderlyingView>(v), std::move(m), std::move(identity));
+}
+
+template<typename UnderlyingView>
+auto scan_inclusive(UnderlyingView&& v) {
+  return scan_inclusive(std::forward<UnderlyingView>(v), std::plus<>{}, range_value_type_t<UnderlyingView>{});
+}
+
+}  // namespace delayed
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_DELAYED_SCAN_H

--- a/third_party/parlayhash/include/parlay/internal/delayed/terminal.h
+++ b/third_party/parlayhash/include/parlay/internal/delayed/terminal.h
@@ -1,0 +1,166 @@
+// Terminal operations on block-iterable sequences are those that convert
+// a block-iterable sequence into a non-block iterable output, such as
+// reduce, which sums each element in the sequence to a single element,
+// or to_sequence, which produces a regular (non-delayed) sequence
+
+#ifndef PARLAY_INTERNAL_DELAYED_TERMINAL_H
+#define PARLAY_INTERNAL_DELAYED_TERMINAL_H
+
+#include <cstddef>
+
+#include <functional>
+#include <utility>
+#include <type_traits>
+
+#include "../../monoid.h"
+#include "../../parallel.h"
+#include "../../range.h"
+#include "../../sequence.h"
+#include "../../slice.h"
+
+#include "../sequence_ops.h"
+
+#include "common.h"
+
+namespace parlay {
+namespace internal {
+namespace delayed {
+
+// ----------------------------------------------------------------------------
+//            Conversion of delayed sequences to regular sequences
+// ----------------------------------------------------------------------------
+
+template<typename Range,
+  std::enable_if_t<is_random_access_range_v<Range>, int> = 0>
+auto to_sequence(Range&& v) {
+  return parlay::to_sequence(std::forward<Range>(v));
+}
+
+template<typename T, typename Alloc = parlay::internal::sequence_default_allocator<T>, typename Range,
+  std::enable_if_t<is_random_access_range_v<Range>, int> = 0>
+auto to_sequence(Range&& v) {
+  return parlay::to_sequence<T, Alloc>(std::forward<Range>(v));
+}
+
+template<typename Range,
+  std::enable_if_t<!is_random_access_range_v<Range> &&
+                    is_block_iterable_range_v<Range>, int> = 0>
+auto to_sequence(Range&& v) {
+  auto sz = parlay::size(v);
+  auto out = parlay::sequence<range_value_type_t<Range>>::uninitialized(sz);
+  parallel_for(0, num_blocks(v), [&](size_t i) {
+    std::uninitialized_copy(begin_block(v, i), end_block(v, i), out.begin() + i * block_size);
+  });
+  return out;
+}
+
+template<typename T, typename Alloc = parlay::internal::sequence_default_allocator<T>, typename Range,
+    std::enable_if_t<!is_random_access_range_v<Range> &&
+                      is_block_iterable_range_v<Range>, int> = 0>
+auto to_sequence(Range&& v) {
+  auto sz = parlay::size(v);
+  auto out = parlay::sequence<T, Alloc>::uninitialized(sz);
+  parallel_for(0, num_blocks(v), [&](size_t i) {
+    std::uninitialized_copy(begin_block(v, i), end_block(v, i), out.begin() + i * block_size);
+  });
+  return out;
+}
+
+// ----------------------------------------------------------------------------
+//                                  Reduce
+// ----------------------------------------------------------------------------
+
+template<typename Range, typename BinaryOperator, typename T,
+  std::enable_if_t<is_random_access_range_v<Range>, int> = 0>
+auto reduce(Range&& v, BinaryOperator f, T identity) {
+  static_assert(is_binary_operator_for_v<BinaryOperator, T, range_reference_type_t<Range>>);
+  return parlay::internal::reduce(make_slice(v), parlay::binary_op(std::move(f), std::move(identity)));
+}
+
+template<typename Range, typename Monoid,
+  std::enable_if_t<is_random_access_range_v<Range>, int> = 0>
+auto reduce(Range&& v, Monoid&& m) {
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<Range>>);
+  return parlay::internal::reduce(make_slice(v), std::forward<Monoid>(m));
+}
+
+template<typename Range,
+  std::enable_if_t<is_random_access_range_v<Range>, int> = 0>
+auto reduce(Range&& v) {
+  static_assert(is_binary_operator_for_v<std::plus<>, range_value_type_t<Range>, range_reference_type_t<Range>>);
+  return reduce(std::forward<Range>(v), std::plus<>{}, range_value_type_t<Range>{});
+}
+
+template<typename Range, typename BinaryOperator, typename T,
+  std::enable_if_t<!is_random_access_range_v<Range> &&
+                    is_block_iterable_range_v<Range>, int> = 0>
+auto reduce(Range&& v, BinaryOperator&& f, T identity) {
+  static_assert(is_binary_operator_for_v<BinaryOperator, T, range_reference_type_t<Range>>);
+
+  auto block_sums = parlay::internal::tabulate(num_blocks(v), [&](size_t i) {
+    T result = identity;
+    auto it = begin_block(v, i), last = end_block(v, i);
+    for (; it != last; ++it) {
+      result = f(std::move(result), *it);
+    }
+    return result;
+  });
+  return parlay::internal::reduce(make_slice(block_sums),
+            parlay::make_monoid(std::forward<BinaryOperator>(f), std::move(identity)));
+}
+
+template<typename Range, typename Monoid,
+  std::enable_if_t<!is_random_access_range_v<Range> &&
+                    is_block_iterable_range_v<Range>, int> = 0>
+auto reduce(Range&& v, Monoid&& m) {
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<Range>>);
+  auto identity = m.identity;
+  return reduce(std::forward<Range>(v), std::forward<Monoid>(m), std::move(identity));
+}
+
+template<typename Range,
+  std::enable_if_t<!is_random_access_range_v<Range> &&
+                    is_block_iterable_range_v<Range>, int> = 0>
+auto reduce(Range&& v) {
+  static_assert(is_binary_operator_for_v<std::plus<>, range_value_type_t<Range>, range_reference_type_t<Range>>);
+  return reduce(std::forward<Range>(v), std::plus<>{}, range_value_type_t<Range>{});
+}
+
+// ----------------------------------------------------------------------------
+//                              For each / apply
+// ----------------------------------------------------------------------------
+
+template<typename Range,  typename UnaryFunction,
+  std::enable_if_t<is_random_access_range_v<Range>, int> = 0>
+void for_each(Range&& v, UnaryFunction&& f) {
+  static_assert(std::is_invocable_v<UnaryFunction, range_reference_type_t<Range>>);
+  parallel_for(0, size(v), [it = std::begin(v), &f](size_t i) {
+    f(it[i]);
+  });
+}
+
+template<typename Range, typename UnaryFunction,
+  std::enable_if_t<!is_random_access_range_v<Range> &&
+                    is_block_iterable_range_v<Range>, int> = 0>
+void for_each(Range&& v, UnaryFunction&& f) {
+  static_assert(std::is_invocable_v<UnaryFunction, range_reference_type_t<Range>>);
+  parallel_for(0, num_blocks(v), [&](size_t i) {
+    auto it = begin_block(v, i), last = end_block(v, i);
+    for (; it != last; ++it) {
+      f(*it);
+    }
+  });
+}
+
+template<typename Range, typename UnaryFunction>
+void apply(Range&& v, UnaryFunction&& f) {
+  static_assert(is_block_iterable_range_v<Range>);
+  static_assert(std::is_invocable_v<UnaryFunction, range_reference_type_t<Range>>);
+  parlay::internal::delayed::for_each(std::forward<Range>(v), std::forward<UnaryFunction>(f));
+}
+
+}  // namespace delayed
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_DELAYED_TERMINAL_H

--- a/third_party/parlayhash/include/parlay/internal/delayed/zip.h
+++ b/third_party/parlayhash/include/parlay/internal/delayed/zip.h
@@ -1,0 +1,147 @@
+
+#ifndef PARLAY_INTERNAL_DELAYED_ZIP_H
+#define PARLAY_INTERNAL_DELAYED_ZIP_H
+
+#include <cstddef>
+
+#include <algorithm>
+#include <iterator>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "common.h"
+
+#include "../sequence_ops.h"
+
+#include "../../range.h"
+#include "../../type_traits.h"
+
+namespace parlay {
+namespace internal {
+namespace delayed {
+
+
+template<typename... UnderlyingViews>
+struct block_delayed_zip_t : public block_iterable_view_base<void, block_delayed_zip_t<UnderlyingViews...>> {
+
+ private:
+  using base = block_iterable_view_base<void, block_delayed_zip_t<UnderlyingViews...>>;
+
+  static_assert(sizeof...(UnderlyingViews) >= 1);
+  static_assert((is_block_iterable_range_v<UnderlyingViews> && ...));
+
+ public:
+  using value_type = std::tuple<range_value_type_t<UnderlyingViews>...>;
+  using reference = std::tuple<range_reference_type_t<UnderlyingViews>...>;
+
+  template<typename... UV>
+  explicit block_delayed_zip_t(int, UV&&... vs) : base(), n_elements((std::min<size_t>)({parlay::size(vs)...})),
+                                                  n_blocks(num_blocks_from_size(n_elements)),
+                                                  base_views(std::forward<UV>(vs)...) {
+    //                         ^
+    // Extra int parameter is used to ensure that this template doesn't
+    // accidentally take over the job of the copy constructor.
+    static_assert((std::is_same_v<UnderlyingViews, UV> && ...));
+  }
+
+  template<bool Const>
+  struct iterator_t {
+   private:
+    using parent_type = maybe_const_t<Const, block_delayed_zip_t<UnderlyingViews...>>;
+
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = std::tuple<range_value_type_t<maybe_const_t<Const, UnderlyingViews>>...>;
+    using reference = std::tuple<range_reference_type_t<maybe_const_t<Const, UnderlyingViews>>...>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+
+    reference operator*() const {
+      return std::apply([](auto&&... it) { return reference{(*it)...}; }, its);
+    }
+
+    iterator_t& operator++() { index++; std::apply([](auto&... it) { (++it, ...); }, its); return *this; }
+    iterator_t operator++(int) { auto tmp = *this; ++(*this); return tmp; }
+
+    friend bool operator==(const iterator_t& x, const iterator_t& y) {
+      return x.index == y.index;
+    }
+
+    friend bool operator!=(const iterator_t& x, const iterator_t& y) {
+      return x.index != y.index;
+    }
+
+    // Conversion from non-const iterator to const iterator
+    /* implicit */ iterator_t(const iterator_t<false>& other) : index(other.index), its(other.its) {}
+
+    iterator_t() : its{} {}
+
+   private:
+    friend parent_type;
+
+    iterator_t(size_t index_, range_iterator_type_t<maybe_const_t<Const, UnderlyingViews>>... its_)
+      : index(index_), its(std::move(its_)...) {}
+
+    size_t index;
+    std::tuple<range_iterator_type_t<maybe_const_t<Const, UnderlyingViews>>...> its;
+  };
+
+  using iterator = iterator_t<false>;
+  using const_iterator = iterator_t<true>;
+
+  // Returns the number of elements in the zipped range.
+  // This is the length of the shortest input range
+  [[nodiscard]] size_t size() const { return n_elements; }
+
+  // Returns the number of blocks in the zipped range
+  auto get_num_blocks() const { return n_blocks; }
+
+  // Return an iterator pointing to the beginning of block i
+  auto get_begin_block(size_t i) {
+    return std::apply([i, n = n_elements](UnderlyingViews&... views) {
+      return iterator(std::min(n, i * block_size), begin_block(views, i)...); }, base_views);
+  }
+
+  // Return an iterator pointing to the beginning of block i
+  template<typename D = int, std::enable_if_t<(is_range_v<const std::remove_reference_t<UnderlyingViews>> && ...), D> = 0>
+  auto get_begin_block(size_t i) const {
+    return std::apply([i, n = n_elements](const UnderlyingViews&... views) {
+      return const_iterator(std::min(n, i * block_size), begin_block(views, i)...); }, base_views);
+  }
+
+ private:
+  size_t n_elements, n_blocks;
+  std::tuple<view_storage_type<UnderlyingViews>...> base_views;
+};
+
+// Note: Fold expressions in templates are bugged in MSVC until version 19.27,
+// so the following fails to compile on earlier versions :(
+
+template<typename... UnderlyingViews,
+    std::enable_if_t<(is_random_access_range_v<UnderlyingViews> && ...), int> = 0>
+auto zip(UnderlyingViews&&... vs) {
+  static_assert(sizeof...(UnderlyingViews) >= 1, "zip should have at least one argument");
+  using value_type = std::tuple<range_value_type_t<UnderlyingViews>...>;
+  using reference_type = std::tuple<range_reference_type_t<UnderlyingViews>...>;
+
+  auto size = (std::min)({parlay::size(vs)...});
+  return parlay::internal::delayed_tabulate<reference_type, value_type>(size,
+    [views = std::tuple<UnderlyingViews...>(std::forward<UnderlyingViews>(vs)...)](size_t i) {
+      return std::apply([i](auto&&... views) { return reference_type(std::begin(views)[i]...); }, views);
+    });
+}
+
+template<typename... UnderlyingViews,
+    std::enable_if_t<((!is_random_access_range_v<UnderlyingViews> || ...) &&
+                       (is_block_iterable_range_v<UnderlyingViews> && ...)), int> = 0>
+auto zip(UnderlyingViews&&... vs) {
+  static_assert(sizeof...(UnderlyingViews) >= 1, "zip should have at least one argument");
+  return block_delayed_zip_t<UnderlyingViews...>(0, std::forward<UnderlyingViews>(vs)...);
+}
+
+}  // namespace delayed
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_DELAYED_ZIP_H

--- a/third_party/parlayhash/include/parlay/internal/file_map.h
+++ b/third_party/parlayhash/include/parlay/internal/file_map.h
@@ -1,0 +1,105 @@
+
+#ifndef PARLAY_INTERNAL_FILE_MAP_H_
+#define PARLAY_INTERNAL_FILE_MAP_H_
+
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#define PARLAY_WINDOWS_FILE_MAP
+#else
+#include <unistd.h>
+#if defined(_POSIX_MAPPED_FILES) && ((_POSIX_MAPPED_FILES + 0) > 0)
+#define PARLAY_POSIX_FILE_MAP
+#endif
+#endif
+
+#if !defined(PARLAY_WINDOWS_FILE_MAP) && !defined(PARLAY_POSIX_FILE_MAP)
+#define PARLAY_NO_FILE_MAP
+#endif
+
+#if defined(PARLAY_WINDOWS_FILE_MAP) && !defined(PARLAY_USE_FALLBACK_FILE_MAP)
+#include "windows/file_map_impl_windows.h"
+#endif
+
+#if defined(PARLAY_POSIX_FILE_MAP) && !defined(PARLAY_USE_FALLBACK_FILE_MAP)
+#include "posix/file_map_impl_posix.h"
+#endif
+
+#if defined(PARLAY_NO_FILE_MAP) || defined(PARLAY_USE_FALLBACK_FILE_MAP)
+
+#include <cassert>
+
+#include <fstream>
+#include <string>
+
+namespace parlay {
+
+// A platform-independent simulation of file map. This one reads in the entire file
+// to main memory all at once. This could be slow, and even worse, could fail badly
+// if the file is so large that it does not fit in main memory!
+
+class file_map {
+  private:
+    std::string contents;
+  public:
+    using value_type = std::string::value_type;
+    using reference = std::string::reference;
+    using const_reference = std::string::const_reference;
+    using iterator = std::string::iterator;
+    using const_iterator = std::string::const_iterator;
+    using pointer = std::string::pointer;
+    using const_pointer = std::string::const_pointer;
+    using difference_type = std::string::difference_type;
+    using size_type = std::string::size_type;
+
+    char operator[] (size_t i) const { return contents[i]; }
+    auto begin() const { return contents.begin(); }
+    auto end() const { return contents.end(); }
+    
+    size_t size() const { return end() - begin(); }
+
+    explicit file_map(const std::string& filename) {
+      std::ifstream in(filename);
+      assert(in.is_open());
+      in.seekg(0, std::ios::end);
+      size_t sz = static_cast<size_t>(in.tellg());
+      contents.resize(sz);
+      in.seekg(0);
+      in.read(&(*contents.begin()), sz);
+    }
+
+    ~file_map() {
+      contents.clear();
+    }
+    
+    file_map(file_map&& other) noexcept : contents(std::move(other.contents)) {
+      other.contents.clear();
+    }
+    
+    file_map& operator=(file_map&& other) {
+      contents = std::move(other.contents);
+      other.contents.clear();
+      return *this;
+    }
+    
+    file_map(const file_map&) = delete;
+    file_map operator=(const file_map&) = delete;
+    
+    void swap(file_map& other) {
+      std::swap(contents, other.contents);
+    }
+
+    bool empty() const {
+      return contents.empty();
+    }
+};
+
+}
+
+#endif  // PARLAY_NO_FILE_MAP
+
+namespace std {
+  inline void swap(parlay::file_map& first, parlay::file_map& second) {
+    first.swap(second);
+  }
+}
+
+#endif  // PARLAY_INTERNAL_FILE_MAP_H_

--- a/third_party/parlayhash/include/parlay/internal/get_time.h
+++ b/third_party/parlayhash/include/parlay/internal/get_time.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+namespace parlay {
+  namespace internal {
+struct timer {
+
+private: 
+  using time_t = decltype(std::chrono::system_clock::now());
+  double total_so_far;
+  time_t last;
+  bool on;
+  std::string name;
+
+  auto get_time() {
+    return std::chrono::system_clock::now();
+  }
+
+  void report(double time, std::string str) {
+    std::ios::fmtflags cout_settings = std::cout.flags();
+    std::cout.precision(4);
+    std::cout << std::fixed;
+    std::cout << name << ": ";
+    if (str.length() > 0)
+      std::cout << str << ": ";
+    std::cout << time << std::endl;
+    std::cout.flags(cout_settings);
+  }
+
+  double diff(time_t t1, time_t t2) {
+    return std::chrono::duration_cast<std::chrono::microseconds>(t1 - t2).count() / 1000000.0;
+  }
+public:
+
+
+  timer(std::string name = "Parlay time", bool start_ = true)
+  : total_so_far(0.0), on(false), name(name) {
+    if (start_) start();
+  }
+  
+  void start () {
+    on = true;
+    last = get_time();
+  }
+
+  double stop () {
+    on = false;
+    double d = diff(get_time(),last);
+    total_so_far += d;
+    return d;
+  }
+
+  void reset() {
+     total_so_far=0.0;
+     on=0;
+  }
+
+  double next_time() {
+    if (!on) return 0.0;
+    time_t t = get_time();
+    double td = diff(t, last);
+    total_so_far += td;
+    last = t;
+    return td;
+  }
+
+  double total_time() {
+    if (on) return total_so_far + diff(get_time(), last);
+    else return total_so_far;
+  }
+
+  void next(std::string str) {
+    if (on) report(next_time(), str);
+  }
+
+  void total() {
+    report(total_time(),"total");
+  }
+};
+
+  }
+}

--- a/third_party/parlayhash/include/parlay/internal/group_by.h
+++ b/third_party/parlayhash/include/parlay/internal/group_by.h
@@ -1,0 +1,357 @@
+#ifndef PARLAY_INTERNAL_GROUP_BY_H_
+#define PARLAY_INTERNAL_GROUP_BY_H_
+
+#include <cstdlib>
+
+#include <functional>
+#include <tuple>      // IWYU pragma: keep
+#include <utility>
+
+#include "../monoid.h"
+#include "../range.h"
+#include "../sequence.h"
+#include "../slice.h"
+#include "../utilities.h"
+//#include "../delayed.h"
+#include "../parallel.h"
+
+#include "block_delayed.h"
+#include "collect_reduce.h"
+#include "counting_sort.h"
+#include "integer_sort.h"
+#include "sample_sort.h"
+#include "sequence_ops.h"
+
+// IWYU pragma: no_include <bits/utility.h>
+
+namespace parlay {
+
+// Clang gives false positives for unused type
+// aliases inside the nested helper structs
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
+
+namespace internal {
+// Given a comparator, return a comparator that compares pair-like types by
+// their first element using the given comparator.
+template<typename Less>
+auto compare_pairs_by_key(Less&& less) {
+  return [less = std::forward<Less>(less)](auto&& a, auto&& b) {
+    return less(std::get<0>(std::forward<decltype(a)>(a)), std::get<0>(std::forward<decltype(b)>(b)));
+  };
+}
+
+constexpr inline auto get_key = [](auto&& a) -> decltype(auto) { return std::get<0>(std::forward<decltype(a)>(a)); };
+constexpr inline auto get_val = [](auto&& a) -> decltype(auto) { return std::get<1>(std::forward<decltype(a)>(a)); };
+}
+
+template <typename Range, typename Comp>
+auto group_by_key_ordered(Range&& S, Comp&& less) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(is_pair_v<range_reference_type_t<Range>>);
+
+  using KV = range_value_type_t<Range>;
+  using K = std::tuple_element_t<0, KV>;
+
+  static_assert(std::is_invocable_r_v<bool, Comp, K, K>);
+
+  size_t n = S.size();
+
+  sequence<KV> sorted;
+  auto comp = internal::compare_pairs_by_key(less);
+  if constexpr(std::is_integral_v<K> && std::is_unsigned_v<K> && sizeof(KV) <= 16) {
+    sorted = internal::integer_sort(make_slice(S), internal::get_key);
+  } else {
+    sorted = internal::sample_sort(make_slice(S), comp, true);
+  }
+
+  auto ids = internal::delayed_tabulate(n, [](size_t i) { return i; });
+  auto idx = block_delayed::filter(ids, [&] (size_t i) {
+    return (i==0) || comp(sorted[i-1], sorted[i]); });
+
+  auto r = internal::tabulate(idx.size(), [&] (size_t i) {
+    size_t start = idx[i];
+    size_t end = ((i==idx.size()-1) ? n : idx[i+1]);
+    return std::pair(std::move(internal::get_key(sorted[idx[i]])),
+                     map(sorted.cut(start,end), [] (auto& kv) {
+		       return std::move(internal::get_val(kv));}));
+  });
+  return r;
+}
+
+template <typename Range>
+auto group_by_key_ordered(Range&& S) {
+  static_assert(is_random_access_range_v<Range>);
+  return parlay::group_by_key_ordered(std::forward<Range>(S), std::less<>{});
+}
+
+
+template <typename arg_type, typename Monoid, typename Hash, typename Equal>
+struct reduce_by_key_helper {
+  using in_type = arg_type;
+  using key_type = std::tuple_element_t<0, in_type>;
+  using value_type = std::tuple_element_t<1, in_type>;
+  using result_type = std::pair<key_type, value_type>;
+  Monoid monoid; Hash hash; Equal equal;
+  reduce_by_key_helper(Monoid const &m, Hash const &h, Equal const &e) :
+      monoid(m), hash(h), equal(e) {};
+
+  template<typename T> static const key_type& get_key(const T& p) { return std::get<0>(p);}
+  template<typename T> static key_type& get_key(T& p) { return std::get<0>(p);}
+
+  void init(result_type &p, in_type const &kv) const {
+    assign_uninitialized(std::get<1>(p), std::get<1>(kv));}
+  void update(result_type &p, in_type const &kv) const {
+    std::get<1>(p) = monoid(std::get<1>(p), std::get<1>(kv)); }
+  static void destruct_val(in_type &kv) {std::get<1>(kv).~value_type();}
+  template <typename Range>
+  result_type reduce(Range &S) const {
+    auto &key = std::get<0>(S[0]);
+    auto sum = internal::reduce(internal::delayed_map(S, [&] (in_type const &kv) {
+      return std::get<1>(kv);}), monoid);
+    return result_type(key, sum);}
+};
+
+// Takes a range of <key_type,value_type> pairs and returns a sequence of
+// the same type, but with equal keys combined into a single element.
+// Values are combined with a monoid, which must be on the value type.
+// Returned in an arbitrary order that depends on the hash function.
+template <typename R,
+    typename Monoid = parlay::plus<std::tuple_element_t<1, range_value_type_t<R>>>,
+    typename Hash = parlay::hash<std::tuple_element_t<0, range_value_type_t<R>>>,
+    typename Equal = std::equal_to<>>
+auto reduce_by_key(R&& A, Monoid&& monoid = {}, Hash&& hash = {}, Equal&& equal = {}) {
+  static_assert(is_random_access_range_v<R>);
+  auto helper = reduce_by_key_helper<range_value_type_t<R>,Monoid,Hash,Equal>{monoid,hash,equal};
+  return internal::collect_reduce_sparse(std::forward<R>(A), helper);
+}
+
+template <typename arg_type, typename Hash, typename Equal>
+struct group_by_key_helper {
+  using in_type = arg_type;
+  using key_type = std::tuple_element_t<0, in_type>;
+  using val_type = std::tuple_element_t<1, in_type>;
+  using seq_type = sequence<val_type>;
+  using result_type = std::pair<key_type,seq_type>;
+  Hash hash; Equal equal;
+  group_by_key_helper(Hash const &h, Equal const &e) : hash(h), equal(e) {};
+  static const key_type& get_key(in_type const &p) { return std::get<0>(p);}
+  static key_type& get_key(in_type &p) { return std::get<0>(p);}
+  static key_type& get_key(result_type &p) {return std::get<0>(p);}
+  static void init(result_type &p, in_type const &kv) {
+    assign_uninitialized(std::get<1>(p),sequence(1, std::get<1>(kv)));}
+  static void update(result_type &p, in_type const &kv) {
+    std::get<1>(p).push_back(std::get<1>(kv)); }
+  static void destruct_val(in_type &kv) {std::get<1>(kv).~val_type();}
+  template <typename Range>
+  static result_type reduce(Range &S) {
+    auto &key = std::get<0>(S[0]);
+    auto vals = internal::map(S, [&] (in_type const &kv) {return std::get<1>(kv);});
+    return result_type(key, vals);}
+};
+
+template <typename R,
+    typename Hash = parlay::hash<std::tuple_element_t<0, range_value_type_t<R>>>,
+    typename Equal = std::equal_to<>>
+auto group_by_key(R&& A, Hash&& hash = {}, Equal&& equal = {}) {
+  static_assert(is_random_access_range_v<R>);
+
+  auto helper = group_by_key_helper<range_value_type_t<R>,Hash,Equal>{hash,equal};
+  return internal::collect_reduce_sparse(std::forward<R>(A), helper);
+}
+
+template <typename arg_type, typename sum_type, typename Hash, typename Equal>
+struct count_by_key_helper {
+  using in_type = arg_type;
+  using key_type = in_type;
+  using val_type = sum_type;
+  using result_type = std::pair<key_type,val_type>;
+  Hash hash; Equal equal;
+  count_by_key_helper(Hash const &h, Equal const &e) : hash(h), equal(e) {};
+  static const key_type& get_key(in_type const &k) {return k;}
+  static key_type& get_key(in_type &k) {return k;}
+  static key_type& get_key(result_type &p) {return std::get<0>(p);}
+  static void init(result_type &p, in_type const&) {std::get<1>(p) = 1;}
+  static void update(result_type &p, in_type const&) {std::get<1>(p) += 1;}
+  static void destruct_val(in_type &) {}
+  template <typename Range>
+  static result_type reduce(Range &S) {return result_type(S[0], S.size());}
+};
+
+// Returns a sequence of <R::value_type,sum_type> pairs, each consisting of
+// a unique value from the input, and the number of times it appears.
+// Returned in an arbitrary order that depends on the hash function.
+template <typename sum_type = size_t,
+    typename R,
+    typename Hash = parlay::hash<range_value_type_t<R>>,
+    typename Equal = std::equal_to<>>
+auto histogram_by_key(R &&A, Hash&& hash = {}, Equal&& equal = {}) {
+  static_assert(is_random_access_range_v<R>);
+  auto helper = count_by_key_helper<range_value_type_t<R>,sum_type,Hash,Equal>{hash,equal};
+  return internal::collect_reduce_sparse(std::forward<R>(A), helper);
+}
+
+template <typename arg_type, typename Hash, typename Equal>
+struct remove_duplicates_helper {
+  using in_type = arg_type;
+  using key_type = in_type;
+  using result_type = in_type;
+  Hash hash; Equal equal;
+  remove_duplicates_helper(Hash const &h, Equal const &e) : hash(h), equal(e) {};
+  static const key_type& get_key(in_type const &k) { return k;}
+  static key_type& get_key(in_type &k) { return k;}
+  static void init(result_type &, in_type const&) {}
+  static void update(result_type &, in_type const&) {}
+  static void destruct_val(in_type &) {}
+  template <typename Range>
+  static result_type reduce(Range S) {return S[0];};
+};
+
+// should be made more efficient by avoiding generating and then stripping counts
+template <typename R,
+    typename Hash = parlay::hash<range_value_type_t<R>>,
+    typename Equal = std::equal_to<>>
+auto remove_duplicates(R&& A, Hash&& hash = {}, Equal&& equal = {}) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<size_t, Hash, range_reference_type_t<R>>);
+  static_assert(std::is_invocable_r_v<bool, Equal, range_reference_type_t<R>, range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  auto helper = remove_duplicates_helper<range_value_type_t<R>,Hash,Equal>{hash,equal};
+  return internal::collect_reduce_sparse(std::forward<R>(A), helper);
+}
+
+// Takes a range of <integer_key,value_type> pairs and returns a sequence of
+// value_type, with all values corresponding to key i, combined at location i.
+// Values are combined with a monoid, which must be on the value type.
+// Must specify the number of buckets and it is an error for a key to be
+// be out of range.
+template <typename R, typename Monoid = parlay::plus<std::tuple_element_t<1, range_value_type_t<R>>>>
+auto reduce_by_index(R&& A, size_t num_buckets, Monoid&& monoid = {}) {
+  struct helper {
+    using in_type = range_value_type_t<R>;
+    using key_type = std::tuple_element_t<0, in_type>;
+    using val_type = std::tuple_element_t<1, in_type>;
+    Monoid mon;
+    static key_type get_key(const in_type& a) { return std::get<0>(a); };
+    static val_type get_val(const in_type& a) { return std::get<1>(a); };
+    val_type init() const {return mon.identity;}
+    void update(val_type& d, val_type const &a) const { d = mon(d, a); };
+    void combine(val_type& d, slice<in_type*,in_type*> s) const {
+      auto vals = internal::delayed_map(s, [&] (in_type &v) { return std::get<1>(v); });
+      d = internal::reduce(vals, mon);
+    }
+  };
+  return internal::collect_reduce(make_slice(A), helper{monoid}, num_buckets);
+}
+
+// Given a sequence of integers creates a histogram with the count
+// of each interger value. The range num_buckets must be specified
+// and it is an error if any integers is out of the range [0:num_buckets).
+template <typename Integer_t, typename R>
+auto histogram_by_index(R&& A, Integer_t num_buckets) {
+  struct helper {
+    using key_type = range_value_type_t<R>;
+    using val_type = Integer_t;
+    size_t n;
+    static key_type get_key(const key_type& a) { return a; }
+    static val_type get_val(const key_type&) { return 1; }
+    static val_type init() {return 0;}
+    void update(val_type& d, val_type a) const { d += a; }
+    static void combine(val_type& d, slice<key_type*,key_type*> s) {
+      d = s.size(); }
+  };
+  return internal::collect_reduce(A, helper{A.size()}, num_buckets);
+}
+
+template <typename Integer_t, typename R>
+auto remove_duplicate_integers(R&& A, Integer_t max_value) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_convertible_v<range_reference_type_t<R>, Integer_t>);
+  static_assert(std::is_integral_v<Integer_t>);
+
+  struct helper {
+    using key_type = range_value_type_t<R>;
+    using val_type = bool;
+    static key_type get_key(const key_type& a) { return a; }
+    static val_type get_val(const key_type&) { return true; }
+    static val_type init() { return false; }
+    static void update(val_type& d, val_type) { d = true; }
+    static void combine(val_type& d, slice<key_type*,key_type*>) {
+      d = true; }
+  };
+  auto flags = internal::collect_reduce(A, helper(), max_value);
+  auto ids = internal::delayed_tabulate(max_value, [](size_t i) -> Integer_t { return i; });
+  return internal::pack(make_slice(ids), make_slice(flags));
+}
+
+template <typename Integer_t, typename R>
+auto group_by_index_(R&& A, Integer_t num_buckets) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_pair_v<range_value_type_t<R>>);
+
+  if (A.size() > static_cast<size_t>(num_buckets)*num_buckets) {
+    auto keys = internal::delayed_map(A, [] (auto const &kv) { return std::get<0>(kv); });
+    auto vals = internal::delayed_map(A, [] (auto const &kv) { return std::get<1>(kv); });
+    return internal::group_by_small_int(make_slice(vals), make_slice(keys), num_buckets);
+  } else {
+    struct helper {
+      using in_type = range_value_type_t<R>;
+      using key_type = std::tuple_element_t<0, in_type>;
+      using val_type = std::tuple_element_t<1, in_type>;
+      using result_type = sequence<val_type>;
+      static key_type get_key(const in_type& a) { return std::get<0>(a); }
+      static val_type get_val(const in_type& a) { return std::get<1>(a); }
+      static result_type init() { return result_type(); }
+      static void update(result_type& d, const val_type& v) { d.push_back(v); }
+      static void update(result_type& d, const result_type& v) {
+        abort(); d.append(std::move(v));}
+      static void combine(result_type& d, slice<in_type*,in_type*> s) {
+        d = internal::map(s, [&] (in_type const &kv) { return get_val(kv); });}
+    };
+    return internal::collect_reduce(A, helper(), num_buckets);
+  }
+}
+
+template <typename Integer_t, typename R>
+auto group_by_index(R&& A, Integer_t num_buckets) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_pair_v<range_value_type_t<R>>);
+  static_assert(std::is_integral_v<Integer_t>);
+  using V = std::tuple_element_t<1, range_value_type_t<R>>;
+  size_t n = A.size();
+  
+  if (n > static_cast<size_t>(num_buckets)*num_buckets) {
+    auto keys = internal::delayed_map(A, [] (auto const &kv) { return std::get<0>(kv); });
+    auto vals = internal::delayed_map(A, [] (auto const &kv) { return std::get<1>(kv); });
+    return internal::group_by_small_int(make_slice(vals), make_slice(keys), num_buckets);
+  }
+  else {
+    size_t bits = log2_up(num_buckets);
+    auto sorted = internal::integer_sort(make_slice(A), internal::get_key, bits);
+
+    auto iota = internal::delayed_tabulate(n, [](Integer_t i) { return i; });
+    auto starts = block_delayed::filter(iota, [&] (size_t i) {
+	return (i==0) || internal::get_key(sorted[i-1]) < internal::get_key(sorted[i]);});
+    size_t m = starts.size();
+
+    sequence<sequence<V>> r(num_buckets);
+    parallel_for(0, m, [&] (size_t i) {
+      size_t start = starts[i];
+      size_t end = ((i == m-1) ? n : starts[i+1]);
+      r[std::get<0>(sorted[starts[i]])] =
+	map(sorted.cut(start, end), [&] (auto kv) {
+	  return std::move(internal::get_val(kv));}, 1000);});
+    return r;
+  }
+}
+			  
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_GROUP_BY_H_

--- a/third_party/parlayhash/include/parlay/internal/heap_tree.h
+++ b/third_party/parlayhash/include/parlay/internal/heap_tree.h
@@ -1,0 +1,59 @@
+#include <cstddef>
+
+#include <functional>
+#include <type_traits>   // IWYU pragma: keep
+
+#include "../sequence.h"
+#include "../utilities.h"
+
+namespace parlay {
+namespace internal {
+
+// An efficient search tree for replacing binary-search on a sorted sequence.
+// Returns the rank of the first element greater than or equal to the key.
+// Reorganizes the values into a "heap ordering":
+// i.e. with root at 0 and the children of position i are at 2*i+1 and 2*i+2.
+// Significantly more efficient than binary search when tree fits in cache
+// since it avoids conditionals.
+// The number of pivots must be 2^i-1 (i.e. fully balanced tree)
+template <typename T>
+struct heap_tree {
+ private:
+  size_t size;
+  sequence<T> tree;
+  size_t levels;
+
+  // converts from sorted sequence into a "heap indexed" tree
+  void to_tree(const sequence<T>& In, size_t root, size_t l, size_t r) {
+    size_t n = r - l;
+    size_t m = l + n / 2;
+    tree[root] = In[m];
+    if (n == 1) return;
+    to_tree(In, 2 * root + 1, l, m);
+    to_tree(In, 2 * root + 2, m + 1, r);
+  }
+
+ public:
+
+  explicit heap_tree(const sequence<T>& keys) :
+      size(keys.size()), tree(size),
+      levels(log2_up(keys.size()+1)-1) {
+
+    to_tree(keys, 0, 0, size);
+  }
+
+  // finds the rank of the given key
+  template <typename Less = std::less<>>
+  size_t rank(const T& key, Less&& less = {}) {
+    static_assert(std::is_invocable_r_v<bool, Less, T, T>);
+    size_t j = 0;
+    for (size_t k = 0; k < levels; k++) {
+      j = 1 + 2 * j + less(tree[j],key);
+    }
+    j = 1 + 2 * j + !less(key,tree[j]);
+    return j - size;
+  }
+};
+
+}  // namespace internal
+}  // namespace parlay

--- a/third_party/parlayhash/include/parlay/internal/integer_sort.h
+++ b/third_party/parlayhash/include/parlay/internal/integer_sort.h
@@ -1,0 +1,400 @@
+
+#ifndef PARLAY_INTEGER_SORT_H_
+#define PARLAY_INTEGER_SORT_H_
+
+#include <cassert>
+#include <cstdio>
+
+#include <algorithm>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "counting_sort.h"
+#include "sequence_ops.h"
+#include "uninitialized_sequence.h"
+#include "get_time.h"
+
+#include "../delayed_sequence.h"
+#include "../monoid.h"
+#include "../parallel.h"
+#include "../range.h"
+#include "../relocation.h"
+#include "../sequence.h"
+#include "../slice.h"
+#include "../utilities.h"
+
+
+namespace parlay {
+namespace internal {
+
+constexpr size_t radix = 8;
+constexpr size_t max_buckets = 1 << radix;
+
+// Use a smaller base case threshold for debugging so that test
+// cases do not need to use extremely large sequences in order
+// to achieve adequate coverage.
+#ifdef DEBUG
+constexpr size_t PARLAY_INTEGER_SORT_BASE_CASE_SIZE = 128;
+#else
+constexpr size_t PARLAY_INTEGER_SORT_BASE_CASE_SIZE = 1 << 17;
+#endif
+
+// a bottom up radix sort
+template <typename InIterator, typename OutIterator, class GetKey>
+void seq_radix_sort_(slice<InIterator, InIterator> In,
+                     slice<OutIterator, OutIterator> Out,
+                     GetKey const &g,
+                     size_t bits,
+                     bool inplace = true) {
+  size_t n = In.size();
+  if (n == 0) return;
+  size_t counts[max_buckets + 1];
+  bool swapped = false;
+  size_t bit_offset = 0;
+  while (bits > 0) {
+    size_t round_bits = (std::min)(radix, bits);
+    size_t num_buckets = (size_t{1} << round_bits);
+    size_t mask = num_buckets - 1;
+
+    if (swapped) {
+      auto get_key = [&](size_t i) -> size_t {
+        return (g(Out[i]) >> bit_offset) & mask;
+      };
+      seq_count_sort_<uninitialized_relocate_tag>(Out, In, delayed_seq<size_t>(n, get_key), counts, num_buckets);
+    }
+
+    else {
+      auto get_key = [&](size_t i) -> size_t {
+        return (g(In[i]) >> bit_offset) & mask;
+      };
+
+      seq_count_sort_<uninitialized_relocate_tag>(In, Out, delayed_seq<size_t>(n, get_key), counts, num_buckets);
+
+    }
+
+    bits = bits - round_bits;
+    bit_offset = bit_offset + round_bits;
+    swapped = !swapped;
+  }
+
+  if (swapped && inplace) {
+    uninitialized_relocate_n(In.begin(), Out.begin(), In.size());
+  }
+  else if (!swapped && !inplace) {
+    uninitialized_relocate_n(Out.begin(), In.begin(), Out.size());
+  }
+}
+
+
+// wrapper to reduce copies and avoid modifying In when not inplace
+// In and Tmp can be the same, but Out must be different
+template <typename inplace_tag, typename assignment_tag, typename InIterator, typename OutIterator, typename TmpIterator, class GetKey>
+void seq_radix_sort(slice<InIterator, InIterator> In,
+                    slice<OutIterator, OutIterator> Out,
+   [[maybe_unused]] slice<TmpIterator, TmpIterator> Tmp,
+                    GetKey const &g,
+                    size_t key_bits) {
+  if constexpr (inplace_tag::value == true) {
+    static_assert(std::is_same_v<assignment_tag, uninitialized_relocate_tag>);
+    seq_radix_sort_(In, Out, g, key_bits, true);
+  }
+  else {
+    bool odd = ((key_bits - 1) / radix) & 1;
+    size_t n = In.size();
+    if (odd) {
+      // We could just use assign_dispatch(Tmp[i], In[i]) for each i, but we
+      // can optimize better by calling destructive_move_slice, since this
+      // has the ability to memcpy multiple elements at once
+      if constexpr (std::is_same_v<assignment_tag, uninitialized_relocate_tag>) {
+        uninitialized_relocate_n(Tmp.begin(), In.begin(), Tmp.size());
+      }
+      else {
+        for (size_t i = 0; i < n; i++)
+          assign_uninitialized(Tmp[i], In[i]);
+      }
+      seq_radix_sort_(Tmp, Out, g, key_bits, false);
+    } else {
+      if constexpr (std::is_same_v<assignment_tag, uninitialized_relocate_tag>) {
+        uninitialized_relocate_n(Out.begin(), In.begin(), Out.size());
+      }
+      else {
+        for (size_t i = 0; i < n; i++)
+          assign_uninitialized(Out[i], In[i]);
+      }
+      seq_radix_sort_(Out, Tmp, g, key_bits, true);
+    }
+  }
+}
+
+// a top down recursive radix sort
+// g extracts the integer keys from In
+// key_bits specifies how many bits there are left
+//
+// inplace_tag must be one of std::true_type or std::false_type. If inplace_tag is true_type,
+// then the output of the sort will remain in In. If inplace_tag is false, then the
+// output of the sort will be written into Out. Furthermore, if inplace_tag is std::true_type,
+// then Tmp must point to the same range as In
+//
+// assignment_tag must be one of uninitialized_copy_tag or uninitialized_relocate_tag. This indicates
+// the manner in which the input is moved from In to Out. If inplace_tag is std::true_type,
+// then this must always be uninitialized_relocate_tag. If inplace_tag is std::false_type, then
+// assignment_tag can be either uninitialized_copy_tag, if the input is to be copied from
+// In to Out, or uninitialized_relocate_tag if the input is to be (destructively) moved from In to
+// Out.
+//
+template <typename inplace_tag, typename assignment_tag,
+          typename InIterator, typename OutIterator, typename TmpIterator, typename Get_Key>
+sequence<size_t> integer_sort_r(slice<InIterator, InIterator> In,
+                                slice<OutIterator, OutIterator> Out,
+                                slice<TmpIterator, TmpIterator> Tmp,
+                                Get_Key const &g, size_t key_bits,
+                                size_t num_buckets,
+                                float parallelism = 1.0) {
+  // Parameter In
+  //  [Preconditions]
+  //  - In owns valid initialized memory
+  //  - If inplace_tag is std::true_type, then In points to mutable (non-const) memory
+  //  - If assignment_tag is uninitialized_copy_tag, then In points to objects of a type
+  //    that is copy constructible
+  //  [Postconditions]
+  //  - If inplace_tag is std::true_type, then In contains the sorted results
+  //  - If inplace_tag is std::false_type and assignment_tag is uninitialized_copy_tag,
+  //    then In contains the original unmodified input
+  //  - If inplace_tag is std::false_type and assignment_tag is uninitialized_relocate_tag, then
+  //    In points to uninitialized memory
+  //
+  // Parameter Out
+  //  [Preconditions]
+  //  - Out points to uninitialized memory
+  //  [Postconditions]
+  //  - If inplace_tag is std::true_type, then Out points to uninitialized memory
+  //  - If inplace_tag is std::false_type, then Out points to the resulting sorted objects
+  //
+  // Parameter Tmp
+  //  [Preconditions]
+  //  - If inplace_tag is std::true_type, then Tmp points to the same range as In
+  //  - If inplace_tag is std::false_type and assignment_tag is uninitialized_copy_tag,
+  //    then Tmp points to uninitialized memory
+  //  - If inplace_tag is std::false_type and assignment_tag is uninitialized_relocate_tag,
+  //    then Tmp points to the same range as In
+  //  [Postconditions]
+  //  - If Tmp does not point to the same range as In, then it points to uninitialized memory
+
+  // Ranges should all have the same underlying type
+  static_assert(std::is_same_v<range_value_type_t<slice<InIterator, InIterator>>,
+                               range_value_type_t<slice<OutIterator, OutIterator>>>);
+  static_assert(std::is_same_v<range_value_type_t<slice<InIterator, InIterator>>,
+                               range_value_type_t<slice<TmpIterator, TmpIterator>>>);
+
+  // assignment_type can only be one of uninitialized_copy_tag or uninitialized_relocate_tag
+  static_assert(std::is_same_v<assignment_tag, uninitialized_copy_tag> || std::is_same_v<assignment_tag, uninitialized_relocate_tag>);
+
+  // assignment_tag is only allowed to be uninitialized_copy_tag if inplace_tag is std::false type
+  static_assert(inplace_tag::value == false || std::is_same_v<assignment_tag, uninitialized_relocate_tag>);
+
+
+  using T = typename slice<InIterator, InIterator>::value_type;
+  timer t("integer sort", false);
+
+  size_t n = In.size();
+  size_t cache_per_thread = 1000000;
+  auto sz = 2 * (size_t)sizeof(T) * n / cache_per_thread;
+  size_t base_bits = sz > 0 ? log2_up(sz) : 0;
+  // keep between 8 and 13
+  base_bits = std::max<size_t>(8, std::min<size_t>(13, base_bits));
+  sequence<size_t> offsets;
+  bool one_bucket;
+  bool return_offsets = (num_buckets > 0);
+
+  if (key_bits == 0) {
+    // If the sort is not inplace, the final result needs to
+    // be moved into Out since it is currently in In.
+    if constexpr (inplace_tag::value == false) {
+
+      // We could just do a parallel for loop and copy/move the elements from
+      // In to Out using assign_dispatch(Out[i], In[i], assignment_tag()), but
+      // this would not allow us to take advantage of the possibly more efficient
+      // uninitialized_relocate_n, which can memcpy multiple elements at a time
+      // to save on performing every copy individually.
+      if constexpr (std::is_same_v<assignment_tag, uninitialized_relocate_tag>) {
+        uninitialized_relocate_n(Out.begin(), In.begin(), Out.size());
+      }
+      else {
+        parallel_for(0, In.size(), [&](size_t i) {
+          assign_uninitialized(Out[i], In[i]);     // Copy from In[i] to Out[i]
+        });
+      }
+    }
+    return sequence<size_t>();
+  }
+  // for small inputs or little parallelism use sequential radix sort
+  else if ((n < PARLAY_INTEGER_SORT_BASE_CASE_SIZE || parallelism < .0001) && !return_offsets) {
+    seq_radix_sort<inplace_tag, assignment_tag>(In, Out, Tmp, g, key_bits);
+    return sequence<size_t>();
+  }
+  // few bits, just do a single parallel count sort
+  else if (key_bits <= base_bits) {
+    size_t mask = (1 << key_bits) - 1;
+    auto f = [&](size_t i) { return static_cast<size_t>(g(In[i]) & mask); };
+    auto get_bits = delayed_seq<size_t>(n, f);
+    size_t num_bkts = (num_buckets == 0) ? (size_t{1} << key_bits) : num_buckets;
+
+    // only uses one bucket optimization (last argument) if inplace
+    std::tie(offsets, one_bucket) = count_sort<assignment_tag>(In, Out,
+      make_slice(get_bits), num_bkts, parallelism, inplace_tag::value);
+    t.next("count sort");
+
+    if constexpr (inplace_tag::value == true) {
+      if (!one_bucket) {
+        uninitialized_relocate_n(In.begin(), Out.begin(), In.size());
+      }
+    }
+
+    if (return_offsets)
+      return offsets;
+    else
+      return sequence<size_t>();
+
+    // recursive case
+  } else {
+    size_t bits = 8;
+    size_t shift_bits = key_bits - bits;
+    size_t num_outer_buckets = (size_t{1} << bits);
+    size_t num_inner_buckets = return_offsets ? ((size_t)1 << shift_bits) : 0;
+    size_t mask = num_outer_buckets - 1;
+    auto f = [&](size_t i) { return static_cast<size_t>((g(In[i]) >> shift_bits) & mask); };
+    auto get_bits = delayed_seq<size_t>(n, f);
+
+    // divide into buckets
+    std::tie(offsets, one_bucket) = count_sort<assignment_tag>(In,
+        Out, make_slice(get_bits), num_outer_buckets, parallelism, !return_offsets);
+    if (parallelism == 1.0) t.next("recursive count sort");
+
+    // if all but one bucket are empty, try again on lower bits
+    if (one_bucket) {
+      return integer_sort_r<inplace_tag, assignment_tag>(In, Out, Tmp, g, shift_bits, 0, parallelism);
+    }
+
+    // After this point, Out is guaranteed to be initialized
+
+    sequence<size_t> inner_offsets(return_offsets ? num_buckets + 1 : 0);
+    if (return_offsets) inner_offsets[num_buckets] = n;
+
+    // recursively sort each bucket
+    parallel_for(
+        0, num_outer_buckets,
+        [&](size_t i) {
+          size_t start = offsets[i];
+          size_t end = offsets[i + 1];
+          auto a = Out.cut(start, end);
+          auto b = Tmp.cut(start, end);
+          sequence<size_t> r;
+
+          auto new_parallelism = (parallelism * static_cast<float>(end - start)) / static_cast<float>(n + 1);
+          r = integer_sort_r<typename std::negation<inplace_tag>::type, uninitialized_relocate_tag>(
+            a, b, a, g, shift_bits, num_inner_buckets, new_parallelism);
+
+          if (return_offsets) {
+            size_t bstart = (std::min)(i * num_inner_buckets, num_buckets);
+            size_t bend = (std::min)((i + 1) * num_inner_buckets, num_buckets);
+            size_t m = (bend - bstart);
+            for (size_t j = 0; j < m; j++)
+              inner_offsets[bstart + j] = offsets[i] + r[j];
+          }
+        },
+        1);
+    return inner_offsets;
+  }
+}
+
+// a top down recursive radix sort
+// g extracts the integer keys from In
+// if inplace is false then result will be placed in Out,
+//    otherwise they are placed in Tmp
+//    Tmp and In can be the same (i.e. to do inplace set them equal)
+// In is not directly modified, but can be indirectly if equal to Tmp
+// bits specifies how many bits there are in the key
+//    if set to 0, then a max is taken over the keys to determine
+// If num_buckets is non-zero then the output sequence will contain
+// the offsets of each bucket (num_bucket of them)
+// num_bucket must be less than or equal to 2^bits
+template <typename inplace_tag, typename assignment_tag, typename InIterator, typename OutIterator, typename TmpIterator, typename Get_Key>
+sequence<size_t> integer_sort_(slice<InIterator, InIterator> In,
+                               slice<OutIterator, OutIterator> Out,
+                               slice<TmpIterator, TmpIterator> Tmp,
+                               Get_Key const &g,
+                               size_t bits,
+                               size_t num_buckets) {
+  if (bits == 0) {
+    auto get_key = [&](size_t i) { return static_cast<size_t>(g(In[i])); };
+    auto keys = delayed_seq<size_t>(In.size(), get_key);
+    bits = log2_up(internal::reduce(make_slice(keys), maximum<size_t>()) + 1);
+  }
+  return integer_sort_r<inplace_tag, assignment_tag>(
+    In, Out, Tmp, g, bits, num_buckets);
+}
+
+template <typename Iterator, typename Get_Key>
+void integer_sort_inplace(slice<Iterator, Iterator> In,
+                          Get_Key const &g, size_t bits = 0) {
+  using value_type = typename slice<Iterator, Iterator>::value_type;
+  auto Tmp = internal::uninitialized_sequence<value_type>(In.size());
+  integer_sort_<std::true_type, uninitialized_relocate_tag>(In, make_slice(Tmp), In, g, bits, 0);
+}
+
+
+template <typename Iterator, typename Get_Key>
+auto integer_sort(slice<Iterator, Iterator> In,
+                  Get_Key const &g,
+                  size_t bits = 0) {
+  using value_type = typename slice<Iterator, Iterator>::value_type;
+  auto Out = sequence<value_type>::uninitialized(In.size());
+  auto Tmp = uninitialized_sequence<value_type>(In.size());
+  integer_sort_<std::false_type, uninitialized_copy_tag>(
+    In, make_slice(Out), make_slice(Tmp), g, bits, 0);
+  return Out;
+}
+
+// Given a sorted sequence of integers in the range [0,..,num_buckets)
+// returns a sequence of length num_buckets+1 with the offset for the
+// start of each integer.   If an integer does not appear, its offset
+// will be the same as the next (i.e. offset[i+1]-offset[i] specifies
+// how many i there are.
+// The last element contains the size of the input.
+template <typename Tint = size_t, typename Iterator, typename Get_Key>
+sequence<Tint> get_counts(slice<Iterator, Iterator> In, Get_Key const &g, size_t num_buckets) {
+  size_t n = In.size();
+  if (n == 0) {
+    return {};
+  }
+  sequence<Tint> starts(num_buckets, (Tint)0);
+  sequence<Tint> ends(num_buckets, (Tint)0);
+  parallel_for(0, n - 1, [&](size_t i) {
+    if (g(In[i]) != g(In[i + 1])) {
+      starts[g(In[i + 1])] = i + 1;
+      ends[g(In[i])] = i + 1;
+    };
+  });
+  ends[g(In[n - 1])] = n;
+  return sequence<Tint>::from_function(num_buckets,
+                        [&](size_t i) { return ends[i] - starts[i]; });
+}
+
+template <typename Tint = size_t, typename Iterator, typename Get_Key>
+auto integer_sort_with_counts(slice<Iterator, Iterator> In, Get_Key const &g, size_t num_buckets) {
+  using T = typename slice<Iterator, Iterator>::value_type;
+  if (In.size() == 0) {
+    return std::make_pair(parlay::sequence<T>{}, parlay::sequence<Tint>(num_buckets));
+  }
+  assert(num_buckets > 0);
+  size_t bits = log2_up(num_buckets);
+  auto R = integer_sort(In, g, bits);
+  return std::make_pair(std::move(R), get_counts<Tint>(make_slice(R), g, num_buckets));
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTEGER_SORT_H_

--- a/third_party/parlayhash/include/parlay/internal/memory_size.h
+++ b/third_party/parlayhash/include/parlay/internal/memory_size.h
@@ -1,0 +1,104 @@
+/*
+ * Author:  David Robert Nadeau
+ * Site:    http://NadeauSoftware.com/
+ * License: Creative Commons Attribution 3.0 Unported License
+ *          http://creativecommons.org/licenses/by/3.0/deed.en_US
+ */
+
+#pragma once
+
+#if defined(_WIN32)
+
+#ifndef NOMINMAX
+#define PARLAY_DEFINED_NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <Windows.h>
+
+#ifdef PARLAY_DEFINED_NOMINMAX
+#undef NOMINMAX
+#endif
+
+#elif defined(__unix__) || defined(__unix) || defined(unix) || \
+    (defined(__APPLE__) && defined(__MACH__))
+#include <sys/param.h>
+#include <sys/types.h>
+#include <unistd.h>
+#if defined(BSD)
+#include <sys/sysctl.h>
+#endif
+
+#else
+#error "Unable to define getMemorySize( ) for an unknown OS."
+#endif
+
+/**
+ * Returns the size of physical memory (RAM) in bytes.
+ */
+static size_t getMemorySize() {
+#if defined(_WIN32) && (defined(__CYGWIN__) || defined(__CYGWIN32__))
+  /* Cygwin under Windows. ------------------------------------ */
+  /* New 64-bit MEMORYSTATUSEX isn't available.  Use old 32.bit */
+  MEMORYSTATUS status;
+  status.dwLength = sizeof(status);
+  GlobalMemoryStatus(&status);
+  return (size_t)status.dwTotalPhys;
+
+#elif defined(_WIN32)
+  /* Windows. ------------------------------------------------- */
+  /* Use new 64-bit MEMORYSTATUSEX, not old 32-bit MEMORYSTATUS */
+  MEMORYSTATUSEX status;
+  status.dwLength = sizeof(status);
+  GlobalMemoryStatusEx(&status);
+  return (size_t)status.ullTotalPhys;
+
+#elif defined(__unix__) || defined(__unix) || defined(unix) || \
+    (defined(__APPLE__) && defined(__MACH__))
+/* UNIX variants. ------------------------------------------- */
+/* Prefer sysctl() over sysconf() except sysctl() HW_REALMEM and HW_PHYSMEM */
+
+#if defined(CTL_HW) && (defined(HW_MEMSIZE) || defined(HW_PHYSMEM64))
+  int mib[2];
+  mib[0] = CTL_HW;
+#if defined(HW_MEMSIZE)
+  mib[1] = HW_MEMSIZE; /* OSX. --------------------- */
+#elif defined(HW_PHYSMEM64)
+  mib[1] = HW_PHYSMEM64; /* NetBSD, OpenBSD. --------- */
+#endif
+  int64_t size = 0;    /* 64-bit */
+  size_t len = sizeof(size);
+  if (sysctl(mib, 2, &size, &len, NULL, 0) == 0) return (size_t)size;
+  return 0L; /* Failed? */
+
+#elif defined(_SC_AIX_REALMEM)
+  /* AIX. ----------------------------------------------------- */
+  return (size_t)sysconf(_SC_AIX_REALMEM) * (size_t)1024L;
+
+#elif defined(_SC_PHYS_PAGES) && defined(_SC_PAGESIZE)
+  /* FreeBSD, Linux, OpenBSD, and Solaris. -------------------- */
+  return (size_t)sysconf(_SC_PHYS_PAGES) * (size_t)sysconf(_SC_PAGESIZE);
+
+#elif defined(_SC_PHYS_PAGES) && defined(_SC_PAGE_SIZE)
+  /* Legacy. -------------------------------------------------- */
+  return (size_t)sysconf(_SC_PHYS_PAGES) * (size_t)sysconf(_SC_PAGE_SIZE);
+
+#elif defined(CTL_HW) && (defined(HW_PHYSMEM) || defined(HW_REALMEM))
+  /* DragonFly BSD, FreeBSD, NetBSD, OpenBSD, and OSX. -------- */
+  int mib[2];
+  mib[0] = CTL_HW;
+#if defined(HW_REALMEM)
+  mib[1] = HW_REALMEM;   /* FreeBSD. ----------------- */
+#elif defined(HW_PYSMEM)
+  mib[1] = HW_PHYSMEM; /* Others. ------------------ */
+#endif
+  unsigned int size = 0; /* 32-bit */
+  size_t len = sizeof(size);
+  if (sysctl(mib, 2, &size, &len, NULL, 0) == 0) return (size_t)size;
+  return 0L; /* Failed? */
+#endif /* sysctl and sysconf variants */
+
+#else
+  return 0L; /* Unknown OS. */
+#endif
+}

--- a/third_party/parlayhash/include/parlay/internal/merge.h
+++ b/third_party/parlayhash/include/parlay/internal/merge.h
@@ -1,0 +1,125 @@
+
+#ifndef PARLAY_MERGE_H_
+#define PARLAY_MERGE_H_
+
+#include "binary_search.h"
+
+#include "../sequence.h"
+#include "../utilities.h"
+
+namespace parlay {
+namespace internal {
+
+// the following parameter can be tuned
+#ifdef PAR_GRANULARITY
+constexpr const size_t _merge_base = PAR_GRANULARITY;
+#else
+constexpr const size_t _merge_base = 2000;
+#endif
+
+template <typename assignment_tag, typename InIterator1, typename InIterator2, typename OutIterator, typename BinaryOp>
+void seq_merge(slice<InIterator1, InIterator1> A,
+               slice<InIterator2, InIterator2> B,
+               slice<OutIterator, OutIterator> R,
+               const BinaryOp &f) {
+  size_t nA = A.size();
+  size_t nB = B.size();
+  size_t i = 0;
+  size_t j = 0;
+  while (true) {
+    if (i == nA) {
+      while (j < nB) {
+        assign_dispatch(R[i + j], B[j], assignment_tag{});
+        j++;
+      }
+      break;
+    }
+    if (j == nB) {
+      while (i < nA) {
+        assign_dispatch(R[i + j], A[i], assignment_tag{});
+        i++;
+      }
+      break;
+    }
+    if (f(B[j], A[i])) {
+      assign_dispatch(R[i + j], B[j], assignment_tag{});
+      j++;
+    } else {
+      assign_dispatch(R[i + j], A[i], assignment_tag{});
+      i++;
+    }
+  }
+}
+
+
+template <typename assignment_tag, typename InIterator1, typename InIterator2, typename OutIterator, typename BinaryOp>
+void merge_into(slice<InIterator1, InIterator1> A,
+            slice<InIterator2, InIterator2> B,
+            slice<OutIterator, OutIterator> R,
+            const BinaryOp &f,
+            bool cons = false) {
+  size_t nA = A.size();
+  size_t nB = B.size();
+  size_t nR = nA + nB;
+  if (nR < _merge_base) {
+    seq_merge<assignment_tag>(A, B, R, f);
+  }
+  else if (nA == 0) {
+    parallel_for(0, nB, [&](size_t i) {
+      assign_dispatch(R[i], B[i], assignment_tag{});
+    });
+  }
+  else if (nB == 0) {
+    parallel_for(0, nA, [&](size_t i) {
+      assign_dispatch(R[i], A[i], assignment_tag{});
+    });
+  }
+  else {
+    size_t mA = nA / 2;
+    // important for stability that binary search identifies
+    // first element in B greater or equal to A[mA]
+    size_t mB = binary_search(B, A[mA], f);
+    if (mB == 0) mA++;  // ensures at least one on each side
+    size_t mR = mA + mB;
+    auto left = [&]() {
+      merge_into<assignment_tag>(A.cut(0, mA), B.cut(0, mB), R.cut(0, mR), f, cons);
+    };
+    auto right = [&]() {
+      merge_into<assignment_tag>(A.cut(mA, nA), B.cut(mB, nB), R.cut(mR, nR), f, cons);
+    };
+    par_do(left, right, cons);
+  }
+}
+
+// Merge A and B, copying their contents
+// into the resulting sequence.
+template <typename IteratorA, typename IteratorB, typename BinaryOp>
+auto merge(slice<IteratorA, IteratorA> A,
+           slice<IteratorB, IteratorB> B,
+           const BinaryOp &f,
+           bool cons = false) {
+    
+  using T = typename slice<IteratorA, IteratorA>::value_type;
+  auto R = sequence<T>::uninitialized(A.size() + B.size());
+  merge_into<uninitialized_copy_tag>(A, B, make_slice(R), f, cons);
+  return R;
+}
+
+// Merge A and B, moving their contents
+// into the resulting sequence
+template <typename IteratorA, typename IteratorB, typename BinaryOp>
+auto merge_move(slice<IteratorA, IteratorA> A,
+                slice<IteratorB, IteratorB> B,
+                const BinaryOp &f,
+                bool cons = false) {
+    
+  using T = typename slice<IteratorA, IteratorA>::value_type;
+  auto R = sequence<T>::uninitialized(A.size() + B.size());
+  merge_into<uninitialized_move_tag>(A, B, make_slice(R), f, cons);
+  return R;
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_MERGE_H_

--- a/third_party/parlayhash/include/parlay/internal/merge_sort.h
+++ b/third_party/parlayhash/include/parlay/internal/merge_sort.h
@@ -1,0 +1,77 @@
+#ifndef PARLAY_MERGE_SORT_H_
+#define PARLAY_MERGE_SORT_H_
+
+#include "merge.h"
+#include "quicksort.h"  // needed for insertion_sort
+
+#include "../utilities.h"
+#include "uninitialized_sequence.h"
+
+namespace parlay {
+namespace internal {
+
+// Size at which to perform insertion sort instead
+constexpr size_t MERGE_SORT_BASE = 48;
+
+// Parallel mergesort
+// This sort is stable
+// if inplace is true then the output is placed in In and
+// Out is just used as temp space.
+template <typename InIterator, typename OutIterator, typename BinaryOp>
+void merge_sort_(slice<InIterator, InIterator> In,
+                 slice<OutIterator, OutIterator> Out,
+                 const BinaryOp& f,
+                 bool inplace) {
+  size_t n = In.size();
+  // Base case
+  if (n < MERGE_SORT_BASE) {
+    insertion_sort(In.begin(), In.size(), f);
+    if (!inplace) {
+      for (size_t i = 0; i < In.size(); i++) {
+        uninitialized_relocate(&Out[i], &In[i]);
+      }
+    }
+  }
+  else {
+    size_t m = n / 2;
+    par_do_if(
+      n > 64,
+      [&]() { merge_sort_(In.cut(0, m), Out.cut(0, m), f, !inplace); },
+      [&]() { merge_sort_(In.cut(m, n), Out.cut(m, n), f, !inplace); },
+    true);
+
+    if (inplace) {
+      merge_into<uninitialized_relocate_tag>(Out.cut(0, m), Out.cut(m, n), In, f);
+    }
+    else {
+      merge_into<uninitialized_relocate_tag>(In.cut(0, m), In.cut(m, n), Out, f);
+    }
+  }
+}
+
+template <typename Iterator, typename BinaryOp>
+void merge_sort_inplace(slice<Iterator, Iterator> In, const BinaryOp& f) {
+  using value_type = typename slice<Iterator, Iterator>::value_type;
+  size_t n = In.size();
+  if (n <= MERGE_SORT_BASE) {
+    insertion_sort(In.begin(), In.size(), f);
+  }
+  else {
+    auto B = uninitialized_sequence<value_type>(n);
+    merge_sort_(In, make_slice(B), f, true);
+  }
+}
+
+// not the most efficent way to do due to extra copy
+template <typename Iterator, typename BinaryOp>
+[[nodiscard]] auto merge_sort(slice<Iterator, Iterator> In, const BinaryOp& f) {
+  using value_type = typename slice<Iterator, Iterator>::value_type;
+  auto A = parlay::sequence<value_type>(In.begin(), In.end());
+  merge_sort_inplace(make_slice(A), f);
+  return A;
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_MERGE_SORT_H_

--- a/third_party/parlayhash/include/parlay/internal/pool_allocator.h
+++ b/third_party/parlayhash/include/parlay/internal/pool_allocator.h
@@ -1,0 +1,200 @@
+
+#ifndef PARLAY_INTERNAL_POOL_ALLOCATOR_H
+#define PARLAY_INTERNAL_POOL_ALLOCATOR_H
+
+#include <cassert>
+#include <cstddef>
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <new>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "../portability.h"
+#include "../utilities.h"
+
+#include "block_allocator.h"
+
+#include "concurrency/hazptr_stack.h"
+
+// IWYU pragma: no_include <array>
+
+namespace parlay {
+namespace internal {
+
+// ****************************************
+//    pool_allocator
+// ****************************************
+
+// Allocates headerless blocks from pools of different sizes.
+// A vector of pool sizes is given to the constructor.
+// Sizes must be at least 8, and must increase.
+// For pools of small blocks (below large_threshold) each thread keeps a
+// thread local list of elements from each pool using the block_allocator.
+// For large blocks there is only one pool shared by all threads. For
+// blocks larger than the maximum pool size, allocation and deallocation
+// is performed directly by operator new.
+struct pool_allocator {
+
+  // Maximum alignment guaranteed by the allocator
+  static inline constexpr size_t max_alignment = 128;
+  
+ private:
+  static inline constexpr size_t large_threshold = (1 << 18);
+
+  size_t num_buckets;
+  size_t num_small;
+  size_t max_small;
+  size_t max_size;
+  std::atomic<size_t> large_allocated{0};
+  std::atomic<size_t> large_used{0};
+
+  std::unique_ptr<size_t[]> sizes;
+  std::unique_ptr<internal::hazptr_stack<void*>[]> large_buckets;
+  unique_array<block_allocator> small_allocators;
+
+  void* allocate_large(size_t n) {
+
+    size_t bucket = num_small;
+    size_t alloc_size;
+    large_used += n;
+
+    if (n <= max_size) {
+      while (n > sizes[bucket]) bucket++;
+      std::optional<void*> r = large_buckets[bucket-num_small].pop();
+      if (r) return *r;
+      alloc_size = sizes[bucket];
+    } else alloc_size = n;
+
+    // Alloc size must be a multiple of the alignment
+    // Round up to the next multiple.
+    if (alloc_size % max_alignment != 0) {
+      alloc_size += (max_alignment - (alloc_size % max_alignment));
+    }
+
+    void* a = ::operator new(alloc_size, std::align_val_t{max_alignment});
+
+    large_allocated += n;
+    return a;
+  }
+
+  void deallocate_large(void* ptr, size_t n) {
+    large_used -= n;
+    if (n > max_size) {
+      ::operator delete(ptr, std::align_val_t{max_alignment});
+      large_allocated -= n;
+    } else {
+      size_t bucket = num_small;
+      while (n > sizes[bucket]) bucket++;
+      large_buckets[bucket-num_small].push(ptr);
+    }
+  }
+
+ public:
+  pool_allocator(const pool_allocator&) = delete;
+  pool_allocator(pool_allocator&&) = delete;
+  pool_allocator& operator=(const pool_allocator&) = delete;
+  pool_allocator& operator=(pool_allocator&&) = delete;
+
+  ~pool_allocator() {
+    clear();
+  }
+
+  explicit pool_allocator(const std::vector<size_t>& sizes_) :
+      num_buckets(sizes_.size()),
+      sizes(std::make_unique<size_t[]>(num_buckets)) {
+
+    std::copy(std::begin(sizes_), std::end(sizes_), sizes.get());
+    max_size = sizes[num_buckets-1];
+    num_small = 0;
+    while (num_small < num_buckets && sizes[num_small] < large_threshold)
+      num_small++;
+    max_small = (num_small > 0) ? sizes[num_small - 1] : 0;
+
+    large_buckets = std::make_unique<internal::hazptr_stack<void*>[]>(num_buckets-num_small);
+    small_allocators = make_unique_array<internal::block_allocator>(num_small, [&](size_t i) {
+      return internal::block_allocator(sizes[i], max_alignment);
+    });
+
+#ifndef NDEBUG
+    size_t prev_bucket_size = 0;
+    for (size_t i = 0; i < num_small; i++) {
+      size_t bucket_size = sizes[i];
+      assert(bucket_size >= 8);
+      assert(bucket_size > prev_bucket_size);
+      prev_bucket_size = bucket_size;
+    }
+#endif
+  }
+
+  void* allocate(size_t n) {
+    if (n > max_small) return allocate_large(n);
+    size_t bucket = 0;
+    while (n > sizes[bucket]) bucket++;
+    return small_allocators[bucket].alloc();
+  }
+
+  void deallocate(void* ptr, size_t n) {
+    if (n > max_small) deallocate_large(ptr, n);
+    else {
+      size_t bucket = 0;
+      while (n > sizes[bucket]) bucket++;
+      small_allocators[bucket].free(ptr);
+    }
+  }
+
+  // allocate, touch, and free to make sure space for small blocks is paged in
+  [[deprecated]] void reserve(size_t) { }
+
+  void print_stats() {
+    size_t total_a = 0;
+    size_t total_u = 0;
+    for (size_t i = 0; i < num_small; i++) {
+      size_t bucket_size = sizes[i];
+      size_t allocated = small_allocators[i].num_allocated_blocks();
+      size_t used = small_allocators[i].num_used_blocks();
+      total_a += allocated * bucket_size;
+      total_u += used * bucket_size;
+      std::cout << "size = " << bucket_size << ", allocated = " << allocated
+                << ", used = " << used << std::endl;
+    }
+    std::cout << "Large allocated = " << large_allocated << std::endl;
+    std::cout << "Total bytes allocated = " << total_a + large_allocated << std::endl;
+    std::cout << "Total bytes used = " << total_u << std::endl;
+  }
+
+  // pair of total currently used space, and total unused space the allocator has in reserve
+  std::pair<size_t,size_t> stats() {
+    size_t total_a = large_allocated;
+    size_t total_u = large_used;
+    for (size_t i = 0; i < num_small; i++) {
+      size_t bucket_size = sizes[i];
+      size_t allocated = small_allocators[i].num_allocated_blocks();
+      size_t used = small_allocators[i].num_used_blocks();
+      total_a += allocated * bucket_size;
+      total_u += used * bucket_size;
+    }
+    return {total_u, total_a-total_u};
+  }
+
+  void clear() {
+    for (size_t i = num_small; i < num_buckets; i++) {
+      std::optional<void*> r = large_buckets[i-num_small].pop();
+      while (r) {
+        large_allocated -= sizes[i];
+        ::operator delete(*r, std::align_val_t{max_alignment});
+        r = large_buckets[i-num_small].pop();
+      }
+    }
+  }
+};
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_POOL_ALLOCATOR_H

--- a/third_party/parlayhash/include/parlay/internal/posix/file_map_impl_posix.h
+++ b/third_party/parlayhash/include/parlay/internal/posix/file_map_impl_posix.h
@@ -1,0 +1,98 @@
+
+#ifndef PARLAY_INTERNAL_POSIX_FILE_MAP_IMPL_POSIX
+#define PARLAY_INTERNAL_POSIX_FILE_MAP_IMPL_POSIX
+
+#include <cassert>
+
+#include <algorithm>
+#include <string>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+namespace parlay {
+
+class file_map {
+  private:
+    char* begin_p;
+    char* end_p;
+  public:
+  
+    using value_type = char;
+    using reference = char&;
+    using const_reference = const char&;
+    using iterator = char*;
+    using const_iterator =  const char*;
+    using pointer = char*;
+    using const_pointer = const char*;
+    using difference_type = std::ptrdiff_t;
+    using size_type = size_t;
+  
+    char operator[] (size_t i) const { return begin_p[i]; }
+    const char* begin() const { return begin_p; }
+    const char* end() const {return end_p; }
+
+    size_t size() const { return end() - begin(); }
+
+    explicit file_map(const std::string& filename) {
+      
+      struct stat sb;
+      int fd = open(filename.c_str(), O_RDONLY);
+      assert(fd != -1);
+      [[maybe_unused]] auto fstat_res = fstat(fd, &sb);
+      assert(fstat_res != -1);
+      assert(S_ISREG(sb.st_mode));
+    
+      char *p = static_cast<char*>(mmap(0, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0));
+      assert(p != MAP_FAILED);
+      [[maybe_unused]] int close_p = ::close(fd);
+      assert(close_p != -1);
+      
+      begin_p = p;
+      end_p = p + sb.st_size;
+    }
+    
+    ~file_map() {
+      close();
+    }
+
+    // moveable but not copyable
+    file_map(const file_map&) = delete;
+    file_map& operator=(const file_map&) = delete;
+    
+    file_map(file_map&& other) noexcept : begin_p(other.begin_p), end_p(other.end_p) {
+      other.begin_p = nullptr;
+      other.end_p = nullptr;
+    }
+    
+    file_map& operator=(file_map&& other) noexcept {
+      close();
+      swap(other);
+      return *this;
+    }
+    
+    void close() {
+      if (begin_p != nullptr) {
+        munmap(begin_p, end_p - begin_p);
+      }
+      begin_p = nullptr;
+      end_p = nullptr;
+    }
+    
+    void swap(file_map& other) {
+      std::swap(other.begin_p, begin_p);
+      std::swap(other.end_p, end_p);
+    }
+    
+    bool empty() const {
+      return begin_p == nullptr;
+    }
+};
+
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_POSIX_FILE_MAP_IMPL_POSIX

--- a/third_party/parlayhash/include/parlay/internal/quicksort.h
+++ b/third_party/parlayhash/include/parlay/internal/quicksort.h
@@ -1,0 +1,271 @@
+
+#ifndef PARLAY_QUICKSORT_H_
+#define PARLAY_QUICKSORT_H_
+
+#include <algorithm>
+#include <new>
+#include <utility>
+#include <cassert>
+
+#include "uninitialized_storage.h"
+#include "uninitialized_sequence.h"
+#include "sequence_ops.h"
+#include "counting_sort.h"
+#include "sequence_ops.h"
+
+#include "../utilities.h"
+
+namespace parlay {
+namespace internal {
+
+template <typename Iterator>
+bool base_case(Iterator x, size_t n) {
+  using value_type = typename std::iterator_traits<Iterator>::value_type;
+  bool large = std::is_pointer<value_type>::value || (sizeof(x) > 8);
+  return large ? (n < 16) : (n < 24);
+}
+
+// Optimized insertion sort using uninitialized relocate
+//
+// Note that the strange looking loop body is really just a
+// slightly more optimized version of:
+//
+//    T tmp = std::move(A[i])
+//    std::ptrdiff_t j = i - 1;
+//    for (; j >= 0 && f(tmp, A[j]); j--) {
+//      A[j+1] = std::move(A[j])
+//    }
+//    A[j+1] = std::move(tmp);
+//
+// but instead of using move, we use relocation to potentially
+// save on wasteful destructor invocations.
+//
+// template <class Iterator, typename BinPred>
+// auto insertion_sort(Iterator A, size_t n, const BinPred& f) {
+//   using T = typename std::iterator_traits<Iterator>::value_type;
+//   for (size_t i = 1; i < n; i++) {
+//     // We want to store the value being moved (A[i]) in a temporary
+//     // variable. In order to take advantage of uninitialized
+//     // relocate, we need uninitialized storage to put it in.
+//     uninitialized_storage<T> temp_storage;
+//     T* tmp = temp_storage.get();
+//     uninitialized_relocate(tmp, &A[i]);
+
+//     std::ptrdiff_t j = i - 1;
+//     for (; j >= 0 && f(*tmp, A[j]); j--) {
+//       uninitialized_relocate(&A[j+1], &A[j]);
+//     }
+//     uninitialized_relocate(&A[j+1], tmp);
+//   }
+// }
+
+template <class Iterator, class BinPred>
+void insertion_sort(Iterator A, size_t n, const BinPred& f) {
+  for (size_t i = 1; i < n; i++) {
+    long j = i;
+    while (--j >= 0 && f(A[j + 1], A[j])) {
+      using std::swap;
+      swap(A[j + 1], A[j]);
+    }
+  }
+}
+
+// Sorts 5 sampled elements and puts them at the front.
+template <class Iterator, class BinPred>
+void sort5(Iterator A, size_t n, const BinPred& f) {
+  size_t size = 5;
+  for (size_t i = 0; i < size; ++i) {
+    size_t j = i + parlay::hash64(i) % (n - i);
+    using std::swap;  // enable ADL.
+    swap(A[i], A[j]);
+  }
+  insertion_sort(A, size, f);
+}
+
+// Dual-pivot partition. Picks two pivots from the input A
+// and then divides it into three parts:
+//
+//   [x < p1), [p1 <= x <= p2], (p2 < x]
+//
+// Returns a triple consisting of iterators to the start
+// of the second and third part, and a boolean flag, which
+// is true if the pivots were equal, and hence the middle
+// part contains all equal elements.
+//
+// Requires that the size of A is at least 5.
+template <class Iterator, class BinPred>
+std::tuple<Iterator, Iterator, bool> split3(Iterator A, size_t n, const BinPred& f) {
+  assert(n >= 5);
+  sort5(A, n, f);
+  
+  // Use A[1] and A[3] as the pivots. Move them to
+  // the front so that A[0] and A[1] are the pivots
+  using std::swap;
+  swap(A[0], A[1]);
+  swap(A[1], A[3]);
+  const auto& p1 = A[0];
+  const auto& p2 = A[1];
+  bool pivots_equal = !f(p1, p2);
+  
+  // set up initial invariants
+  auto L = A + 2;
+  auto R = A + n - 1;
+  while (f(*L, p1)) L++;
+  while (f(p2, *R)) R--;
+  auto M = L;
+  
+  // invariants:
+  //  below L is less than p1,
+  //  above R is greater than p2
+  //  between L and M are between p1 and p2 inclusive
+  //  between M and R are unprocessed
+  while (M <= R) {
+
+    if (f(*M, p1)) {
+      swap(*M, *L);
+      L++;
+    } else if (f(p2, *M)) {
+      swap(*M, *R);
+      if (f(*M, p1)) {
+        swap(*L, *M);
+        L++;
+      }
+
+      R--;
+      while (f(p2, *R)) R--;
+    }
+    M++;
+  }
+
+  // Swap the pivots into position
+  L -= 2;
+  swap(A[1], *(L+1));
+  swap(A[0], *L);
+  swap(*(L+1), *R);
+
+  return std::make_tuple(L, M, pivots_equal);
+}
+
+template <class Iterator, class BinPred>
+void quicksort_serial(Iterator A, size_t n, const BinPred& f) {
+  while (!base_case(A, n)) {
+    auto [L, M, mid_eq] = split3(A, n, f);
+    if (!mid_eq) quicksort_serial(L+1, M - L-1, f);
+    quicksort_serial(M, A + n - M, f);
+    n = L - A;
+  }
+
+  insertion_sort(A, n, f);
+}
+
+template <class Iterator, class BinPred>
+void quicksort(Iterator A, size_t n, const BinPred& f) {
+  if (n < (1 << 8))
+    quicksort_serial(A, n, f);
+  else {
+    auto [L, M, mid_eq] = split3(A, n, f);
+    // Note: generic lambda capture for L and M (i.e. writing L = L, etc.)
+    // in the capture is required due to a defect in the C++ standard which
+    // prohibits capturing names resulting from a structured binding!
+    auto left = [&, L = L]() { quicksort(A, L - A, f); };
+    auto mid = [&, L = L, M = M]() { quicksort(L + 1, M - L - 1, f); };
+    auto right = [&, M = M]() { quicksort(M, A + n - M, f); };
+
+    if (!mid_eq)
+      par_do3(left, mid, right);
+    else
+      par_do(left, right);
+  }
+}
+
+template <class Iterator, class BinPred>
+void quicksort(slice<Iterator, Iterator> A, const BinPred& f) {
+  quicksort(A.begin(), A.size(), f);
+}
+
+//// Fully Parallel version below here
+
+// ---------------  Not currently tested or used ----------------
+
+template <class assignment_tag, class Iterator, class BinPred>
+std::tuple<size_t, size_t, bool> p_split3(slice<Iterator, Iterator> A,
+                                          slice<Iterator, Iterator> B,
+                                          const BinPred& f) {
+  using E = typename std::iterator_traits<Iterator>::value_type;
+  size_t n = A.size();
+  sort5(A.begin(), n, f);
+  E p1 = A[1];
+  E p2 = A[3];
+  if (!f(A[0], A[1])) p1 = p2;  // if few elements less than p1, then set to p2
+  if (!f(A[3], A[4]))
+    p2 = p1;  // if few elements greater than p2, then set to p1
+  if (true) {
+    auto flag = [&](size_t i) { return f(A[i], p1) ? 0 : f(p2, A[i]) ? 2 : 1; };
+    auto r = split_three<assignment_tag>(A, make_slice(B),
+					 make_slice(delayed_seq<unsigned char>(n, flag)),
+					 fl_conservative);
+    return std::make_tuple(r.first, r.first + r.second, !f(p1, p2));
+  } else { // currently not used 
+    auto buckets = dseq(n, [&] (size_t i) {
+	    return f(A[i], p1) ? 0 : f(p2, A[i]) ? 2 : 1; });
+    auto r = count_sort<assignment_tag>(A, B, make_slice(buckets), 3, .9);
+    return std::make_tuple(r.first[0], r.first[0] + r.first[1], !f(p1, p2));
+  } 
+}
+
+// The fully parallel version copies back and forth between two arrays
+// inplace: if true then result is put back in In
+//     and Out is just used as temp space
+//     otherwise result is in Out
+//     In and Out cannot be the same (Out is needed as temp space)
+// cut_size: is when to revert to  quicksort.
+//    If -1 then it uses a default based on number of threads
+template <typename assignment_tag, typename InIterator, typename OutIterator, typename F>
+void p_quicksort_(slice<InIterator, InIterator> In,
+                  slice<OutIterator, OutIterator> Out,
+                  const F& f,
+                  bool inplace = false,
+                  long cut_size = -1) {
+  size_t n = In.size();
+  if (cut_size == -1)
+    cut_size = std::max<long>((3 * n) / num_workers(), (1 << 14));
+  if (n < (size_t)cut_size) {
+    quicksort(In.begin(), n, f);
+    if (!inplace)
+      parallel_for(0, n, [&] (size_t i) {
+         assign_dispatch(Out[i], In[i], assignment_tag()); }, 2000);
+  } else {
+    size_t l, m;
+    bool mid_eq;
+    std::tie(l, m, mid_eq) = p_split3<assignment_tag>(In, Out, f);
+    par_do3(
+        [&]() {
+          p_quicksort_<assignment_tag>(Out.cut(0, l), In.cut(0, l), f, !inplace, cut_size);
+        },
+        [&]() {
+          auto copy_in = [&](size_t i) { In[i] = Out[i]; };
+          if (!mid_eq)
+            p_quicksort_<assignment_tag>(Out.cut(l, m), In.cut(l, m), f, !inplace,
+                         cut_size);
+          else if (inplace)
+            parallel_for(l, m, copy_in, 2000);
+        },
+        [&]() {
+          p_quicksort_<assignment_tag>(Out.cut(m, n), In.cut(m, n), f, !inplace, cut_size);
+        });
+  }
+}
+
+template <typename Iterator, class F>
+void p_quicksort_inplace(slice<Iterator, Iterator> In, const F& f) {
+  using value_type = typename slice<Iterator, Iterator>::value_type;
+
+  auto Tmp = uninitialized_sequence<value_type>(In.size());
+  p_quicksort_<uninitialized_move_tag>(In, make_slice(Tmp), f, true);
+  //p_quicksort_<uninitialized_relocate_tag>(In, make_slice(Tmp), f, true);
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_QUICKSORT_H_

--- a/third_party/parlayhash/include/parlay/internal/sample_sort.h
+++ b/third_party/parlayhash/include/parlay/internal/sample_sort.h
@@ -1,0 +1,305 @@
+// This file is basically the cache-oblivious sorting algorithm from:
+//
+// Low depth cache-oblivious algorithms.
+// Guy E. Blelloch, Phillip B. Gibbons and  Harsha Vardhan Simhadri.
+// Proc. ACM symposium on Parallelism in algorithms and architectures (SPAA),
+// 2010
+
+#ifndef PARLAY_SAMPLE_SORT_H_
+#define PARLAY_SAMPLE_SORT_H_
+
+#include <cassert>
+#include <cstdio>
+
+#include <iterator>
+#include <limits>
+#include <type_traits>
+
+#include "bucket_sort.h"
+#include "quicksort.h"
+#include "sequence_ops.h"
+#include "transpose.h"
+#include "uninitialized_sequence.h"
+
+#include "../delayed_sequence.h"
+#include "../parallel.h"
+#include "../relocation.h"
+#include "../sequence.h"
+#include "../slice.h"
+#include "../utilities.h"
+
+namespace parlay {
+namespace internal {
+
+// the following parameters can be tuned
+constexpr const size_t QUICKSORT_THRESHOLD = 16384;
+constexpr const size_t OVER_SAMPLE = 8;
+
+// generates counts in Sc for the number of keys in Sa between consecutive
+// values of Sb. Sa and Sb must be sorted
+template <typename InIterator, typename PivotIterator, typename CountIterator, typename Compare>
+void get_bucket_counts(slice<InIterator, InIterator> sA,
+                       slice<PivotIterator, PivotIterator> sB,
+                       slice<CountIterator, CountIterator> sC,
+                       Compare f) {
+  using s_size_t = typename std::iterator_traits<CountIterator>::value_type;
+
+  if (sA.size() == 0 || sB.size() == 0) return;
+  for (auto& c : sC) c = 0;
+  auto itA = sA.begin();
+  auto itB = sB.begin();
+  auto itC = sC.begin();
+  while (true) {
+    while (f(*itA, *itB)) {
+      assert(itC != sC.end());
+      (*itC)++;
+      if (++itA == sA.end()) return;
+    }
+    itB++;
+    itC++;
+    if (itB == sB.end()) break;
+    if (!(f(*(itB - 1), *itB))) {
+      while (!f(*itB, *itA)) {
+        assert(itC != sC.end());
+        (*itC)++;
+        if (++itA == sA.end()) return;
+      }
+      itB++;
+      itC++;
+      if (itB == sB.end()) break;
+    }
+  }
+  assert(itC != sC.end());
+  *itC = static_cast<s_size_t>(sA.end() - itA);
+}
+
+template <typename Iterator, typename Compare>
+void seq_sort_inplace(slice<Iterator, Iterator> A, const Compare& less, bool stable) {
+  using value_type = typename slice<Iterator, Iterator>::value_type;
+  if (((sizeof(value_type) > 8) || std::is_pointer<value_type>::value))
+    if (!stable) quicksort(A.begin(), A.size(), less);
+    else bucket_sort(A, less, true); //merge_sort_inplace(A, less);
+  else
+    bucket_sort(A, less, stable);
+}
+
+template <typename assignment_tag, typename InIterator, typename OutIterator, typename Compare>
+void seq_sort_(slice<InIterator, InIterator> In,
+               slice<OutIterator, OutIterator> Out,
+               const Compare& less,
+               bool stable = false) {
+  size_t l = In.size();
+  for (size_t j = 0; j < l; j++) assign_dispatch(Out[j], In[j], assignment_tag());
+  seq_sort_inplace(Out, less, stable);
+}
+
+
+// Fully in place version of sample sort. Makes no copies of any elements
+// in the input array. This version can not be stable, unfortunately.
+template <typename s_size_t = size_t,
+          typename InIterator, typename OutIterator,
+          typename Compare>
+void sample_sort_inplace_(slice<InIterator, InIterator> In,
+                  slice<OutIterator, OutIterator> Out,
+                  const Compare& less) {
+  using value_type = typename slice<InIterator, InIterator>::value_type;
+  size_t n = In.size();
+
+  if (n < QUICKSORT_THRESHOLD) {
+    seq_sort_inplace(In, less, false);
+  } else {
+    // The larger these are, the more comparisons are done but less
+    // overhead for the transpose.
+    size_t bucket_quotient = 4;
+    size_t block_quotient = 4;
+    if (std::is_pointer<value_type>::value) {
+      bucket_quotient = 2;
+      block_quotient = 3;
+    } else if (sizeof(value_type) > 8) {
+      bucket_quotient = 3;
+      block_quotient = 3;
+    }
+
+    // How many samples to take in terms of blocks, i.e.,
+    // we take sample_blocks * block_size samples
+    size_t sample_blocks = 4;
+
+    size_t sqrt = static_cast<size_t>(std::sqrt(n));
+    size_t num_blocks = size_t{1} << log2_up((sqrt / block_quotient) + 1);
+    size_t block_size = ((n - 1) / num_blocks) + 1;
+    size_t num_buckets = (sqrt / bucket_quotient) + 1;
+    size_t sample_set_size = sample_blocks * block_size;
+    size_t m = num_blocks * num_buckets;
+
+    // We want to select evenly spaced pivots from the sorted samples
+    // Since we sampled sample_set_size many elements, and we need
+    // exactly num_buckets - 1, we sample at stride:
+    assert(sample_set_size >= num_buckets - 1);
+    size_t stride = sample_set_size / (num_buckets - 1);
+    assert(stride >= 1);
+
+    // In place sampling!. Just swap elements to the front of
+    // the sequence to be used as the samples. This way, no
+    // copying is required! This is essentially just k iterations
+    // of a Knuth shuffle.
+    for (size_t i = 0; i < sample_set_size; i++) {
+      size_t j = i + hash64(i) % (n - i);
+      using std::swap;
+      swap(In[i], In[j]);
+    }
+
+    // sort the samples
+    auto sample_set = make_slice(In.begin(), In.begin() + sample_set_size);
+    quicksort(sample_set.begin(), sample_set_size, less);
+
+    // Pivots returns by reference to avoid making copies
+    auto pivots = delayed_seq<const value_type&>(num_buckets - 1, [&](size_t i) -> const value_type& {
+      assert(stride * i < sample_set_size);
+      return sample_set[stride * i];
+    });
+
+    // sort each block and merge with samples to get counts for each bucket
+    auto Tmp = uninitialized_sequence<value_type>(n);
+    auto counts = sequence<s_size_t>::uninitialized(m + 1);
+    counts[m] = 0;
+
+    sliced_for(n, block_size, [&](size_t i, size_t start, size_t end) {
+      // The sample blocks are already sorted, so we don't need to sort them again.
+      if (i >= sample_blocks) {
+        seq_sort_<uninitialized_relocate_tag>(In.cut(start, end), make_slice(Tmp).cut(start, end), less, false);
+        get_bucket_counts(make_slice(Tmp).cut(start, end), make_slice(pivots),
+                          make_slice(counts).cut(i * num_buckets, (i + 1) * num_buckets), less);
+      }
+      else {
+        get_bucket_counts(make_slice(In).cut(start, end), make_slice(pivots),
+                          make_slice(counts).cut(i * num_buckets, (i + 1) * num_buckets), less);
+      }
+    });
+
+    // Sample block is already sorted, so we don't need to sort it again.
+    // We can just move it straight over into the other sorted blocks
+    uninitialized_relocate_n(Tmp.begin(), sample_set.begin(), sample_set_size);
+
+    // move data from blocks to buckets
+    auto bucket_offsets =
+        transpose_buckets<uninitialized_relocate_tag>(Tmp.begin(), Out.begin(), counts, n, block_size,
+                          num_blocks, num_buckets);
+
+    // sort within each bucket
+    parallel_for(0, num_buckets, [&](size_t i) {
+      size_t start = bucket_offsets[i];
+      size_t end = bucket_offsets[i + 1];
+      // This could be optimized by not sorting a bucket if its two adjacent
+      // pivots were equal, since this means that all of the contents of the
+      // bucket are equal. But we don't know where the pivots are anymore
+      // since we just merged them in. We could chose to precompute flags
+      // indicating which adjacent pivots are equal, but is it worth it?
+      seq_sort_inplace(Out.cut(start, end), less, false);
+     }, 1);
+  }
+}
+
+// Copying version of sample sort. This one makes copies of the input
+// elements when sorting them into the output. Roughly (\sqrt{n})
+// additional copies are also made to copy the pivots. This one can
+// be stable.
+template <typename s_size_t = size_t,
+    typename InIterator, typename OutIterator,
+    typename Compare>
+void sample_sort_(slice<InIterator, InIterator> In,
+                          slice<OutIterator, OutIterator> Out,
+                          const Compare& less,
+                          bool stable = false) {
+  using value_type = typename slice<InIterator, InIterator>::value_type;
+  size_t n = In.size();
+
+  if (n < QUICKSORT_THRESHOLD) {
+    seq_sort_<uninitialized_copy_tag>(In, Out, less, stable);
+  } else {
+    // The larger these are, the more comparisons are done but less
+    // overhead for the transpose.
+    size_t bucket_quotient = 4;
+    size_t block_quotient = 4;
+    if (std::is_pointer<value_type>::value) {
+      bucket_quotient = 2;
+      block_quotient = 3;
+    } else if (sizeof(value_type) > 8) {
+      bucket_quotient = 3;
+      block_quotient = 3;
+    }
+    size_t sqrt = static_cast<size_t>(std::sqrt(n));
+    size_t num_blocks = size_t{1} << log2_up((sqrt / block_quotient) + 1);
+    size_t block_size = ((n - 1) / num_blocks) + 1;
+    size_t num_buckets = (sqrt / bucket_quotient) + 1;
+    size_t sample_set_size = num_buckets * OVER_SAMPLE;
+    size_t m = num_blocks * num_buckets;
+
+    // generate "random" samples with oversampling
+    auto sample_set = sequence<value_type>::from_function(sample_set_size,
+                                                          [&](size_t i) { return In[hash64(i) % n]; });
+    // sort the samples
+    quicksort(sample_set.begin(), sample_set_size, less);
+
+    // subselect samples at even stride
+    auto pivots = sequence<value_type>::from_function(num_buckets - 1,
+                                                      [&](size_t i) { return sample_set[OVER_SAMPLE * i]; });
+
+    auto Tmp = uninitialized_sequence<value_type>(n);
+
+    // sort each block and merge with samples to get counts for each bucket
+    auto counts = sequence<s_size_t>::uninitialized(m + 1);
+    counts[m] = 0;
+    sliced_for(n, block_size, [&](size_t i, size_t start, size_t end) {
+      seq_sort_<uninitialized_copy_tag>(In.cut(start, end), make_slice(Tmp).cut(start, end), less, stable);
+      get_bucket_counts(make_slice(Tmp).cut(start, end), make_slice(pivots),
+                        make_slice(counts).cut(i * num_buckets, (i + 1) * num_buckets), less);
+    });
+
+    // move data from blocks to buckets
+    auto bucket_offsets =
+        transpose_buckets<uninitialized_relocate_tag>(Tmp.begin(), Out.begin(), counts, n, block_size,
+                                                      num_blocks, num_buckets);
+
+    // sort within each bucket
+    parallel_for(0, num_buckets, [&](size_t i) {
+      size_t start = bucket_offsets[i];
+      size_t end = bucket_offsets[i + 1];
+
+      // buckets need not be sorted if two consecutive pivots are equal
+      if (i == 0 || i == num_buckets - 1 || less(pivots[i - 1], pivots[i])) {
+        seq_sort_inplace(Out.cut(start, end), less, stable);
+      }
+    }, 1);
+  }
+}
+
+template <typename Iterator, typename Compare>
+auto sample_sort(slice<Iterator, Iterator> A,
+                 const Compare& less,
+                 bool stable = false) {
+  using value_type = typename slice<Iterator, Iterator>::value_type;
+  sequence<value_type> R = sequence<value_type>::uninitialized(A.size());
+  if (A.size() < (std::numeric_limits<unsigned int>::max)()) {
+    sample_sort_<unsigned int>(A, make_slice(R), less, stable);
+  }
+  else {
+    sample_sort_<size_t>(A, make_slice(R), less, stable);
+  }
+  return R;
+}
+
+template <class Iterator, typename Compare>
+void sample_sort_inplace(slice<Iterator, Iterator> A,
+                         const Compare& less) {
+  if (A.size() < (std::numeric_limits<unsigned int>::max)()) {
+    sample_sort_inplace_<unsigned int>(A, A, less);
+  }
+  else {
+    sample_sort_inplace_<size_t>(A, A, less);
+  }
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_SAMPLE_SORT_H_

--- a/third_party/parlayhash/include/parlay/internal/scheduler_plugins/cilkplus.h
+++ b/third_party/parlayhash/include/parlay/internal/scheduler_plugins/cilkplus.h
@@ -1,0 +1,51 @@
+#ifndef PARLAY_INTERNAL_SCHEDULER_PLUGINS_CILKPLUS_H_
+#define PARLAY_INTERNAL_SCHEDULER_PLUGINS_CILKPLUS_H_
+
+#include <cstddef>
+
+#include <type_traits>
+
+#include <cilk/cilk.h>
+#include <cilk/cilk_api.h>
+
+namespace parlay {
+
+// IWYU pragma: private, include "../../parallel.h"
+
+inline size_t num_workers() { return __cilkrts_get_nworkers(); }
+inline size_t worker_id() { return __cilkrts_get_worker_number(); }
+
+template <typename Lf, typename Rf>
+inline void par_do(Lf&& left, Rf&& right, bool) {
+  static_assert(std::is_invocable_v<Lf&&>);
+  static_assert(std::is_invocable_v<Rf&&>);
+  cilk_spawn std::forward<Rf>(right)();
+  std::forward<Lf>(left)();
+  cilk_sync;
+}
+
+template <typename F>
+inline void parallel_for(size_t start, size_t end, F&& f, long granularity, bool) {
+  static_assert(std::is_invocable_v< F&, size_t>);
+  if (granularity == 0)
+    cilk_for (size_t i=start; i<end; i++) f(i);
+  else if ((end - start) <= static_cast<size_t>(granularity))
+    for (size_t i=start; i < end; i++) f(i);
+  else {
+    size_t n = end-start;
+    size_t mid = (start + (9*(n+1))/16);
+    cilk_spawn parallel_for(start, mid, f, granularity);
+    parallel_for(mid, end, f, granularity);
+    cilk_sync;
+  }
+}
+
+template <typename... Fs>
+void execute_with_scheduler(Fs...) {
+  struct Illegal {};
+  static_assert((std::is_same_v<Illegal, Fs> && ...), "parlay::execute_with_scheduler is only available in the Parlay scheduler and is not compatible with CilkPlus");
+}
+
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_SCHEDULER_PLUGINS_CILKPLUS_H_

--- a/third_party/parlayhash/include/parlay/internal/scheduler_plugins/omp.h
+++ b/third_party/parlayhash/include/parlay/internal/scheduler_plugins/omp.h
@@ -1,0 +1,121 @@
+// Scheduler plugin for OpenMP
+//
+// Critical Note: It is **very important** that we do not accidentally nest
+// parallel regions in OpenMP, because this will result in duplicate worker
+// IDs (each team gets assigned their own sequential worker IDs from 0 to
+// omp_get_num_threads() - 1). Therefore, we always check whether we are
+// already inside a parallel region before creating one. If we are already
+// inside one, tasks will just make use of the existing threads in the team.
+//
+
+#ifndef PARLAY_INTERNAL_SCHEDULER_PLUGINS_OMP_H_
+#define PARLAY_INTERNAL_SCHEDULER_PLUGINS_OMP_H_
+
+#include <omp.h>
+
+#include <type_traits>
+#include <utility>
+
+namespace parlay {
+
+// IWYU pragma: private, include "../../parallel.h"
+
+inline size_t num_workers() {
+  return omp_get_max_threads();
+}
+
+inline size_t worker_id() {
+  return omp_get_thread_num();
+}
+
+
+template <typename F>
+inline void parallel_for(size_t start, size_t end, F&& f, long granularity, bool) {
+  static_assert(std::is_invocable_v<F&, size_t>);
+
+  if (end == start + 1) {
+    f(start);
+  }
+  else if ((end - start) <= static_cast<size_t>(granularity)) {
+    for (size_t i=start; i < end; i++) {
+      f(i);
+    }
+  }
+  else if (!omp_in_parallel()) {
+    #pragma omp parallel
+    {
+      #pragma omp single
+      {
+        if (granularity <= 1) {
+          #pragma omp taskloop
+          for (size_t i = start; i < end; i++) {
+            f(i);
+          }
+        }
+        else {
+          #pragma omp taskloop grainsize(granularity)
+          for (size_t i = start; i < end; i++) {
+            f(i);
+          }
+        }
+      }
+    }
+  }
+  else {
+    if (granularity <= 1) {
+      #pragma omp taskloop shared(f)
+      for (size_t i = start; i < end; i++) {
+        f(i);
+      }
+    }
+    else {
+      #pragma omp taskloop grainsize(granularity) shared(f)
+      for (size_t i = start; i < end; i++) {
+        f(i);
+      }
+    }
+  }
+}
+
+template <typename Lf, typename Rf>
+inline void par_do(Lf&& left, Rf&& right, bool) {
+  static_assert(std::is_invocable_v<Lf&&>);
+  static_assert(std::is_invocable_v<Rf&&>);
+
+  // If we are not yet in a parallel region, start one
+  if (!omp_in_parallel()) {
+    #pragma omp parallel
+    {
+      #pragma omp single
+      {
+        #pragma omp taskgroup
+        {
+          #pragma omp task untied
+          { std::forward<Rf>(right)(); }
+
+          { std::forward<Lf>(left)(); }
+        }
+      }  // omp single
+    }  // omp parallel
+  }
+  // Already inside a parallel region, avoid creating nested one (see comment at top)
+  else {
+    #pragma omp taskgroup
+    {
+      #pragma omp task untied shared(right)
+      { std::forward<Rf>(right)(); }
+
+      { std::forward<Lf>(left)(); }
+    }
+  }
+}
+
+template <typename... Fs>
+void execute_with_scheduler(Fs...) {
+  struct Illegal {};
+  static_assert((std::is_same_v<Illegal, Fs> && ...), "parlay::execute_with_scheduler is only available in the Parlay scheduler and is not compatible with OpenMP");
+}
+
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_SCHEDULER_PLUGINS_OMP_H_

--- a/third_party/parlayhash/include/parlay/internal/scheduler_plugins/opencilk.h
+++ b/third_party/parlayhash/include/parlay/internal/scheduler_plugins/opencilk.h
@@ -1,0 +1,58 @@
+#ifndef PARLAY_INTERNAL_SCHEDULER_PLUGINS_OPENCILK_H_
+#define PARLAY_INTERNAL_SCHEDULER_PLUGINS_OPENCILK_H_
+
+#include <cstddef>
+
+#include <type_traits>
+
+#include <cilk/cilk.h>
+#include <cilk/cilk_api.h>
+
+namespace parlay {
+
+// IWYU pragma: private, include "../../parallel.h"
+
+inline size_t num_workers() { return __cilkrts_get_nworkers(); }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+inline size_t worker_id() { return __cilkrts_get_worker_number(); }
+
+#pragma clang diagnostic pop
+
+template <typename Lf, typename Rf>
+inline void par_do(Lf&& left, Rf&& right, bool) {
+  static_assert(std::is_invocable_v<Lf&&>);
+  static_assert(std::is_invocable_v<Rf&&>);
+  cilk_spawn std::forward<Rf>(right)();
+  std::forward<Lf>(left)();
+  cilk_sync;
+}
+
+template <typename F>
+inline void parallel_for(size_t start, size_t end, F&& f, long granularity, bool) {
+  static_assert(std::is_invocable_v<F&, size_t>);
+  if (granularity == 0)
+    cilk_for (size_t i=start; i<end; i++) f(i);
+  else if ((end - start) <= static_cast<size_t>(granularity))
+    for (size_t i=start; i < end; i++) f(i);
+  else {
+    size_t n = end-start;
+    size_t mid = (start + (9*(n+1))/16);
+    cilk_spawn parallel_for(start, mid, f, granularity);
+    parallel_for(mid, end, f, granularity);
+    cilk_sync;
+  }
+}
+
+template <typename... Fs>
+void execute_with_scheduler(Fs...) {
+  struct Illegal {};
+  static_assert((std::is_same_v<Illegal, Fs> && ...), "parlay::execute_with_scheduler is only available in the Parlay scheduler and is not compatible with OpenCilk");
+}
+
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_SCHEDULER_PLUGINS_OPENCILK_H_
+

--- a/third_party/parlayhash/include/parlay/internal/scheduler_plugins/sequential.h
+++ b/third_party/parlayhash/include/parlay/internal/scheduler_plugins/sequential.h
@@ -1,0 +1,46 @@
+#ifndef PARLAY_INTERNAL_SCHEDULER_PLUGINS_SEQUENTIAL_H_
+#define PARLAY_INTERNAL_SCHEDULER_PLUGINS_SEQUENTIAL_H_
+
+#include <cstddef>
+
+#include <functional>
+#include <utility>
+
+namespace parlay {
+
+// IWYU pragma: private, include "../../parallel.h"
+
+inline size_t num_workers() { return 1; }
+inline size_t worker_id() { return 0; }
+inline void set_num_workers(int) { }
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4267) // conversion from 'size_t' to *, possible loss of data
+#endif
+
+template <class F>
+inline void parallel_for(size_t start, size_t end, F&& f, long, bool) {
+  for (size_t i=start; i<end; i++) {
+    f(i);
+  }
+}
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+template <typename Lf, typename Rf>
+inline void par_do(Lf&& left, Rf&& right, bool) {
+  std::forward<Lf>(left)();
+  std::forward<Rf>(right)();
+}
+
+template <typename F>
+void execute_with_scheduler(unsigned int, F&& f) {
+  std::invoke(std::forward<F>(f));
+}
+
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_SCHEDULER_PLUGINS_SEQUENTIAL_H_

--- a/third_party/parlayhash/include/parlay/internal/scheduler_plugins/tbb.h
+++ b/third_party/parlayhash/include/parlay/internal/scheduler_plugins/tbb.h
@@ -1,0 +1,61 @@
+#ifndef PARLAY_INTERNAL_SCHEDULER_PLUGINS_TBB_H_
+#define PARLAY_INTERNAL_SCHEDULER_PLUGINS_TBB_H_
+
+#include <cstddef>
+
+#include <type_traits>
+
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_invoke.h>
+#include <tbb/task_arena.h>
+
+namespace parlay {
+
+// IWYU pragma: private, include "../../parallel.h"
+
+inline size_t num_workers() { return tbb::this_task_arena::max_concurrency(); }
+
+inline size_t worker_id() {
+  auto id = tbb::this_task_arena::current_thread_index();
+  return id == tbb::task_arena::not_initialized ? 0 : id;
+}
+
+template <typename F>
+inline void parallel_for(size_t start, size_t end, F&& f, long granularity, bool) {
+  static_assert(std::is_invocable_v<F&, size_t>);
+  // Use TBB's automatic granularity partitioner (tbb::auto_partitioner)
+  if (granularity == 0) {
+    tbb::parallel_for(tbb::blocked_range<size_t>(start, end), [&](const tbb::blocked_range<size_t>& r) {
+      for (auto i = r.begin(); i != r.end(); ++i) {
+        f(i);
+      }
+    }, tbb::auto_partitioner{});
+  }
+  // Otherwise, use the granularity specified by the user (tbb::simple_partitioner)
+  else {
+    tbb::parallel_for(tbb::blocked_range<size_t>(start, end, granularity), [&](const tbb::blocked_range<size_t>& r) {
+      for (auto i = r.begin(); i != r.end(); ++i) {
+        f(i);
+      }
+    }, tbb::simple_partitioner{});
+  }
+}
+
+template <typename Lf, typename Rf>
+inline void par_do(Lf&& left, Rf&& right, bool) {
+  static_assert(std::is_invocable_v<Lf&&>);
+  static_assert(std::is_invocable_v<Rf&&>);
+  tbb::parallel_invoke(std::forward<Lf>(left), std::forward<Rf>(right));
+}
+
+template <typename... Fs>
+void execute_with_scheduler(Fs...) {
+  struct Illegal {};
+  static_assert((std::is_same_v<Illegal, Fs> && ...), "parlay::execute_with_scheduler is only available in the Parlay scheduler and is not compatible with TBB");
+}
+
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_SCHEDULER_PLUGINS_TBB_H_
+

--- a/third_party/parlayhash/include/parlay/internal/sequence_base.h
+++ b/third_party/parlayhash/include/parlay/internal/sequence_base.h
@@ -1,0 +1,594 @@
+// This base class handles storage layout and memory allocation for sequences.
+//
+// It also handles whether the sequence is big or small (small size optimized).
+// Conversion from small to large sequences and all allocations are handled here.
+// This allows the higher-level logic of the sequence implementation to be written
+// agnostic to these details, while this class handles the low-level stuff.
+
+#ifndef PARLAY_INTERNAL_SEQUENCE_BASE_H
+#define PARLAY_INTERNAL_SEQUENCE_BASE_H
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include <array>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+#include "../parallel.h"
+#include "../portability.h"
+#include "../relocation.h"
+#include "../type_traits.h"      // IWYU pragma: keep  // for is_trivially_relocatable
+
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+#include "debug_uninitialized.h"
+#endif
+
+namespace parlay {
+namespace sequence_internal {
+
+// Sequence base class that handles storage layout and memory allocation
+//
+// Template arguments:
+//  T = element type of the sequence
+//  Allocator = An allocator for elements of type T
+//  EnableSSO = True to enable small-size optimization
+template<typename T, typename Allocator, bool EnableSSO>
+struct alignas(uint64_t) sequence_base {
+
+  // Only use SSO for trivial types
+  constexpr static bool use_sso = EnableSSO && std::is_trivial<T>::value;
+
+  // The maximum length of a sequence is 2^48 - 1.
+  constexpr static uint64_t _max_size = (1LL << 48LL) - 1LL;
+
+  using allocator_type = Allocator;
+  using T_allocator_type = typename std::allocator_traits<allocator_type>::template rebind_alloc<T>;
+  using raw_allocator_type = typename std::allocator_traits<allocator_type>::template rebind_alloc<std::byte>;
+
+  using value_type = T;
+
+  // For trivial types, we want to specify a loop granularity so that (a) time isn't wasted
+  // by the automatic granularity control on very small sequences, and (b) to give the optimizer
+  // a higher chance to combine adjacent loop iterations (e.g. by converting copies in a loop
+  // into a memcpy)
+
+  static constexpr size_t copy_granularity(size_t) {
+    return (std::is_trivially_copyable_v<value_type>) ? (1 + (1024 * sizeof(size_t) / sizeof(T))) : 0;
+  }
+
+  static constexpr size_t initialization_granularity(size_t) {
+    return (std::is_trivially_default_constructible_v<value_type>) ? (1 + (1024 * sizeof(size_t) / sizeof(T))) : 0;
+  }
+
+  // This class handles internal memory allocation and whether
+  // the sequence is big or small. We inherit from Allocator to
+  // employ empty base optimization so that the size of the
+  // sequence type is not increased when the allocator is stateless.
+  // The memory layout is organized roughly as follows:
+  //
+  // struct {
+  //
+  //   union {
+  //     // Long sequence
+  //     struct {
+  //       void*            buffer     --->   size_t        capacity
+  //       uint64_t         n : 48            value_type[]  elements
+  //     }
+  //     // Short sequence
+  //     struct {
+  //       unsigned char    buffer[15]
+  //     }
+  //   }
+  //
+  //   // Only included when EnableSSO is true
+  //   uint8_t              small_n : 7
+  //   uint8_t              flag    : 1
+  // }
+  //
+  // The union contains either a long sequence, which is a pointer
+  // to a heap-allocated buffer prepended with its capacity, and a
+  // 48-bit integer that stores the current size of the sequence.
+  // Alternatively, it contains a short sequence, which is 15 bytes
+  // of inline memory used to store elements of type T.
+  //
+  // If SSO is enabled, the 1 bit flag indicates whether the sequence
+  // is long (1) or short (0). If the sequence is short, its size is
+  // stored in the 7-bit size variable. This means that a zero-initialized
+  // object represents a valid empty sequence. Short size optimization is
+  // only enabled for trivial types, which means that a sequence is trivially
+  // movable (i.e. you can move it by copying its raw bytes and zeroing
+  // out the old one).
+  //
+  // On compilers / platforms that support the GNU C packed struct
+  // extension, all of this fits into 16 bytes. This means that sequences
+  // can be compare-exchanged (CAS'ed) on platforms that support a
+  // 16-byte CAS operation. On other compilers / platforms, a sequence
+  // might be 24 bytes if EnableSSO is true.
+  //
+  struct storage_impl : public T_allocator_type {
+
+    // Empty constructor
+    storage_impl() : T_allocator_type(), _data() { set_to_empty_representation(); }
+
+    // Copy constructor
+    storage_impl(const storage_impl& other) : T_allocator_type(other) {
+      if (other.is_small()) {
+        std::memcpy(static_cast<void*>(std::addressof(_data)), static_cast<const void*>(std::addressof(other._data)),
+                    sizeof(_data));
+      } else {
+        auto n = other.size();
+        initialize_capacity(n);
+        auto buffer = data();
+        auto other_buffer = other.data();
+        parallel_for(
+            0, n, [&](size_t i) { initialize_explicit(buffer + i, other_buffer[i]); }, copy_granularity(n));
+        set_size(n);
+      }
+    }
+
+    // Move constructor
+    storage_impl(storage_impl&& other) noexcept { move_from(std::move(other)); }
+
+    // Move assignment
+    storage_impl& operator=(storage_impl&& other) noexcept {
+      clear();
+      move_from(std::move(other));
+      return *this;
+    }
+
+    // Allocator access
+
+    T_allocator_type& get_T_allocator() { return *static_cast<T_allocator_type*>(this); }
+
+    const T_allocator_type& get_T_allocator() const { return *static_cast<const T_allocator_type*>(this); }
+
+    allocator_type get_allocator() const { return allocator_type(get_T_allocator()); }
+
+    raw_allocator_type get_raw_allocator() const { return raw_allocator_type(get_T_allocator()); }
+
+    // Swap a sequence backend with another. Since small sequences
+    // must contain trivial types, a sequence can always be swapped
+    // by swapping raw bytes.
+    void swap(storage_impl& other) {
+      // Swap raw bytes. Every linter complains about this so
+      // we need a lot of warning suppressions, unfortunately
+      std::byte tmp[sizeof(*this)];
+      // cppcheck-suppress memsetClass
+      std::memcpy(std::addressof(tmp), static_cast<void*>(this), sizeof(*this));    // NOLINT
+      // cppcheck-suppress memsetClass
+      std::memcpy(static_cast<void*>(this), &other, sizeof(*this));                 // NOLINT
+      // cppcheck-suppress memsetClass
+      std::memcpy(static_cast<void*>(std::addressof(other)), &tmp, sizeof(*this));  // NOLINT
+    }
+
+    // Destroy a sequence backend
+    ~storage_impl() { clear(); }
+
+    // Move the contents of other into this sequence
+    // Assumes that this sequence is empty. Callers
+    // should call clear() before calling this function.
+    void move_from(storage_impl&& other) {
+      // Since small sequences contain trivial types, moving
+      // them just means copying their raw bytes, and zeroing
+      // out the old sequence. For large sequences, this will
+      // copy their buffer pointer and size.
+
+      // cppcheck-suppress memsetClass
+      std::memcpy(static_cast<void*>(this), &other, sizeof(*this));  // NOLINT
+
+      other.set_to_empty_representation();
+    }
+
+    // Call the destructor on all elements
+    void destroy_all() {
+      if (!std::is_trivially_destructible<value_type>::value) {
+        auto n = size();
+        auto current_buffer = data();
+        parallel_for(0, n, [&](size_t i) { destroy(&current_buffer[i]); });
+      }
+    }
+
+    // Destroy all elements, free the buffer (if any)
+    // and set the sequence to the empty sequence
+    void clear() {
+      // Small sequences can only hold trivial
+      // types, so no destruction is necessary
+      if (!is_small()) {
+        destroy_all();
+        auto alloc = get_raw_allocator();
+        _data.long_mode.buffer.free_buffer(alloc);
+      }
+
+      set_to_empty_representation();
+    }
+
+    // Free the buffer without destroying the elements
+    // of the sequence. This is intended for use after
+    // the contents of the sequence are relocated
+    void clear_without_destruction() {
+      // Small sequences can only hold trivial
+      // types, so no destruction is necessary
+      if (!is_small()) {
+        auto alloc = get_raw_allocator();
+        _data.long_mode.buffer.free_buffer(alloc);
+      }
+
+      set_to_empty_representation();
+    }
+
+// GCC-8+ is unhappy with memsetting the object to zero
+#if defined(__GNUC__) && __GNUC__ >= 8 && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
+    // A zero-byte-filled sequence always corresponds
+    // to an empty sequence, whether small or large
+    void set_to_empty_representation() {
+      // cppcheck-suppress memsetClass
+      std::memset(this, 0, sizeof(*this));  // NOLINT
+    }
+
+#if defined(__GNUC__) && __GNUC__ >= 8 && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+// GCC gives a lot of false positive diagnoses for
+// "maybe uninitialized" variables inside long_seq
+// and capacitated_buffer so we disable that check
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+    // A buffer of value_types with a size_t prepended
+    // to the front to store the capacity. Does not
+    // handle construction or destruction or the
+    // elements in the buffer.
+    //
+    // IMPORTANT: Memory is not freed on destruction since it
+    // requires a reference to the allocator to do so, so
+    // free_buffer(alloc) must be called manually before the
+    // buffer is destroyed!
+    struct capacitated_buffer {
+
+      // Prepended header buffer. This is the magic type that makes
+      // this all work. It works by constructing a buffer of size
+      //
+      //   offsetof(header, data) + capacity * sizeof(value_type)
+      //
+      // in order to get an array of value_types of size capacity.
+      //
+      // How/why does this work? First a disclaimer: This is still almost
+      // certainly undefined behaviour, but until C++ gets flexible array members
+      // this is probably the best we can do. The trick we use is to have a
+      // single std::byte data member that is aligned to the alignment of a
+      // value_type object to tell us how far away from capacity we should put
+      // the data. This prevents alignment issues where the data might get too
+      // close to the capacity. With this member, we can use offsetof to compute
+      // its position, at which we then allocate space for capacity elements
+      // of type value_type.
+      struct header {
+        const size_t capacity;
+        union {
+          alignas(value_type) std::byte data[1];
+        };
+
+        static header* create(size_t capacity, raw_allocator_type& a) {
+          auto buffer_size = offsetof(header, data) + capacity * sizeof(value_type);
+          std::byte* bytes = std::allocator_traits<raw_allocator_type>::allocate(a, buffer_size);
+          return new (bytes) header(capacity);
+        }
+
+        static void destroy(header* p, raw_allocator_type& a) {
+          auto buffer_size = offsetof(header, data) + p->capacity * sizeof(value_type);
+          std::byte* bytes = reinterpret_cast<std::byte*>(p);
+          std::allocator_traits<raw_allocator_type>::deallocate(a, bytes, buffer_size);
+        }
+
+        explicit header(size_t _capacity) : capacity(_capacity) {}
+        ~header() = delete;
+
+        value_type* get_data() { return reinterpret_cast<value_type*>(std::addressof(data)); }
+        const value_type* get_data() const { return reinterpret_cast<const value_type*>(std::addressof(data)); }
+      };
+
+      // Construct a capacitated buffer with the capacity to hold the given
+      // number of objects of type value_type, using the given allocator
+      capacitated_buffer(size_t capacity, raw_allocator_type& a) : buffer(header::create(capacity, a)) {
+        assert(buffer != nullptr);
+        assert(get_capacity() == capacity);
+      }
+
+      // This unfortunately can not go in the destructor and be done
+      // automatically because we need a reference to the allocator
+      // to deallocate the buffer, and we do not want to store the
+      // allocator here.
+      void free_buffer(raw_allocator_type& a) {
+        if (buffer != nullptr) {
+          header::destroy(buffer, a);
+          buffer = nullptr;
+        }
+      }
+
+      size_t get_capacity() const {
+        if (buffer != nullptr) {
+          return buffer->capacity;
+        } else {
+          return 0;
+        }
+      }
+
+      value_type* data() {
+        if (buffer != nullptr) {
+          return buffer->get_data();
+        } else {
+          return nullptr;
+        }
+      }
+
+      const value_type* data() const {
+        if (buffer != nullptr) {
+          return buffer->get_data();
+        } else {
+          return nullptr;
+        }
+      }
+
+      header* buffer;
+    } PARLAY_PACKED;
+
+    // A not-short-size-optimized sequence. Elements are
+    // stored in a heap-allocated buffer. We use a 48-bit
+    // integer to store the size so that there is room left
+    // over for the flag to discriminate between small and
+    // large sequences.
+
+    // This requires the GNU C packed struct extension which
+    // might not always be available, in which case this object
+    // will be 16 bytes, making the entire sequence 24 bytes.
+    struct long_seq {
+      capacitated_buffer buffer;
+      uint64_t n : 48;
+
+      long_seq(capacitated_buffer _buffer, uint64_t _n) : buffer(_buffer), n(_n) {}
+      ~long_seq() = default;
+
+      void set_size(size_t new_size) { n = new_size; }
+
+      size_t get_size() const { return n; }
+
+      size_t capacity() const { return buffer.get_capacity(); }
+
+      value_type* data() { return buffer.data(); }
+
+      const value_type* data() const { return buffer.data(); }
+    } PARLAY_PACKED;
+
+    // The maximum capacity of a short-size-optimized sequence
+    constexpr static size_t short_capacity = (sizeof(capacitated_buffer) + sizeof(uint64_t) - 1) / sizeof(value_type);
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+    // A short-size-optimized sequence. Elements are stored
+    // inline in the data structure.
+    struct short_seq {
+      std::array<value_type, short_capacity> elements;
+
+      short_seq() = delete;
+      ~short_seq() = delete;
+
+      value_type* data() { return elements.data(); }
+      const value_type* data() const { return elements.data(); }
+    } PARLAY_PACKED;
+
+
+    // Store either a short or a long sequence. By default, we
+    // store an empty short sequence, which can be represented
+    // by a zero-initialized object.
+    //
+    // Flag is used to discriminate which type is currently stored
+    // by the union. 1 corresponds to a long sequence, 0 to a short
+    // sequence.
+    struct _data_impl {
+      _data_impl() {}
+      ~_data_impl(){};
+
+      union {
+        typename std::conditional<use_sso, short_seq, void*>::type short_mode;
+        long_seq long_mode;
+      } PARLAY_PACKED;
+
+      uint8_t small_n : 7;
+      uint8_t flag : 1;
+    } _data;
+
+    // Returns true if the sequence is in small size mode
+    constexpr bool is_small() const {
+      if constexpr (use_sso) {
+        return _data.flag == 0;
+      } else {
+        return false;
+      }
+    }
+
+    // Return the size of the sequence
+    size_t size() const {
+      if constexpr (use_sso) {
+        if (is_small())
+          return _data.small_n;
+        else
+          return _data.long_mode.get_size();
+      } else {
+        return _data.long_mode.get_size();
+      }
+    }
+
+    // Return the capacity of the sequence
+    size_t capacity() const {
+      if (is_small())
+        return short_capacity;
+      else
+        return _data.long_mode.capacity();
+    }
+
+    value_type* data() {
+      if constexpr (use_sso) {
+        if (is_small()) return _data.short_mode.data();
+        else return _data.long_mode.data();
+      }
+      else {
+        return _data.long_mode.data();
+      }
+    }
+
+    const value_type* data() const {
+      if constexpr (use_sso) {
+        if (is_small()) return _data.short_mode.data();
+        else return _data.long_mode.data();
+      }
+      else {
+        return _data.long_mode.data();
+      }
+    }
+
+    void set_size(size_t new_size) {
+      assert(new_size <= capacity());
+      if constexpr (use_sso) {
+        if (is_small())
+          _data.small_n = new_size;
+        else
+          _data.long_mode.set_size(new_size);
+      } else {
+        _data.long_mode.set_size(new_size);
+      }
+    }
+
+    // Constructs an object of type value_type at an
+    // uninitialized memory location p using args...
+    template<typename... Args>
+    void initialize(value_type* p, Args&&... args) {
+      std::allocator_traits<T_allocator_type>::construct(*this, p, std::forward<Args>(args)...);
+    }
+
+    // Constructs an object of type value_type at an uninitialized
+    // memory location p using f() by copy elision. This circumvents
+    // the allocator and hence should only be used when initialize
+    // and initialize_explicit are not applicable (e.g., for a type
+    // that is not copyable or movable).
+    template<typename F>
+    void initialize_with_copy_elision(value_type* p, F&& f) {
+      static_assert(std::is_same_v<value_type, std::invoke_result_t<F&&>>);
+      new (p) value_type(f());
+    }
+
+    // Perform a copy or move initialization. This is equivalent
+    // to initialize(forward(v)) above, except that it will not
+    // allow accidental implicit conversions. This prevents someone
+    // from, for example, attempting to append {1,2,3} to a
+    // sequence of vectors, and ending up with 3 new vectors
+    // of length 1,2,3 respectively.
+
+    void initialize_explicit(value_type* p, const value_type& v) {
+      std::allocator_traits<T_allocator_type>::construct(*this, p, v);
+    }
+
+    void initialize_explicit(value_type* p, value_type&& v) {
+      std::allocator_traits<T_allocator_type>::construct(*this, p, std::move(v));
+    }
+
+    // Destroy the object of type value_type pointed to by p
+    void destroy(value_type* p) { std::allocator_traits<T_allocator_type>::destroy(*this, p); }
+
+    // Return a reference to the i'th element
+    value_type& at(size_t i) { return data()[i]; }
+
+    const value_type& at(size_t i) const { return data()[i]; }
+
+    // Should only be called during initialization. Same as
+    // ensure_capacity, except does not need to copy elements
+    // from the existing buffer.
+    void initialize_capacity(size_t desired) {
+      if constexpr (use_sso) {
+        // Initialize the sequence in large mode
+        if (short_capacity < desired) {
+          auto alloc = get_raw_allocator();
+          _data.flag = 1;
+          _data.long_mode = long_seq(capacitated_buffer(desired, alloc), 0);
+        } else {
+          _data.flag = 0;
+        }
+      } else {
+        auto alloc = get_raw_allocator();
+        _data.long_mode = long_seq(capacitated_buffer(desired, alloc), 0);
+      }
+      assert(capacity() >= desired);
+    }
+
+    // Ensure that the capacity is at least new_capacity. The
+    // actual capacity may be increased to a larger amount.
+    void ensure_capacity(size_t desired) {
+      auto current = capacity();
+
+      // Allocate a new buffer and move the current
+      // contents of the sequence into the new buffer
+      if (current < desired) {
+        // Allocate a new buffer that is at least
+        // 50% larger than the old capacity
+        size_t new_capacity = (std::max)(desired, (5 * current)/ 2);//(15 * current + 9) / 10);
+        auto alloc = get_raw_allocator();
+        capacitated_buffer new_buffer(new_capacity, alloc);
+
+        // If uninitialized debugging is enabled, mark the new memory as uninitialized
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+        if constexpr (std::is_same_v<value_type, internal::UninitializedTracker>) {
+          auto buffer = new_buffer.data();
+          parallel_for(0, new_buffer.get_capacity(), [&](size_t i) {
+            buffer[i].initialized = false;
+            PARLAY_ASSERT_UNINITIALIZED(buffer[i]);
+          });
+        }
+#endif
+
+        // Move initialize the new buffer with the
+        // contents of the old buffer
+        auto n = size();
+        auto dest_buffer = new_buffer.data();
+        auto current_buffer = data();
+        uninitialized_relocate_n_a(dest_buffer, current_buffer, n, *this);
+
+        // Destroy the old stuff
+        if (!is_small()) {
+          _data.long_mode.buffer.free_buffer(alloc);
+        }
+
+        // Assign the new stuff
+        if constexpr (use_sso) {
+          _data.flag = 1;  // mark as a large sequence
+        }
+        _data.long_mode = long_seq(new_buffer, n);
+      }
+
+      assert(capacity() >= desired);
+    }
+  };
+
+  sequence_base() : storage() { num_workers();  /* Touch the scheduler to force it to initialize before any sequence */ }
+  explicit sequence_base(const storage_impl& other) : storage(other) {}
+  explicit sequence_base(storage_impl&& other) : storage(std::move(other)) {}
+  ~sequence_base() {}
+
+  storage_impl storage;
+};
+
+}  // namespace sequence_internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_SEQUENCE_BASE_H

--- a/third_party/parlayhash/include/parlay/internal/sequence_ops.h
+++ b/third_party/parlayhash/include/parlay/internal/sequence_ops.h
@@ -1,0 +1,488 @@
+
+#ifndef PARLAY_SEQUENCE_OPS_H_
+#define PARLAY_SEQUENCE_OPS_H_
+
+#include <cmath>
+#include <cstddef>
+
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+
+#include "../delayed_sequence.h"
+#include "../monoid.h"
+#include "../parallel.h"
+#include "../range.h"
+#include "../sequence.h"
+#include "../slice.h"
+#include "../utilities.h"
+
+namespace parlay {
+namespace internal {
+
+// Return a sequence consisting of the elements
+//   f(0), f(1), ... f(n)
+template<typename UnaryOp>
+auto tabulate(size_t n, UnaryOp&& f, size_t granularity=0) {
+  static_assert(std::is_invocable_v<UnaryOp, size_t>);
+  static_assert(!std::is_void_v<std::invoke_result_t<UnaryOp, size_t>>);
+  static_assert(!std::is_array_v<std::invoke_result_t<UnaryOp, size_t>>);
+  return sequence<typename std::decay_t<std::invoke_result_t<UnaryOp, size_t>>>
+    ::from_function(n, std::forward<UnaryOp>(f), granularity);
+}
+
+// Return a sequence consisting of the elements
+//   f(0), f(1), ... f(n)
+template<typename T, typename UnaryOp>
+auto tabulate(size_t n, UnaryOp&& f, size_t granularity=0) {
+  static_assert(std::is_invocable_v<UnaryOp, size_t>);
+  static_assert(!std::is_void_v<std::invoke_result_t<UnaryOp, size_t>>);
+  static_assert(!std::is_array_v<std::invoke_result_t<UnaryOp, size_t>>);
+  static_assert(std::is_convertible_v<std::invoke_result_t<UnaryOp, size_t>, T>);
+  return sequence<T>::from_function(n, std::forward<UnaryOp>(f), granularity);
+}
+
+// Return a sequence consisting of the elements
+//   f(r[0]), f(r[1]), ..., f(r[n-1])
+template<typename R, typename UnaryOp>
+auto map(R&& r, UnaryOp&& f, size_t granularity=0) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<UnaryOp, range_reference_type_t<R>>);
+  static_assert(!std::is_void_v<std::invoke_result_t<UnaryOp, range_reference_type_t<R>>>);
+  return tabulate(parlay::size(r), [f = std::forward<UnaryOp>(f), it = std::begin(r)]
+      (size_t i) -> decltype(auto) { return f(it[i]); }, granularity);
+}
+
+// Return a delayed sequence consisting of the elements
+//   f(0), f(1), ... f(n)
+template<typename F>
+auto delayed_tabulate(size_t n, F f) {
+  static_assert(std::is_invocable_v<const F&, size_t>);
+  using T = std::invoke_result_t<const F&, size_t>;
+  static_assert(!std::is_void_v<T>);
+  using V = std::remove_cv_t<std::remove_reference_t<T>>;
+  return delayed_sequence<T, V, F>(n, std::move(f));
+}
+
+// Return a delayed sequence consisting of the elements
+//   f(0), f(1), ... f(n)
+template<typename T, typename F>
+auto delayed_tabulate(size_t n, F f) {
+  static_assert(std::is_invocable_v<const F&, size_t>);
+  static_assert(std::is_convertible_v<std::invoke_result_t<const F&, size_t>, T>);
+  return delayed_sequence<T, std::remove_cv_t<std::remove_reference_t<T>>, F>(n, std::move(f));
+}
+
+// Return a delayed sequence consisting of the elements
+//   f(0), f(1), ... f(n)
+template<typename T, typename V, typename F>
+auto delayed_tabulate(size_t n, F f) {
+  static_assert(std::is_invocable_v<const F&, size_t>);
+  static_assert(std::is_convertible_v<std::invoke_result_t<const F&, size_t>, T>);
+  return delayed_sequence<T, V, F>(n, std::move(f));
+}
+
+// Return a delayed sequence consisting of the elements
+//   f(r[0]), f(r[1]), ..., f(r[n-1])
+//
+// If r is a temporary, the delayed sequence will take
+// ownership of it by moving it. If r is a reference,
+// the delayed sequence will hold a reference to it, so
+// r must remain alive as long as the delayed sequence.
+template<typename R, typename UnaryOp,
+    std::enable_if_t<std::is_rvalue_reference_v<R&&>, int> = 0>
+auto delayed_map(R&& r, UnaryOp f) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<const UnaryOp&, range_reference_type_t<R>>);
+  static_assert(!std::is_void_v<std::invoke_result_t<const UnaryOp&, range_reference_type_t<R>>>);
+
+  // The closure object keeps a cache of the begin iterator to the range r.
+  //
+  // This is useful because some ranges might perform something like small-size optimization
+  // where calling std::begin(r) could have overhead. By keeping the iterator cached, we can
+  // random-access from it in the lambda without experiencing this overhead every time
+  struct closure {
+    closure(R&& r_) : r(std::move(r_)), it(std::begin(r)) {}
+    closure(const closure& other) : r(other.r), it(std::begin(r)) {}
+    closure(closure&& other) noexcept(std::is_nothrow_move_constructible_v<R>)
+        : r(std::move(other.r)), it(std::begin(r)) {}
+    closure& operator=(const closure& other) { r = other.r; it = std::begin(r); return *this; }
+    closure& operator=(closure&& other) noexcept(std::is_nothrow_move_assignable_v<R>) {
+      r = std::move(other.r); it = std::begin(r); return *this; }
+    R r;
+    range_iterator_type_t<R> it;
+  };
+
+  size_t n = parlay::size(r);
+  return delayed_tabulate(n, [ c = closure(std::forward<R>(r)), f = std::move(f) ]
+      (size_t i) -> decltype(auto) { return f(c.it[i]); });
+}
+
+template<typename R, typename UnaryOp,
+    std::enable_if_t<std::is_lvalue_reference_v<R&&>, int> = 0>
+auto delayed_map(R&& r, UnaryOp f) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<const UnaryOp&, range_reference_type_t<R>>);
+  static_assert(!std::is_void_v<std::invoke_result_t<const UnaryOp&, range_reference_type_t<R>>>);
+
+  size_t n = parlay::size(r);
+  return delayed_tabulate(n, [ri = std::begin(r), f = std::move(f) ]
+      (size_t i) -> decltype(auto) { return f(ri[i]); });
+}
+
+// Renamed. Use delayed_tabulate
+template <typename F>
+auto dseq (size_t n, F f) {
+  return delayed_tabulate(n, std::move(f));
+}
+
+// Renamed. Use delayed_map.
+template<typename R, typename UnaryOp>
+auto dmap(R&& r, UnaryOp f) {
+  return delayed_map(std::forward<R>(r), std::move(f));
+}
+
+template <typename T>
+auto singleton(T const &v) -> sequence<T> {
+  return sequence<T>(1, v);
+}
+
+template <typename Seq, typename Range>
+auto copy(Seq const &A, Range R, flags) -> void {
+  parallel_for(0, A.size(), [&](size_t i) { R[i] = A[i]; });
+}
+
+constexpr const size_t _log_block_size = 10;
+constexpr const size_t _block_size = (1 << _log_block_size);
+
+inline size_t num_blocks(size_t n, size_t block_size) {
+  if (n == 0)
+    return 0;
+  else
+    return (1 + ((n)-1) / (block_size));
+}
+
+template <typename F>
+void sliced_for(size_t n, size_t block_size, const F &f, flags fl = no_flag) {
+  size_t l = num_blocks(n, block_size);
+  auto body = [&](size_t i) {
+    size_t s = i * block_size;
+    size_t e = (std::min)(s + block_size, n);
+    f(i, s, e);
+  };
+  parallel_for(0, l, body, 1, 0 != (fl & fl_conservative));
+}
+
+template <typename Seq, typename Monoid>
+auto reduce_serial(Seq const &A, Monoid&& m) {
+  static_assert(is_random_access_range_v<Seq>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<Seq>>);
+  using T = monoid_value_type_t<Monoid>;
+  if (A.size() == 0) return m.identity;
+  T r = A[0];
+  for (size_t j = 1; j < A.size(); j++) {
+    r = m(std::move(r), A[j]);
+  }
+  return r;
+}
+
+template <typename Seq, typename Monoid>
+auto reduce(Seq const &A, Monoid&& m, flags fl = no_flag) {
+  static_assert(is_random_access_range_v<Seq>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<Seq>>);
+  using T = monoid_value_type_t<Monoid>;
+  size_t n = A.size();
+  size_t block_size = (std::max)(_block_size, 4 * static_cast<size_t>(std::ceil(std::sqrt(n))));
+  size_t l = num_blocks(n, block_size);
+  if (l == 0) return m.identity;
+  if (l == 1 || (fl & fl_sequential)) {
+    return reduce_serial(A, m);
+  }
+  auto sums = sequence<T>::uninitialized(l);
+  sliced_for(n, block_size, [&](size_t i, size_t s, size_t e) {
+    assign_uninitialized(sums[i], reduce_serial(make_slice(A).cut(s, e), m));
+  });
+  T r = internal::reduce(sums, m);
+  return r;
+}
+
+const flags fl_scan_inclusive = (1 << 4);
+
+template <typename In_Seq, typename Out_Seq, typename Monoid>
+auto scan_serial(In_Seq const &In, Out_Seq Out, Monoid&& m,
+                 monoid_value_type_t<Monoid> offset, flags fl, bool out_uninitialized = false) {
+  static_assert(is_random_access_range_v<In_Seq>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<In_Seq>>);
+  using T = monoid_value_type_t<Monoid>;
+  T r = std::move(offset);
+  size_t n = In.size();
+  bool inclusive = fl & fl_scan_inclusive;
+  if (inclusive) {
+    for (size_t i = 0; i < n; i++) {
+      r = m(std::move(r), In[i]);
+      if (out_uninitialized) assign_uninitialized(Out[i], r);
+      else Out[i] = r;
+    }
+  } else {
+    for (size_t i = 0; i < n; i++) {
+      T t = In[i];
+      if (out_uninitialized) assign_uninitialized(Out[i], r);
+      else Out[i] = r;
+      r = m(std::move(r), t);
+    }
+  }
+  return r;
+}
+
+  
+template <typename In_Seq, typename Out_Range, class Monoid>
+auto scan_(In_Seq const &In, Out_Range Out, Monoid&& m, flags fl, bool out_uninitialized=false) {
+  static_assert(is_random_access_range_v<In_Seq>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<In_Seq>>);
+  using T = monoid_value_type_t<Monoid>;
+  size_t n = In.size();
+  size_t l = num_blocks(n, _block_size);
+  if (l <= 2 || fl & fl_sequential)
+    return scan_serial(In, Out, m, m.identity, fl, out_uninitialized);
+  auto sums = sequence<T>::uninitialized(l);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    assign_uninitialized(sums[i], reduce_serial(make_slice(In).cut(s, e), m));
+  });
+  T total = scan_serial(sums, make_slice(sums), m, m.identity, 0, false);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    auto O = make_slice(Out).cut(s, e);
+    scan_serial(make_slice(In).cut(s, e), O, m, sums[i], fl, out_uninitialized);
+  });
+  return total;
+}
+
+template <typename Iterator, typename Monoid>
+auto scan_inplace(slice<Iterator, Iterator> In, Monoid&& m, flags fl = no_flag) {
+  static_assert(is_monoid_for_v<Monoid, iterator_reference_type_t<Iterator>>);
+  return scan_(In, In, std::forward<Monoid>(m), fl);
+}
+
+template <typename In_Seq, typename Monoid>
+auto scan(In_Seq const &In, Monoid&& m, flags fl = no_flag) {
+  static_assert(is_random_access_range_v<In_Seq>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<In_Seq>>);
+  using T = monoid_value_type_t<Monoid>;
+  auto Out = sequence<T>::uninitialized(In.size());
+  return std::make_pair(std::move(Out), scan_(In, make_slice(Out), std::forward<Monoid>(m), fl, true));
+}
+
+// do in place if rvalue reference to a sequence<T>
+template <typename T, typename Monoid,
+    std::enable_if_t<std::is_same_v<T, monoid_value_type_t<Monoid>>, int> = 0>
+auto scan(sequence<T>&& In, Monoid&& m, flags fl = no_flag) {
+  static_assert(is_monoid_v<Monoid>);
+  sequence<T> Out = std::move(In);
+  T total = scan_(make_slice(Out), make_slice(Out), std::forward<Monoid>(m), fl);
+  return std::make_pair(std::move(Out), total);
+}
+
+template <typename Seq>
+size_t sum_bools_serial(Seq const &I) {
+  size_t r = 0;
+  for (size_t j = 0; j < I.size(); j++) {
+    r += static_cast<bool>(I[j]);
+  }
+  return r;
+}
+
+template <typename In_Seq, typename Bool_Seq>
+auto pack_serial(In_Seq const &In, Bool_Seq const &Fl)
+    -> sequence<typename In_Seq::value_type> {
+  using T = typename In_Seq::value_type;
+  size_t n = In.size();
+  size_t m = sum_bools_serial(Fl);
+  sequence<T> Out = sequence<T>::uninitialized(m);
+  size_t k = 0;
+  for (size_t i = 0; i < n; i++)
+    if (Fl[i]) assign_uninitialized(Out[k++], In[i]);
+  return Out;
+}
+
+
+template <class Slice, class Slice2, typename Out_Seq>
+size_t pack_serial_at(Slice In, Slice2 Fl, Out_Seq Out) {
+  size_t k = 0;
+  for (size_t i = 0; i < In.size(); i++)
+    if (Fl[i]) assign_uninitialized(Out[k++], In[i]);
+  return k;
+}
+
+template <typename In_Seq, typename Bool_Seq>
+auto pack(In_Seq const &In, Bool_Seq const &Fl, flags fl = no_flag)
+    -> sequence<typename In_Seq::value_type> {
+  using T = typename In_Seq::value_type;
+  size_t n = In.size();
+  size_t l = num_blocks(n, _block_size);
+  if (l == 1 || fl & fl_sequential) return pack_serial(In, Fl);
+  auto sums = sequence<size_t>::uninitialized(l);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    assign_uninitialized(sums[i], sum_bools_serial(make_slice(Fl).cut(s, e)));
+  });
+  size_t m = scan_inplace(make_slice(sums), plus<size_t>());
+  sequence<T> Out = sequence<T>::uninitialized(m);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    pack_serial_at(make_slice(In).cut(s, e), make_slice(Fl).cut(s, e),
+                   make_slice(Out).cut(sums[i], (i == l - 1) ? m : sums[i + 1]));
+  });
+  return Out;
+}
+
+// Pack the output to the output range.
+template <typename In_Seq, typename Bool_Seq, typename Out_Seq>
+size_t pack_out(In_Seq const &In, Bool_Seq const &Fl, /* uninitialized */ Out_Seq Out, flags fl = no_flag) {
+  size_t n = In.size();
+  size_t l = num_blocks(n, _block_size);
+  if (l <= 1 || fl & fl_sequential) {
+    return pack_serial_at(In, make_slice(Fl).cut(0, In.size()), Out);
+  }
+  sequence<size_t> Sums(l);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    Sums[i] = sum_bools_serial(make_slice(Fl).cut(s, e));
+  });
+  size_t m = scan_inplace(make_slice(Sums), plus<size_t>());
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    pack_serial_at(make_slice(In).cut(s, e), make_slice(Fl).cut(s, e),
+                   make_slice(Out).cut(Sums[i], (i == l - 1) ? m : Sums[i + 1]));
+  });
+  return m;
+}
+
+// like filter but applies g before returning result
+template <typename In_Seq, typename F, typename G>
+auto filter_map(In_Seq const &In, F&& f, G&& g) {
+  using outT = std::invoke_result_t<G, range_reference_type_t<In_Seq>>;
+  size_t n = In.size();
+  size_t l = num_blocks(n, _block_size);
+  auto in_mapped = delayed_seq<outT>(n, [&] (size_t i) { return g(In[i]); });
+
+  sequence<size_t> Sums(l);
+  sequence<bool> Fl(n);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    size_t r = 0;
+    for (size_t j = s; j < e; j++) r += (Fl[j] = f(In[j]));
+    Sums[i] = r;
+  });
+  size_t m = scan_inplace(make_slice(Sums), plus<size_t>());
+  sequence<outT> Out = sequence<outT>::uninitialized(m);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    pack_serial_at(make_slice(in_mapped).cut(s, e),
+		   make_slice(Fl).cut(s, e), make_slice(Out).cut(Sums[i], (i == l - 1) ? m : Sums[i + 1]));
+  });
+  return Out;
+}
+
+template <typename In_Seq, typename F>
+auto filter(In_Seq const &In, F&& f) -> sequence<typename In_Seq::value_type> {
+  auto identity = [](auto&& x) -> range_value_type_t<In_Seq> { return std::forward<decltype(x)>(x); };
+  return filter_map(In, std::forward<F>(f), identity);
+}
+
+template <typename In_Seq, typename F>
+auto filter(In_Seq const &In, F&& f, flags) {
+  return filter(In, std::forward<F>(f));
+}
+
+// Filter and write the output to the output range.
+template <typename In_Seq, typename Out_Seq, typename F>
+size_t filter_out(In_Seq const &In, /* uninitialized */ Out_Seq Out, F&& f) {
+  size_t n = In.size();
+  size_t l = num_blocks(n, _block_size);
+  sequence<size_t> Sums(l);
+  sequence<bool> Fl(n);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    size_t r = 0;
+    for (size_t j = s; j < e; j++) r += (Fl[j] = f(In[j]));
+    Sums[i] = r;
+  });
+  size_t m = scan_inplace(make_slice(Sums), plus<size_t>());
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    pack_serial_at(make_slice(In).cut(s, e), make_slice(Fl).cut(s, e),
+                   make_slice(Out).cut(Sums[i], (i == l - 1) ? m : Sums[i + 1]));
+  });
+  return m;
+}
+
+template <typename In_Seq, typename Out_Seq, typename F>
+size_t filter_out(In_Seq const &In, /* uninitialized */ Out_Seq Out, F&& f, flags) {
+  return filter_out(In, Out, std::forward<F>(f));
+}
+
+template <typename Idx_Type, typename Bool_Seq>
+auto pack_index(Bool_Seq const &Fl, flags fl = no_flag) {
+  auto identity = [](size_t i) -> Idx_Type { return static_cast<Idx_Type>(i); };
+  return pack(delayed_tabulate(Fl.size(), identity), Fl, fl);
+}
+
+template <typename assignment_tag, typename InIterator, typename OutIterator, typename Char_Seq>
+std::pair<size_t, size_t> split_three(slice<InIterator, InIterator> In,
+                                      slice<OutIterator, OutIterator> Out,
+                                      Char_Seq const &Fl, flags fl = no_flag) {
+  size_t n = In.size();
+  size_t l = num_blocks(n, _block_size);
+  sequence<size_t> Sums0(l);
+  sequence<size_t> Sums1(l);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    size_t c0 = 0;
+    size_t c1 = 0;
+    for (size_t j = s; j < e; j++) {
+      if (Fl[j] == 0) c0++;
+      else if (Fl[j] == 1) c1++;
+    }
+    Sums0[i] = c0;
+    Sums1[i] = c1;
+  }, fl);
+  size_t m0 = scan_inplace(make_slice(Sums0), plus<size_t>());
+  size_t m1 = scan_inplace(make_slice(Sums1), plus<size_t>());
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    size_t c0 = Sums0[i];
+    size_t c1 = m0 + Sums1[i];
+    size_t c2 = m0 + m1 + (s - Sums0[i] - Sums1[i]);
+    for (size_t j = s; j < e; j++) {
+      if (Fl[j] == 0) {
+        assign_dispatch(Out[c0++], In[j], assignment_tag());
+      } else if (Fl[j] == 1) {
+        assign_dispatch(Out[c1++], In[j], assignment_tag());
+      } else {
+        assign_dispatch(Out[c2++], In[j], assignment_tag());
+      }
+    }
+  }, fl);
+  return std::make_pair(m0, m1);
+}
+
+template <typename In_Seq, typename Bool_Seq>
+auto split_two(In_Seq const &In, Bool_Seq const &Fl, flags fl = no_flag)
+    -> std::pair<sequence<typename In_Seq::value_type>, size_t> {
+  using T = typename In_Seq::value_type;
+  size_t n = In.size();
+  size_t l = num_blocks(n, _block_size);
+  sequence<size_t> Sums(l);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    size_t c = 0;
+    for (size_t j = s; j < e; j++) c += (Fl[j] == false);
+    Sums[i] = c;
+  }, fl);
+  size_t m = scan_inplace(make_slice(Sums), plus<size_t>());
+  sequence<T> Out = sequence<T>::uninitialized(n);
+  sliced_for(n, _block_size, [&](size_t i, size_t s, size_t e) {
+    size_t c0 = Sums[i];
+    size_t c1 = s + (m - c0);
+    for (size_t j = s; j < e; j++) {
+      if (Fl[j] == false)
+        assign_uninitialized(Out[c0++], In[j]);
+      else
+        assign_uninitialized(Out[c1++], In[j]);
+    }
+  }, fl);
+  return std::make_pair(std::move(Out), m);
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_SEQUENCE_OPS_H_

--- a/third_party/parlayhash/include/parlay/internal/stream_delayed.h
+++ b/third_party/parlayhash/include/parlay/internal/stream_delayed.h
@@ -1,0 +1,209 @@
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>        // IWYU pragma: keep
+
+#include "../sequence.h"
+#include "../utilities.h"
+
+#include "uninitialized_sequence.h"
+
+namespace parlay {
+namespace stream_delayed {
+
+// decorates a minimal iterator Iter that just needs to support:
+//    ++iter, *iter, and value_type
+// to make into a more full fledged forward range type,
+// including a forward iterator, and corresponding sentinal.
+template <typename Iter>
+struct forward_delayed_sequence {
+   public:
+  using value_type = typename Iter::value_type;
+  struct sentinal;
+
+  struct iterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = typename Iter::value_type;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const value_type*;
+    using reference = value_type;
+
+    Iter ii;
+    size_t count;
+
+    iterator(Iter ii, size_t n) : ii(ii), count(n) {}
+    iterator& operator++() {
+      ++ii;
+      count--;
+      return *this; }
+    iterator operator++(int) {
+      iterator tmp = *this;
+      ++(*this);
+      return tmp; }
+    value_type operator*() const { return *ii; }
+    bool operator!=([[maybe_unused]] const sentinal& other) const {
+      return count != 0; }
+    bool operator==([[maybe_unused]] const sentinal& other) const {
+      return count == 0; }
+  };
+
+  struct sentinal {
+    size_t operator-(const iterator& i) const {
+      return i.count; }
+    size_t operator-(iterator& i) {
+      return i.count; }
+    bool operator!=(const iterator& other) const {
+      return other.count != 0; }
+    bool operator==(const iterator& other) const {
+      return other.count == 0; }
+  };
+
+  const iterator begin_;
+  iterator begin() const {return begin_;}
+  sentinal end() const {return sentinal();}
+  size_t size() const {return begin_.count;}
+  forward_delayed_sequence(Iter ii, size_t n)
+      : begin_(iterator(ii, n)) {}
+};
+
+template <typename Seq1, typename Seq2, typename F>
+auto zip_with(Seq1 &S1, Seq2 &S2, F f) {
+  struct iter {
+
+// Clang incorrectly warns that these type aliases are unused
+#if defined(__clang__)
+#if __has_warning("-Wunused-local-typedef")
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif  // __has_warning("-Wunused-local-typedef")
+#endif  // __clang__
+    using iter1_t = decltype(S1.begin());
+    using iter2_t = decltype(S2.begin());
+#if defined(__clang__)
+#if __has_warning("-Wunused-local-typedef")
+#pragma clang diagnostic pop
+#endif  // __has_warning("-Wunused-local-typedef")
+#endif  // __clang__
+
+    using value_type = decltype(f(*(S1.begin()),*(S2.begin())));
+    F g;
+    iter1_t iter1;
+    iter2_t iter2;
+    iter& operator++() {++iter1; ++iter2; return *this;}
+    value_type operator*() const {return g(*iter1, *iter2);}
+    iter(F g, iter1_t iter1, iter2_t iter2) : g(g), iter1(iter1), iter2(iter2) {}
+  };
+  return forward_delayed_sequence(iter(f, S1.begin(),S2.begin()), S1.end()-S1.begin());
+}
+
+template <typename Seq1, typename Seq2>
+auto zip(Seq1 &S1, Seq2 &S2) {
+  auto f = [] (auto a, auto b) {return std::pair(a,b);};
+  return zip_with(S1, S2, f);
+}
+
+template <typename Seq, typename F>
+auto map(Seq &S, F f) {
+  struct iter {
+    using iter_t = decltype(S.begin());
+    using value_type = decltype(f(*(S.begin())));
+    F g;
+    iter_t input_iter;
+    iter& operator++() {++input_iter; return *this;}
+    value_type operator*() const {return g(*input_iter);}
+    iter(F g, iter_t input_iter) : g(g), input_iter(input_iter) {}
+  };
+  return forward_delayed_sequence(iter(f, S.begin()), S.end()-S.begin());
+}
+
+template <typename T, typename F, typename Seq>
+auto scan(F f, T const &init, const Seq &S, bool inclusive=false) {
+  using input_iter_t = decltype(S.begin());
+  struct iter {
+    using value_type = T;
+    F f;
+    value_type value;
+    input_iter_t input_iterator;
+
+    iter& operator++() {
+      value = f(value, *input_iterator);
+      ++input_iterator;
+      return *this; }
+    T operator*() const { return value; }
+    iter(F const &f, T const& init, input_iter_t input_iterator) :
+        f(f), value(init), input_iterator(input_iterator) {}
+  };
+  size_t size = S.end() - S.begin();
+  if (inclusive) {
+    auto start = S.begin();
+    auto next = f(init,*start);
+    return forward_delayed_sequence(iter(f, next, ++start), size);
+  }
+  return forward_delayed_sequence(iter(f, init, S.begin()), size);
+}
+
+template <typename T, typename F, typename Seq>
+T reduce(F f, T const &init, const Seq &a) {
+  auto result = init;
+  for (auto s = a.begin(); s != a.end(); ++s)
+    result = f(result,*s);
+  return result;
+}
+
+template <typename Seq, typename F>
+void apply(const Seq &a, F f) {
+  for (auto s = a.begin(); s != a.end(); ++s) f(*s);
+}
+
+template <typename Seq1, typename Seq2, typename F>
+void zip_apply(const Seq1 &s1, const Seq2 &s2, F f) {
+  auto i1 = s1.begin();
+  for (auto i2 = s2.begin(); i1 != s1.end(); ++i1, ++i2)
+    f(*i1,*i2);
+}
+
+
+// allocates own temporary space, returns just filtered sequence
+template <typename SeqIn, typename F, typename G>
+auto filter_map(const SeqIn &In, F f, G g) {
+  size_t n = In.size();
+  using T = decltype(g(*(In.begin())));
+  auto tmp_out = parlay::internal::uninitialized_sequence<T>(n);
+  auto out_iter = tmp_out.begin();
+  for (auto s = In.begin(); s != In.end(); ++s) {
+    auto val = *s;
+    if (f(val)) {
+      *out_iter = g(val);
+      ++out_iter;
+    }
+  }
+  size_t m = out_iter - tmp_out.begin();
+  auto result = parlay::sequence<T>::uninitialized(m);
+  for (size_t i=0; i < m; i++)
+    assign_uninitialized(result[i], std::move(tmp_out[i]));
+  return result;
+}
+
+  // allocates own temporary space, returns just filtered sequence
+template <typename SeqIn, typename F>
+auto filter_op(const SeqIn &In, F f) {
+  size_t n = In.size();
+  using T = typename std::remove_reference<decltype(f(*(In.begin())).value())>::type;
+  auto tmp_out = parlay::internal::uninitialized_sequence<T>(n);
+  auto out_iter = tmp_out.begin();
+  for (auto s = In.begin(); s != In.end(); ++s) {
+    auto opt_val = f(*s);
+    if (opt_val) {
+      *out_iter = opt_val.value();
+      ++out_iter;
+    }
+  }
+  size_t m = out_iter - tmp_out.begin();
+  auto result = parlay::sequence<T>::uninitialized(m);
+  for (size_t i=0; i < m; i++)
+    assign_uninitialized(result[i], std::move(tmp_out[i]));
+  return result;
+}
+
+}  // namespace stream_delayed
+}  // namespace parlay

--- a/third_party/parlayhash/include/parlay/internal/thread_id_pool.h
+++ b/third_party/parlayhash/include/parlay/internal/thread_id_pool.h
@@ -1,0 +1,160 @@
+
+#ifndef PARLAY_INTERNAL_THREAD_ID_POOL_H_
+#define PARLAY_INTERNAL_THREAD_ID_POOL_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+namespace parlay {
+namespace internal {
+
+using thread_id_type = unsigned int;
+
+// A ThreadIdPool hands out and maintains available unique dense IDs for active threads.
+// Each thread that requests an ID will get one in the range from [0...get_num_thread_ids()).
+// When the pool runs out of available IDs, it will allocate new ones, increasing the result
+// of get_num_thread_ids().  Threads that die will return their ID to the pool for re-use by
+// a subsequently spawned thread.
+//
+// There is a global singleton instance of ThreadIdPool given by ThreadIdPool::instance(),
+// however this function is private and should not be called by the outside world. The public
+// API through which the world can access thread IDs is limited to the free functions:
+//
+// - get_thread_id() -> size_t:  Returns the thread ID of the current thread. Will assign
+//                               one if this thread doesn't have one yet.
+// - get_num_thread_ids() -> size_t:  Returns the number of unique thread IDs that have
+//                                    been handed out.
+//
+class ThreadIdPool : public std::enable_shared_from_this<ThreadIdPool> {
+
+  // Prevent public construction since this class is meant as a global singleton
+  struct private_constructor {
+    explicit private_constructor() = default;
+  };
+
+ public:
+
+  // Returns a unique thread ID for the current thread in the range [0...get_num_thread_ids())
+  friend thread_id_type get_thread_id();
+
+  // Returns the number of assigned thread IDs in the range [0...get_num_thread_ids())
+  friend thread_id_type get_num_thread_ids();
+
+
+  ~ThreadIdPool() noexcept {
+    size_t num_destroyed = 0;
+    for (auto current = available_ids.load(std::memory_order_relaxed); current; num_destroyed++) {
+      auto old = std::exchange(current, current->next);
+      delete old;
+    }
+    assert(num_destroyed == num_thread_ids.load(std::memory_order_relaxed));
+  }
+
+  // The constructor must be public since we make_shared it, but we protect it with a private parameter type
+  explicit ThreadIdPool(private_constructor) noexcept : num_thread_ids(0), available_ids(nullptr) { }
+
+  ThreadIdPool(const ThreadIdPool&) = delete;
+  ThreadIdPool& operator=(const ThreadIdPool&) = delete;
+
+ private:
+
+  // A ThreadId corresponds to a unique ID number in the range [0...num_thread_ids). When it is
+  // not in use (the thread that owned it dies), it is returned to the global pool which maintains
+  // a linked list of available ones.
+  class ThreadId {
+    friend class ThreadIdPool;
+
+    explicit ThreadId(const thread_id_type id_) noexcept : id(id_), next(nullptr) { }
+
+   public:
+    const thread_id_type id;
+   private:
+    ThreadId* next;
+  };
+
+  // A ThreadIdOwner indicates that a thread is currently in possession of the given ThreadID.
+  // Each thread has a static thread_local ThreadIdOwner containing the ID that it owns.
+  // On construction, it acquires an available ThreadID, and on destruction, it releases
+  // it back to the pool. The ThreadIdOwner stores a shared_ptr to the pool to guarantee
+  // that the pool does not get destroyed before a detached thread returns its ID.
+  class ThreadIdOwner {
+    friend class ThreadIdPool;
+
+    explicit ThreadIdOwner(ThreadIdPool& pool_)
+        : pool(pool_.shared_from_this()), node(pool->acquire()), id(node->id) { }
+
+    ~ThreadIdOwner() { pool->relinquish(node); }
+
+   private:
+    const std::shared_ptr<ThreadIdPool> pool;
+    ThreadId* const node;
+
+   public:
+    const thread_id_type id;
+  };
+
+  // Grab a free ID from the available list, or if there are none available, allocate a new one.
+  ThreadId* acquire() {
+    if (available_ids.load(std::memory_order_relaxed)) {
+      // We only take the lock if there are available IDs in the pool. In the common case
+      // where there are no relinquished IDs available for re-use we don't need the lock.
+      static std::mutex m_;
+      std::lock_guard<std::mutex> g_{m_};
+
+      ThreadId* current = available_ids.load(std::memory_order_relaxed);
+      while (current && !available_ids.compare_exchange_weak(current, current->next,
+               std::memory_order_acquire, std::memory_order_relaxed)) {}
+      if (current) { return current; }
+    }
+    return new ThreadId(num_thread_ids.fetch_add(1));
+  }
+
+  // Given the ID back to the global pool for reuse
+  void relinquish(ThreadId* p) {
+    p->next = available_ids.load(std::memory_order_relaxed);
+    while (!available_ids.compare_exchange_weak(p->next, p,
+             std::memory_order_release, std::memory_order_relaxed)) {}
+  }
+
+  static inline const ThreadIdOwner& get_local_thread_id() {
+    static const thread_local ThreadIdPool::ThreadIdOwner my_id(instance());
+    return my_id;
+  }
+
+  static inline ThreadIdPool& instance() {
+    // We hold the global thread id pool inside a shared_ptr because it is possible
+    // for threads to be spawned *before* the ID pool has been initialized, which
+    // means that they may outlive this static variable. Each ThreadId holds onto
+    // a copy of the shared_ptr to ensure that the pool stays alive long enough
+    // for the IDs to relinquish themselves back to the pool.
+    //
+    // I think it is still possible to cause a segfault by spawning a new thread
+    // *after* the static destructors have run... so please do not spawn threads
+    // inside your static destructors :)
+    static const std::shared_ptr<ThreadIdPool> pool = std::make_shared<ThreadIdPool>(private_constructor{});
+    return *pool;
+  }
+
+  std::atomic<size_t> num_thread_ids;
+  std::atomic<ThreadId*> available_ids;
+};
+
+inline thread_id_type get_thread_id() {
+  return ThreadIdPool::get_local_thread_id().id;
+}
+
+inline thread_id_type get_num_thread_ids() {
+  return ThreadIdPool::instance().num_thread_ids.load();
+}
+
+
+}  // namespace internal
+}  // namespace parlay
+
+
+#endif  // PARLAY_INTERNAL_THREAD_ID_POOL_H_

--- a/third_party/parlayhash/include/parlay/internal/thread_ids.h~
+++ b/third_party/parlayhash/include/parlay/internal/thread_ids.h~
@@ -1,0 +1,88 @@
+// MIT license (https://opensource.org/license/mit/)
+// Initial Author: Guy Blelloch
+// Developed as part of cmuparlay/parlaylib
+
+// Supports unique thread ids for std:threads.  Supports
+//   thread_id.get() -- returns a unique, and fixed, id for the thread
+//   thread_id.max_current_id() -- returns an upper bound on any thread id up to the current time
+//   const thread_id.max_id -- returns an upper bound on any id ever used
+// The id will be allocated on first use within an std::thread and
+// retired when thread finishes (if one was allocated).
+// Ids are allocated starting at 0 and going up.
+// When a thread finishes its id is then available for reuse.
+// The value returned by max_id() never decreases.
+// Currently limit is max_id=1024 concurrent thread ids.
+
+#ifndef PARLAY_THREAD_IDS_
+#define PARLAY_THREAD_IDS_
+
+#include <atomic>
+#include <vector>
+
+namespace parlay {
+  namespace internal {
+
+static constexpr int max_thread_ids = 1024;
+
+// Maintains a pool of ids which threads can grab a unique id from. In
+// particular it atomically maintains a boolean vector marked as full
+// (true) in index i if id i is being used.  When asking for a new id
+// using add_id(), it looks for the first empty (false) slot, marks it
+// as full (true) and returns its index.  When giving up an id with
+// remove_id(int i) it sets slot i to empty (false).
+struct thread_id_pool {
+private:
+  std::vector<std::atomic<bool>> id_slots;
+  std::atomic<long> max_used ;
+
+public:
+  long max_id() {return max_used.load();}
+  
+  long add_id() {
+    long i;
+    bool old;
+    do {
+      old = false;
+      for (i=0; (i < max_thread_ids) && id_slots[i]; i++);
+      assert(i < max_thread_ids);
+    } while (!id_slots[i].compare_exchange_strong(old, true));
+    long max_id_used = max_used.load();
+    while (i > max_id_used &&
+	   max_used.compare_exchange_strong(max_id_used, i));
+    //std::cout << "adding: " << i << std::endl;
+    return i;
+  }
+
+  void remove_id(long i) {
+    //std::cout << "removing: " << i << std::endl;
+    id_slots[i] = false; }
+
+  thread_id_pool() :
+    id_slots(std::vector<std::atomic<bool>>(max_thread_ids)),
+    max_used(0) {
+    std::fill(id_slots.begin(), id_slots.end(), false); 
+  }
+};
+
+extern inline thread_id_pool& thread_ids() {
+  static thread_id_pool global_thread_id_pool;
+  return global_thread_id_pool;
+}
+
+struct thread_id_t {
+  long id;
+  long get() {
+    if (id == -1) id = thread_ids().add_id();
+    return id;
+  }
+  static constexpr int max_id = max_thread_ids;
+  static long max_current_id() {return thread_ids().max_id(); }
+  thread_id_t() : id(-1) {}
+  ~thread_id_t() { if (id != -1) thread_ids().remove_id(id);}
+};
+
+thread_local thread_id_t thread_id;
+}  // namespace internal
+} // namespace parlay
+
+#endif // PARLAY_THREAD_IDS_

--- a/third_party/parlayhash/include/parlay/internal/transpose.h
+++ b/third_party/parlayhash/include/parlay/internal/transpose.h
@@ -1,0 +1,242 @@
+
+#ifndef PARLAY_INTERNAL_TRANSPOSE_H_
+#define PARLAY_INTERNAL_TRANSPOSE_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include "../monoid.h"
+#include "../parallel.h"
+#include "../sequence.h"
+#include "../slice.h"
+#include "../utilities.h"
+
+#include "sequence_ops.h"
+
+namespace parlay {
+namespace internal {
+
+#ifdef PAR_GRANULARITY
+constexpr const size_t TRANS_THRESHHOLD = PAR_GRANULARITY / 4;
+#else
+constexpr const size_t TRANS_THRESHHOLD = 500;
+#endif
+
+#ifdef DEBUG
+constexpr const size_t NON_CACHE_OBLIVIOUS_THRESHOLD = 10000;
+#else
+constexpr const size_t NON_CACHE_OBLIVIOUS_THRESHOLD = 1 << 22;
+#endif
+
+inline size_t split(size_t n) { return n / 2; }
+
+// Given a flat matrix represented in row-major order (i.e., a matrix where
+// each row is written one after the other in a 1D sequence), computes the
+// transpose of that matrix.
+//
+// E.g., given [1,2,3,1,2,3,1,2,3] which represents the matrix
+//
+//  1 2 3
+//  1 2 3
+//  1 2 3
+//
+// it computes [1,1,1,2,2,2,3,3,3] which represents the transpose matrix
+//
+//  1 1 1
+//  2 2 2
+//  3 3 3
+//
+// Alternatively, you can think of it as swapping to column-major
+// representation when starting from row-major representation
+//
+template <typename assignment_tag, typename InIterator, typename OutIterator>
+struct transpose {
+  InIterator In;
+  OutIterator Out;
+  transpose(InIterator In_, OutIterator Out_) : In(std::move(In_)), Out(std::move(Out_)) {}
+
+  void transR(size_t rStart, size_t rCount, size_t rLength, size_t cStart,
+              size_t cCount, size_t cLength) {
+    if (cCount * rCount < TRANS_THRESHHOLD) {
+      for (size_t i = rStart; i < rStart + rCount; i++)
+        for (size_t j = cStart; j < cStart + cCount; j++)
+          assign_dispatch(Out[j * cLength + i], In[i * rLength + j], assignment_tag());
+    } else if (cCount > rCount) {
+      size_t l1 = split(cCount);
+      size_t l2 = cCount - l1;
+      auto left = [&]() {
+        transR(rStart, rCount, rLength, cStart, l1, cLength);
+      };
+      auto right = [&]() {
+        transR(rStart, rCount, rLength, cStart + l1, l2, cLength);
+      };
+      par_do(left, right);
+    } else {
+      size_t l1 = split(rCount);
+      size_t l2 = rCount - l1;
+      auto left = [&]() {
+        transR(rStart, l1, rLength, cStart, cCount, cLength);
+      };
+      auto right = [&]() {
+        transR(rStart + l1, l2, rLength, cStart, cCount, cLength);
+      };
+      par_do(left, right);
+    }
+  }
+
+  void trans(size_t rCount, size_t cCount) {
+    transR(0, rCount, cCount, 0, cCount, rCount);
+  }
+};
+
+// Given a flat matrix represented in row-major order, in which the rows are divided
+// into contiguous chunks, computes the matrix resulting from transposing those chunks,
+// in row-major order. Note that as the matrix is represented in row-major order, it
+// may have rows of different lengths, so it might not be a real matrix.
+//
+// For example, consider the following matrix in which the rows are chunked
+//
+// [ ( 1  2) ( 3  4  5) ( 6  7  8  9) ]
+// [ (10 11) (12 13 14) (15 16 17 18) ]
+//
+// Its block-transpose is
+//
+// [ ( 1  2) (10 11) ]
+// [ ( 3  4  5) (12 13 14) ]
+// [ (6  7  8  9) (15 16 17 18) ]
+//
+// (which of course is represented in row-major order because it isn't a real matrix
+// as it has imbalanced rows)
+//
+// The input to the problem is given in the form of the input matrix in row-major order,
+// the output destination, and the offsets that define where each chunk begins in the
+// input and output. For example, the input offsets for the matrix above are
+//
+// [ 0 2 5 ]
+// [ 0 2 5 ]
+//
+// again, given in row-major order. You can think of the offsets as the prefix sum of
+// the chunk sizes.
+//
+template <typename assignment_tag, typename InIterator, typename OutIterator, typename CountIterator, typename DestIterator>
+struct blockTrans {
+  InIterator In;
+  OutIterator Out;
+  CountIterator InOffset;
+  DestIterator OutOffset;
+
+  blockTrans(InIterator In_, OutIterator Out_, CountIterator InOffset_, DestIterator OutOffset_)
+      : In(std::move(In_)), Out(std::move(Out_)), InOffset(std::move(InOffset_)), OutOffset(std::move(OutOffset_)) {}
+
+  void transR(size_t rStart, size_t rCount, size_t rLength, size_t cStart,
+              size_t cCount, size_t cLength) {
+    if (cCount * rCount < TRANS_THRESHHOLD * 16) {
+      parallel_for(rStart, rStart + rCount, [&](size_t i) {
+        for (size_t j = cStart; j < cStart + cCount; j++) {
+          size_t sa = InOffset[i * rLength + j];
+          size_t sb = OutOffset[j * cLength + i];
+          size_t l = InOffset[i * rLength + j + 1] - sa;
+          for (size_t k = 0; k < l; k++) {
+            assign_dispatch(Out[k + sb], In[k + sa], assignment_tag());
+          }
+        }
+      });
+    } else if (cCount > rCount) {
+      size_t l1 = split(cCount);
+      size_t l2 = cCount - l1;
+      auto left = [&]() {
+        transR(rStart, rCount, rLength, cStart, l1, cLength);
+      };
+      auto right = [&]() {
+        transR(rStart, rCount, rLength, cStart + l1, l2, cLength);
+      };
+      par_do(left, right);
+    } else {
+      size_t l1 = split(rCount);
+      size_t l2 = rCount - l1;
+      auto left = [&]() {
+        transR(rStart, l1, rLength, cStart, cCount, cLength);
+      };
+      auto right = [&]() {
+        transR(rStart + l1, l2, rLength, cStart, cCount, cLength);
+      };
+      par_do(left, right);
+    }
+  }
+
+  void trans(size_t rCount, size_t cCount) {
+    transR(0, rCount, cCount, 0, cCount, rCount);
+  }
+};
+
+// Moves values from blocks to buckets
+// From is sorted by key within each block, in block major
+// counts is the # of keys in each bucket for each block, in block major
+// From and To are of length n
+// counts is of length num_blocks * num_buckets
+//
+template <typename assignment_tag, typename InIterator, typename OutIterator, typename s_size_t>
+sequence<size_t> transpose_buckets(InIterator From, OutIterator To,
+                                   sequence<s_size_t>& counts, size_t n,
+                                   size_t block_size, size_t num_blocks,
+                                   size_t num_buckets) {
+  size_t m = num_buckets * num_blocks;
+  sequence<s_size_t> dest_offsets;
+  auto add = plus<s_size_t>();
+
+  // for smaller input do non-cache oblivious version
+  if (n < NON_CACHE_OBLIVIOUS_THRESHOLD || num_buckets <= 512 || num_blocks <= 512) {
+    size_t block_bits = log2_up(num_blocks);
+    size_t block_mask = num_blocks - 1;
+    assert(size_t{1} << block_bits == num_blocks);
+
+    // determine the destination offsets
+    auto get = [&](size_t i) {
+      return counts[(i >> block_bits) + num_buckets * (i & block_mask)];
+    };
+
+    // slow down?
+    dest_offsets = sequence<s_size_t>::from_function(m, get);
+    [[maybe_unused]] auto sum = scan_inplace(make_slice(dest_offsets), add);
+    assert(sum == n);
+
+    // send each key to correct location within its bucket
+    auto f = [&](size_t i) {
+      size_t s_offset = i * block_size;
+      for (size_t j = 0; j < num_buckets; j++) {
+        size_t d_offset = dest_offsets[i + num_blocks * j];
+        size_t len = counts[i * num_buckets + j];
+        for (size_t k = 0; k < len; k++)
+          assign_dispatch(To[d_offset++], From[s_offset++], assignment_tag());
+      }
+    };
+    parallel_for(0, num_blocks, f, 1);
+  } else {  // for larger input do cache efficient transpose
+    dest_offsets = sequence<s_size_t>::uninitialized(m);
+    transpose<uninitialized_copy_tag, decltype(counts.begin()), decltype(dest_offsets.begin())>
+      (counts.begin(), dest_offsets.begin()).trans(num_blocks, num_buckets);
+
+    // do both scans inplace
+    [[maybe_unused]] size_t total = scan_inplace(make_slice(dest_offsets), add);
+    [[maybe_unused]] size_t total2 = scan_inplace(make_slice(counts), add);
+    assert(total == n && total2 == n);
+
+    counts[m] = static_cast<s_size_t>(n);
+
+    blockTrans<assignment_tag, InIterator, OutIterator,
+               typename sequence<s_size_t>::iterator,
+               typename sequence<s_size_t>::iterator>(
+      From, To, counts.begin(), dest_offsets.begin())
+        .trans(num_blocks, num_buckets);
+  }
+
+  // return the bucket offsets, padded with n at the end
+  return sequence<size_t>::from_function(num_buckets + 1, [&](size_t i) {
+    return (i == num_buckets) ? n : dest_offsets[i * num_blocks];
+  });
+}
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_TRANSPOSE_H_

--- a/third_party/parlayhash/include/parlay/internal/uninitialized_sequence.h
+++ b/third_party/parlayhash/include/parlay/internal/uninitialized_sequence.h
@@ -1,0 +1,193 @@
+
+#ifndef PARLAY_INTERNAL_UNINITIALIZED_SEQUENCE_H_
+#define PARLAY_INTERNAL_UNINITIALIZED_SEQUENCE_H_
+
+#include <iterator>
+#include <memory>
+
+#include "../alloc.h"
+#include "../portability.h"
+
+#include "debug_uninitialized.h"
+
+namespace parlay {
+namespace internal {
+  
+#ifndef PARLAY_USE_STD_ALLOC
+template<typename T>
+using _uninitialized_sequence_default_allocator = parlay::allocator<T>;
+#else
+template<typename T>
+using _uninitialized_sequence_default_allocator = std::allocator<T>;
+#endif
+
+// An uninitialized fixed-size sequence container.
+//
+// By uninitialized, we mean two things:
+//  - The constructor uninitialized_sequence<T>(n) does not initialize its elements
+//  - The destructor ~uninitialized_sequence() also DOES NOT destroy its elements
+//
+// In other words, the elements of the sequence are uninitialized upon construction,
+// and are also required to be uninitialized when the sequence is destroyed.
+//
+// Q: What on earth is the purpose of such a container??
+// A: Its purpose is to be used as temporary storage for out of place algorithms
+//    that use uninitialized_relocate. Since the container begins in an uninitialized
+//    state, it is valid to uninitialized_relocate objects into it, and then
+//    uninitialized_relocate them back out. This leaves the elements uninitialized,
+//    so that no destructors will accidentally be triggered for moved-out-of objects.
+//
+template<typename T, typename Alloc = _uninitialized_sequence_default_allocator<T>>
+class uninitialized_sequence {
+ public:
+  using value_type = T;
+  using reference = T&;
+  using const_reference = const T&;
+  using difference_type = std::ptrdiff_t;
+  using size_type = size_t;
+  using pointer = T*;
+  using const_pointer = const T*;
+  
+  using iterator = T*;
+  using const_iterator = const T*;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  using allocator_type = Alloc;
+  
+ private: 
+  struct uninitialized_sequence_impl : public allocator_type {
+    size_t n;
+    value_type* data;
+    explicit uninitialized_sequence_impl(size_t _n, const allocator_type& alloc)
+             : allocator_type(alloc),
+               n(_n),
+               data(std::allocator_traits<allocator_type>::allocate(*this, n)) { }
+    ~uninitialized_sequence_impl() {
+      std::allocator_traits<allocator_type>::deallocate(*this, data, n);
+    }
+
+    // Delete copy for uninitialized sequences
+    uninitialized_sequence_impl(const uninitialized_sequence_impl&) = delete;
+    uninitialized_sequence_impl& operator=(const uninitialized_sequence_impl&) = delete;
+
+    // Move constructing an uninitialized sequence
+    // leaves the other sequence in an empty state
+    uninitialized_sequence_impl(uninitialized_sequence_impl&& other) noexcept : data(other.data), n(other.n) {
+      other.data = nullptr;
+      other.n = 0;
+    }
+
+    // Move assigning an uninitialized sequence clears the current sequence
+    // (without destruction) and swaps it with the given other sequence
+    uninitialized_sequence_impl& operator=(uninitialized_sequence_impl&& other) noexcept {
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+      // If uninitialized memory debugging is turned on, make sure that
+      // each object of type UninitializedTracker is destroyed or still
+      // uninitialized by the time this sequence is destroyed
+      auto buffer = impl.data;
+      parallel_for(0, impl.n, [&](size_t i) {
+        PARLAY_ASSERT_UNINITIALIZED(buffer[i]);
+      });
+#endif
+      n = 0;
+      data = nullptr;
+      std::swap(n, other.n);
+      std::swap(data, other.data);
+    }
+
+  } impl;
+
+ public:
+  explicit uninitialized_sequence(size_t n, const allocator_type& alloc = {})
+           : impl(n, alloc) {
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+    // If uninitialized memory debugging is turned on, make sure that
+    // each object of type UninitializedTracker is appropriately set
+    // to its uninitialized state.
+    if constexpr (std::is_same_v<value_type, UninitializedTracker>) {
+      auto buffer = impl.data;
+      parallel_for(0, n, [&](size_t i) {
+        buffer[i].initialized = false;
+      });
+    }
+#endif
+  }
+
+  uninitialized_sequence(const uninitialized_sequence<T, Alloc>&) = delete;
+  uninitialized_sequence& operator=(const uninitialized_sequence<T, Alloc>&) = delete;
+
+  uninitialized_sequence(uninitialized_sequence<T, Alloc>&&) noexcept = default;
+  uninitialized_sequence& operator=(uninitialized_sequence<T, Alloc>&&) noexcept = default;
+
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+  // If uninitialized memory debugging is turned on, make sure that
+  // each object of type UninitializedTracker is destroyed or still
+  // uninitialized by the time this sequence is destroyed
+  ~uninitialized_sequence() {
+    auto buffer = impl.data;
+    parallel_for(0, impl.n, [&](size_t i) {
+      PARLAY_ASSERT_UNINITIALIZED(buffer[i]);
+    });
+  }
+#else
+  ~uninitialized_sequence() = default;
+#endif
+
+  iterator begin() { return impl.data; }
+  iterator end() { return impl.data + impl.n; }
+
+  const_iterator begin() const { return impl.data; }
+  const_iterator end() const { return impl.data + impl.n; }
+
+  const_iterator cbegin() const { return impl.data; }
+  const_iterator cend() const { return impl.data + impl.n; }
+  
+  reverse_iterator rbegin() { return std::make_reverse_iterator(end()); }
+  reverse_iterator rend() { return std::make_reverse_iterator(begin()); }
+  
+  const_reverse_iterator rbegin() const { return std::make_reverse_iterator(end()); }
+  const_reverse_iterator rend() const { return std::make_reverse_iterator(begin()); }
+  
+  const_reverse_iterator crbegin() const { return std::make_reverse_iterator(cend()); }
+  const_reverse_iterator crend() const { return std::make_reverse_iterator(cbegin()); }
+  
+  void swap(uninitialized_sequence<T, Alloc>& other) {
+    std::swap(impl.n, other.impl.n);
+    std::swap(impl.data, other.impl.data);
+  }
+  
+  [[nodiscard]] size_type size() const { return impl.n; }
+  
+  value_type* data() { return impl.data; }
+  
+  const value_type* data() const { return impl.data; }
+
+  value_type& operator[](size_t i) { return impl.data[i]; }
+  const value_type& operator[](size_t i) const { return impl.data[i]; }
+  
+  value_type& at(size_t i) {
+    if (i >= size()) {
+      throw_exception_or_terminate<std::out_of_range>("uninitialized_sequence access out of bounds: length = " +
+                                                      std::to_string(size()) + ", index = " + std::to_string(i));
+    }
+    else {
+      return impl.data[i];
+    }
+  }
+  
+  const value_type& at(size_t i) const {
+    if (i >= size()) {
+      throw_exception_or_terminate<std::out_of_range>("uninitialized_sequence access out of bounds: length = " +
+                                                      std::to_string(size()) + ", index = " + std::to_string(i));
+    }
+    else {
+      return impl.data[i];
+    }
+  }
+};  
+  
+}  // namespace internal  
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_UNINITIALIZED_SEQUENCE_H_

--- a/third_party/parlayhash/include/parlay/internal/uninitialized_storage.h
+++ b/third_party/parlayhash/include/parlay/internal/uninitialized_storage.h
@@ -1,0 +1,61 @@
+
+#ifndef PARLAY_INTERNAL_UNINITIALIZED_STORAGE_H_
+#define PARLAY_INTERNAL_UNINITIALIZED_STORAGE_H_
+
+#include <memory>
+#include <new>
+
+#include "debug_uninitialized.h"
+
+namespace parlay {
+namespace internal {
+
+// Contains uninitialized correctly aligned storage large enough to
+// hold a single object of type T. The object is not initialized
+// and its destructor is not ran when the storage goes out of
+// scope. The purpose of such an object is to act as temp space
+// when using uninitialized_relocate
+template<typename T>
+class uninitialized_storage {
+  using value_type = T;
+  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage;
+
+ public:
+  uninitialized_storage() {
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+    // If uninitialized memory debugging is turned on, make sure that
+    // each object of type UninitializedTracker is appropriately set
+    // to its uninitialized state.
+    if constexpr (std::is_same_v<value_type, UninitializedTracker>) {
+      get()->initialized = false;
+    }
+#endif
+  }
+
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+  ~uninitialized_storage() {
+    PARLAY_ASSERT_UNINITIALIZED(*get());
+  }
+#endif
+
+  value_type* get() {
+#ifdef __cpp_lib_launder
+    return std::launder(reinterpret_cast<value_type*>(std::addressof(storage)));
+#else
+    return reinterpret_cast<value_type*>(std::addressof(storage));
+#endif  // __cpp_lib_launder
+  }
+
+  const value_type* get() const {
+#ifdef __cpp_lib_launder
+    return std::launder(reinterpret_cast<const value_type*>(std::addressof(storage)));
+#else
+    return reinterpret_cast<const value_type*>(std::addressof(storage));
+#endif  // __cpp_lib_launder
+  }
+};
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_UNINITIALIZED_STORAGE_H_

--- a/third_party/parlayhash/include/parlay/internal/windows/file_map_impl_windows.h
+++ b/third_party/parlayhash/include/parlay/internal/windows/file_map_impl_windows.h
@@ -1,0 +1,139 @@
+ 
+#ifndef PARLAY_INTERNAL_WINDOWS_FILE_MAP_IMPL_WINDOWS_H_
+#define PARLAY_INTERNAL_WINDOWS_FILE_MAP_IMPL_WINDOWS_H_
+
+#include <cassert>
+#include <cstdio>
+
+#include <algorithm>
+#include <string>
+
+#ifndef NOMINMAX
+#define PARLAY_DEFINED_NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <tchar.h>
+#include <strsafe.h>
+#include <windows.h>
+
+#ifdef PARLAY_DEFINED_NOMINMAX
+#undef NOMINMAX
+#endif
+
+namespace parlay {
+
+struct file_map {
+  private:
+    HANDLE hMapFile;      // handle for the file's memory-mapped region
+    HANDLE hFile;         // the file handle
+
+    char* first;
+    size_t size;
+  public:
+    using value_type = char;
+    using reference = char&;
+    using const_reference = const char&;
+    using iterator = char*;
+    using const_iterator = const char*;
+    using pointer = char*;
+    using const_pointer = const char*;
+    using difference_type = std::ptrdiff_t;
+    using size_type = size_t;
+
+    char operator[] (size_t i) const { return begin()[i]; }
+    const char* begin() const { return first; }
+    const char* end() const { return first + size; }
+
+    explicit file_map(const std::string& filename) {
+
+      // Open file handle
+      hFile = CreateFile(filename.c_str(),
+        GENERIC_READ,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        NULL);
+
+      assert(hFile != INVALID_HANDLE_VALUE);
+
+      // Create a file mapping object for the file
+      // Note that it is a good idea to ensure the file size is not zero
+      hMapFile = CreateFileMapping(hFile,          // current file handle
+        NULL,            // default security
+        PAGE_READONLY,   // read/write permission
+        0,               // size of mapping object, high
+        0,               // size of mapping object, low
+        NULL);           // name of mapping object
+
+      assert(hMapFile != NULL);
+
+      first = static_cast<char*>(
+        MapViewOfFile(hMapFile,       // handle to mapping object
+        FILE_MAP_READ,                    // read/write
+        0,
+        0,
+        0)
+      );
+
+      assert(first != nullptr);
+
+      LARGE_INTEGER file_size;
+      GetFileSizeEx(hFile, &file_size);
+      size = static_cast<size_t>(file_size.QuadPart);
+    }
+    
+    ~file_map() {
+        close();
+    }
+
+    // moveable but not copyable
+    file_map(const file_map&) = delete;
+    file_map& operator=(const file_map&) = delete;
+    
+    file_map(file_map&& other) noexcept : hMapFile(other.hMapFile), hFile(other.hFile), first(other.first), size(other.size)  {
+      other.hMapFile = NULL;
+      other.hFile = NULL;
+      other.first = nullptr;
+      other.size = 0;
+    }
+    
+    file_map& operator=(file_map&& other) noexcept {
+      close();
+      swap(other);
+      return *this;
+    }
+    
+    void close() {
+      if (first != nullptr) {
+        auto unmapped = UnmapViewOfFile(first);
+        assert(unmapped);
+        auto closedMapping = CloseHandle(hMapFile);
+        assert(closedMapping);
+        auto closedFile = CloseHandle(hFile);
+        assert(closedFile);
+
+        first = nullptr;
+        size = 0;
+        hFile = NULL;
+        hMapFile = NULL;
+      }
+    }
+
+    void swap(file_map& other) {
+      std::swap(hFile, other.hFile);
+      std::swap(hMapFile, other.hMapFile);
+      std::swap(first, other.first);
+      std::swap(size, other.size);
+    }
+
+    bool empty() const {
+      return first == nullptr;
+    }
+};
+
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_WINDOWS_FILE_MAP_IMPL_WINDOWS_H_
+ 

--- a/third_party/parlayhash/include/parlay/internal/work_stealing_deque.h
+++ b/third_party/parlayhash/include/parlay/internal/work_stealing_deque.h
@@ -1,0 +1,119 @@
+
+#ifndef PARLAY_INTERNAL_WORK_STEALING_DEQUE_H_
+#define PARLAY_INTERNAL_WORK_STEALING_DEQUE_H_
+
+#include <cassert>
+
+#include <atomic>
+#include <iostream>
+#include <utility>
+
+namespace parlay {
+namespace internal {
+
+// Deque from Arora, Blumofe, and Plaxton (SPAA, 1998).
+//
+// Supports:
+//
+// push_bottom:   Only the owning thread may call this
+// pop_bottom:    Only the owning thread may call this
+// pop_top:       Non-owning threads may call this
+//
+template <typename Job>
+struct Deque {
+  using qidx = unsigned int;
+  using tag_t = unsigned int;
+
+  // use std::atomic<age_t> for atomic access.
+  // Note: Explicit alignment specifier required
+  // to ensure that Clang inlines atomic loads.
+  struct alignas(int64_t) age_t {
+    // cppcheck bug prevents it from seeing usage with braced initializer
+    tag_t tag;                // cppcheck-suppress unusedStructMember
+    qidx top;                 // cppcheck-suppress unusedStructMember
+  };
+
+  // align to avoid false sharing
+  struct alignas(64) padded_job {
+    std::atomic<Job*> job;
+  };
+
+  static constexpr int q_size = 1000;
+  std::atomic<qidx> bot;
+  std::atomic<age_t> age;
+  std::array<padded_job, q_size> deq;
+
+  Deque() : bot(0), age(age_t{0, 0}) {}
+
+  // Adds a new job to the bottom of the queue. Only the owning
+  // thread can push new items. This must not be called by any
+  // other thread.
+  //
+  // Returns true if the queue was empty before this push
+  bool push_bottom(Job* job) {
+    auto local_bot = bot.load(std::memory_order_acquire);      // atomic load
+    deq[local_bot].job.store(job, std::memory_order_release);  // shared store
+    local_bot += 1;
+    if (local_bot == q_size) {
+      std::cerr << "internal error: scheduler queue overflow\n";
+      std::abort();
+    }
+    bot.store(local_bot, std::memory_order_seq_cst);  // shared store
+    return (local_bot == 1);
+  }
+
+  // Pop an item from the top of the queue, i.e., the end that is not
+  // pushed onto. Threads other than the owner can use this function.
+  //
+  // Returns {job, empty}, where empty is true if job was the
+  // only job on the queue, i.e., the queue is now empty
+  std::pair<Job*, bool> pop_top() {
+    auto old_age = age.load(std::memory_order_acquire);    // atomic load
+    auto local_bot = bot.load(std::memory_order_acquire);  // atomic load
+    if (local_bot > old_age.top) {
+      auto job = deq[old_age.top].job.load(std::memory_order_acquire);  // atomic load
+      auto new_age = old_age;
+      new_age.top = new_age.top + 1;
+      if (age.compare_exchange_strong(old_age, new_age))
+        return {job, (local_bot == old_age.top + 1)};
+      else
+        return {nullptr, (local_bot == old_age.top + 1)};
+    }
+    return {nullptr, true};
+  }
+
+  // Pop an item from the bottom of the queue. Only the owning
+  // thread can pop from this end. This must not be called by any
+  // other thread.
+  Job* pop_bottom() {
+    Job* result = nullptr;
+    auto local_bot = bot.load(std::memory_order_acquire);  // atomic load
+    if (local_bot != 0) {
+      local_bot--;
+      bot.store(local_bot, std::memory_order_release);  // shared store
+      std::atomic_thread_fence(std::memory_order_seq_cst);
+      auto job =
+          deq[local_bot].job.load(std::memory_order_acquire);  // atomic load
+      auto old_age = age.load(std::memory_order_acquire);      // atomic load
+      if (local_bot > old_age.top)
+        result = job;
+      else {
+        bot.store(0, std::memory_order_release);  // shared store
+        auto new_age = age_t{old_age.tag + 1, 0};
+        if ((local_bot == old_age.top) &&
+            age.compare_exchange_strong(old_age, new_age))
+          result = job;
+        else {
+          age.store(new_age, std::memory_order_seq_cst);  // shared store
+          result = nullptr;
+        }
+      }
+    }
+    return result;
+  }
+};
+
+}  // namespace internal
+}  // namespace parlay
+
+#endif  // PARLAY_INTERNAL_WORK_STEALING_DEQUE_H_

--- a/third_party/parlayhash/include/parlay/internal/work_stealing_job.h
+++ b/third_party/parlayhash/include/parlay/internal/work_stealing_job.h
@@ -1,0 +1,54 @@
+
+#ifndef PARLAY_INTERNAL_WORK_STEALING_JOB_H_
+#define PARLAY_INTERNAL_WORK_STEALING_JOB_H_
+
+#include <cassert>
+
+#include <atomic>
+#include <thread>
+#include <type_traits>    // IWYU pragma: keep
+
+
+namespace parlay {
+
+// Jobs are thunks -- i.e., functions that take no arguments
+// and return nothing. Could be a lambda, e.g. [] () {}.
+
+struct WorkStealingJob {
+  WorkStealingJob() : done{false} { }
+  virtual ~WorkStealingJob() = default;
+  void operator()() {
+    assert(done.load(std::memory_order_relaxed) == false);
+    execute();
+    done.store(true, std::memory_order_release);
+  }
+  [[nodiscard]] bool finished() const noexcept {
+    return done.load(std::memory_order_acquire);
+  }
+  void wait() const noexcept {
+    while (!finished())
+      std::this_thread::yield();
+  }
+ protected:
+  virtual void execute() = 0;
+  std::atomic<bool> done;
+};
+
+// Holds a type-specific reference to a callable object
+template<typename F>
+struct JobImpl : WorkStealingJob {
+  static_assert(std::is_invocable_v<F&>);
+  explicit JobImpl(F& _f) : WorkStealingJob(), f(_f) { }
+  void execute() override {
+    f();
+  }
+ private:
+  F& f;
+};
+
+template<typename F>
+JobImpl<F> make_job(F& f) { return JobImpl(f); }
+
+}
+
+#endif  // PARLAY_INTERNAL_WORK_STEALING_JOB_H_

--- a/third_party/parlayhash/include/parlay/io.h
+++ b/third_party/parlayhash/include/parlay/io.h
@@ -1,0 +1,399 @@
+#ifndef PARLAY_IO_H_
+#define PARLAY_IO_H_
+
+#include <cassert>
+#include <cctype>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include <algorithm>
+#include <array>            // IWYU pragma: keep
+#include <iterator>
+#include <fstream>
+#include <string>
+#include <utility>
+
+#include "primitives.h"
+#include "sequence.h"
+#include "slice.h"
+
+
+// IWYU pragma: no_include <tuple>
+
+namespace parlay {
+
+// ----------------------------------------------------------------------------
+//                                  I/O
+// ----------------------------------------------------------------------------
+
+// Reads a character sequence from a file between the bytes [start, end) :
+//    if end is zero or larger than file, then returns full file
+//    if start past end of file then returns an empty string.
+// If null_terminate is true, a null terminator (an extra '0' character)
+// is be appended to the sequence.
+inline chars chars_from_file(const std::string& filename,
+           bool null_terminate=false, std::streamoff start=0, std::streamoff end=0) {
+  std::ifstream file (filename, std::ios::in | std::ios::binary | std::ios::ate);
+  assert(file.is_open());
+  auto length = static_cast<std::streamoff>(file.tellg());
+  start = (std::min)(start,length);
+  if (end == 0) end = length;
+  else end = (std::min)(end,length);
+  std::streamsize n = end - start;
+  file.seekg (start, std::ios::beg);
+  auto chars = chars::uninitialized(static_cast<size_t>(n) + null_terminate);
+  file.read (chars.data(), n);
+  file.close();
+  if (null_terminate) {
+    chars[static_cast<size_t>(n)] = 0;
+  }
+  return chars;
+}
+
+// Writes a character sequence to a stream
+inline void chars_to_stream(const chars& S, std::ostream& os) {
+  os.write(S.data(), static_cast<std::streamsize>(S.size()));
+}
+
+// Writes a character sequence to a file, returns 0 if successful
+inline void chars_to_file(const chars& S, const std::string& filename) {
+  std::ofstream file_stream (filename, std::ios::out | std::ios::binary);
+  assert(file_stream.is_open());
+  chars_to_stream(S, file_stream);
+}
+
+// Writes a character sequence to a stream
+inline std::ostream& operator<<(std::ostream& os, const chars& s) {
+  chars_to_stream(s, os);
+  return os;
+}
+
+}
+
+#include "internal/file_map.h"  // IWYU pragma: export
+
+namespace parlay {
+
+// ----------------------------------------------------------------------------
+//                                  Parsing
+// ----------------------------------------------------------------------------
+
+namespace internal {
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif
+
+// Interpret a character sequence as an integral type Integer_.
+//
+// Faster than using std::stoi(std::string(...)) by a factor of
+// approximately 3-4 since it doesn't have to allocate a new string.
+template<typename Integer_, typename It_>
+Integer_ chars_to_int_t(slice<It_, It_> str) {
+  static_assert(std::is_integral_v<Integer_>);
+
+  size_t i = 0;
+
+  if constexpr (std::is_signed_v<Integer_>) {
+    // Compute the negative of str[i...], assuming that the sign has already
+    // been read. Why negative? Because in two's complement, the smallest
+    // possible value has greater magnitude by one than the largest possible
+    // value. That is, INT_MAX = 2147483647 but INT_MIN = -2147483648, so if
+    // we stored the result as a positive integer, we would overflow when reading
+    // INT_MIN, which is technically undefined behavior!
+    auto read_digits = [&]() {
+      Integer_ r = 0;
+      while (i < str.size() && std::isdigit(static_cast<unsigned char>(str[i])))
+        r = r * 10 - (str[i++] - '0');
+      return r;
+    };
+    if (str[i] == '-') {
+      i++;
+      return read_digits();
+    } else {
+      if (str[i] == '+') i++;
+      return -read_digits();
+    }
+  }
+  else {
+    auto read_digits = [&]() {
+      Integer_ r = 0;
+      while (i < str.size() && std::isdigit(static_cast<unsigned char>(str[i])))
+        r = r * 10 + (str[i++] - '0');
+      return r;
+    };
+    if (str[i] == '-') {
+      i++;
+      return -read_digits();
+    } else {
+      if (str[i] == '+') i++;
+      return read_digits();
+    }
+  }
+}
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+// Interpret a character sequence as a double. Performs
+// no error checking, so the behaviour is unspecified
+// if the given sequence is not a valid double.
+//
+// Significantly faster than std::stod if the number
+// is not too big since we can just read the digits and
+// divide or multiple exactly.  Otherwise we fall back
+// to std::stod / std::stof / std::stold.
+template<typename Float_, size_t max_len, int64_t max_exp, int64_t max_man, typename FallbackF>
+Float_ chars_to_float_t(const chars& s, FallbackF&& fallback) {
+
+  static const Float_ pow_ten[] = {
+    Float_{1e0},  Float_{1e1},  Float_{1e2},  Float_{1e3},  Float_{1e4},
+    Float_{1e5},  Float_{1e6},  Float_{1e7},  Float_{1e8},  Float_{1e9},
+    Float_{1e10}, Float_{1e11}, Float_{1e12}, Float_{1e13}, Float_{1e14},
+    Float_{1e15}, Float_{1e16}, Float_{1e17}, Float_{1e18}, Float_{1e19},
+    Float_{1e20}, Float_{1e21}, Float_{1e22}
+  };
+
+  // Fast Path
+  auto str = make_slice(s);
+  auto sz = str.size();
+  if (sz <= max_len) {
+    size_t i = 0;
+    uint64_t r = 0;
+    int64_t exponent = 0;
+    bool is_negative = false;
+    
+    while (std::isspace(static_cast<unsigned char>(str[i]))) {
+      i++;
+    }
+    
+    // Detect sign
+    if (str[i] == '-') {
+      is_negative = true;
+      i++;
+    }
+    else if (str[i] == '+') {
+      i++;
+    }
+    
+    // Catches inf and nan
+    if (str[i] == 'i' || str[i] == 'n') {
+      return fallback(s);
+    }
+    
+    // Read digits
+    while (i < sz && std::isdigit(static_cast<unsigned char>(str[i]))) {
+      r = r * 10 + (str[i++] - '0');
+    }
+    
+    // Whole number. No decimal point and no exponent. Easy.
+    if (i == sz) {
+      if (r < (uint64_t{1} << max_man)) {
+        Float_ res = static_cast<Float_>(r);
+        if (is_negative) res = -res;
+        return res;
+      }
+      else {
+        return fallback(s);
+      }
+    }
+    
+    // Found the exponent. No decimal point
+    if (str[i] == 'e' || str[i] == 'E') {
+      exponent = static_cast<int64_t>(internal::chars_to_int_t<uint64_t>(str.cut(i+1, sz)));
+      i = sz;
+    }
+    // Found the decimal point. Continue looking until we find an exponent or the end
+    else {
+      assert(str[i] == '.' || str[i] == ',');
+      int64_t period = static_cast<int64_t>(i++);
+      
+      while (i < sz && std::isdigit(static_cast<unsigned char>(str[i]))) {
+        r = r * 10 + (str[i++] - '0');
+      }
+      
+      exponent = -(static_cast<int64_t>(i) - period - 1);
+      
+      if (i < sz && (str[i] == 'e' || str[i] == 'E')) {
+        exponent += static_cast<int64_t>(internal::chars_to_int_t<uint64_t>(str.cut(i+1, sz)));
+        i = sz;
+      }
+    }
+
+    assert(i == sz);
+    
+    // We can represent this exactly!
+    if (-max_exp <= exponent && exponent <= max_exp && r < (uint64_t{1} << max_man)) {
+      Float_ result = static_cast<Float_>(r);
+      Float_ tens = exponent > 0 ? pow_ten[exponent] : pow_ten[-exponent];
+      if (exponent < 0) result = result / tens;
+      else if (exponent > 0) result = result * tens;
+      if (is_negative) result = -result;
+      return result;
+    }
+  }
+  
+  // Slow path: Just fall back to std::stof/std::stod/std::stold
+  return fallback(s);
+}
+
+}
+
+inline int chars_to_int(const chars& s) { return internal::chars_to_int_t<int>(make_slice(s)); }
+inline long chars_to_long(const chars& s) { return internal::chars_to_int_t<long>(make_slice(s)); }
+inline long long chars_to_long_long(const chars& s) { return internal::chars_to_int_t<long long>(make_slice(s)); }
+
+inline unsigned int chars_to_uint(const chars& s) { return internal::chars_to_int_t<unsigned int>(make_slice(s)); }
+inline unsigned long chars_to_ulong(const chars& s) { return internal::chars_to_int_t<unsigned long>(make_slice(s)); }
+inline unsigned long long chars_to_ulong_long(const chars& s) { return internal::chars_to_int_t<unsigned long long>(make_slice(s)); }
+
+
+inline float chars_to_float(const chars& s) {
+  return internal::chars_to_float_t<float, 10, 10, 24>(s, [](const auto& str) {
+    return std::stof(std::string(std::begin(str), std::end(str))); });
+}
+
+inline double chars_to_double(const chars& s) {
+  return internal::chars_to_float_t<double, 18, 22, 53>(s, [](const auto& str) {
+    return std::stod(std::string(std::begin(str), std::end(str))); });
+}
+
+inline long double chars_to_long_double(const chars& s) {
+  return internal::chars_to_float_t<long double, 18, 22, 53>(s, [](const auto& str) {
+    return std::stold(std::string(std::begin(str), std::end(str))); });
+}
+
+
+// ----------------------------------------------------------------------------
+//                                Formatting
+// ----------------------------------------------------------------------------
+
+// Still a work in progress. TODO: Improve these?
+
+inline chars to_chars(char c) {
+  return chars(1, c);
+}
+
+inline chars to_chars(bool v) {
+  return to_chars(v ? '1' : '0');
+}
+
+inline chars to_chars(long v) {
+  constexpr int max_len = 21;
+  char s[max_len + 1];
+  int l = std::snprintf(s, max_len, "%ld", v);
+  return chars(s, s + (std::min)(max_len - 1, l));
+}
+
+inline chars to_chars(int v) {
+  return to_chars((long) v);
+};
+
+inline chars to_chars(unsigned long v) {
+  constexpr int max_len = 21;
+  char s[max_len + 1];
+  int l = std::snprintf(s, max_len, "%lu", v);
+  return chars(s, s + (std::min)(max_len - 1, l));
+}
+
+inline chars to_chars(unsigned int v) {
+  return to_chars((unsigned long) v);
+};
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
+#endif
+
+inline chars to_chars(long long v) {
+  constexpr int max_len = 21;
+  char s[max_len + 1];
+  int l = std::snprintf(s, max_len, "%" PRId64, v);
+  return chars(s, s + (std::min)(max_len - 1, l));
+}
+
+inline chars to_chars(unsigned long long v) {
+  constexpr int max_len = 21;
+  char s[max_len + 1];
+  int l = std::snprintf(s, max_len, "%" PRIu64, v);
+  return chars(s, s + (std::min)(max_len - 1, l));
+}
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+inline chars to_chars(double v) {
+  constexpr int max_len = 21;
+  char s[max_len + 1];
+  int l = std::snprintf(s, max_len, "%.11le", v);
+  return chars(s, s + (std::min)(max_len - 1, l));
+}
+
+inline chars to_chars(float v) {
+  return to_chars((double) v);
+};
+
+inline chars to_chars(const std::string& s) {
+  return chars::from_function(s.size(), [&](size_t i) -> char { return s[i]; });
+}
+
+inline chars to_chars(const char* s) {
+  size_t l = std::strlen(s);
+  return chars::from_function(l, [&](size_t i) -> char { return s[i]; });
+}
+
+template<typename A, typename B>
+chars to_chars(const std::pair<A, B>& p) {
+  sequence<chars> s = {
+      to_chars('('), to_chars(p.first),
+      to_chars(std::string(", ")),
+      to_chars(p.second), to_chars(')')};
+  return flatten(s);
+}
+
+template<typename A, long unsigned int N>
+chars to_chars(const std::array<A, N>& P) {
+  if (N == 0) return to_chars(std::string("[]"));
+  auto separator = to_chars(std::string(", "));
+  return flatten(tabulate(2 * N + 1, [&](size_t i) {
+    if (i == 0) return to_chars('[');
+    if (i == 2 * N) return to_chars(']');
+    if (i & 1) return to_chars(P[i / 2]);
+    return separator;
+  }));
+}
+
+template<typename T>
+chars to_chars(const slice<T, T>& A) {
+  auto n = A.size();
+  if (n == 0) return to_chars(std::string("[]"));
+  auto separator = to_chars(std::string(", "));
+  return flatten(tabulate(2 * n + 1, [&](size_t i) {
+    if (i == 0) return to_chars('[');
+    if (i == 2 * n) return to_chars(']');
+    if (i & 1) return to_chars(A[i / 2]);
+    return separator;
+  }));
+}
+
+template<class T>
+chars to_chars(const sequence<T>& A) {
+  return to_chars(make_slice(A));
+}
+
+inline chars to_chars(const chars& s) {
+  return s;
+}
+
+inline chars to_chars(chars&& s) {
+  return std::move(s);
+}
+
+}  // namespace parlay
+
+#endif  // PARLAY_IO_H_

--- a/third_party/parlayhash/include/parlay/monoid.h
+++ b/third_party/parlayhash/include/parlay/monoid.h
@@ -1,0 +1,318 @@
+
+#ifndef PARLAY_MONOID_H_
+#define PARLAY_MONOID_H_
+
+#include <cstddef>
+
+#include <algorithm>    // IWYU pragma: keep
+#include <array>
+#include <iterator>
+#include <functional>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+#include "portability.h"
+#include "type_traits.h"
+
+namespace parlay {
+
+// Definition of various monoids. Each consists of:
+//   T identity    : returns identity for the monoid
+//   T f(T&&, T&&) : adds two elements, must be associative
+
+// ----------------------------- Type traits -------------------------------------------
+
+// Type trait for detecting the value type of a Monoid, denoted by the type of "identity"
+template<typename Monoid_>
+using monoid_value_type = type_identity<decltype(std::remove_reference_t<Monoid_>::identity)>;
+
+// Returns the value type of the given Monoid, denoted by the type of "identity"
+template<typename Monoid_>
+using monoid_value_type_t = typename monoid_value_type<Monoid_>::type;
+
+// Defines the member value true if Monoid_ is a valid monoid. That is, it has
+// a member "identity" of some type T which is move constructible, and is a binary
+// operator over the type T
+template<typename Monoid_, typename = void>
+struct is_monoid : public std::false_type {};
+
+template<typename Monoid_>
+struct is_monoid<Monoid_, std::void_t<
+  monoid_value_type_t<Monoid_>,
+  std::enable_if_t< std::is_move_constructible_v<monoid_value_type_t<Monoid_>> >,
+  std::enable_if_t< is_binary_operator_for_v<Monoid_, monoid_value_type_t<Monoid_>> >
+>> : public std::true_type {};
+
+// True if Monoid_ is a valid monoid. That is, it has a member "identity" of some
+// type T which is move constructible, and a member f, which is a valid binary
+// operator over the type T
+template<typename Monoid_>
+inline constexpr bool is_monoid_v = is_monoid<Monoid_>::value;
+
+// Defines the member value true if Monoid_ is a valid monoid (see is_monoid)
+// and the binary operator defined by the monoid is applicable to the type T
+template<typename Monoid_, typename T, typename = void>
+struct is_monoid_for : public std::false_type {};
+
+template<typename Monoid_, typename T>
+struct is_monoid_for<Monoid_, T, std::void_t<
+  std::enable_if_t< is_monoid_v<Monoid_> >,
+  std::enable_if_t< is_binary_operator_for_v<Monoid_, monoid_value_type_t<Monoid_>, T> >
+>> : public std::true_type {};
+
+// True if Monoid_ is a valid monoid (see is_monoid_v) and the binary operator
+// defined by the monoid is applicable to the type T
+template<typename Monoid_, typename T>
+inline constexpr bool is_monoid_for_v = is_monoid_for<Monoid_, T>::value;
+
+// ----------------------------- Definitions -------------------------------------------
+
+// Built-in monoids with sensible default identities
+
+template<typename T>
+struct plus : public std::plus<> {
+  static_assert(is_binary_operator_for_v<std::plus<>, T>);
+  T identity;
+  plus() : identity(0) { }
+  explicit plus(T identity_) : identity(std::move(identity_)) { }
+};
+
+template<typename T>
+struct multiplies : public std::multiplies<>  {
+  static_assert(is_binary_operator_for_v<std::multiplies<>, T>);
+  T identity;
+  multiplies() : identity(1) { }
+  explicit multiplies(T identity_) : identity(std::move(identity_)) { }
+};
+
+template<typename T>
+struct logical_and : public std::logical_and<> {
+  static_assert(is_binary_operator_for_v<std::logical_and<>, T>);
+  T identity;
+  logical_and() : identity(true) { }
+  explicit logical_and(T identity_) : identity(std::move(identity_)) { }
+};
+
+template<typename T>
+struct logical_or : public std::logical_or<> {
+  static_assert(is_binary_operator_for_v<std::logical_or<>, T>);
+  T identity;
+  logical_or() : identity(false) { }
+  explicit logical_or(T identity_) : identity(std::move(identity_)) { }
+};
+
+template<typename T>
+struct bit_or : public std::bit_or<> {
+  static_assert(is_binary_operator_for_v<std::bit_or<>, T>);
+  T identity;
+  bit_or() : identity(0) { }
+  explicit bit_or(T identity_) : identity(std::move(identity_)) { }
+};
+
+template<typename T>
+struct bit_xor : public std::bit_xor<> {
+  static_assert(is_binary_operator_for_v<std::bit_xor<>, T>);
+  T identity;
+  bit_xor() : identity(0) { }
+  explicit bit_xor(T identity_) : identity(std::move(identity_)) { }
+};
+
+template<typename T>
+struct bit_and : public std::bit_and<> {
+  static_assert(is_binary_operator_for_v<std::bit_and<>, T>);
+  T identity;
+  bit_and() : identity(~static_cast<T>(0)) { }
+  explicit bit_and(T identity_) : identity(std::move(identity_)) { }
+};
+
+template<typename T>
+struct maximum {
+  T identity;
+  maximum() : identity(std::numeric_limits<T>::lowest()) { }
+  explicit maximum(T identity_) : identity(std::move(identity_)) { }
+  template<typename T1, typename T2>
+  T operator()(T1&& x, T2&& y) const { return std::max<T>(std::forward<T1>(x), std::forward<T2>(y)); }
+};
+
+template<typename T>
+struct minimum {
+  T identity;
+  minimum() : identity(std::numeric_limits<T>::max()) { }
+  explicit minimum(T identity_) : identity(std::move(identity_)) { }
+  template<typename T1, typename T2>
+  T operator()(T1&& x, T2&& y) const { return std::min<T>(std::forward<T1>(x), std::forward<T2>(y)); }
+};
+
+// -------------------------- Custom user-defined monoids ------------------------------
+
+template <typename F, typename TT, typename = void>
+struct monoid {
+  static_assert(is_binary_operator_for_v<F, TT>);
+  using T = TT;
+  T identity;
+  F f;
+  monoid(F f, T id) : identity(std::move(id)), f(std::move(f)) { }
+  template<typename T1, typename T2>
+  PARLAY_INLINE decltype(auto) operator()(T1&& x, T2&& y) const {
+    static_assert(std::is_invocable_r_v<T, const F&, T1, T2>);
+    return std::invoke(f, std::forward<T1>(x), std::forward<T2>(y));
+  }
+};
+
+template<typename F, typename TT>
+struct monoid<F, TT, std::enable_if_t<std::is_class_v<F>>> : public F {
+  static_assert(is_binary_operator_for_v<F, TT>);
+  using T = TT;
+  T identity;
+  monoid(F f, T id) : F(std::move(f)), identity(std::move(id)) { }
+};
+
+template<typename F, typename T>
+monoid<F, T> binary_op(F f, T id) {
+  static_assert(is_binary_operator_for_v<F, T>);
+  return monoid<F, T>(std::move(f), std::move(id));
+}
+
+// ----------------------------- Legacy definitions -------------------------------------------
+// These are now deprecated. They remain here for backwards compatibility
+
+// Defines the member value true if Monoid_ is a valid legacy monoid. That is, it has
+// a typedef T which is move constructible, a member "identity" of type T , and a member
+// f, which is a valid binary operator over the type T.
+//
+// Library functions that used legacy monoids have overloads that still support them,
+// e.g., parlay::reduce and parlay::scan, but all new library functions will only support
+// the new monoids. This ensures backward compatibility, but encourages the use of the
+// new ones for new code.
+template<typename Monoid_, typename = void>
+struct is_legacy_monoid : public std::false_type {};
+
+template<typename Monoid_>
+struct is_legacy_monoid<Monoid_, std::void_t<
+  typename std::remove_reference_t<Monoid_>::T,
+  monoid_value_type_t<Monoid_>,
+  decltype( std::declval<Monoid_>().f(std::declval<monoid_value_type_t<Monoid_>>(),
+                                      std::declval<monoid_value_type_t<Monoid_>>()) ),
+  std::enable_if_t< std::is_same_v<monoid_value_type_t<Monoid_>, typename std::remove_reference_t<Monoid_>::T> >,
+  std::enable_if_t< std::is_move_constructible_v<monoid_value_type_t<Monoid_>> >,
+  std::enable_if_t< std::is_convertible_v<decltype(std::declval<Monoid_>().f(
+    std::declval<monoid_value_type_t<Monoid_>>(), std::declval<monoid_value_type_t<Monoid_>>()) ),
+      monoid_value_type_t<Monoid_>> >
+>> : public std::true_type {};
+
+// True if Monoid_ is a valid legacy monoid. That is, it has a typedef T which is
+// move constructible, a member "identity" of type T , and a member f, which is a
+// valid binary operator over the type T
+template<typename Monoid_>
+inline constexpr bool is_legacy_monoid_v = is_legacy_monoid<Monoid_>::value;
+
+// Takes a legacy monoid and adds an operator() to make it compatible with the
+// newer monoid interface
+template<typename LegacyMonoid>
+struct legacy_monoid_adapter : public LegacyMonoid {
+  static_assert(is_legacy_monoid_v<LegacyMonoid>);
+
+  explicit legacy_monoid_adapter(LegacyMonoid m) : LegacyMonoid(std::move(m)) { }
+
+  template<typename T1, typename T2> PARLAY_INLINE
+  decltype(auto) operator()(T1&& x, T2&& y) { return this->f(std::forward<T1>(x), std::forward<T2>(y)); }
+
+  template<typename T1, typename T2> PARLAY_INLINE
+  decltype(auto) operator()(T1&& x, T2&& y) const { return this->f(std::forward<T1>(x), std::forward<T2>(y)); }
+};
+
+template <typename F, typename T>
+monoid<F, T> make_monoid(F f, T id) {
+  static_assert(is_binary_operator_for_v<F, T>);
+  return monoid<F, T>(std::move(f), std::move(id));
+}
+
+template <typename M1, typename M2>
+auto pair_monoid(M1 m1, M2 m2) {
+  static_assert(is_legacy_monoid_v<M1>);
+  static_assert(is_legacy_monoid_v<M2>);
+  using P = std::pair<monoid_value_type_t<M1>, monoid_value_type_t<M2>>;
+  auto identity = P(m1.identity, m2.identity);
+  auto f = [m1 = std::move(m1), m2 = std::move(m2)](auto&& a, auto&& b) {
+    return P(m1.f(std::get<0>(std::forward<decltype(a)>(a)), std::get<0>(std::forward<decltype(b)>(b))),
+             m2.f(std::get<1>(std::forward<decltype(a)>(a)), std::get<1>(std::forward<decltype(b)>(b))));
+  };
+  return make_monoid(std::move(f), std::move(identity));
+}
+
+template <typename M, size_t n>
+auto array_monoid(M m) {
+  using Ar = std::array<monoid_value_type_t<M>, n>;
+  Ar id;
+  for (size_t i = 0; i < n; i++) id[i] = m.identity;
+  auto f = [m = std::move(m)](Ar a, Ar b) {
+    Ar r;
+    for (size_t i = 0; i < n; i++) r[i] = m.f(a[i], b[i]);
+    return r;
+  };
+  return make_monoid(std::move(f), std::move(id));
+}
+
+template <class TT>
+struct addm {
+  using T = TT;
+  addm() : identity(0) {}
+  T identity;
+  static T f(T a, T b) { return a + b; }
+};
+
+template <class TT>
+struct maxm {
+  using T = TT;
+  maxm() : identity(std::numeric_limits<T>::lowest()) {}
+  T identity;
+  static T f(T a, T b) { return (std::max)(a, b); }
+};
+
+template <class T1, class T2>
+struct maxm<std::pair<T1, T2>> {
+  using T = std::pair<T1, T2>;
+  maxm() : identity(std::make_pair(std::numeric_limits<T1>::lowest(), std::numeric_limits<T2>::lowest())) {}
+  T identity;
+  static T f(T a, T b) { return (std::max)(a, b); }
+};
+
+template <class TT>
+struct minm {
+  using T = TT;
+  minm() : identity((std::numeric_limits<T>::max)()) {}
+  T identity;
+  static T f(T a, T b) { return (std::min)(a, b); }
+};
+
+template <class T1, class T2>
+struct minm<std::pair<T1, T2>> {
+  using T = std::pair<T1, T2>;
+  minm() : identity(std::make_pair((std::numeric_limits<T1>::max)(), (std::numeric_limits<T2>::max)())) {}
+  T identity;
+  static T f(T a, T b) { return (std::min)(a, b); }
+};
+
+template <class TT>
+struct xorm {
+  using T = TT;
+  xorm() : identity(0) {}
+  T identity;
+  static T f(T a, T b) { return a ^ b; }
+};
+
+template <class TT>
+struct minmaxm {
+  using T = std::pair<TT, TT>;
+  minmaxm() : identity(T((std::numeric_limits<TT>::max)(), (std::numeric_limits<TT>::lowest)())) {}
+  T identity;
+  static T f(T a, T b) {
+    return T((std::min)(a.first, b.first), (std::max)(a.second, b.second));
+  }
+};
+
+
+}  // namespace parlay
+
+#endif  // PARLAY_MONOID_H_

--- a/third_party/parlayhash/include/parlay/nscheduler.h
+++ b/third_party/parlayhash/include/parlay/nscheduler.h
@@ -1,0 +1,430 @@
+
+#ifndef PARLAY_SCHEDULER_H_
+#define PARLAY_SCHEDULER_H_
+
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>         // IWYU pragma: keep
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <type_traits>    // IWYU pragma: keep
+#include <utility>
+#include <vector>
+
+#include "internal/work_stealing_deque.h"
+#include "internal/work_stealing_job.h"
+
+// IWYU pragma: no_include <bits/chrono.h>
+// IWYU pragma: no_include <bits/this_thread_sleep.h>
+
+
+
+// True if the scheduler should scale the number of awake workers
+// proportional to the amount of work to be done. This saves CPU
+// time if there is not any parallel work available, but may cause
+// some startup lag when more parallelism becomes available.
+//
+// Default: true
+#ifndef PARLAY_ELASTIC_PARALLELISM
+#define PARLAY_ELASTIC_PARALLELISM true
+#endif
+
+
+// PARLAY_ELASTIC_STEAL_TIMEOUT sets the number of microseconds
+// that a worker will attempt to steal jobs, such that if no
+// jobs are successfully stolen, it will go to sleep.
+//
+// Default: 10000 (10 milliseconds)
+#ifndef PARLAY_ELASTIC_STEAL_TIMEOUT
+#define PARLAY_ELASTIC_STEAL_TIMEOUT 10000
+#endif
+
+
+#if PARLAY_ELASTIC_PARALLELISM
+#include "internal/atomic_wait.h"
+#endif
+
+namespace parlay {
+
+template <typename Job>
+struct scheduler;
+
+  // structure that holds a pointer to the scheduler instance and the worker_id within the scheduler
+  template <typename Job>
+  struct workerInfo {
+    int worker_id;
+    scheduler<Job>* my_scheduler;
+    workerInfo() : worker_id(-1), my_scheduler(nullptr) {}
+    workerInfo(int localid, scheduler<Job>* s) :
+      worker_id(localid),
+      my_scheduler(s) {} //std::cout << "worker starting: " << localid << std::endl;}
+
+    workerInfo& operator=(const workerInfo& w) = delete;
+    workerInfo(const workerInfo& w) = delete;
+    workerInfo& operator=(workerInfo&& w) noexcept {
+      if (this != &w) {
+	worker_id = w.worker_id;
+	my_scheduler = w.my_scheduler;
+	w.my_scheduler = nullptr;
+      }
+      return *this;
+    }
+    workerInfo(workerInfo&& w) noexcept {*this = std::move(w);}
+    ~workerInfo() {} // if (my_scheduler) std::cout << "worker ending: " << worker_id << std::endl;}
+  };
+  
+template <typename Job>
+struct scheduler {
+  static_assert(std::is_invocable_r_v<void, Job&>);
+
+  // After YIELD_FACTOR * P unsuccessful steal attempts, a
+  // a worker will sleep briefly for SLEEP_FACTOR * P nanoseconds
+  // to give other threads a chance to work and save some cycles.
+  constexpr static size_t YIELD_FACTOR = 200;
+  constexpr static size_t SLEEP_FACTOR = 200;
+
+  // The length of time that a worker must fail to steal anything
+  // before it goes to sleep to save CPU time.
+  constexpr static std::chrono::microseconds STEAL_TIMEOUT{PARLAY_ELASTIC_STEAL_TIMEOUT};
+
+ public:
+  unsigned int num_threads;
+
+  static thread_local workerInfo<Job> worker_info;
+
+  explicit scheduler(size_t num_workers)
+      : num_threads(num_workers),
+        num_deques(num_threads),
+        num_awake_workers(num_threads),
+	hold_old_worker_info(workerInfo<Job>{0, this}),
+	deques(num_deques),
+        attempts(num_deques),
+        spawned_threads(),
+	shutdown_on_destruct(true),
+        finished_flag(false) {
+
+    // swap in new worker info, and save old
+    std::swap(worker_info, hold_old_worker_info);
+    // Spawn num_threads many threads on startup
+    for (unsigned int i = 1; i < num_threads; i++) {
+      spawned_threads.emplace_back([&, i] {
+         worker(workerInfo<Job>(i, this)); });
+    }
+  }
+
+  template <typename F>
+  explicit scheduler(size_t num_workers, F&& f)
+    : num_threads(num_workers),
+      num_deques(num_threads),
+      num_awake_workers(num_threads),
+      deques(num_deques),
+      attempts(num_deques),
+      spawned_threads(),
+      shutdown_on_destruct(false),
+      finished_flag(false) {
+
+    // create main thread
+    auto main_thread = std::thread([&] { worker_info = workerInfo<Job>(0,this); f(); shutdown();});
+
+    // Create other threads
+    for (unsigned int i = 1; i < num_threads; i++) {
+      spawned_threads.emplace_back([&, i] { worker(workerInfo<Job>(i, this));});}
+
+    main_thread.join();
+  }
+
+  ~scheduler() {
+    if (shutdown_on_destruct) {
+      shutdown();
+      std::swap(worker_info, hold_old_worker_info);
+    }
+  }
+
+  // Push onto local stack.
+  void spawn(Job* job) {
+    int id = worker_id();
+    [[maybe_unused]] bool first = deques[id].push_bottom(job);
+#if PARLAY_ELASTIC_PARALLELISM
+    if (first) wake_up_a_worker();
+#endif
+  }
+
+  // Wait until the given condition is true.
+  //
+  // If conservative, this thread will simply busy wait. Otherwise,
+  // it will look for work to steal and keep itself occupied. This
+  // can deadlock if the stolen work wants a lock held by the code
+  // that is waiting, so avoid that.
+  template <typename F>
+  void wait_until(F&& done, bool conservative = false) {
+    // Conservative avoids deadlock if scheduler is used in conjunction
+    // with user locks enclosing a wait.
+    if (conservative) {
+      while (!done())
+        std::this_thread::yield();
+    }
+    // If not conservative, schedule within the wait.
+    // Can deadlock if a stolen job uses same lock as encloses the wait.
+    else {
+      do_work_until(std::forward<F>(done));
+    }
+  }
+
+  // Pop from local stack.
+  Job* get_own_job() {
+    auto id = worker_id();
+    return deques[id].pop_bottom();
+  }
+
+  unsigned int num_workers() { return num_threads; }
+  unsigned int worker_id() { return worker_info.worker_id; }
+
+  bool finished() const noexcept {
+    return finished_flag.load(std::memory_order_acquire);
+  }
+
+ private:
+  // Align to avoid false sharing.
+  struct alignas(128) attempt {
+    size_t val;
+  };
+
+  int num_deques;
+  std::atomic<size_t> num_awake_workers;
+  workerInfo<Job> hold_old_worker_info;
+  std::vector<internal::Deque<Job>> deques;
+  std::vector<attempt> attempts;
+  std::vector<std::thread> spawned_threads;
+  std::atomic<int> finished_flag;
+
+  std::atomic<size_t> wake_up_counter{0};
+  std::atomic<size_t> num_finished_workers{0};
+  bool shutdown_on_destruct;
+  
+  // Start an individual worker task, stealing work if no local
+  // work is available. May go to sleep if no work is available
+  // for a long time, until woken up again when notified that
+  // new work is available.
+  void worker(workerInfo<Job> w) {
+    worker_info = std::move(w);
+#if PARLAY_ELASTIC_PARALLELISM
+    wait_for_work();
+#endif
+    while (!finished()) {
+      Job* job = get_job([&]() { return finished(); }, PARLAY_ELASTIC_PARALLELISM);
+      if (job)(*job)();
+#if PARLAY_ELASTIC_PARALLELISM
+      else if (!finished()) {
+        // If no job was stolen, the worker should go to
+        // sleep and wait until more work is available
+        wait_for_work();
+      }
+#endif
+    }
+    assert(finished());
+    num_finished_workers.fetch_add(1);
+  }
+
+  // Runs tasks until done(), stealing work if necessary.
+  //
+  // Does not sleep or time out since this can be called
+  // by the main thread and by join points, for which sleeping
+  // would cause deadlock, and timing out could cause a join
+  // point to resume execution before the job it was waiting
+  // on has completed.
+  template <typename F>
+  void do_work_until(F&& done) {
+    while (true) {
+      Job* job = get_job(done, false);  // timeout MUST BE false
+      if (!job) return;
+      (*job)();
+    }
+    assert(done());
+  }
+
+  // Find a job, first trying local stack, then random steals.
+  //
+  // Returns nullptr if break_early() returns true before a job
+  // is found, or, if timeout is true and it takes longer than
+  // STEAL_TIMEOUT to find a job to steal.
+  template <typename F>
+  Job* get_job(F&& break_early, bool timeout) {
+    if (break_early()) return nullptr;
+    Job* job = get_own_job();
+    if (job) return job;
+    else job = steal_job(std::forward<F>(break_early), timeout);
+    return job;
+  }
+  
+  // Find a job with random steals.
+  //
+  // Returns nullptr if break_early() returns true before a job
+  // is found, or, if timeout is true and it takes longer than
+  // STEAL_TIMEOUT to find a job to steal.
+  template<typename F>
+  Job* steal_job(F&& break_early, bool timeout) {
+    size_t id = worker_id();
+    const auto start_time = std::chrono::steady_clock::now();
+    do {
+      // By coupon collector's problem, this should touch all.
+      for (size_t i = 0; i <= YIELD_FACTOR * num_deques; i++) {
+        if (break_early()) return nullptr;
+        Job* job = try_steal(id);
+        if (job) return job;
+      }
+      std::this_thread::sleep_for(std::chrono::nanoseconds(num_deques * 100));
+    } while (!timeout || std::chrono::steady_clock::now() - start_time < STEAL_TIMEOUT);
+    return nullptr;
+  }
+
+  Job* try_steal(size_t id) {
+    // use hashing to get "random" target
+    size_t target = (hash(id) + hash(attempts[id].val)) % num_deques;
+    attempts[id].val++;
+    auto [job, empty] = deques[target].pop_top();
+#if PARLAY_ELASTIC_PARALLELISM
+    if (!empty) wake_up_a_worker();
+#endif
+    return job;
+  }
+
+#if PARLAY_ELASTIC_PARALLELISM
+
+  // Wakes up at least one sleeping worker (more than one
+  // worker may be woken up depending on the implementation).
+  void wake_up_a_worker() {
+    if (num_awake_workers.load(std::memory_order_acquire) < num_threads) {
+      wake_up_counter.fetch_add(1);
+      parlay::atomic_notify_one(&wake_up_counter);
+    }
+  }
+  
+  // Wake up all sleeping workers
+  void wake_up_all_workers() {
+    if (num_awake_workers.load(std::memory_order_acquire) < num_threads) {
+      wake_up_counter.fetch_add(1);
+      parlay::atomic_notify_all(&wake_up_counter);
+    }
+  }
+  
+  // Wait until notified to wake up
+  void wait_for_work() {
+    num_awake_workers.fetch_sub(1);
+    parlay::atomic_wait(&wake_up_counter, wake_up_counter.load());
+    num_awake_workers.fetch_add(1);
+  }
+
+#endif
+
+  size_t hash(uint64_t x) {
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+    x = x ^ (x >> 31);
+    return static_cast<size_t>(x);
+  }
+  
+  void shutdown() {
+    finished_flag.store(true, std::memory_order_release);
+#if PARLAY_ELASTIC_PARALLELISM
+    // We must spam wake all workers until they finish in
+    // case any of them are just about to fall asleep, since
+    // they might therefore miss the flag to finish
+    while (num_finished_workers.load() < num_threads - 1) {
+      wake_up_all_workers();
+      std::this_thread::yield();
+    }
+#endif
+    for (unsigned int i = 1; i < num_threads; i++) {
+      spawned_threads[i - 1].join();
+    }
+  }
+};
+
+template <typename Job>
+thread_local workerInfo<Job> scheduler<Job>::worker_info;
+
+class fork_join_scheduler {
+  using Job = WorkStealingJob;
+  using scheduler_t = scheduler<Job>;
+
+ public:
+
+  // Fork two thunks and wait until they both finish.
+  template <typename L, typename R>
+  static void pardo(scheduler_t* sched, L&& left, R&& right, bool conservative = false) {
+    auto execute_right = [&]() { std::forward<R>(right)(); };
+    auto right_job = make_job(right);
+    
+    sched->spawn(&right_job);
+    std::forward<L>(left)();
+    if (const Job* job = sched->get_own_job(); job != nullptr) {
+      assert(job == &right_job);
+      execute_right();
+    }
+    else {
+      //sched->wait_for(right_job, conservative);
+      auto done = [&]() { return right_job.finished(); };
+      sched->wait_until(done, conservative);
+      assert(right_job.finished());
+    }
+  }
+
+  template <typename F>
+  static void parfor(scheduler_t* sched, size_t start, size_t end, F&& f,
+		     size_t granularity = 0, bool conservative = false) {
+    if (end <= start) return;
+    if (granularity == 0) {
+      size_t done = get_granularity(start, end, f);
+      granularity = std::max(done, (end - start) /
+			     static_cast<size_t>(128 * sched->num_threads));
+      start += done;
+    }
+    parfor_(sched, start, end, f, granularity, conservative);
+  }
+
+ private:
+  template <typename F>
+  static size_t get_granularity(size_t start, size_t end, F&& f) {
+    size_t done = 0;
+    size_t sz = 1;
+    unsigned long long int ticks = 0;
+    do {
+      sz = std::min(sz, end - (start + done));
+      auto tstart = std::chrono::steady_clock::now();
+      for (size_t i = 0; i < sz; i++) f(start + done + i);
+      auto tstop = std::chrono::steady_clock::now();
+      ticks = static_cast<unsigned long long int>(std::chrono::duration_cast<
+                std::chrono::nanoseconds>(tstop - tstart).count());
+      done += sz;
+      sz *= 2;
+    } while (ticks < 1000 && done < (end - start));
+    return done;
+  }
+
+  template <typename F>
+  static void parfor_(scheduler_t* sched, size_t start, size_t end, F&& f,
+	       size_t granularity, bool conservative) {
+    if ((end - start) <= granularity)
+      for (size_t i = start; i < end; i++) f(i);
+    else {
+      size_t n = end - start;
+      // Not in middle to avoid clashes on set-associative caches on powers of 2.
+      size_t mid = (start + (9 * (n + 1)) / 16);
+      pardo(sched,
+	    [&]() { parfor_(sched, start, mid, f, granularity, conservative); },
+	    [&]() { parfor_(sched, mid, end, f, granularity, conservative); },
+	    conservative);
+    }
+  }
+
+};
+
+}  // namespace parlay
+
+#endif  // PARLAY_SCHEDULER_H_

--- a/third_party/parlayhash/include/parlay/parallel.h
+++ b/third_party/parlayhash/include/parlay/parallel.h
@@ -1,0 +1,228 @@
+
+#ifndef PARLAY_PARALLEL_H_
+#define PARLAY_PARALLEL_H_
+
+#include <cassert>
+#include <cstdlib>
+
+#include <algorithm>
+#include <functional>
+#include <string>
+#include <thread>
+#include <type_traits>  // IWYU pragma: keep
+#include <utility>
+
+// ----------------------------------------------------------------------------
+// All scheduler plugins are required to implement the
+// following four functions to integrate with parlay:
+//  - num_workers :   return the max number of workers
+//  - worker_id :     return the id of the current worker
+//  - parallel_for :  execute a given loop body in parallel
+//  - par_do :        execute two given functions in parallel
+// ----------------------------------------------------------------------------
+
+namespace parlay {
+
+// number of threads available from OS
+inline size_t num_workers();
+
+// id of running thread, should be numbered from [0...num-workers)
+inline size_t worker_id();
+
+// parallel loop from start (inclusive) to end (exclusive) running
+// function f.
+//    f should map size_t to void.
+//    granularity is the number of iterations to run sequentially
+//      if 0 (default) then the scheduler will decide
+//    conservative uses a safer scheduler
+template <typename F>
+inline void parallel_for(size_t start, size_t end, F&& f, long granularity = 0,
+                         bool conservative = false);
+
+// runs the thunks left and right in parallel.
+//    both left and write should map void to void
+//    conservative uses a safer scheduler
+template <typename Lf, typename Rf>
+inline void par_do(Lf&& left, Rf&& right, bool conservative = false);
+
+// ----------------------------------------------------------------------------
+//          Extra functions implemented on top of the four basic ones
+//
+//  - parallel_do : alias of par_do
+//  - blocked_for : parallelize a loop over a sequence of blocks
+// ----------------------------------------------------------------------------
+
+// Given two functions left and right, both invocable with no arguments,
+// invokes both of them potentially in parallel.
+template <typename Lf, typename Rf>
+inline void parallel_do(Lf&& left, Rf&& right, bool conservative = false) {
+  static_assert(std::is_invocable_v<Lf&&>);
+  static_assert(std::is_invocable_v<Rf&&>);
+  par_do(std::forward<Lf>(left), std::forward<Rf>(right), conservative);
+}
+
+template<typename F>
+inline void blocked_for(size_t start, size_t end, size_t block_size, F&& f, bool conservative = false) {
+  static_assert(std::is_invocable_v<F&, size_t, size_t, size_t>);
+  assert(block_size > 0);
+  if (start < end) {
+    size_t n_blocks = (end - start + block_size - 1) / block_size;
+    parallel_for(0, n_blocks, [&](size_t i) {
+      size_t s = start + i * block_size;
+      size_t e = (std::min)(s + block_size, end);
+      f(i, s, e);
+    }, 0, conservative);
+  }
+}
+
+// ----------------------------------------------------------------------------
+//                              Some more extras
+//
+//  - par_do_if :   execute in parallel if do_parallel is true, else sequential
+//  - par_do3 :     parallelize three jobs
+//  - par_do3_if :  guess from the two above
+// ----------------------------------------------------------------------------
+
+template <typename Lf, typename Rf>
+static void par_do_if(bool do_parallel, Lf&& left, Rf&& right, bool cons = false) {
+  if (do_parallel)
+    par_do(std::forward<Lf>(left), std::forward<Rf>(right), cons);
+  else {
+    std::forward<Lf>(left)();
+    std::forward<Rf>(right)();
+  }
+}
+
+template <typename Lf, typename Mf, typename Rf>
+inline void par_do3(Lf&& left, Mf&& mid, Rf&& right) {
+  auto left_mid = [&]() { par_do(std::forward<Lf>(left), std::forward<Mf>(mid)); };
+  par_do(left_mid, std::forward<Rf>(right));
+}
+
+template <typename Lf, typename Mf, typename Rf>
+static void par_do3_if(bool do_parallel, Lf&& left, Mf&& mid, Rf&& right) {
+  if (do_parallel)
+    par_do3(std::forward<Lf>(left), std::forward<Mf>(mid), std::forward<Rf>(right));
+  else {
+    std::forward<Lf>(left)();
+    std::forward<Mf>(mid)();
+    std::forward<Rf>(right)();
+  }
+}
+
+}  // namespace parlay
+
+//****************************************************
+//                Scheduler selection
+//****************************************************
+
+// Cilk Scheduler
+#if defined(PARLAY_CILKPLUS)
+#include "internal/scheduler_plugins/cilkplus.h"    // IWYU pragma: keep, export
+
+#elif defined(PARLAY_OPENCILK)
+#include "internal/scheduler_plugins/opencilk.h"    // IWYU pragma: keep, export
+
+// OpenMP Scheduler
+#elif defined(PARLAY_OPENMP)
+#include "internal/scheduler_plugins/omp.h"         // IWYU pragma: keep, export
+
+// Intel's Thread Building Blocks Scheduler
+#elif defined(PARLAY_TBB)
+#include "internal/scheduler_plugins/tbb.h"         // IWYU pragma: keep, export
+
+// No Parallelism
+#elif defined(PARLAY_SEQUENTIAL)
+#include "internal/scheduler_plugins/sequential.h"  // IWYU pragma: keep, export
+
+// Parlay's Homegrown Scheduler
+#else
+
+#define PARLAY_USING_PARLAY_SCHEDULER
+
+#include "scheduler.h"
+
+#include "internal/work_stealing_job.h"
+
+
+namespace parlay {
+  
+namespace internal {
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)  // 'getenv': This function or variable may be unsafe.
+#endif
+
+// Determine the number of workers to spawn
+inline unsigned int init_num_workers() {
+  if (const auto env_p = std::getenv("PARLAY_NUM_THREADS")) {
+    return std::stoi(env_p);
+  } else {
+    return std::thread::hardware_concurrency();
+  }
+}
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+using scheduler_type = scheduler<WorkStealingJob>;
+
+extern inline scheduler_type& get_current_scheduler() {
+  auto current_scheduler = scheduler_type::get_current_scheduler();
+  if (current_scheduler == nullptr) {
+    static thread_local scheduler_type local_scheduler(init_num_workers());
+    return local_scheduler;
+  }
+  return *current_scheduler;
+}
+
+}  // namespace internal
+
+inline size_t num_workers() {
+  return internal::get_current_scheduler().num_workers();
+}
+
+inline size_t worker_id() {
+  return internal::get_current_scheduler().worker_id();
+}
+
+template <typename F>
+inline void parallel_for(size_t start, size_t end, F&& f, long granularity, bool conservative) {
+  static_assert(std::is_invocable_v<F&, size_t>);
+
+  if (start + 1 == end) {
+    f(start);
+  }
+  else if ((end - start) <= static_cast<size_t>(granularity)) {
+    for (size_t i = start; i < end; i++) f(i);
+  }
+  else if (end > start) {
+    fork_join_scheduler::parfor(internal::get_current_scheduler(), start, end,
+      std::forward<F>(f), static_cast<size_t>(granularity), conservative);
+  }
+}
+
+template <typename Lf, typename Rf>
+inline void par_do(Lf&& left, Rf&& right, bool conservative) {
+  static_assert(std::is_invocable_v<Lf&&>);
+  static_assert(std::is_invocable_v<Rf&&>);
+  return fork_join_scheduler::pardo(internal::get_current_scheduler(), std::forward<Lf>(left), std::forward<Rf>(right), conservative);
+}
+
+// Execute the given function f() on p threads inside its own private scheduler instance
+//
+// The scheduler instance is destroyed upon completion and can not be re-used. Creating a
+// scheduler is expensive, so it's not a good idea to use this for very cheap functions f.
+template <typename F>
+void execute_with_scheduler(unsigned int p, F&& f) {
+  internal::scheduler_type scheduler(p);
+  std::invoke(std::forward<F>(f));
+}
+
+}  // namespace parlay
+
+#endif
+
+#endif  // PARLAY_PARALELL_H_

--- a/third_party/parlayhash/include/parlay/portability.h
+++ b/third_party/parlayhash/include/parlay/portability.h
@@ -1,0 +1,112 @@
+
+#ifndef PARLAY_PORTABILITY_H_
+#define PARLAY_PORTABILITY_H_
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define PARLAY_DEFINED_NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#ifdef PARLAY_DEFINED_NOMINMAX
+#undef NOMINMAX
+#endif
+#endif
+
+#include <cstdlib>
+
+#include <iostream>
+
+namespace parlay {
+
+// PARLAY_INLINE: Ask the compiler politely to inline the given function.
+#if defined(__GNUC__)
+#define PARLAY_INLINE inline  __attribute__((__always_inline__))
+#elif defined(_MSC_VER)
+#define PARLAY_INLINE __forceinline
+#else
+#define PARLAY_INLINE inline
+#endif
+
+// PARLAY_NOINLINE: Ask the compiler to *not* inline the given function
+#if defined(__GNUC__)
+#define PARLAY_NOINLINE __attribute__((__noinline__))
+#elif defined(_MSC_VER)
+#define PARLAY_NOINLINE __declspec(noinline)
+#else
+#define PARLAY_NOINLINE
+#endif
+
+// PARLAY_COLD: Ask the compiler to place the given function far away from other code
+#if defined(__GNUC__)
+#define PARLAY_COLD __attribute__((__cold__))
+#elif defined(_MSC_VER)
+#define PARLAY_COLD
+#else
+#define PARLAY_COLD
+#endif
+
+
+// PARLAY_PACKED: Ask the compiler to pack a struct into less memory by not padding
+#if defined(__GNUC__)
+#define PARLAY_PACKED __attribute__((packed))
+#else
+#define PARLAY_PACKED
+#endif
+
+// PARLAY_NO_UNIQUE_ADDR: Allow a member object to occupy no space
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(no_unique_address)
+#define PARLAY_NO_UNIQUE_ADDR [[no_unique_address]]
+#else
+#define PARLAY_NO_UNIQUE_ADDR
+#endif
+#else
+#define PARLAY_NO_UNIQUE_ADDR
+#endif
+
+// PARLAY_PREFETCH: Prefetch data into cache
+#if defined(__GNUC__)
+#define PARLAY_PREFETCH(addr, rw, locality) __builtin_prefetch ((addr), (rw), (locality))
+#elif defined(_MSC_VER)
+#define PARLAY_PREFETCH(addr, rw, locality)                                                 \
+  PreFetchCacheLine(((locality) ? PF_TEMPORAL_LEVEL_1 : PF_NON_TEMPORAL_LEVEL_ALL), (addr))
+#else
+#define PARLAY_PREFETCH(addr, rw, locality)
+#endif
+
+
+#if defined(__cplusplus) && __cplusplus >= 202002L
+#define PARLAY_LIKELY [[likely]]
+#define PARLAY_UNLIKELY [[unlikely]]
+#else
+#define PARLAY_LIKELY
+#define PARLAY_UNLIKELY
+#endif
+
+// Check for exceptions. The standard suggests __cpp_exceptions. Clang/GCC defined __EXCEPTIONS.
+// MSVC disables them with _HAS_EXCEPTIONS=0.  Might not cover obscure compilers/STLs.
+//
+// Exceptions can be explicitly disabled in Parlay with PARLAY_NO_EXCEPTIONS.
+#if !defined(PARLAY_NO_EXCEPTIONS) &&                            \
+    ((defined(__cpp_exceptions) && __cpp_exceptions != 0) ||     \
+     (defined(__EXCEPTIONS)) ||                                  \
+     (defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 1) ||       \
+     (defined(_MSC_VER) && !defined(_HAS_EXCEPTIONS)))
+#define PARLAY_EXCEPTIONS_ENABLED
+#endif
+
+template<typename Exception, typename... Args>
+[[noreturn]] PARLAY_NOINLINE PARLAY_COLD void throw_exception_or_terminate(Args&&... args) {
+#if defined(PARLAY_EXCEPTIONS_ENABLED)
+  throw Exception{std::forward<Args>(args)...};
+#else
+  std::cerr << Exception{std::forward<Args>(args)...}.what() << "\n";
+  std::terminate();
+#endif
+}
+
+
+}  // namespace parlay
+
+#endif  // PARLAY_PORTABILITY_H_

--- a/third_party/parlayhash/include/parlay/primitives.h
+++ b/third_party/parlayhash/include/parlay/primitives.h
@@ -1,0 +1,1299 @@
+
+#ifndef PARLAY_PRIMITIVES_H_
+#define PARLAY_PRIMITIVES_H_
+
+#include <cassert>
+#include <cstddef>
+#include <cctype>
+
+#include <algorithm>
+#include <atomic>
+#include <functional>
+#include <optional>
+#include <random>
+#include <tuple>                          // IWYU pragma: keep
+#include <type_traits>
+#include <utility>
+
+#include "internal/counting_sort.h"
+#include "internal/integer_sort.h"
+#include "internal/group_by.h"            // IWYU pragma: export
+#include "internal/heap_tree.h"           // IWYU pragma: keep
+#include "internal/merge.h"
+#include "internal/merge_sort.h"
+#include "internal/sequence_ops.h"        // IWYU pragma: export
+#include "internal/sample_sort.h"
+
+#include "delayed.h"
+#include "delayed_sequence.h"
+#include "monoid.h"                       // IWYU pragma: export
+#include "parallel.h"
+#include "random.h"
+#include "range.h"
+#include "relocation.h"
+#include "sequence.h"
+#include "slice.h"
+#include "type_traits.h"               // IWYU pragma: keep
+#include "utilities.h"
+
+// IWYU pragma: no_include <sstream>
+// IWYU pragma: no_include <bits/utility.h>
+
+namespace parlay {
+
+/* -------------------- Map and Tabulate -------------------- */
+// Pull all of these from internal/sequence_ops.h
+
+using internal::tabulate;
+
+// Return a sequence consisting of the elements
+//   f(r[0]), f(r[1]), ..., f(r[n-1])
+using internal::map;
+
+// Return a delayed sequence consisting of the elements
+//   f(0), f(1), ... f(n)
+using internal::delayed_tabulate;
+
+// Return a delayed sequence consisting of the elements
+//   f(r[0]), f(r[1]), ..., f(r[n-1])
+//
+// If r is a temporary, the delayed sequence will take
+// ownership of it by moving it. If r is a reference,
+// the delayed sequence will hold a reference to it, so
+// r must remain alive as long as the delayed sequence.
+using internal::delayed_map;
+
+// Renamed to delayed_seq
+using internal::dseq;
+
+// Renamed to delayed_map.
+using internal::dmap;
+
+/* -------------------- Copying -------------------- */
+
+// Copy the elements from the range in into the range out
+// The range out must be at least as large as in.
+template<typename R_in, typename R_out>
+void copy(R_in&& in, R_out&& out) {
+  static_assert(is_random_access_range_v<R_in>);
+  static_assert(is_random_access_range_v<R_out>);
+  static_assert(std::is_assignable_v<range_reference_type_t<R_out>, range_reference_type_t<R_in>>);
+  assert(parlay::size(out) >= parlay::size(in));
+  parallel_for(0, parlay::size(in), [in_it = std::begin(in), out_it = std::begin(out)](size_t i) {
+    out_it[i] = in_it[i];
+  });
+}
+
+/* ---------------------- Reduce ---------------------- */
+
+// Compute the reduction of the elements of r with respect
+// to m. That is, given a sequence r[0], ..., r[n-1], and
+// an associative operation +, compute
+//  r[0] + r[1] + ... + r[n-1]
+template<typename R, typename Monoid,
+         std::enable_if_t<is_monoid_v<Monoid>, int> = 0>
+auto reduce(R&& r, Monoid&& m) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<R>>);
+  return internal::reduce(make_slice(r), std::forward<Monoid>(m));
+}
+
+template<typename R, typename LegacyMonoid,
+    std::enable_if_t<!is_monoid_v<LegacyMonoid> && is_legacy_monoid_v<LegacyMonoid>, int> = 0>
+auto reduce(R&& r, LegacyMonoid m) {
+  static_assert(is_random_access_range_v<R>);
+  return parlay::reduce(std::forward<R>(r), legacy_monoid_adapter(std::move(m)));
+}
+
+// Compute the sum of the elements of r
+template<typename R>
+auto reduce(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  return parlay::reduce(r, parlay::plus<range_value_type_t<R>>());
+}
+
+/* ---------------------- Scans --------------------- */
+
+template<typename R>
+auto scan(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  return internal::scan(make_slice(r), parlay::plus<range_value_type_t<R>>());
+}
+
+template<typename R>
+auto scan_inclusive(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  return internal::scan(make_slice(r), parlay::plus<range_value_type_t<R>>(), internal::fl_scan_inclusive).first;
+}
+
+template<typename R>
+auto scan_inplace(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  return internal::scan_inplace(make_slice(r), parlay::plus<range_value_type_t<R>>());
+}
+
+template<typename R>
+auto scan_inclusive_inplace(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  return internal::scan_inplace(make_slice(r), parlay::plus<range_value_type_t<R>>(), internal::fl_scan_inclusive);
+}
+
+template<typename R, typename Monoid,
+         std::enable_if_t<is_monoid_v<Monoid>, int> = 0>
+auto scan(R&& r, Monoid&& m) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<R>>);
+  return internal::scan(make_slice(r), std::forward<Monoid>(m));
+}
+
+template<typename R, typename LegacyMonoid,
+         std::enable_if_t<!is_monoid_v<LegacyMonoid> && is_legacy_monoid_v<LegacyMonoid>, int> = 0>
+auto scan(R&& r, LegacyMonoid m) {
+  static_assert(is_random_access_range_v<R>);
+  return parlay::scan(make_slice(r), legacy_monoid_adapter(std::move(m)));
+}
+
+template<typename R, typename Monoid,
+         std::enable_if_t<is_monoid_v<Monoid>, int> = 0>
+auto scan_inclusive(R&& r, Monoid&& m) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<R>>);
+  return internal::scan(make_slice(r), std::forward<Monoid>(m), internal::fl_scan_inclusive).first;
+}
+
+template<typename R, typename LegacyMonoid,
+         std::enable_if_t<!is_monoid_v<LegacyMonoid> && is_legacy_monoid_v<LegacyMonoid>, int> = 0>
+auto scan_inclusive(R&& r, LegacyMonoid m) {
+  static_assert(is_random_access_range_v<R>);
+  return parlay::scan_inclusive(std::forward<R>(r), legacy_monoid_adapter(std::move(m)));
+}
+
+template<typename R, typename Monoid,
+         std::enable_if_t<is_monoid_v<Monoid>, int> = 0>
+auto scan_inplace(R&& r, Monoid&& m) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<R>>);
+  return internal::scan_inplace(make_slice(r), std::forward<Monoid>(m));
+}
+
+template<typename R, typename LegacyMonoid,
+         std::enable_if_t<!is_monoid_v<LegacyMonoid> && is_legacy_monoid_v<LegacyMonoid>, int> = 0>
+auto scan_inplace(R&& r, LegacyMonoid m) {
+  static_assert(is_random_access_range_v<R>);
+  return parlay::scan_inplace(std::forward<R>(r), legacy_monoid_adapter(std::move(m)));
+}
+
+template<typename R, typename Monoid,
+         std::enable_if_t<is_monoid_v<Monoid>, int> = 0>
+auto scan_inclusive_inplace(R&& r, Monoid&& m) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_monoid_for_v<Monoid, range_reference_type_t<R>>);
+  return internal::scan_inplace(make_slice(r), std::forward<Monoid>(m), internal::fl_scan_inclusive);
+}
+
+template<typename R, typename LegacyMonoid,
+         std::enable_if_t<!is_monoid_v<LegacyMonoid> && is_legacy_monoid_v<LegacyMonoid>, int> = 0>
+auto scan_inclusive_inplace(R&& r, LegacyMonoid m) {
+  static_assert(is_random_access_range_v<R>);
+  return parlay::scan_inclusive_inplace(std::forward<R>(r), legacy_monoid_adapter(std::move(m)));
+}
+
+/* ----------------------- Pack ----------------------- */
+
+template<typename R, typename BoolSeq>
+auto pack(R&& r, BoolSeq&& b) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_random_access_range_v<BoolSeq>);
+  static_assert(std::is_convertible_v<range_reference_type_t<BoolSeq>, bool>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return internal::pack(make_slice(r), make_slice(b));
+}
+
+template<typename R_in, typename BoolSeq, typename R_out>
+[[deprecated("Use pack_into_uninitialized instead.")]]
+auto pack_into(R_in&& in, BoolSeq&& b, R_out&& out) {
+  static_assert(is_random_access_range_v<R_in>);
+  static_assert(is_random_access_range_v<R_out>);
+  static_assert(is_random_access_range_v<BoolSeq>);
+  static_assert(std::is_convertible_v<range_reference_type_t<BoolSeq>, bool>);
+  static_assert(std::is_constructible_v<std::remove_reference_t<range_reference_type_t<R_out>>,
+                                        range_reference_type_t<R_in>>);
+  return internal::pack_out(make_slice(in), b, make_slice(out));
+}
+
+template<typename R_in, typename BoolSeq, typename R_out>
+auto pack_into_uninitialized(R_in&& in, BoolSeq&& b, R_out&& out) {
+  static_assert(is_random_access_range_v<R_in>);
+  static_assert(is_random_access_range_v<R_out>);
+  static_assert(is_random_access_range_v<BoolSeq>);
+  static_assert(std::is_convertible_v<range_reference_type_t<BoolSeq>, bool>);
+  static_assert(std::is_constructible_v<std::remove_reference_t<range_reference_type_t<R_out>>,
+                                        range_reference_type_t<R_in>>);
+  return internal::pack_out(make_slice(in), b, make_slice(out));
+}
+
+// Return a sequence consisting of the indices such that
+// b[i] is true, or is implicitly convertible to true.
+template<typename BoolSeq>
+auto pack_index(BoolSeq&& b) {
+  static_assert(is_random_access_range_v<BoolSeq>);
+  static_assert(std::is_convertible_v<range_reference_type_t<BoolSeq>, bool>);
+  return internal::pack_index<size_t>(make_slice(b));
+}
+
+// Return a sequence consisting of the indices such that
+// b[i] is true, or is implicitly convertible to true.
+template<typename IndexType, typename BoolSeq>
+auto pack_index(BoolSeq&& b) {
+  static_assert(is_random_access_range_v<BoolSeq>);
+  static_assert(std::is_convertible_v<range_reference_type_t<BoolSeq>, bool>);
+  return internal::pack_index<IndexType>(make_slice(b));
+}
+
+/* ----------------------- Filter --------------------- */
+
+// Return a sequence consisting of the elements x of
+// r such that f(x) == true.
+template<typename R, typename UnaryPred>
+auto filter(R&& r, UnaryPred&& f) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPred, range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return internal::filter(make_slice(r), std::forward<UnaryPred>(f));
+}
+
+template<typename R_in, typename R_out, typename UnaryPred>
+[[deprecated("Use filter_into_uninitialized instead.")]]
+auto filter_into(R_in&& in, R_out&& out, UnaryPred&& f) {
+  static_assert(is_random_access_range_v<R_in>);
+  static_assert(is_random_access_range_v<R_out>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPred, range_reference_type_t<R_in>>);
+  static_assert(std::is_constructible_v<std::remove_reference_t<range_reference_type_t<R_out>>,
+                                        range_reference_type_t<R_in>>);
+  return internal::filter_out(make_slice(in), make_slice(out), std::forward<UnaryPred>(f));
+}
+
+template<typename R_in, typename R_out, typename UnaryPred>
+auto filter_into_uninitialized(R_in&& in, R_out&& out, UnaryPred&& f) {
+  static_assert(is_random_access_range_v<R_in>);
+  static_assert(is_random_access_range_v<R_out>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPred, range_reference_type_t<R_in>>);
+  static_assert(std::is_constructible_v<std::remove_reference_t<range_reference_type_t<R_out>>,
+                                        range_reference_type_t<R_in>>);
+  return internal::filter_out(make_slice(in), make_slice(out), std::forward<UnaryPred>(f));
+}
+
+/* ----------------------- Partition --------------------- */
+
+// TODO: Partition
+
+// TODO: nth element
+
+// TODO: partial sort? maybe
+
+/* ----------------------- Merging --------------------- */
+
+template<typename R1, typename R2, typename BinaryPred>
+auto merge(R1&& r1, R2&& r2, BinaryPred&& pred) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(std::is_same_v<range_value_type_t<R1>, range_value_type_t<R2>>);
+  static_assert(std::is_invocable_r_v<bool, BinaryPred, range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R1>, range_reference_type_t<R1>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R1>, range_reference_type_t<R2>>);
+  return internal::merge(make_slice(r1), make_slice(r2), std::forward<BinaryPred>(pred));
+}
+
+template<typename R1, typename R2>
+auto merge(R1&& r1, R2&& r2) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(is_less_than_comparable_v<range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return parlay::merge(r1, r2, std::less<>());
+}
+
+/* -------------------- General Sorting -------------------- */
+
+// Sort the given sequence and return the sorted sequence
+template<typename R>
+[[nodiscard]] auto sort(R&& in) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_less_than_comparable_v<range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return internal::sample_sort(make_slice(in), std::less<>());
+}
+
+// Sort the given sequence with respect to the given
+// comparison operation. Elements are sorted such that
+// for an element x < y in the sequence, comp(x,y) = true
+template<typename R, typename Compare>
+[[nodiscard]] auto sort(R&& in, Compare&& comp) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<R>, range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return internal::sample_sort(make_slice(in), std::forward<Compare>(comp));
+}
+
+template<typename R>
+[[nodiscard]] auto stable_sort(R&& in) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_less_than_comparable_v<range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return internal::sample_sort(make_slice(in), std::less<>{}, true);
+}
+
+template<typename R, typename Compare>
+[[nodiscard]] auto stable_sort(R&& in, Compare&& comp) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<R>, range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return internal::sample_sort(make_slice(in), std::forward<Compare>(comp), true);
+}
+
+template<typename R, typename Compare>
+void sort_inplace(R&& in, Compare&& comp) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<R>, range_reference_type_t<R>>);
+  static_assert(std::is_swappable_v<range_reference_type_t<R>>);
+  internal::sample_sort_inplace(make_slice(in), std::forward<Compare>(comp));
+}
+
+template<typename R>
+void sort_inplace(R&& in) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_less_than_comparable_v<range_reference_type_t<R>>);
+  static_assert(std::is_swappable_v<range_reference_type_t<R>>);
+  sort_inplace(std::forward<R>(in), std::less<>{});
+}
+
+template<typename R, typename Compare>
+void stable_sort_inplace(R&& in, Compare&& comp) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<R>, range_reference_type_t<R>>);
+  static_assert(std::is_swappable_v<range_reference_type_t<R>>);
+  internal::merge_sort_inplace(make_slice(in), std::forward<Compare>(comp));
+}
+
+template<typename R>
+void stable_sort_inplace(R&& in) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_less_than_comparable_v<range_reference_type_t<R>>);
+  static_assert(std::is_swappable_v<range_reference_type_t<R>>);
+  stable_sort_inplace(std::forward<R>(in), std::less<>{});
+}
+
+/* -------------------- Integer Sorting -------------------- */
+
+template<typename R>
+[[nodiscard]] auto integer_sort(R&& in) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_integral_v<range_value_type_t<R>>);
+  static_assert(std::is_unsigned_v<range_value_type_t<R>>);
+  return internal::integer_sort(make_slice(in), [](auto x) { return x; }); 
+}
+
+template<typename R, typename Key>
+[[nodiscard]] auto integer_sort(R&& in, Key&& key) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<Key, range_reference_type_t<R>>);
+  using key_type = std::invoke_result_t<Key, range_reference_type_t<R>>;
+  static_assert(std::is_integral_v<key_type>);
+  static_assert(std::is_unsigned_v<key_type>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return internal::integer_sort(make_slice(in), std::forward<Key>(key));
+}
+
+template<typename R>
+void integer_sort_inplace(R&& in) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_integral_v<range_value_type_t<R>>);
+  static_assert(std::is_unsigned_v<range_value_type_t<R>>);
+  internal::integer_sort_inplace(make_slice(in), [](auto x) { return x; });
+}
+
+template<typename R, typename Key>
+void integer_sort_inplace(R&& in, Key&& key) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<Key, range_reference_type_t<R>>);
+  using key_type = std::invoke_result_t<Key, range_reference_type_t<R>>;
+  static_assert(std::is_integral_v<key_type>);
+  static_assert(std::is_unsigned_v<key_type>);
+  static_assert(std::is_swappable_v<range_reference_type_t<R>>);
+  internal::integer_sort_inplace(make_slice(in), std::forward<Key>(key));
+}
+
+template<typename R, typename Key>
+[[nodiscard]] auto stable_integer_sort(R&& in, Key&& key) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<Key, range_reference_type_t<R>>);
+  using key_type = std::invoke_result_t<Key, range_reference_type_t<R>>;
+  static_assert(std::is_integral_v<key_type>);
+  static_assert(std::is_unsigned_v<key_type>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return internal::integer_sort(make_slice(in), std::forward<Key>(key));
+}
+
+template<typename R, typename Key>
+void stable_integer_sort_inplace(R&& in, Key&& key) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<Key, range_reference_type_t<R>>);
+  using key_type = std::invoke_result_t<Key, range_reference_type_t<R>>;
+  static_assert(std::is_integral_v<key_type>);
+  static_assert(std::is_unsigned_v<key_type>);
+  static_assert(std::is_swappable_v<range_reference_type_t<R>>);
+  internal::integer_sort_inplace(make_slice(in), std::forward<Key>(key));
+}
+
+/* -------------------- Counting Sort -------------------- */
+
+template<typename Range>
+[[nodiscard]] auto counting_sort(Range&& in, size_t num_buckets) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(std::is_integral_v<range_value_type_t<Range>>);
+  static_assert(std::is_unsigned_v<range_value_type_t<Range>>);
+  return internal::count_sort(make_slice(in), make_slice(in), num_buckets);
+}
+
+template<typename Range, typename Key>
+[[nodiscard]] auto counting_sort(Range&& in, size_t num_buckets, Key&& key) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(std::is_invocable_v<Key, range_reference_type_t<Range>>);
+  using key_type = std::invoke_result_t<Key, range_reference_type_t<Range>>;
+  static_assert(std::is_integral_v<key_type>);
+  static_assert(std::is_unsigned_v<key_type>);
+  auto keys = internal::delayed_map(in, std::forward<Key>(key));
+  return internal::count_sort(make_slice(in), keys, num_buckets);
+}
+
+template<typename Range>
+auto counting_sort_inplace(Range&& in, size_t num_buckets) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(std::is_integral_v<range_value_type_t<Range>>);
+  static_assert(std::is_unsigned_v<range_value_type_t<Range>>);
+  return internal::count_sort_inplace(make_slice(in), make_slice(in), num_buckets);
+}
+
+template<typename Range, typename Key>
+auto counting_sort_inplace(Range&& in, size_t num_buckets, Key&& key) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(std::is_invocable_v<Key, range_reference_type_t<Range>>);
+  using key_type = std::invoke_result_t<Key, range_reference_type_t<Range>>;
+  static_assert(std::is_integral_v<key_type>);
+  static_assert(std::is_unsigned_v<key_type>);
+  auto keys = internal::delayed_map(in, std::forward<Key>(key));
+  return internal::count_sort_inplace(make_slice(in), keys, num_buckets);
+}
+
+template<typename Range>
+[[nodiscard]] auto counting_sort_by_keys(Range&& in, size_t num_buckets) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(is_pair_v<range_reference_type_t<Range>>);
+  static_assert(std::is_integral_v<std::tuple_element_t<0, range_reference_type_t<Range>>>);
+  static_assert(std::is_unsigned_v<std::tuple_element_t<0, range_reference_type_t<Range>>>);
+  auto values = delayed::values_view(in);
+  return internal::count_sort(make_slice(values), delayed::keys_view(in), num_buckets);
+}
+
+/* -------------------- Internal count and find -------------------- */
+
+namespace internal {
+
+template <typename IntegerPred>
+size_t count_if_index(size_t n, IntegerPred&& p) {
+  static_assert(std::is_invocable_r_v<bool, IntegerPred, size_t>);
+  auto BS = delayed_tabulate(n, [&](size_t i) -> size_t {
+      return static_cast<bool>(p(i)); });
+  return parlay::reduce(make_slice(BS));
+}
+
+template <typename IntegerPred>
+size_t find_if_index(size_t n, IntegerPred&& p, size_t granularity = 1000) {
+  static_assert(std::is_invocable_r_v<bool, IntegerPred, size_t>);
+  size_t i;
+  for (i = 0; i < (std::min)(granularity, n); i++)
+    if (p(i)) return i;
+  if (i == n) return n;
+  size_t start = granularity;
+  size_t block_size = 2 * granularity;
+  std::atomic<size_t> result(n);
+  while (start < n) {
+    size_t end = (std::min)(n, start + block_size);
+    parallel_for(start, end, [&](size_t j) {
+      if (p(j)) write_min(&result, j, std::less<>());
+    }, granularity);
+    if (auto res = result.load(); res < n) return res;
+    start += block_size;
+    block_size *= 2;
+  }
+  return n;
+}
+
+}  // namespace internal
+
+/* -------------------- For each -------------------- */
+
+template <typename R, typename UnaryFunction>
+void for_each(R&& r , UnaryFunction&& f) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<UnaryFunction, range_reference_type_t<R>>);
+  // TODO: For many iterator types, calling operator[] is slower than ++.
+  // Would be nice if this could instead use ++ at the leaves
+  parallel_for(0, parlay::size(r),
+    [&f, it = std::begin(r)](size_t i) { f(it[i]); });
+}
+
+/* -------------------- Counting -------------------- */
+
+template <typename R, typename UnaryPredicate>
+size_t count_if(R&& r, UnaryPredicate&& p) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPredicate, range_reference_type_t<R>>);
+  return internal::count_if_index(parlay::size(r),
+    [&p, it = std::begin(r)](size_t i) { return p(it[i]); });
+}
+
+template <typename R, class T>
+size_t count(R&& r, const T& value) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R>, const T&>);
+  return internal::count_if_index(parlay::size(r),
+     [&] (size_t i) { return r[i] == value; });
+}
+
+/* -------------------- Boolean searching -------------------- */
+
+template <typename R, typename UnaryPredicate>
+bool all_of(R&& r, UnaryPredicate&& p) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPredicate, range_reference_type_t<R>>);
+  return parlay::count_if(r, std::forward<UnaryPredicate>(p)) == parlay::size(r);
+}
+
+template <typename R, typename UnaryPredicate>
+bool any_of(R&& r, UnaryPredicate&& p) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPredicate, range_reference_type_t<R>>);
+  return parlay::count_if(r, std::forward<UnaryPredicate>(p)) > 1;
+}
+
+template <typename R, typename UnaryPredicate>
+bool none_of(R&& r, UnaryPredicate&& p) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPredicate, range_reference_type_t<R>>);
+  return parlay::count_if(r, std::forward<UnaryPredicate>(p)) == 0;
+}
+
+/* -------------------- Finding -------------------- */
+
+template <typename R, typename UnaryPredicate>
+auto find_if(R&& r, UnaryPredicate&& p) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPredicate, range_reference_type_t<R>>);
+  return std::begin(r) + internal::find_if_index(parlay::size(r),
+    [&p, it = std::begin(r)](size_t i) { return p(it[i]); });
+}
+
+template <typename R, typename T>
+auto find(R&& r, const T& value) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R>, const T&>);
+  return parlay::find_if(r, [&](auto&& x) { return std::forward<decltype(x)>(x) == value; });
+}
+
+template <typename R, typename UnaryPredicate>
+auto find_if_not(R&& r, UnaryPredicate&& p) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPredicate, range_reference_type_t<R>>);
+  return std::begin(r) + internal::find_if_index(parlay::size(r),
+    [&p, it = std::begin(r)](size_t i) { return !p(it[i]); });
+}
+
+template <typename R1, typename R2, typename BinaryPredicate>
+auto find_first_of(R1&& r1, R2&& r2, BinaryPredicate&& p) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(std::is_invocable_r_v<bool, BinaryPredicate, range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return std::begin(r1) + internal::find_if_index(parlay::size(r1), [&, it = std::begin(r1)] (size_t i) {
+    return find_if(r2, [&, it](auto&& x) { return p(std::forward<decltype(x)>(x), it[i]); }) != std::end(r2);
+  });
+}
+
+template <typename R1, typename R2>
+auto find_first_of(R1&& r1, R2&& r2) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return parlay::find_first_of(std::forward<R1>(r1), std::forward<R2>(r2), std::equal_to<>());
+}
+
+/* -------------------- Adjacent Finding -------------------- */
+
+template <typename R, typename BinaryPred>
+auto adjacent_find(R&& r, BinaryPred&& p) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, BinaryPred, range_reference_type_t<R>, range_reference_type_t<R>>);
+  auto idx = internal::find_if_index(parlay::size(r) - 1,
+                 [&p, it = std::begin(r)](size_t i) {
+                   return p(it[i], it[i + 1]); });
+  if (idx == parlay::size(r) - 1) return std::end(r);
+  else return std::begin(r) + idx;
+}
+
+template <typename R>
+auto adjacent_find(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R>>);
+  return parlay::adjacent_find(std::forward<R>(r), std::equal_to<>());
+}
+
+/* ----------------------- Mismatch ----------------------- */
+
+template <typename R1, typename R2, typename BinaryPred>
+auto mismatch(R1&& r1, R2&& r2, BinaryPred p) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(std::is_invocable_r_v<bool, BinaryPred, range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  auto d = internal::find_if_index(std::min(parlay::size(r1), parlay::size(r2)),
+    [&p, it1 = std::begin(r1), it2 = std::begin(r2)](size_t i) {
+      return !p(it1[i], it2[i]); });
+  return std::make_pair(std::begin(r1) + d, std::begin(r2) + d);
+}
+
+template <typename R1, typename R2>
+auto mismatch(R1&& r1, R2&& r2) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return parlay::mismatch(std::forward<R1>(r1), std::forward<R2>(r2), std::equal_to<>());
+}
+
+/* ----------------------- Pattern search ----------------------- */
+
+template <typename R1, typename R2, typename BinaryPred>
+auto search(R1&& r1, R2&& r2, BinaryPred pred) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(std::is_invocable_r_v<bool, BinaryPred, range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return std::begin(r1) + internal::find_if_index(parlay::size(r1), [&](size_t i) {
+    if (i + parlay::size(r2) > parlay::size(r1)) return false;
+    size_t j;
+    for (j = 0; j < parlay::size(r2); j++)
+      if (!pred(r1[i + j], r2[j])) break;
+    return (j == parlay::size(r2));
+  });
+}
+
+template <typename R1, typename R2>
+auto search(R1&& r1, R2&& r2) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return parlay::search(r1, r2, std::equal_to<>());
+}
+
+template <typename R1, typename R2, typename BinaryPred>
+auto find_end(R1&& r1, R2&& r2, BinaryPred&& p) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(std::is_invocable_r_v<bool, BinaryPred, range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  size_t n1 = parlay::size(r1);
+  size_t n2 = parlay::size(r2);
+
+  // According to the C++ standard, std::find_end should return the end iterator if the pattern is empty
+  if (n2 == 0) return std::end(r1);
+
+  size_t idx = internal::find_if_index(n1 - n2 + 1, [&](size_t i) {
+    size_t j;
+    for (j = 0; j < n2; j++)
+      if (!p(r1[(n1 - i - n2) + j], r2[j])) break;
+    return (j == parlay::size(r2));
+  });
+
+  if (idx == n1 - n2 + 1) return std::end(r1);
+  else return std::begin(r1) + n1 - idx - n2;
+}
+
+template <typename R1, typename R2>
+auto find_end(R1&& r1, R2&& r2) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return parlay::find_end(std::forward<R1>(r1), std::forward<R2>(r2), std::equal_to<>());
+}
+
+/* ------------------------- Equal ------------------------- */
+
+template <typename R1, typename R2, class BinaryPred>
+bool equal(R1&& r1, R2&& r2, BinaryPred&& p) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(std::is_invocable_r_v<bool, BinaryPred, range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return parlay::size(r1) == parlay::size(r2) &&
+    internal::find_if_index(parlay::size(r1),
+      [&p, it1 = std::begin(r1), it2 = std::begin(r2)](size_t i)
+        { return !p(it1[i], it2[i]); }) == parlay::size(r1);
+}
+
+template <typename R1, typename R2>
+bool equal(R1&& r1, R2&& r2) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return parlay::equal(r1, r2, std::equal_to<>());
+}
+
+/* ---------------------- Lex compare ---------------------- */
+
+template <typename R1, typename R2, class Compare>
+bool lexicographical_compare(R1&& r1, R2&& r2, Compare&& less) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  size_t m = (std::min)(parlay::size(r1), parlay::size(r2));
+  size_t i = internal::find_if_index(m, [&less, it1 = std::begin(r1), it2 = std::begin(r2)](size_t i)
+      { return less(it1[i], it2[i]) || less(it2[i], it1[i]); });
+  return (i < m) ? (less(std::begin(r1)[i], std::begin(r2)[i]))
+    : (parlay::size(r1) < parlay::size(r2));
+}
+
+template <typename R1, typename R2>
+inline bool lexicographical_compare(R1&& r1, R2&& r2) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  static_assert(is_less_than_comparable_v<range_reference_type_t<R1>, range_reference_type_t<R2>>);
+  return parlay::lexicographical_compare(std::forward<R1>(r1), std::forward<R2>(r2), std::less<>{});}
+
+template <typename T, typename Alloc, bool EnableSSO>
+inline bool operator<(const sequence<T,Alloc,EnableSSO> &a, const sequence<T,Alloc,EnableSSO> &b) {
+  if (a.size() > 1000) 
+    return lexicographical_compare(a, b);
+  auto sa = a.begin();
+  auto sb = b.begin();
+  auto ea = sa + (std::min)(a.size(),b.size());
+  while (sa < ea && *sa == *sb) {sa++; sb++;}
+  return sa == ea ? (a.size() < b.size()) : *sa < *sb;
+};
+
+
+/* -------------------- Remove duplicates -------------------- */
+
+template <typename R, typename BinaryPredicate>
+auto unique(R&& r, BinaryPredicate&& eq) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, BinaryPredicate, range_reference_type_t<R>, range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  auto b = internal::delayed_tabulate(parlay::size(r), [&eq, it = std::begin(r)](size_t i)
+      { return (i == 0) || !eq(it[i], it[i - 1]); });
+  return parlay::pack(r, b);
+}
+
+template<typename R>
+auto unique(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return parlay::unique(r, std::equal_to<>());
+}
+
+
+/* -------------------- Min and max -------------------- */
+
+// needs to return location, and take comparison
+template <typename R, typename Compare>
+auto min_element(R&& r, Compare&& comp) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<R>, range_reference_type_t<R>>);
+  size_t n = parlay::size(r);
+  if (n == 0) return std::begin(r);
+  auto SS = delayed_seq<size_t>(n, [&](size_t i) { return i; });
+  auto f = [&comp, it = std::begin(r)](size_t l, size_t r)
+    { return (!comp(it[r], it[l]) ? l : r); };
+  return std::begin(r) + internal::reduce(make_slice(SS), make_monoid(f, (size_t)parlay::size(r)));
+}
+
+template <typename R>
+auto min_element(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_less_than_comparable_v<range_reference_type_t<R>>);
+  return parlay::min_element(std::forward<R>(r), std::less<>());
+}
+
+template <typename R, typename Compare>
+auto max_element(R&& r, Compare&& comp) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<R>, range_reference_type_t<R>>);
+  return parlay::min_element(std::forward<R>(r), [&](auto&& a, auto&& b) {
+    return comp(std::forward<decltype(b)>(b), std::forward<decltype(a)>(a)); });
+}
+
+template <typename R>
+auto max_element(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_less_than_comparable_v<range_reference_type_t<R>>);
+  return parlay::max_element(std::forward<R>(r), std::less<>());
+}
+
+template <typename R, typename Compare>
+auto minmax_element(R&& r, Compare&& comp) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<R>, range_reference_type_t<R>>);
+  size_t n = parlay::size(r);
+  if (n == 0) return std::make_pair(std::begin(r), std::begin(r));
+  auto SS = delayed_seq<std::pair<size_t, size_t>>(parlay::size(r),
+    [&](size_t i) { return std::make_pair(i, i); });
+  auto f = [&comp, it = std::begin(r)](const auto& l, const auto& r) {
+    return (std::make_pair(!comp(it[r.first], it[l.first]) ? l.first : r.first,
+              !comp(it[l.second], it[r.second]) ? l.second : r.second));
+  };
+  auto ds = internal::reduce(make_slice(SS), make_monoid(f, std::make_pair(n, n)));
+  return std::make_pair(std::begin(r) + ds.first, std::begin(r) + ds.second);
+}
+
+template <typename R>
+auto minmax_element(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_less_than_comparable_v<range_reference_type_t<R>>);
+  return parlay::minmax_element(std::forward<R>(r), std::less<>());
+}
+
+/* -------------------- Permutations -------------------- */
+
+template <typename R>
+auto reverse(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  auto n = parlay::size(r);
+  return internal::tabulate<range_value_type_t<R>>(n, [n, it = std::begin(r)](size_t i) {
+    return it[n - i - 1];
+  });
+}
+
+template <typename R>
+auto reverse_inplace(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_swappable_v<range_reference_type_t<R>>);
+  auto n = parlay::size(r);
+  parallel_for(0, n/2, [n, it = std::begin(r)] (size_t i) {
+    using std::swap;
+    swap(it[i], it[n - i - 1]);
+  });
+}
+
+template <typename R>
+auto rotate(const R& r, size_t t) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  size_t n = parlay::size(r);
+  return internal::tabulate<range_value_type_t<R>>(parlay::size(r),
+    [n, t, it = std::begin(r)](size_t i) {
+      size_t j = (i + t < n) ? (i + t) : i + t - n;
+      return it[j];
+    });
+}
+
+/* -------------------- Is sorted? -------------------- */
+
+template <typename R, typename Compare>
+bool is_sorted(R&& r, Compare&& comp) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare,range_reference_type_t<R>, range_reference_type_t<R>>);
+  if (parlay::size(r) == 0) return true;
+  auto B = delayed_seq<bool>(parlay::size(r) - 1, [&comp, it = std::begin(r)](size_t i)
+      { return comp(it[i + 1], it[i]); });
+  return (internal::reduce(make_slice(B), parlay::make_monoid(std::logical_or<>(), false)) == 0);
+}
+
+template <typename R>
+bool is_sorted(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_less_than_comparable_v<R>);
+  return parlay::is_sorted(std::forward<R>(r), std::less<>());
+}
+
+template <typename R, typename Compare>
+auto is_sorted_until(R&& r, Compare&& comp) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare,range_reference_type_t<R>, range_reference_type_t<R>>);
+  if (parlay::size(r) == 0) return std::begin(r);
+  return std::begin(r) + internal::find_if_index(parlay::size(r) - 1,
+    [&comp, it = std::begin(r)](size_t i) { return comp(it[i + 1], it[i]); }) + 1;
+}
+
+template <typename R>
+auto is_sorted_until(R& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_less_than_comparable_v<R>);
+  return parlay::is_sorted_until(std::forward<R>(r), std::less<>());
+}
+
+/* -------------------- Is partitioned? -------------------- */
+
+template <typename R, typename UnaryPred>
+bool is_partitioned(R&& r, UnaryPred&& f) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPred, range_reference_type_t<R>>);
+  auto n = parlay::size(r);
+  auto d = internal::find_if_index(n, [&f, it = std::begin(r)](size_t i) {
+    return !f(it[i]);
+  });
+  if (d == n) return true;
+  auto d2 = internal::find_if_index(n - d - 1, [&f, it = std::begin(r) + d + 1](size_t i) {
+    return f(it[i]);
+  });
+  return (d2 == n - d - 1);
+}
+
+/* -------------------- Remove -------------------- */
+
+template <typename R, typename UnaryPred>
+auto remove_if(R&& r, UnaryPred&& pred) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPred, range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  auto flags = delayed_seq<bool>(parlay::size(r),
+    [&pred, it = std::begin(r)](size_t i) { return !pred(it[i]); });
+  return internal::pack(r, flags);
+}
+
+template<typename R, typename T>
+auto remove(R&& r, const T& v) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_equality_comparable_v<range_reference_type_t<R>, const T&>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return remove_if(r, [&](auto&& x) { return std::forward<decltype(x)>(x) == v; });
+}
+
+/* -------------------- Iota -------------------- */
+
+template <typename Index>
+auto iota(Index n) {
+  static_assert(std::is_integral_v<Index>);
+  return delayed_tabulate<Index, Index>(n, [](size_t i) -> Index { return i; });
+}
+
+/* -------------------- Flatten -------------------- */
+
+template <typename R>
+auto flatten(R&& r) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(is_random_access_range_v<range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<range_reference_type_t<R>>,
+                                        range_reference_type_t<range_reference_type_t<R>>>);
+
+  // For prvalue ranges, we materialize the range to avoid generating its elements multiple
+  // times, or worse, generating them then taking references to them that dangle!
+  if constexpr (!std::is_reference_v<range_reference_type_t<R>>) {
+    return flatten(to_sequence(std::forward<R>(r)));
+  }
+
+  using T = range_value_type_t<range_reference_type_t<R>>;
+  auto offsets = tabulate(parlay::size(r), [it = std::begin(r)](size_t i)
+                          { return parlay::size(it[i]); });
+  size_t len = internal::scan_inplace(make_slice(offsets), plus<size_t>());
+  auto res = sequence<T>::uninitialized(len);
+  parallel_for(0, parlay::size(r), [&, it = std::begin(r)](size_t i) {
+    auto dit = std::begin(res)+offsets[i];
+    auto&& inner = it[i];
+    auto sit = std::begin(inner);
+    parallel_for(0, parlay::size(inner), [=] (size_t j) {
+      assign_uninitialized(*(dit+j), *(sit+j));
+    }, 1000);
+  });
+  return res;
+}
+
+
+template <typename T>
+auto flatten(sequence<sequence<T>>&& r) {
+  static_assert(std::is_move_constructible_v<T>);
+  auto offsets = tabulate(parlay::size(r),
+    [it = std::begin(r)](size_t i) { return parlay::size(it[i]); });
+  size_t len = internal::scan_inplace(make_slice(offsets), plus<size_t>());
+  auto res = sequence<T>::uninitialized(len);
+  parallel_for(0, parlay::size(r), [&, it = std::begin(r)](size_t i) {
+    uninitialized_relocate_n(std::begin(res)+offsets[i], std::begin(it[i]), it[i].size());
+    clear_relocated(it[i]);
+  });
+  r.clear();
+  return res;
+}
+
+/* -------------------- Tokens and split -------------------- */
+
+// Return true if the given character is considered whitespace.
+// Whitespace characters are ' ', '\f', '\n', '\r'. '\t'. '\v'.
+bool inline is_whitespace(unsigned char c) {
+  return std::isspace(c);
+}
+
+namespace internal {
+template<typename R, typename UnaryOp, typename UnaryPred = decltype(is_whitespace)>
+auto map_tokens_small(R&& r, UnaryOp&& f, UnaryPred&& is_space = is_whitespace) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<UnaryOp, decltype(make_slice(r))>);
+
+  using f_return_type = std::invoke_result_t<UnaryOp, decltype(make_slice(r))>;
+
+  auto S = make_slice(r);
+  size_t n = S.size();
+
+  if (n == 0) {
+    if constexpr (std::is_void_v<f_return_type>) return;
+    else return sequence<f_return_type>();
+  }
+
+  // sequence<long> Locations = pack_index<long>(Flags);
+  sequence<size_t> Locations = internal::delayed::to_sequence(
+                               internal::delayed::filter_op(
+                                 parlay::iota<size_t>(n + 1),
+                                 [&](size_t i) -> std::optional<size_t> {
+    if ((i == 0) ? !is_space(S[0]) : (i == n) ? !is_space(S[n - 1]) : is_space(S[i - 1]) != is_space(S[i]))
+      return std::make_optional(i);
+    else
+      return std::nullopt;
+  }));
+
+  // If f does not return anything, just apply f
+  // to each token and don't return anything
+  if constexpr (std::is_void_v<f_return_type>) {
+    parallel_for(0, Locations.size() / 2, [&](size_t i) {
+      f(S.cut(Locations[2 * i], Locations[2 * i + 1]));
+    });
+  }
+  // If f does return something, apply f to each token
+  // and return a sequence of the resulting values
+  else {
+    return tabulate(Locations.size() / 2, [&](size_t i) {
+      return f(S.cut(Locations[2 * i], Locations[2 * i + 1]));
+    });
+  }
+}
+}
+
+// Apply the given function f to each token of the given range.
+//
+// The tokens are the longest contiguous subsequences of non space characters.
+// where spaces are define by the unary predicate is_space. By default, is_space
+// correponds to std::isspace, which is true for ' ', '\f', '\n', '\r'. '\t'. '\v'
+//
+// If f has no return value (i.e. void), this function returns nothing. Otherwise,
+// this function returns a sequence consisting of the returned values of f for
+// each token.
+template<typename R, typename UnaryOp, typename UnaryPred = decltype(is_whitespace)>
+auto map_tokens(R&& r, UnaryOp&& f, UnaryPred&& is_space = is_whitespace) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_v<UnaryOp, decltype(make_slice(r))>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPred, range_reference_type_t<R>>);
+
+  using f_return_type = decltype(f(make_slice(r)));
+  auto A = make_slice(r);
+  using ipair = std::pair<long, long>;
+  size_t n = A.size();
+
+  if (n == 0) {
+    if constexpr (std::is_void_v<f_return_type>) return;
+    else return sequence<f_return_type>();
+  }
+
+  auto is_start = [&](size_t i) { return ((i == 0) || is_space(A[i - 1])) && (i != n) && !(is_space(A[i])); };
+  auto is_end = [&](size_t i) { return ((i == n) || (is_space(A[i]))) && (i != 0) && !is_space(A[i - 1]); };
+
+  // associative combining function
+  // first = # of starts, second = index of last start
+  auto g = [](ipair a, ipair b) { return (b.first == 0) ? a : ipair(a.first + b.first, b.second); };
+
+  auto in = internal::delayed_tabulate(n + 1, [&](size_t i) -> ipair {
+    return is_start(i) ? ipair(1, i) : ipair(0, 0); });
+  auto [offsets, sum] = internal::delayed::scan(in, g, ipair(0, 0));
+
+  auto z = internal::delayed::zip(offsets, parlay::iota(n + 1));
+
+  auto start = std::begin(r);
+
+  if constexpr (std::is_same_v<f_return_type, void>)
+    internal::delayed::apply(z, [&](auto&& x) {
+      if (is_end(std::get<1>(x))) f(make_slice(std::get<0>(x).second + start, std::get<1>(x) + start));
+    });
+  else {
+    auto result = sequence<f_return_type>::uninitialized(sum.first);
+    internal::delayed::apply(z, [&](auto&& x) {
+      if (is_end(std::get<1>(x)))
+        assign_uninitialized(result[std::get<0>(x).first - 1],
+                             f(make_slice(start + std::get<0>(x).second, start + std::get<1>(x))));
+    });
+    return result;
+  }
+}
+
+// Returns a sequence of tokens, each represented as a sequence of chars.
+// The tokens are the longest contiguous subsequences of non space characters.
+// where spaces are define by the unary predicate is_space. By default, is_space
+// correponds to std::isspace, which is true for ' ', '\f', '\n', '\r'. '\t'. '\v'
+template <typename Range, typename UnaryPred = decltype(is_whitespace)>
+sequence<parlay::chars> tokens(Range&& R, UnaryPred&& is_space = is_whitespace) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(std::is_convertible_v<range_reference_type_t<Range>, char>);
+  static_assert(std::is_invocable_r_v<bool, UnaryPred, range_reference_type_t<Range>>);
+  auto to_token = [](auto&& x) { return to_short_sequence(std::forward<decltype(x)>(x)); };
+  if (parlay::size(R) < 2000) return internal::map_tokens_small(R, to_token, is_space);
+  else return map_tokens(R, to_token, is_space);
+}
+
+// Like split_at, but applies the given function f to each of the
+// contiguous subsequences of R delimited by positions i such that
+// flags[i] is (or converts to) true.
+template <typename Range, typename BoolRange, typename UnaryOp>
+auto map_split_at(Range&& R, BoolRange&& flags, UnaryOp&& f) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(is_random_access_range_v<BoolRange>);
+  static_assert(std::is_convertible_v<range_reference_type_t<BoolRange>, bool>);
+  static_assert(std::is_invocable_v<UnaryOp, decltype(make_slice(R))>);
+
+  auto S = make_slice(R);
+  auto Flags = make_slice(flags);
+  size_t n = S.size();
+  assert(Flags.size() == n);
+
+  sequence<size_t> Locations = pack_index<size_t>(Flags);
+  size_t m = Locations.size();
+
+  return tabulate(m + 1, [&] (size_t i) {
+    size_t start = (i==0) ? 0 : Locations[i-1] + 1;
+    size_t end = (i==m) ? n : Locations[i] + 1;
+    return f(S.cut(start, end)); });
+}
+
+// Partitions R into contiguous subsequences, by marking the last
+// element of each subsequence with a true in flags.  There is an
+// implied flag at the end.  Returns a nested sequence whose sum of
+// lengths is equal to the original length.  If the last position is
+// marked as true, then there will be an empty subsequence at the end.
+// The length of the result is therefore always one more than the
+// number of true flags.
+template <typename Range, typename BoolRange>
+auto split_at(Range&& R, BoolRange&& flags) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(is_random_access_range_v<BoolRange>);
+  static_assert(std::is_convertible_v<range_value_type_t<BoolRange>, bool>);
+  static_assert(std::is_constructible_v<range_value_type_t<Range>, range_reference_type_t<Range>>);
+  if constexpr (std::is_same<range_value_type_t<Range>, char>::value)
+    return parlay::map_split_at(R, flags, [](auto&& x) { return to_short_sequence(std::forward<decltype(x)>(x)); });
+  else
+    return parlay::map_split_at(R, flags, [](auto&& x) { return to_sequence(std::forward<decltype(x)>(x)); });
+}
+
+
+/* -------------------- Other Utilities -------------------- */
+
+template <typename R, typename Compare = std::less<>>
+auto remove_duplicates_ordered(R&& s, Compare&& less = {}) {
+  static_assert(is_random_access_range_v<R>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<R>, range_reference_type_t<R>>);
+  static_assert(std::is_constructible_v<range_value_type_t<R>, range_reference_type_t<R>>);
+  return unique(stable_sort(s, less), [&] (auto&& a, auto&& b) {
+      return !less(a,b) && !less(b,a);});
+}
+
+// returns sequence with element of same type as the first argument
+template <typename R1, typename R2>
+auto append(R1&& s1, R2&& s2) {
+  static_assert(is_random_access_range_v<R1>);
+  static_assert(is_random_access_range_v<R2>);
+  using T = range_value_type_t<R1>;
+  static_assert(std::is_constructible_v<T, range_reference_type_t<R1>>);
+  static_assert(std::is_constructible_v<T, range_reference_type_t<R2>>);
+  size_t n1 = s1.size();
+  return tabulate(n1 + s2.size(), [&] (size_t i) -> T {
+      return (i < n1) ? s1[i] : s2[i-n1];});
+}
+
+template<typename Range, typename UnaryOperator>
+auto map_maybe(Range&& v, UnaryOperator&& p) {
+  return internal::delayed::to_sequence(
+    internal::delayed::filter_op(std::forward<Range>(v), std::forward<UnaryOperator>(p)));
+}
+
+template<typename... Ranges>
+auto zip(Ranges&&... rs) {
+  return internal::delayed::to_sequence(internal::delayed::zip(std::forward<Ranges>(rs)...));
+}
+
+// Returns a sequence consisting of the rank of each element in the input range. The rank
+// of an element is the number of elements in the range that compare less than it, according
+// to the binary operator compare, which defaults to less-than comparison.
+template<typename size_type, typename Range, typename BinaryOperator = std::less<>>
+auto rank(Range&& r, BinaryOperator&& compare = {}) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(std::is_invocable_r_v<bool, BinaryOperator, range_reference_type_t<Range>, range_reference_type_t<Range>>);
+  parlay::sequence<size_type> position = parlay::to_sequence(parlay::iota<size_type>(size(r)));
+  parlay::stable_sort_inplace(position, [it = std::begin(r), compare = std::forward<BinaryOperator>(compare)]
+                                (auto i, auto j) { return compare(it[i], it[j]); });
+  auto rank = parlay::sequence<size_type>::uninitialized(position.size());
+  parallel_for(0, position.size(), [&](size_t i) {
+    rank[position[i]] = i;
+  });
+  return rank;
+}
+
+template<typename Range, typename BinaryOperator = std::less<>>
+auto rank(Range&& r, BinaryOperator&& compare = {}) {
+  return parlay::rank<std::make_unsigned_t<range_difference_type_t<Range>>>(
+      std::forward<Range>(r), std::forward<BinaryOperator>(compare));
+}
+
+
+template <typename Range, typename Compare = std::less<>>
+auto kth_smallest_copy(Range&& in, size_t k, Compare&& less = {}) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(std::is_constructible_v<range_value_type_t<Range>, range_reference_type_t<Range>>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<Range>, range_reference_type_t<Range>>);
+
+  size_t n = parlay::size(in);
+  assert(k < n);
+  if (n <= 1000) return parlay::sort(std::forward<Range>(in), std::forward<Compare>(less))[k];
+
+  auto it = std::begin(in);
+
+  // pick 31 pivots by randomly choosing 8 * 31 keys, sorting them,
+  // and taking every 8th key (i.e. oversampling)
+  constexpr size_t sample_size = 31;
+  constexpr size_t over = 8;
+
+  parlay::random_generator gen;
+  std::uniform_int_distribution<size_t> dis(0, n-1);
+  auto pivots = parlay::sort(parlay::tabulate(sample_size*over, [&] (size_t i) -> range_value_type_t<Range> {
+    auto r = gen[i];
+    return it[dis(r)];
+  }), less);
+  pivots = parlay::tabulate(sample_size,[&] (size_t i) { return pivots[i*over]; });
+
+  // Determine which of the 32 buckets each key belongs in
+  internal::heap_tree ss(pivots);
+  auto ids = parlay::tabulate(n, [&] (long i) -> unsigned char {
+    return ss.rank(it[i], less);});
+
+  // Count how many in keys are each bucket
+  auto sums = parlay::histogram_by_index(ids, sample_size+1);
+  
+  // find which bucket k belongs in, and pack the keys in that bucket into next
+  auto [offsets, total] = parlay::scan(sums);
+  auto id = std::upper_bound(offsets.begin(), offsets.end(), k) - offsets.begin() - 1;
+  auto next = parlay::pack(in, parlay::delayed_map(ids, [=] (auto b) {return b == id;}));
+  
+  // recurse on much smaller set, adjusting k as needed
+  return kth_smallest_copy(next, k - offsets[id], std::forward<Compare>(less));
+}
+
+template <typename Range, typename Compare = std::less<>>
+auto kth_smallest(Range&& in, size_t k, Compare&& less = {}) {
+  static_assert(is_random_access_range_v<Range>);
+  static_assert(std::is_invocable_r_v<bool, Compare, range_reference_type_t<Range>, range_reference_type_t<Range>>);
+  auto iterators = parlay::tabulate(parlay::size(in), [it = std::begin(in)](size_t i) { return it + i; });
+  return kth_smallest_copy(iterators, k, [less = std::forward<Compare>(less)](auto&& it1, auto&& it2) {
+    return less(*it1, *it2);
+  });
+}
+
+}  // namespace parlay
+
+#endif  // PARLAY_PRIMITIVES_H_

--- a/third_party/parlayhash/include/parlay/random.h
+++ b/third_party/parlayhash/include/parlay/random.h
@@ -1,0 +1,163 @@
+
+#ifndef PARLAY_RANDOM_H_
+#define PARLAY_RANDOM_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include <tuple>
+#include <limits>
+
+#include "delayed_sequence.h"
+#include "parallel.h"
+#include "range.h"
+#include "sequence.h"
+#include "slice.h"
+#include "utilities.h"
+
+#include "internal/counting_sort.h"
+
+// IWYU pragma: no_include <sstream>
+
+namespace parlay {
+
+// A deterministic random bit generator satisfying uniform_random_bit_generator
+// Can therefore be used as the engine for C++'s <random> number generators.
+// For example, to generate uniform random integers, write
+//
+//    parlay::random_generator gen;
+//    std::uniform_int_distribution<vertex> dis(0, n-1);
+//
+// then generate random numbers by invoking dis(gen). Note that each generator
+// should only be used by one thread at a time (they are not thread safe).
+//
+// To generate random numbers in parallel, the generator supports an operator[],
+// which creates another generator seeded from the current state and a given seed.
+// For example, to generate random numbers in parallel, you could write
+//
+//    parlay::random_generator gen;
+//    std::uniform_int_distribution<vertex> dis(0, n-1);
+//    auto result = parlay::tabulate(n, [&](size_t i) {
+//      auto r = gen[i];
+//      return dis(r);
+//    });
+//
+// The quality of randomness should be good enough for simple randomized algorithms,
+// but should not be relied upon for anything that requires high-quality randomness.
+//
+struct random_generator {
+ public:
+  using result_type = size_t;
+  explicit random_generator(size_t seed) : state(seed) { }
+  random_generator() : state(0) { }
+  void seed(result_type value = 0) { state = value; }
+  result_type operator()() { return state = hash64(state); }
+  static constexpr result_type max() { return std::numeric_limits<result_type>::max(); }
+  static constexpr result_type min() { return std::numeric_limits<result_type>::lowest(); }
+  random_generator operator[](size_t i) const {
+    return random_generator(static_cast<size_t>(hash64((i+1)*0x7fffffff + state))); }
+ private:
+  result_type state = 0;
+};
+
+struct random {
+ public:
+  random(size_t seed) : state(seed){};
+  random() : state(0){};
+  random fork(uint64_t i) const { return random(static_cast<size_t>(hash64(hash64(i + state)))); }
+  random next() const { return fork(0); }
+  size_t ith_rand(uint64_t i) const { return static_cast<size_t>(hash64(i + state)); }
+  size_t operator[](size_t i) const { return ith_rand(i); }
+  size_t rand() { return ith_rand(0); }
+  size_t max() { return std::numeric_limits<size_t>::max(); }
+ private:
+  size_t state = 0;
+};
+
+namespace internal {
+
+// inplace sequential version
+template <typename Iterator>
+void seq_random_shuffle_(slice<Iterator, Iterator> A, random r = random()) {
+  // the Knuth shuffle
+  size_t n = A.size();
+  if (n < 2) return;
+  for (size_t i=n-1; i > 0; i--) {
+    using std::swap;
+    swap(A[i], A[r.ith_rand(i) % (i + 1)]);
+  }
+}
+
+template <typename InIterator, typename OutIterator>
+void random_shuffle_(slice<InIterator, InIterator> In,
+                     slice<OutIterator, OutIterator> Out,
+                     random r = random()) {
+                       
+  size_t n = In.size();
+  if (n < SEQ_THRESHOLD) {
+    parallel_for(0,n,[&] (size_t i) {
+      assign_uninitialized(Out[i], In[i]);
+    });
+    seq_random_shuffle_(Out, r);
+    return;
+  }
+
+  size_t bits = 10;
+  if (n < (1 << 27)) {
+    bits = (log2_up(n) - 7)/2;
+  }
+  else {
+    bits = (log2_up(n) - 17);
+  }
+  
+  size_t num_buckets = (size_t{1} << bits);
+  size_t mask = num_buckets - 1;
+  auto rand_pos = [&] (size_t i) -> size_t {
+    return r.ith_rand(i) & mask;
+  };
+
+  auto get_pos = delayed_seq<size_t>(n, rand_pos);
+
+  // first randomly sorts based on random values [0,num_buckets)
+  sequence<size_t> bucket_offsets;
+  bool single;
+  std::tie(bucket_offsets, single) = count_sort<uninitialized_copy_tag>(
+        make_slice(In), make_slice(Out), make_slice(get_pos), num_buckets);
+
+  // now sequentially randomly shuffle within each bucket
+  auto bucket_f = [&] (size_t i) {
+    size_t start = bucket_offsets[i];
+    size_t end = bucket_offsets[i+1];
+    seq_random_shuffle_(make_slice(Out).cut(start,end), r.fork(i));
+  };
+  parallel_for(0, num_buckets, bucket_f, 1);
+}
+
+}  // namespace internal
+
+// Generate a random permutation of the given range
+// Note that unless a seeded RNG is provided, the
+// same permutation will be generated every time by
+// the default seed
+template <PARLAY_RANGE_TYPE R>
+auto random_shuffle(const R& In, random r = random()) {
+  using T = range_value_type_t<R>;
+  auto Out = sequence<T>::uninitialized(In.size());
+  internal::random_shuffle_(make_slice(In), make_slice(Out), r);
+  return Out;
+}
+
+// Generate a random permutation of the integers from 0 to n - 1
+// Note that unless a seeded RNG is provided, the
+// same permutation will be generated every time by
+// the default seed
+template <typename Integer_>
+sequence<Integer_> random_permutation(Integer_ n, random r = random()) {
+  auto id = sequence<Integer_>::from_function(n,
+    [&] (Integer_ i) -> Integer_ { return i; });
+  return random_shuffle(id, r);
+}
+
+}  // namespace parlay
+
+#endif  // PARLAY_RANDOM_H_

--- a/third_party/parlayhash/include/parlay/range.h
+++ b/third_party/parlayhash/include/parlay/range.h
@@ -1,0 +1,598 @@
+// Type traits and concepts for range properties
+//
+// This file defines C++17 "concepts-lite" style traits
+// for detecting properties of ranges, and for determining
+// whether given types are a particular type of range.
+//
+// The concept traits do not exhaustively check that all
+// requirements of the concept are satisfied, just most of
+// the ones that are do-able enough in C++17 without
+// going overboard. They should be more than thorough
+// enough to use for SFINAE, and pretty good for sanity
+// checking that an implementation of a container or range
+// adapter has implemented the required features.
+//
+// Range Traits:
+//   range_iterator_type  : the type of a range's iterator, i.e. the type of std::begin(r)
+//   range_sentinel_type  : the type of a range's sentinel, i.e., the type of std::end(r)
+//   range_value_type     : the value type of the contents of a range
+//   range_reference_type : the type obtained by dereferencing a range's iterator
+//
+// Iterator Concepts:
+//   is_iterator                : true if the given type is an iterator
+//   is_sentinel_for            : true if the second type is a sentinel for the first (iterator) type
+//   is_contiguous_iterator     : true if the given type is a contiguous iterator
+//   is_random_access_iterator  : true if the given type is a random access iterator
+//   is_bidirectional_iterator  : true if the given type is a bidirectional iterator
+//   is_forward_iterator        : true if the given type is a forward iterator
+//   is_input_iterator          : true if the given type is an input iterator
+//   is_output_iterator         : true if the given type is an output iterator
+//
+// Range Concepts:
+//   is_range                   : true if the given type is a range
+//   is_common_range            : true if the given type is a common range (iterator and sentinel are the same type)
+//   is_contiguous_range        : true if the given type is a contiguous range
+//   is_random_access_range     : true if the given type is a random access range
+//   is_bidirectional_range     : true if the given type is a bidirectional range
+//   is_forward_range           : true if the given type is a forward range
+//   is_input_ranger            : true if the given type is an input range
+//   is_output_range            : true if the given type is an output range
+//   is_block_iterable_range    : true if the given type is a block-iterable range
+//
+// Range Operations:
+//   size : return the size of a range
+//
+
+#ifndef PARLAY_RANGE_H_
+#define PARLAY_RANGE_H_
+
+#include <cstddef>
+
+#include <iterator>       // IWYU pragma: keep
+#include <type_traits>
+#include <utility>
+
+#include "type_traits.h"
+
+// Old macros that we used to use to conditionally
+// insert type constraints if concepts were enabled.
+// Here for backwards compatibility.
+#define PARLAY_RANGE_TYPE typename
+#define PARLAY_RANGE auto
+
+namespace parlay {
+
+/*  ----------------------------- Iterator traits --------------------------------
+    Type traits that deduce useful types about an iterator.
+
+    iterator_category        : the category tag type of the iterator
+    iterator_value_type      : the value type of the iterator
+    iterator_reference_type  : the type obtained by dereferencing an iterator
+    iterator_difference_type : a type that can represent the difference between two iterators
+*/
+
+// Deduce the iterator category of the given iterator type
+template<typename It_>
+using iterator_category = type_identity<typename std::iterator_traits<It_>::iterator_category>;
+
+template<typename It_>
+using iterator_category_t = typename iterator_category<It_>::type;
+
+// Deduce the value type of the given iterator type
+template<typename It_>
+using iterator_value_type = type_identity<typename std::iterator_traits<It_>::value_type>;
+
+// Deduce the value type of the given iterator type
+template<typename It_>
+using iterator_value_type_t = typename iterator_value_type<It_>::type;
+
+// Deduce the reference type of the given iterator type
+template<typename It_>
+using iterator_reference_type = type_identity<typename std::iterator_traits<It_>::reference>;
+
+// Deduce the reference type of the given iterator type
+template<typename It_>
+using iterator_reference_type_t = typename iterator_reference_type<It_>::type;
+
+// Deduce the difference type of the given iterator type
+template<typename It_>
+using iterator_difference_type = type_identity<typename std::iterator_traits<It_>::difference_type>;
+
+// Deduce the difference type of the given iterator type
+template<typename It_>
+using iterator_difference_type_t = typename iterator_difference_type<It_>::type;
+
+/*  ----------------------------- Range traits --------------------------------
+    Type traits that deduce useful types about a range.
+
+    range_iterator_type   : the type of a range's iterator, i.e. the type of std::begin(r)
+    range_sentinel_type   : the type of a range's sentinel, i.e., the type of std::end(r)
+    range_value_type      : the value type of the contents of a range
+    range_reference_type  : the type obtained by dereferencing a range's iterator
+    range_difference_type : a type that can represent the difference between two iterators
+*/
+
+// Deduce the iterator type of the range type T
+template<typename Range_>
+using range_iterator_type = type_identity<decltype(std::begin(std::declval<Range_&>()))>;
+
+// Deduce the iterator type of the range type T
+template<typename Range_>
+using range_iterator_type_t = typename range_iterator_type<Range_>::type;
+
+// Deduce the sentinel (end iterator) type of the range type T
+template<typename Range_>
+using range_sentinel_type = type_identity<decltype(std::end(std::declval<Range_&>()))>;
+
+// Deduce the sentinel (end iterator) type of the range type T
+template<typename Range_>
+using range_sentinel_type_t = typename range_sentinel_type<Range_>::type;
+
+// Deduce the underlying value type of a range. This should correspond to a
+// type that can be used to safely copy a value obtained by one of its iterators
+template<typename Range_>
+using range_value_type = type_identity<iterator_value_type_t<range_iterator_type_t<Range_>>>;
+
+// Deduce the underlying value type of a range. This should correspond to a
+// type that can be used to safely copy a value obtained by one of its iterators
+template<typename Range_>
+using range_value_type_t = typename range_value_type<Range_>::type;
+
+// Deduce the reference type of a range. This is the type obtained by dereferencing one of its iterators.
+template<typename Range_>
+using range_reference_type = type_identity<iterator_reference_type_t<range_iterator_type_t<Range_>>>;
+
+// Deduce the reference type of a range. This is the type obtained by dereferencing one of its iterators.
+template<typename Range_>
+using range_reference_type_t = typename range_reference_type<Range_>::type;
+
+// Deduce the difference type of a range. This is a type that can be used to
+// represent a difference between two iterators
+template<typename Range_>
+using range_difference_type = type_identity<iterator_difference_type_t<range_iterator_type_t<Range_>>>;
+
+// Deduce the difference type of a range. This is a type that can be used to
+//// represent a difference between two iterators
+template<typename Range_>
+using range_difference_type_t = typename range_difference_type<Range_>::type;
+
+//  --------------------- Iterator concept traits -----------------------
+
+// Provides the member value true if It_ is an iterator type
+template<typename It_, typename = std::void_t<>>
+struct is_iterator : public std::false_type {};
+
+template<typename It_>
+struct is_iterator<It_, std::void_t<
+  iterator_category<It_>,
+  decltype( ++std::declval<It_&>() ),
+  decltype( *std::declval<It_&>() ),
+  std::enable_if_t< std::is_swappable_v<It_&> >,
+  std::enable_if_t< std::is_same_v<decltype(++std::declval<It_&>()), It_&> >,
+  std::enable_if_t< std::is_copy_constructible_v<It_> >,
+  std::enable_if_t< std::is_copy_assignable_v<It_> >,
+  std::enable_if_t< std::is_destructible_v<It_> >
+>> : public std::true_type {};
+
+// True if It_ is an iterator type
+template<typename It_>
+inline constexpr bool is_iterator_v = is_iterator<It_>::value;
+
+// Provides the member value true if Sentinel_ is a sentinel type
+// for the iterator type It_
+template<typename It_, typename Sentinel_, typename = std::void_t<>>
+struct is_sentinel_for : public std::false_type {};
+
+template<typename It_, typename Sentinel_>
+struct is_sentinel_for<It_, Sentinel_, std::void_t<
+  std::enable_if_t< is_iterator_v<It_> >,
+  std::enable_if_t< is_equality_comparable_v<It_, Sentinel_> >,
+  std::enable_if_t< std::is_default_constructible_v<Sentinel_> >,
+  std::enable_if_t< std::is_copy_constructible_v<Sentinel_> >,
+  std::enable_if_t< std::is_copy_assignable_v<Sentinel_> >
+>> : public std::true_type {};
+
+// True if Sentinel_ is a sentinel type for the iterator It_
+template<typename It_, typename Sentinel_>
+inline constexpr bool is_sentinel_for_v = is_sentinel_for<It_, Sentinel_>::value;
+
+// Provides the member value true if Sentinel_ is a sized sentinel type
+// for the iterator type It_
+template<typename It_, typename Sentinel_, typename = std::void_t<>>
+struct is_sized_sentinel_for : public std::false_type {};
+
+template<typename It_, typename Sentinel_>
+struct is_sized_sentinel_for<It_, Sentinel_, std::void_t<
+  std::enable_if_t< is_sentinel_for_v<It_, Sentinel_> >,
+  std::enable_if_t< std::is_same_v<decltype(std::declval<It_>() - std::declval<Sentinel_>()), iterator_difference_type_t<It_>> >,
+  std::enable_if_t< std::is_same_v<decltype(std::declval<Sentinel_>() - std::declval<It_>()), iterator_difference_type_t<It_>> >
+>> : std::true_type {};
+
+// True if Sentinel_ is a sized sentinel type for the iterator It_
+template<typename It_, typename Sentinel_>
+inline constexpr bool is_sized_sentinel_for_v = is_sized_sentinel_for<It_, Sentinel_>::value;
+
+// Defines a member constant value true if the iterator It_ is at least an input iterator
+template<typename It_, typename = std::void_t<>>
+struct is_input_iterator : public std::false_type {};
+
+template<typename It_>
+struct is_input_iterator<It_, std::void_t<
+  decltype( std::declval<It_&>()++ ),
+  std::enable_if_t< is_iterator_v<It_> >,
+  std::enable_if_t< is_equality_comparable_v<It_&, It_&> >,
+  std::enable_if_t< std::is_base_of_v<std::input_iterator_tag, iterator_category_t<It_>> >,
+  std::enable_if_t< std::is_same_v<decltype(*std::declval<It_&>()), iterator_reference_type_t<It_>> >
+>> : public std::true_type {};
+
+// true if the iterator type It_ is at least an input iterator
+template<typename It_>
+inline constexpr bool is_input_iterator_v = is_input_iterator<It_>::value;
+
+// Defines a member constant value true if the iterator It_ is an output iterator
+template<typename It_, typename = std::void_t<>>
+struct is_output_iterator : public std::false_type {};
+
+template<typename It_>
+struct is_output_iterator<It_, std::void_t<
+  std::enable_if_t< is_iterator_v<It_> >,
+  std::enable_if_t< std::is_base_of_v<std::output_iterator_tag, iterator_category_t<It_>> >
+>> : public std::true_type {};
+
+// true if the iterator type It_ is an output iterator
+template<typename It_>
+inline constexpr bool is_output_iterator_v = is_output_iterator<It_>::value;
+
+// Defines a member constant value true if the iterator It_ is at least a forward iterator
+template<typename It_, typename = std::void_t<>>
+struct is_forward_iterator : public std::false_type {};
+
+template<typename It_>
+struct is_forward_iterator<It_, std::void_t<
+  std::enable_if_t< is_input_iterator_v<It_> >,
+  std::enable_if_t< std::is_base_of_v<std::forward_iterator_tag, iterator_category_t<It_>> >,
+  std::enable_if_t< std::is_default_constructible_v<It_> >,
+  std::enable_if_t< std::is_convertible_v<decltype(std::declval<It_&>()++), const std::remove_reference_t<It_>&> >,
+  std::enable_if_t< std::is_same_v<decltype(*(std::declval<It_&>()++)), iterator_reference_type_t<It_>> >
+>> : public std::true_type {};
+
+// true if the iterator type It_ is at least a forward iterator
+template<typename It_>
+inline constexpr bool is_forward_iterator_v = is_forward_iterator<It_>::value;
+
+// Defines a member constant value true if the iterator It_ is at least a bidirectional iterator
+template<typename It_, typename = std::void_t<>>
+struct is_bidirectional_iterator : public std::false_type {};
+
+template<typename It_>
+struct is_bidirectional_iterator<It_, std::void_t<
+  decltype( --std::declval<It_&>() ),
+  decltype( std::declval<It_&>()-- ),
+  std::enable_if_t< is_forward_iterator_v<It_> >,
+  std::enable_if_t< std::is_base_of_v<std::bidirectional_iterator_tag, iterator_category_t<It_>> >,
+  std::enable_if_t< std::is_convertible_v<decltype(std::declval<It_&>()--), const std::remove_reference_t<It_>&> >,
+  std::enable_if_t< std::is_same_v<decltype(*(std::declval<It_&>()--)), iterator_reference_type_t<It_>> >
+>> : public std::true_type {};
+
+// true if the iterator type It is at least a bidirectional iterator
+template<typename It_>
+inline constexpr bool is_bidirectional_iterator_v = is_bidirectional_iterator<It_>::value;
+
+// Defines a member constant value true if the iterator It_ is at least a random-access iterator
+template<typename It_, typename = std::void_t<>>
+struct is_random_access_iterator : public std::false_type {};
+
+template<typename It_>
+struct is_random_access_iterator<It_, std::void_t<
+  std::enable_if_t< is_bidirectional_iterator_v<It_> >,
+  std::enable_if_t< std::is_base_of_v<std::random_access_iterator_tag, iterator_category_t<It_>> >,
+  std::enable_if_t< std::is_same_v<decltype(std::declval<It_&>() += std::declval<iterator_difference_type_t<It_>>()), It_&> >,
+  std::enable_if_t< std::is_same_v<decltype(std::declval<It_>() + std::declval<iterator_difference_type_t<It_>>()), It_> >,
+  std::enable_if_t< std::is_same_v<decltype(std::declval<It_&>() -= std::declval<iterator_difference_type_t<It_>>()), It_&> >,
+  std::enable_if_t< std::is_same_v<decltype(std::declval<It_>() - std::declval<iterator_difference_type_t<It_>>()), It_> >,
+  std::enable_if_t< std::is_same_v<decltype(std::declval<It_>() - std::declval<It_>()), iterator_difference_type_t<It_>> >,
+  std::enable_if_t< std::is_same_v<decltype(std::declval<It_>()[std::declval<iterator_difference_type_t<It_>>()]), iterator_reference_type_t<It_>> >,
+  std::enable_if_t< std::is_convertible_v<decltype(std::declval<It_>() < std::declval<It_>()), bool> >,
+  std::enable_if_t< std::is_convertible_v<decltype(std::declval<It_>() > std::declval<It_>()), bool> >,
+  std::enable_if_t< std::is_convertible_v<decltype(std::declval<It_>() >= std::declval<It_>()), bool> >,
+  std::enable_if_t< std::is_convertible_v<decltype(std::declval<It_>() <= std::declval<It_>()), bool> >
+>> : public std::true_type {};
+
+// true if the iterator type It_ is at least a random-access iterator
+template<typename It_>
+inline constexpr bool is_random_access_iterator_v = is_random_access_iterator<It_>::value;
+
+// Defines a member constant value true if the iterator type It_ is a contiguous iterator
+template<typename It_>
+using is_contiguous_iterator = std::is_pointer<It_>;
+
+// true if the iterator type It_ corresponds to a contiguous iterator type
+template<typename It_>
+inline constexpr bool is_contiguous_iterator_v = is_contiguous_iterator<It_>::value;
+
+
+//  --------------------- Range concept traits -----------------------
+
+// Provides the member value true if Range_ is a range
+template<typename, typename = std::void_t<>>
+struct is_range : public std::false_type {};
+
+template<typename Range_>
+struct is_range<Range_, std::void_t<
+  decltype( std::begin(std::declval<Range_&>()) ),
+  decltype( std::end(std::declval<Range_&>()) ),
+  std::enable_if_t< is_sentinel_for_v<range_iterator_type_t<Range_>, range_sentinel_type_t<Range_>> >
+>> : public std::true_type {};
+
+// True if the given type Range_ is a range
+template<typename Range_>
+inline constexpr bool is_range_v = is_range<Range_>::value;
+
+// Provides the member value true if Range_ is a common range,
+// i.e., a range whose iterator and sentinel types are the same
+template<typename, typename = std::void_t<>>
+struct is_common_range : public std::false_type {};
+
+template<typename Range_>
+struct is_common_range<Range_, std::void_t<
+  std::enable_if_t< is_range_v<Range_> >,
+  std::enable_if_t< std::is_same_v<range_iterator_type_t<Range_>, range_sentinel_type_t<Range_>> >
+>> : public std::true_type {};
+
+// True if the given type is a common range, i.e., a range
+// whose iterator and sentinel types are the same
+template<typename Range_>
+inline constexpr bool is_common_range_v = is_common_range<Range_>::value;
+
+// Defines a member constant value true if the range type Range_ is an input range
+template<typename, typename = std::void_t<>>
+struct is_input_range : public std::false_type {};
+
+template<typename Range_>
+struct is_input_range<Range_, std::void_t<
+  std::enable_if_t< is_range_v<Range_> >,
+  std::enable_if_t< is_input_iterator_v<range_iterator_type_t<Range_>> >
+>> : public std::true_type {};
+
+// true if the range type Range_ is an input range
+template<typename Range_>
+inline constexpr bool is_input_range_v = is_input_range<Range_>::value;
+
+// Defines a member constant value true if the range type Range_ is an output range
+template<typename, typename = std::void_t<>>
+struct is_output_range : public std::false_type {};
+
+template<typename Range_>
+struct is_output_range<Range_, std::void_t<
+  std::enable_if_t< is_range_v<Range_> >,
+  std::enable_if_t< is_output_iterator_v<range_iterator_type_t<Range_>> >
+>> : public std::true_type {};
+
+// true if the range type Range_ is an output range
+template<typename Range_>
+inline constexpr bool is_output_range_v = is_output_range<Range_>::value;
+
+// Defines a member constant value true if the range type Range_ is a forward range
+template<typename, typename = std::void_t<>>
+struct is_forward_range : public std::false_type {};
+
+template<typename Range_>
+struct is_forward_range<Range_, std::void_t<
+  std::enable_if_t< is_range_v<Range_> >,
+  std::enable_if_t< is_forward_iterator_v<range_iterator_type_t<Range_>> >
+>> : public std::true_type {};
+
+// true if the range type Range_ is a forward range
+template<typename Range_>
+inline constexpr bool is_forward_range_v = is_forward_range<Range_>::value;
+
+// Defines a member constant value true if the range type Range_ is a bidirectional range
+template<typename, typename = std::void_t<>>
+struct is_bidirectional_range : public std::false_type {};
+
+template<typename Range_>
+struct is_bidirectional_range<Range_, std::void_t<
+  std::enable_if_t< is_range_v<Range_> >,
+  std::enable_if_t< is_bidirectional_iterator_v<range_iterator_type_t<Range_>> >
+>> : public std::true_type {};
+
+// true if the range type Range_ is a bidirectional range
+template<typename Range_>
+inline constexpr bool is_bidirectional_range_v = is_bidirectional_range<Range_>::value;
+
+// Defines a member constant value true if the range type Range_ is a random-access range
+template<typename, typename = std::void_t<>>
+struct is_random_access_range : public std::false_type {};
+
+template<typename Range_>
+struct is_random_access_range<Range_, std::void_t<
+  std::enable_if_t< is_range_v<Range_> >,
+  std::enable_if_t< is_random_access_iterator_v<range_iterator_type_t<Range_>> >
+>> : public std::true_type {};
+
+// true if the range type Range_ is a random-access range
+template<typename Range_>
+inline constexpr bool is_random_access_range_v = is_random_access_range<Range_>::value;
+
+// Defines a member constant value true if the range Range_ is a contiguous range
+template<typename, typename = std::void_t<>>
+struct is_contiguous_range : public std::false_type {};
+
+template<typename Range_>
+struct is_contiguous_range<Range_, std::void_t<
+  std::enable_if_t< is_range_v<Range_> >,
+  std::enable_if_t< is_contiguous_iterator_v<range_iterator_type_t<Range_>> >
+>> : public std::true_type {};
+
+// true if the range type Range_ corresponds to a contiguous range
+template<typename Range_>
+inline constexpr bool is_contiguous_range_v = is_contiguous_range<Range_>::value;
+
+namespace internal {
+
+// A type satisfies the block-iterable interface if it supports:
+//
+//  size() const -> size_t
+//  get_num_blocks() const -> size_t
+//  get_begin_block(size_t) -> iterator
+//  get_end_block(size_t) -> iterator
+//  get_begin_block(size_t) const -> const_iterator
+//  get_end_block(size_t) const -> const_iterator
+//
+// where iterator and const_iterator is the common iterator type for the range when
+// it is non-const or const respectively. iterator and const_iterator may be the same
+// if that is semantically appropriate.
+//
+// Note that the const overloads are optional if the view can not be const.
+//
+template<typename, typename = std::void_t<>>
+struct has_block_iterable_interface : public std::false_type {};
+
+template<typename T>
+struct has_block_iterable_interface<T, std::void_t<
+  decltype( std::declval<T&>().get_begin_block((size_t)0) ),
+  decltype( std::declval<T&>().get_end_block((size_t)0) ),
+  decltype( std::declval<T&>().size() ),
+  decltype( std::declval<T&>().get_num_blocks() ),
+  std::enable_if_t< std::is_same_v<decltype(std::declval<T&>().get_begin_block((size_t)0)), range_iterator_type_t<T&>> >,
+  std::enable_if_t< std::is_same_v<decltype(std::declval<T&>().get_end_block((size_t)0)), range_iterator_type_t<T&>> >,
+  std::enable_if_t< std::is_convertible_v<decltype(std::declval<T&>().size()), size_t> >,
+  std::enable_if_t< std::is_convertible_v<decltype(std::declval<T&>().get_num_blocks()), size_t> >
+>> : public std::true_type {};
+
+template<typename T>
+inline constexpr bool has_block_iterable_interface_v = has_block_iterable_interface<T>::value;
+
+}  // namespace internal
+
+// Provides a member constant value true if the range Range is block iterable.
+// A range is block-iterable if it is a common range, and is either random access
+// or it supports the block-iterable interface, meaning it provides the member
+// functions size(), get_num_blocks(), get_begin_block(size_t), get_end_block(size_t)
+template<typename, typename = std::void_t<>>
+struct is_block_iterable_range : public std::false_type {};
+
+template<typename Range_>
+struct is_block_iterable_range<Range_, std::void_t<
+  std::enable_if_t< is_common_range_v<Range_> >,
+  std::enable_if_t< is_random_access_range_v<Range_> || internal::has_block_iterable_interface_v<Range_> >
+>> : public std::true_type {};
+
+// true if the range Range_ is block iterable
+template<typename Range_>
+inline constexpr bool is_block_iterable_range_v = is_block_iterable_range<Range_>::value;
+
+/*  --------------------- Range size -----------------------
+    size(r) -> size_t : returns the size of a range
+*/
+
+// Defines the member value true if the given type is an array of known bound
+template<typename T>
+struct is_bounded_array: std::false_type {};
+
+template<typename T, std::size_t N>
+struct is_bounded_array<T[N]> : std::true_type {};
+
+// true if the given type is an array of known bound
+template<typename T>
+inline constexpr bool is_bounded_array_v = is_bounded_array<T>::value;
+
+namespace internal {
+
+// Defines the member value true if the given type has a member function size()
+// which takes no arguments
+template<typename, typename = std::void_t<>>
+struct has_size_member : public std::false_type {};
+
+template<typename Range_>
+struct has_size_member<Range_, std::void_t<
+  decltype( std::declval<Range_>().size() )
+>> : std::true_type {};
+
+// true if the given type has a member function size() which takes no arguments
+template<typename Range_>
+inline constexpr bool has_size_member_v = has_size_member<Range_>::value;
+
+namespace nonmember_size_impl {
+
+// Deleting the size function in this scope forces overload
+// resolution to look for ADL matches for the size function
+
+template<typename T>
+void size(T&) = delete;
+
+template<typename T>
+void size(const T&) = delete;
+
+// Defines the member value true if the given type has a non-
+// member function size(r) that can be found via ADL
+template<typename, typename = std::void_t<>>
+struct has_nonmember_size : public std::false_type {};
+
+template<typename Range_>
+struct has_nonmember_size<Range_, std::void_t<
+ decltype( size(std::declval<Range_>()) )
+>> : std::true_type {};
+
+// true if the given type has a non-member function size(r) that can be found via ADL
+template<typename Range_>
+inline constexpr bool has_nonmember_size_v = has_nonmember_size<Range_>::value;
+
+// Invokes the non-member size function for the given range
+template<typename Range_>
+auto invoke_size(Range_&& r) {
+  static_assert(has_nonmember_size_v<Range_>);
+  return size(std::forward<Range_>(r));
+}
+
+}  // namespace nonmember_size_impl
+
+// The implementation of parlay::size is hidden inside a namespace
+// and pulled in with a using directive to hide it from ADL
+namespace size_impl {
+
+// Return the size (number of elements) of the range r. This is:
+//
+// * std::extent_v<Range_>          if Range_ is a bounded array type
+// * FORWARD(r).size()              if Range_ is a type with a .size() member
+// * size(FORWARD(r))               if a non-member size function is found by ADL
+// * std::end(r) - std::begin(r)    if begin(r) and end(r) model a sized-sentinel pair
+//
+// In the future, this could be replaced by C++20 std::ranges::size
+template<typename Range_>
+auto size(Range_&& r) {
+  static_assert(is_range_v<Range_>);
+  static_assert(is_bounded_array_v<Range_> ||
+                has_size_member_v<Range_> ||
+                nonmember_size_impl::has_nonmember_size_v<Range_> ||
+                is_sized_sentinel_for_v<range_iterator_type_t<Range_>, range_sentinel_type_t<Range_>>);
+
+  if constexpr (is_bounded_array_v<Range_>) {
+    return std::extent_v<Range_>;
+  }
+  else if constexpr (has_size_member_v<Range_>) {
+    return std::forward<Range_>(r).size();
+  }
+  else if constexpr (nonmember_size_impl::has_nonmember_size_v<Range_>) {
+    return nonmember_size_impl::invoke_size(std::forward<Range_>(r));
+  }
+  else {
+    return std::make_unsigned_t<range_difference_type_t<Range_>>(std::end(r) - std::begin(r));
+  }
+}
+
+}  // size_impl
+
+} // namespace internal
+
+using internal::size_impl::size;
+
+// A functional that takes a range r and returns its size as given by parlay::size(FORWARD(r))
+struct size_of {
+  template<typename Range_>
+  decltype(auto) operator()(Range_&& r) const { return parlay::size(std::forward<Range_>(r)); }
+};
+
+}  // namespace parlay
+
+#endif  // PARLAY_RANGE_H_

--- a/third_party/parlayhash/include/parlay/relocation.h
+++ b/third_party/parlayhash/include/parlay/relocation.h
@@ -1,0 +1,165 @@
+#ifndef PARLAY_RELOCATION_H_
+#define PARLAY_RELOCATION_H_
+
+#include <cstring>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <new>                 // IWYU pragma: keep
+#include <type_traits>
+#include <utility>
+
+#include "parallel.h"
+#include "range.h"             // IWYU pragma: keep
+#include "type_traits.h"       // IWYU pragma: keep
+#include "utilities.h"         // IWYU pragma: keep
+
+#include "internal/debug_uninitialized.h"
+
+namespace parlay {
+
+/*
+    Relocation (a.k.a. "destructive move")
+
+  The relocation of object a into memory b is equivalent to a move
+  construction of a into b, followed by the destruction of what
+  remains at a. In other words, it is
+
+    new (b) T(std::move(*a));
+    a->~T();
+
+  For many types, however, this can be optimized by replacing it with just
+
+    std::memcpy(b, a, sizeof(T));
+
+   We call any such types trivially relocatable. This is clearly
+   true for any trivial type, but it also turns out to be true
+   for most other standard types, such as vectors, unique_ptrs,
+   and more. The key observation is that the only reason that
+   the move operations of these types is non-trivial is because
+   they must clear out the source object after moving from it.
+   If, however, the source object is treated as uninitialized
+   memory after relocation, then it does not have to be cleared
+   out, since its destructor will not run.
+
+   A strong motivating use case for relocation is in dynamically
+   sized containers (e.g. vector, or parlay::sequence). When
+   performing a resize operation, one has to move all of the
+   contents of the old buffer into the new one, and destroy
+   the contents of the old buffer, like so (ignoring allocator
+   details)
+
+   parallel_for(0, n, [&](size_t i) {
+     new (&new_buffer[i]) std::move(current_buffer[i]));
+     current_buffer[i].~value_type();
+   });
+
+   This can be replaced with
+
+   parallel_for(0, n, [&](size_t i) {
+     uninitialized_relocate(&new_buffer[i], &current_buffer[i]);
+   });
+
+   or even, for better performance yet
+
+   uninitialized_relocate_n(new_buffer, current_buffer, n);
+
+   The uninitialized_relocate functions will use the optimized
+   memcpy-based approach for any types for which it is suitable,
+   and otherwise, will fall back to the generic approach.
+*/
+
+// Relocate the given range of n elements [from, from + n) into uninitialized
+// memory at [to, to + n), such that both the source and destination memory
+// were allocated by the given allocator.
+template<typename It1, typename It2, typename Alloc>
+inline void uninitialized_relocate_n_a(It1 to, It2 from, size_t n, Alloc& alloc) {
+  using T = typename std::iterator_traits<It1>::value_type;
+  static_assert(std::is_same_v<typename std::iterator_traits<It2>::value_type, T>);
+  static_assert(std::is_same_v<typename std::allocator_traits<Alloc>::value_type, T>);
+
+  constexpr bool trivially_relocatable = is_trivially_relocatable_v<T>;
+  constexpr bool trivial_alloc = is_trivial_allocator_v<Alloc, T>;
+  constexpr bool contiguous = is_contiguous_iterator_v<It1> && is_contiguous_iterator_v<It2>;
+  constexpr bool random_access = is_random_access_iterator_v<It1> && is_random_access_iterator_v<It2>;
+
+  // The most efficient scenario -- The objects are trivially relocatable, the allocator
+  // has no special behaviour, and the iterators point to contiguous memory so we can
+  // memcpy chunks of more than one T object at a time.
+  if constexpr (trivially_relocatable && contiguous && trivial_alloc) {
+    constexpr size_t chunk_size = 1024 * sizeof(size_t) / sizeof(T);
+    const size_t n_chunks = (n + chunk_size - 1) / chunk_size;
+    parallel_for(0, n_chunks, [&](size_t i) {
+      size_t n_objects = (std::min)(chunk_size, n - i * chunk_size);
+      size_t n_bytes = sizeof(T) * n_objects;
+      void* src = static_cast<void*>(std::addressof(*(from + i * chunk_size)));
+      void* dest = static_cast<void*>(std::addressof(*(to + i * chunk_size)));
+      std::memcpy(dest, src, n_bytes);
+    }, 1);
+  // The next best thing -- If the objects are trivially relocatable and the allocator
+  // has no special behaviour, so long as the iterators are random access, we can still
+  // relocate everything in parallel, just not by memcpying multiple objects at a time
+  } else if constexpr (trivially_relocatable && random_access && trivial_alloc) {
+    constexpr size_t chunk_size = 1024 * sizeof(size_t) / sizeof(T);
+    const size_t n_chunks = (n + chunk_size - 1) / chunk_size;
+    parallel_for(0, n_chunks, [&](size_t i) {
+      for (size_t j = 0; j < chunk_size && (j + i *chunk_size < n); j++) {
+        void* src = static_cast<void*>(std::addressof(from[j + i * chunk_size]));
+        void* dest = static_cast<void*>(std::addressof(to[j + i * chunk_size]));
+        std::memcpy(dest, src, sizeof(T));
+      }
+    }, 1);
+  }
+  // The iterators are not random access, but we can still relocate, just not in parallel
+  else if constexpr (trivially_relocatable && trivial_alloc) {
+    for (size_t i = 0; i < n; i++) {
+      std::memcpy(std::addressof(*to), std::addressof(*from), sizeof(T));
+      to++;
+      from++;
+    }
+  }
+  // After this point, the object can not be trivially relocated, either because it is not
+  // trivially relocatable, or because the allocator has specialized behaviour. We now fall
+  // back to just doing a "destructive move" manually.
+  else if constexpr (random_access) {
+    static_assert(std::is_move_constructible<T>::value);
+    static_assert(std::is_destructible<T>::value);
+    parallel_for(0, n, [&](size_t i) {
+      PARLAY_ASSERT_UNINITIALIZED(to[i]);
+      std::allocator_traits<Alloc>::construct(alloc, std::addressof(to[i]), std::move(from[i]));
+      std::allocator_traits<Alloc>::destroy(alloc, std::addressof(from[i]));
+      PARLAY_ASSERT_UNINITIALIZED(from[i]);
+    });
+  }
+  // The worst case. No parallelism and no fast relocation.
+  else {
+    static_assert(std::is_move_constructible<T>::value);
+    static_assert(std::is_destructible<T>::value);
+    for (size_t i = 0; i < n; i++) {
+      PARLAY_ASSERT_UNINITIALIZED(*to);
+      std::allocator_traits<Alloc>::construct(alloc, std::addressof(*to), std::move(*from));
+      std::allocator_traits<Alloc>::destroy(alloc, std::addressof(*from));
+      PARLAY_ASSERT_UNINITIALIZED(*from);
+      to++;
+      from++;
+    }
+  }
+}
+
+// Relocate the given range of n elements [from, from + n) into uninitialized
+// memory at [to, to + n). Relocation is done as if the memory was allocated
+// by a standard allocator (e.g. std::allocator, parlay::allocator, malloc)
+//
+// For an allocator-aware version that respects the construction and destruction
+// behaviour of the allocator, use uninitialized_relocate_n_a.
+template<typename Iterator1, typename Iterator2>
+inline void uninitialized_relocate_n(Iterator1 to, Iterator2 from, size_t n) {
+  using T = typename std::iterator_traits<Iterator1>::value_type;
+  std::allocator<T> a;
+  uninitialized_relocate_n_a(to, from, n, a);
+}
+
+}
+
+#endif  // PARLAY_RELOCATION_H_

--- a/third_party/parlayhash/include/parlay/scheduler.h
+++ b/third_party/parlayhash/include/parlay/scheduler.h
@@ -1,0 +1,403 @@
+
+#ifndef PARLAY_SCHEDULER_H_
+#define PARLAY_SCHEDULER_H_
+
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>         // IWYU pragma: keep
+#include <memory>
+#include <thread>
+#include <type_traits>    // IWYU pragma: keep
+#include <utility>
+#include <vector>
+
+#include "internal/work_stealing_deque.h"         // IWYU pragma: keep
+#include "internal/work_stealing_job.h"
+
+// IWYU pragma: no_include <bits/chrono.h>
+// IWYU pragma: no_include <bits/this_thread_sleep.h>
+
+
+
+// True if the scheduler should scale the number of awake workers
+// proportional to the amount of work to be done. This saves CPU
+// time if there is not any parallel work available, but may cause
+// some startup lag when more parallelism becomes available.
+//
+// Default: true
+#ifndef PARLAY_ELASTIC_PARALLELISM
+#define PARLAY_ELASTIC_PARALLELISM true
+#endif
+
+
+// PARLAY_ELASTIC_STEAL_TIMEOUT sets the number of microseconds
+// that a worker will attempt to steal jobs, such that if no
+// jobs are successfully stolen, it will go to sleep.
+//
+// Default: 10000 (10 milliseconds)
+#ifndef PARLAY_ELASTIC_STEAL_TIMEOUT
+#define PARLAY_ELASTIC_STEAL_TIMEOUT 10000
+#endif
+
+
+#if PARLAY_ELASTIC_PARALLELISM
+#include "internal/atomic_wait.h"
+#endif
+
+namespace parlay {
+
+
+template <typename Job>
+struct scheduler {
+
+  using worker_id_type = unsigned int;
+
+ private:
+  static_assert(std::is_invocable_r_v<void, Job&>);
+
+  struct workerInfo {
+    static constexpr worker_id_type UNINITIALIZED = std::numeric_limits<worker_id_type>::max();
+
+    worker_id_type worker_id;
+    scheduler* my_scheduler;
+
+    workerInfo() : worker_id(UNINITIALIZED), my_scheduler(nullptr) {}
+    workerInfo(std::size_t worker_id_, scheduler* s) : worker_id(worker_id_), my_scheduler(s) {}
+
+    workerInfo& operator=(const workerInfo&) = delete;
+    workerInfo(const workerInfo&) = delete;
+
+    workerInfo& operator=(workerInfo&& w) noexcept {
+      if (this != &w) {
+        worker_id = std::exchange(w.worker_id, UNINITIALIZED);
+        my_scheduler = std::exchange(w.my_scheduler, nullptr);
+      }
+      return *this;
+    }
+
+    workerInfo(workerInfo&& w) noexcept { *this = std::move(w); }
+  };
+
+  // After YIELD_FACTOR * P unsuccessful steal attempts, a
+  // a worker will sleep briefly for SLEEP_FACTOR * P nanoseconds
+  // to give other threads a chance to work and save some cycles.
+  constexpr static size_t YIELD_FACTOR = 200;
+  constexpr static size_t SLEEP_FACTOR = 200;
+
+  // The length of time that a worker must fail to steal anything
+  // before it goes to sleep to save CPU time.
+  constexpr static std::chrono::microseconds STEAL_TIMEOUT{PARLAY_ELASTIC_STEAL_TIMEOUT};
+
+  static inline thread_local workerInfo worker_info{};
+
+ public:
+
+  const worker_id_type num_threads;
+
+  // If the current thread is a worker of an existing scheduler, or the thread that spawned
+  // a scheduler, return the most recent such scheduler.  Otherwise, returns null.
+  static scheduler* get_current_scheduler() {
+    return worker_info.my_scheduler;
+  }
+
+  explicit scheduler(size_t num_workers)
+      : num_threads(num_workers),
+        num_deques(num_threads),
+        num_awake_workers(num_threads),
+        parent_worker_info(std::exchange(worker_info, workerInfo{0, this})),
+        deques(num_deques),
+        attempts(num_deques),
+        spawned_threads(),
+        finished_flag(false) {
+
+    // Spawn num_threads many threads on startup
+    for (worker_id_type i = 1; i < num_threads; ++i) {
+      spawned_threads.emplace_back([&, i]() {
+        worker_info = {i, this};
+        worker();
+      });
+    }
+  }
+
+  ~scheduler() {
+    shutdown();
+    worker_info = std::move(parent_worker_info);
+  }
+
+  // Push onto local stack.
+  void spawn(Job* job) {
+    int id = worker_id();
+    [[maybe_unused]] bool first = deques[id].push_bottom(job);
+#if PARLAY_ELASTIC_PARALLELISM
+    if (first) wake_up_a_worker();
+#endif
+  }
+
+  // Wait until the given condition is true.
+  //
+  // If conservative, this thread will simply busy wait. Otherwise,
+  // it will look for work to steal and keep itself occupied. This
+  // can deadlock if the stolen work wants a lock held by the code
+  // that is waiting, so avoid that.
+  template <typename F>
+  void wait_until(F&& done, bool conservative = false) {
+    // Conservative avoids deadlock if scheduler is used in conjunction
+    // with user locks enclosing a wait.
+    if (conservative) {
+      while (!done())
+        std::this_thread::yield();
+    }
+    // If not conservative, schedule within the wait.
+    // Can deadlock if a stolen job uses same lock as encloses the wait.
+    else {
+      do_work_until(std::forward<F>(done));
+    }
+  }
+
+  // Pop from local stack.
+  Job* get_own_job() {
+    auto id = worker_id();
+    return deques[id].pop_bottom();
+  }
+
+  worker_id_type num_workers() { return num_threads; }
+  worker_id_type worker_id() { return worker_info.worker_id; }
+
+  bool finished() const noexcept {
+    return finished_flag.load(std::memory_order_acquire);
+  }
+
+ private:
+  // Align to avoid false sharing.
+  struct alignas(128) attempt {
+    size_t val;
+  };
+
+  int num_deques;
+  std::atomic<size_t> num_awake_workers;
+  workerInfo parent_worker_info;
+  std::vector<internal::Deque<Job>> deques;
+  std::vector<attempt> attempts;
+  std::vector<std::thread> spawned_threads;
+  std::atomic<int> finished_flag;
+
+  std::atomic<size_t> wake_up_counter{0};
+  std::atomic<size_t> num_finished_workers{0};
+
+  // Start an individual worker task, stealing work if no local
+  // work is available. May go to sleep if no work is available
+  // for a long time, until woken up again when notified that
+  // new work is available.
+  void worker() {
+#if PARLAY_ELASTIC_PARALLELISM
+    wait_for_work();
+#endif
+    while (!finished()) {
+      Job* job = get_job([&]() { return finished(); }, PARLAY_ELASTIC_PARALLELISM);
+      if (job)(*job)();
+#if PARLAY_ELASTIC_PARALLELISM
+      else if (!finished()) {
+        // If no job was stolen, the worker should go to
+        // sleep and wait until more work is available
+        wait_for_work();
+      }
+#endif
+    }
+    assert(finished());
+    num_finished_workers.fetch_add(1);
+  }
+
+  // Runs tasks until done(), stealing work if necessary.
+  //
+  // Does not sleep or time out since this can be called
+  // by the main thread and by join points, for which sleeping
+  // would cause deadlock, and timing out could cause a join
+  // point to resume execution before the job it was waiting
+  // on has completed.
+  template <typename F>
+  void do_work_until(F&& done) {
+    while (true) {
+      Job* job = get_job(done, false);  // timeout MUST BE false
+      if (!job) return;
+      (*job)();
+    }
+    assert(done());
+  }
+
+  // Find a job, first trying local stack, then random steals.
+  //
+  // Returns nullptr if break_early() returns true before a job
+  // is found, or, if timeout is true and it takes longer than
+  // STEAL_TIMEOUT to find a job to steal.
+  template <typename F>
+  Job* get_job(F&& break_early, bool timeout) {
+    if (break_early()) return nullptr;
+    Job* job = get_own_job();
+    if (job) return job;
+    else job = steal_job(std::forward<F>(break_early), timeout);
+    return job;
+  }
+  
+  // Find a job with random steals.
+  //
+  // Returns nullptr if break_early() returns true before a job
+  // is found, or, if timeout is true and it takes longer than
+  // STEAL_TIMEOUT to find a job to steal.
+  template<typename F>
+  Job* steal_job(F&& break_early, bool timeout) {
+    size_t id = worker_id();
+    const auto start_time = std::chrono::steady_clock::now();
+    do {
+      // By coupon collector's problem, this should touch all.
+      for (size_t i = 0; i <= YIELD_FACTOR * num_deques; i++) {
+        if (break_early()) return nullptr;
+        Job* job = try_steal(id);
+        if (job) return job;
+      }
+      std::this_thread::sleep_for(std::chrono::nanoseconds(num_deques * 100));
+    } while (!timeout || std::chrono::steady_clock::now() - start_time < STEAL_TIMEOUT);
+    return nullptr;
+  }
+
+  Job* try_steal(size_t id) {
+    // use hashing to get "random" target
+    size_t target = (hash(id) + hash(attempts[id].val)) % num_deques;
+    attempts[id].val++;
+    auto [job, empty] = deques[target].pop_top();
+#if PARLAY_ELASTIC_PARALLELISM
+    if (!empty) wake_up_a_worker();
+#endif
+    return job;
+  }
+
+#if PARLAY_ELASTIC_PARALLELISM
+
+  // Wakes up at least one sleeping worker (more than one
+  // worker may be woken up depending on the implementation).
+  void wake_up_a_worker() {
+    if (num_awake_workers.load(std::memory_order_acquire) < num_threads) {
+      wake_up_counter.fetch_add(1);
+      parlay::atomic_notify_one(&wake_up_counter);
+    }
+  }
+  
+  // Wake up all sleeping workers
+  void wake_up_all_workers() {
+    if (num_awake_workers.load(std::memory_order_acquire) < num_threads) {
+      wake_up_counter.fetch_add(1);
+      parlay::atomic_notify_all(&wake_up_counter);
+    }
+  }
+  
+  // Wait until notified to wake up
+  void wait_for_work() {
+    num_awake_workers.fetch_sub(1);
+    parlay::atomic_wait(&wake_up_counter, wake_up_counter.load());
+    num_awake_workers.fetch_add(1);
+  }
+
+#endif
+
+  size_t hash(uint64_t x) {
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+    x = x ^ (x >> 31);
+    return static_cast<size_t>(x);
+  }
+  
+  void shutdown() {
+    finished_flag.store(true, std::memory_order_release);
+#if PARLAY_ELASTIC_PARALLELISM
+    // We must spam wake all workers until they finish in
+    // case any of them are just about to fall asleep, since
+    // they might therefore miss the flag to finish
+    while (num_finished_workers.load() < num_threads - 1) {
+      wake_up_all_workers();
+      std::this_thread::yield();
+    }
+#endif
+    for (worker_id_type i = 1; i < num_threads; ++i) {
+      spawned_threads[i - 1].join();
+    }
+  }
+};
+
+
+class fork_join_scheduler {
+  using Job = WorkStealingJob;
+  using scheduler_t = scheduler<Job>;
+
+ public:
+
+  // Fork two thunks and wait until they both finish.
+  template <typename L, typename R>
+  static void pardo(scheduler_t& scheduler, L&& left, R&& right, bool conservative = false) {
+    auto execute_right = [&]() { std::forward<R>(right)(); };
+    auto right_job = make_job(right);
+    scheduler.spawn(&right_job);
+    std::forward<L>(left)();
+    if (const Job* job = scheduler.get_own_job(); job != nullptr) {
+      assert(job == &right_job);
+      execute_right();
+    }
+    else {
+      auto done = [&]() { return right_job.finished(); };
+      scheduler.wait_until(done, conservative);
+      assert(right_job.finished());
+    }
+  }
+
+  template <typename F>
+  static void parfor(scheduler_t& scheduler, size_t start, size_t end, F&& f, size_t granularity = 0, bool conservative = false) {
+    if (end <= start) return;
+    if (granularity == 0) {
+      size_t done = get_granularity(start, end, f);
+      granularity = std::max(done, (end - start) / static_cast<size_t>(128 * scheduler.num_threads));
+      start += done;
+    }
+    parfor_(scheduler, start, end, f, granularity, conservative);
+  }
+
+ private:
+  template <typename F>
+  static size_t get_granularity(size_t start, size_t end, F& f) {
+    size_t done = 0;
+    size_t sz = 1;
+    unsigned long long int ticks = 0;
+    do {
+      sz = std::min(sz, end - (start + done));
+      auto tstart = std::chrono::steady_clock::now();
+      for (size_t i = 0; i < sz; i++) f(start + done + i);
+      auto tstop = std::chrono::steady_clock::now();
+      ticks = static_cast<unsigned long long int>(std::chrono::duration_cast<
+                std::chrono::nanoseconds>(tstop - tstart).count());
+      done += sz;
+      sz *= 2;
+    } while (ticks < 1000 && done < (end - start));
+    return done;
+  }
+
+  template <typename F>
+  static void parfor_(scheduler_t& scheduler, size_t start, size_t end, F& f, size_t granularity, bool conservative) {
+    if ((end - start) <= granularity)
+      for (size_t i = start; i < end; i++) f(i);
+    else {
+      size_t n = end - start;
+      // Not in middle to avoid clashes on set-associative caches on powers of 2.
+      size_t mid = (start + (9 * (n + 1)) / 16);
+      pardo(scheduler,
+            [&]() { parfor_(scheduler, start, mid, f, granularity, conservative); },
+            [&]() { parfor_(scheduler, mid, end, f, granularity, conservative); },
+            conservative);
+    }
+  }
+
+};
+
+}  // namespace parlay
+
+#endif  // PARLAY_SCHEDULER_H_

--- a/third_party/parlayhash/include/parlay/sequence.h
+++ b/third_party/parlayhash/include/parlay/sequence.h
@@ -1,0 +1,826 @@
+// A sequence is a dynamic array supporting parallel modification operations. It can be thought of as a
+// parallel version of std::vector.
+//
+// Parlay sequences also support optional small-size optimization, where short sequences of trivial
+// types are stored inline in the object rather than allocated on the heap. By default, small-size
+// optimization is not enabled. A type alias, short_sequence, is provided, that turns on small-size
+// optimization.
+//
+
+#ifndef PARLAY_SEQUENCE_H_
+#define PARLAY_SEQUENCE_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <functional>          // IWYU pragma: keep
+#include <iostream>
+#include <initializer_list>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// Falsely suggested for std::hash
+// IWYU pragma: no_include <string_view>
+// IWYU pragma: no_include <system_error>
+// IWYU pragma: no_include <variant>
+
+#include "alloc.h"
+#include "parallel.h"
+#include "portability.h"
+#include "range.h"
+#include "slice.h"
+#include "type_traits.h"      // IWYU pragma: keep  // for is_trivially_relocatable
+#include "utilities.h"
+
+#include "internal/sequence_base.h"
+
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+#include "internal/debug_uninitialized.h"
+#endif
+
+namespace parlay {
+
+// If the macro PARLAY_USE_STD_ALLOC is defined, sequences will default
+// to using std::allocator instead of parlay::allocator.
+namespace internal {
+#ifndef PARLAY_USE_STD_ALLOC
+template<typename T>
+using sequence_default_allocator = parlay::allocator<T>;
+#else
+template<typename T>
+using sequence_default_allocator = std::allocator<T>;
+#endif
+}  // namespace internal
+
+
+// A sequence is a dynamic array supporting parallel modification operations.
+// It is designed to be a fully-parallel drop-in replacement for std::vector.
+//
+// Template arguments:
+//  T:          the value type of the sequence
+//  Allocator:  an allocator for type T
+//  EnableSSO:  true to enable small-size optimization
+//
+template<typename T, typename Allocator = internal::sequence_default_allocator<T>, bool EnableSSO = std::is_same<T, char>::value>
+class sequence : protected sequence_internal::sequence_base<T, Allocator, EnableSSO> {
+
+  static_assert(std::is_same_v<typename std::remove_cv_t<T>, T>, "sequences must have a non-const, non-volatile value_type");
+  static_assert(std::is_same_v<typename std::decay_t<T>, T>, "sequences must not have an array, reference, or function value_type");
+  static_assert(!std::is_void_v<T>, "sequences must not have a void value_type");
+  static_assert(std::is_destructible_v<T>, "sequences must have a destructible value_type");
+
+ public:
+
+  // --------------- Container requirements ---------------
+
+  using value_type = T;
+  using reference = T&;
+  using const_reference = const T&;
+  using difference_type = std::ptrdiff_t;
+  using size_type = size_t;
+  using pointer = T*;
+  using const_pointer = const T*;
+
+  using iterator = T*;
+  using const_iterator = const T*;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  using view_type = slice<iterator, iterator>;
+  using const_view_type = slice<const_iterator, const_iterator>;
+
+  using sequence_type = sequence<T, Allocator, EnableSSO>;
+  using sequence_base_type = sequence_internal::sequence_base<T, Allocator, EnableSSO>;
+  using allocator_type = Allocator;
+
+  using sequence_base_type::storage;
+  using sequence_base_type::_max_size;
+  using sequence_base_type::copy_granularity;
+  using sequence_base_type::initialization_granularity;
+
+  // creates an empty sequence
+  sequence() : sequence_base_type() {}
+
+  // creates a copy of s
+  sequence(const sequence_type& s) : sequence_base_type(s.storage) {}
+
+  // moves rv
+  sequence(sequence_type&& rv) noexcept : sequence_base_type(std::move(rv.storage)) {}
+
+  // copy and move assignment
+  sequence_type& operator=(sequence_type b) {
+    swap(b);
+    return *this;
+  }
+
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+  // If uninitialized memory debugging is turned on, make sure that
+  // each object of type UninitializedTracker has been initialized
+  // since we are about to run their destructors!
+  ~sequence() {
+    auto buffer = storage.data();
+    parallel_for(0, size(), [&](size_t i) { PARLAY_ASSERT_INITIALIZED(buffer[i]); });
+  }
+#endif
+
+  allocator_type get_allocator() const { return storage.get_allocator(); }
+
+  iterator begin() { return storage.data(); }
+  iterator end() { return storage.data() + storage.size(); }
+
+  const_iterator begin() const { return storage.data(); }
+  const_iterator end() const { return storage.data() + storage.size(); }
+
+  const_iterator cbegin() const { return storage.data(); }
+  const_iterator cend() const { return storage.data() + storage.size(); }
+
+  reverse_iterator rbegin() { return std::make_reverse_iterator(end()); }
+  reverse_iterator rend() { return std::make_reverse_iterator(begin()); }
+
+  const_reverse_iterator rbegin() const { return std::make_reverse_iterator(end()); }
+  const_reverse_iterator rend() const { return std::make_reverse_iterator(begin()); }
+
+  const_reverse_iterator crbegin() const { return std::make_reverse_iterator(cend()); }
+  const_reverse_iterator crend() const { return std::make_reverse_iterator(cbegin()); }
+
+  bool operator==(const sequence_type& other) const { return size() == other.size() && compare_equal(other.begin()); }
+
+  bool operator!=(const sequence_type& b) const { return !(*this == b); }
+
+  void swap(sequence_type& b) { storage.swap(b.storage); }
+
+  size_type size() const { return storage.size(); }
+
+  size_type max_size() const {
+    if ((std::numeric_limits<size_type>::max)() < _max_size) {
+      return (std::numeric_limits<size_type>::max)();
+    } else {
+      return _max_size;
+    }
+  }
+
+  bool empty() const { return size() == 0; }
+
+  // -------------- Random access interface ----------------
+
+  value_type* data() { return storage.data(); }
+
+  const value_type* data() const { return storage.data(); }
+
+  value_type& operator[](size_t i) { return storage.at(i); }
+  const value_type& operator[](size_t i) const { return storage.at(i); }
+
+  value_type& at(size_t i) {
+    if (i >= size()) {
+      throw_exception_or_terminate<std::out_of_range>(
+          "sequence access out of bounds: length = " + std::to_string(size()) + ", index = " + std::to_string(i));
+    } else {
+      return storage.at(i);
+    }
+  }
+
+  const value_type& at(size_t i) const {
+    if (i >= size()) {
+      throw_exception_or_terminate<std::out_of_range>(
+          "sequence access out of bounds: length = " + std::to_string(size()) + ", index = " + std::to_string(i));
+    } else {
+      return storage.at(i);
+    }
+  }
+
+  // ------------ SequenceContainer requirements ---------------
+
+  // Construct a sequence of length n. Elements will be
+  // value initialized
+  explicit sequence(size_t n) : sequence_base_type() { initialize_default(n); }
+
+  // Constructs a sequence consisting of n copies of t
+  sequence(size_t n, const value_type& t) : sequence_base_type() { initialize_fill(n, t); }
+
+  // Constructs a sequence consisting of the elements
+  // in the given iterator range
+  template<typename Iterator_>
+  sequence(Iterator_ i, Iterator_ j) : sequence_base_type() {
+    initialize_dispatch(i, j, std::is_integral<Iterator_>());
+  }
+
+  // Constructs a sequence from the elements of the given initializer list
+  //
+  // Note: cppcheck flags all implicit constructors. This one is okay since
+  // we want to convert initializer lists into sequences.
+  sequence(std::initializer_list<value_type> l) :
+      sequence_base_type() {  // cppcheck-suppress noExplicitConstructor
+    initialize_range(std::begin(l), std::end(l),
+                     typename std::iterator_traits<decltype(std::begin(l))>::iterator_category());
+  }
+
+  sequence_type& operator=(std::initializer_list<value_type> l) {
+    storage.clear();
+    initialize_range(std::begin(l), std::end(l),
+                     typename std::iterator_traits<decltype(std::begin(l))>::iterator_category());
+    return *this;
+  }
+
+  template<typename... Args>
+  iterator emplace(iterator p, Args&&... args) {
+    if (p == end()) {
+      return emplace_back(std::forward<Args>(args)...);
+    } else {
+      // p might be invalidated when the capacity is increased,
+      // so we need to remember where it occurs in the sequence
+      auto pos = p - begin();
+      storage.ensure_capacity(size() + 1);
+      p = begin() + pos;
+
+      // Note that "it" is guaranteed to remain valid even after
+      // the call to move_append since we ensured that there was
+      // sufficient capacity already, so a second reallocation will
+      // never happen after this point
+      auto the_tail = pop_tail(p);
+      auto it = emplace_back(std::forward<Args>(args)...);
+      move_append(the_tail);
+      return it;
+    }
+  }
+
+  template<typename... Args>
+  iterator emplace_back(Args&&... args) {
+    storage.ensure_capacity(size() + 1);
+    storage.initialize(end(), std::forward<Args>(args)...);
+    storage.set_size(size() + 1);
+    return end() - 1;
+  }
+
+  iterator push_back(const value_type& v) { return emplace_back(v); }
+
+  iterator push_back(value_type&& v) { return emplace_back(std::move(v)); }
+
+  template<typename Iterator_>
+  iterator append(Iterator_ first, Iterator_ last) {
+    return append_dispatch(first, last, std::is_integral<Iterator_>());
+  }
+
+  template<typename R>
+  iterator append(R&& r) {
+    return append(std::begin(r), std::end(r));
+  }
+
+  // Append the given sequence r. Since r is an rvalue, we can
+  // move its elements instead of copying them. Furthermore, if
+  // the current sequence is empty and doesn't own a large buffer,
+  // we can simply move assign the entire sequence r
+  iterator append(sequence_type&& r) {
+    if (empty() && capacity() <= r.size()) {
+      *this = std::move(r);
+      return begin();
+    } else {
+      return append(std::make_move_iterator(std::begin(r)), std::make_move_iterator(std::end(r)));
+    }
+  }
+
+  iterator append(size_t n, const value_type& t) { return append_n(n, t); }
+
+  iterator insert(iterator p, const value_type& t) { return emplace(p, t); }
+
+  iterator insert(iterator p, value_type&& rv) { return emplace(p, std::move(rv)); }
+
+  iterator insert(iterator p, size_t n, const value_type& t) { return insert_n(p, n, t); }
+
+  template<typename Iterator_>
+  iterator insert(iterator p, Iterator_ i, Iterator_ j) {
+    return insert_dispatch(p, i, j, std::is_integral<Iterator_>());
+  }
+
+  template<typename Range,
+    std::enable_if_t<!std::is_same_v<std::decay_t<Range>, value_type> &&
+                      is_input_range_v<Range> &&
+                      std::is_constructible_v<value_type, range_reference_type_t<Range>>, int> = 0>
+  iterator insert(iterator p, Range&& r) {
+    return insert(p, std::begin(r), std::end(r));
+  }
+
+  iterator insert(iterator p, sequence_type&& r) {
+    return insert(p, std::make_move_iterator(std::begin(r)), std::make_move_iterator(std::end(r)));
+  }
+
+  iterator insert(iterator p, std::initializer_list<value_type> l) {
+    return insert_range(p, std::begin(l), std::end(l));
+  }
+
+  iterator erase(iterator q) {
+    if (q == end() - 1) {
+      pop_back();
+      return end();
+    } else {
+      auto pos = q - begin();
+      auto the_tail = pop_tail(q + 1);
+      pop_back();
+      move_append(the_tail);
+      return begin() + pos;
+    }
+  }
+
+  iterator erase(iterator q1, iterator q2) {
+    auto pos = q1 - begin();
+    auto the_tail = pop_tail(q2);
+    resize(size() - (q2 - q1));
+    move_append(the_tail);
+    return begin() + pos;
+  }
+
+  void pop_back() {
+    storage.destroy(end() - 1);
+    storage.set_size(size() - 1);
+  }
+
+  // if all elements have been relocated out of this sequence then don't
+  // destroy them (it would not only be inefficient, but incorrect).
+  // Note that this is all or none: i.e. they better all be relocated for
+  // this function, or none for the standard destructor or clear().
+  // It is not a member function, so as to discourage its use by naive users.
+  friend void clear_relocated(sequence& S) { S.storage.clear_without_destruction(); }
+
+  void clear() { storage.clear(); }
+
+
+  void resize(size_t new_size, const value_type& v = value_type()) {
+    auto current = size();
+    if (new_size < current) {
+      if constexpr (!std::is_trivially_destructible_v<value_type>) {
+        auto buffer = storage.data();
+        parallel_for(new_size, current, [&](size_t i) { storage.destroy(&buffer[i]); });
+      }
+    } else {
+      storage.ensure_capacity(new_size);
+      assert(storage.capacity() >= new_size);
+      auto buffer = storage.data();
+      parallel_for(
+          current, new_size, [&](size_t i) { storage.initialize_explicit(&buffer[i], v); },
+          copy_granularity(new_size - current));
+    }
+    storage.set_size(new_size);
+  }
+
+  void reserve(size_t amount) {
+    storage.ensure_capacity(amount);
+    assert(storage.capacity() >= amount);
+  }
+
+  size_t capacity() const { return storage.capacity(); }
+
+  template<typename Iterator_>
+  void assign(Iterator_ i, Iterator_ j) {
+    storage.clear();
+    initialize_dispatch(i, j, std::is_integral<Iterator_>());
+  }
+
+  void assign(size_t n, const value_type& v) {
+    storage.clear();
+    return initialize_fill(n, v);
+  }
+
+  void assign(std::initializer_list<value_type> l) { assign(std::begin(l), std::end(l)); }
+
+  template<typename R>
+  void assign(R&& r) {
+    assign(std::begin(r), std::end(r));
+  }
+
+  void assign(sequence_type&& r) { *this = std::move(r); }
+
+  value_type& front() { return *begin(); }
+  value_type& back() { return *(end() - 1); }
+
+  const value_type& front() const { return *begin(); }
+  const value_type& back() const { return *(end() - 1); }
+
+  auto head(iterator p) { return make_slice(begin(), p); }
+
+  auto head(size_type len) { return make_slice(begin(), begin() + len); }
+
+  auto tail(iterator p) { return make_slice(p, end()); }
+
+  auto tail(size_type len) { return make_slice(end() - len, end()); }
+
+  auto cut(size_type s, size_type e) { return make_slice(begin() + s, begin() + e); }
+
+  // Const versions of slices
+
+  auto head(iterator p) const { return make_slice(begin(), p); }
+
+  auto head(size_type len) const { return make_slice(begin(), begin() + len); }
+
+  auto tail(iterator p) const { return make_slice(p, end()); }
+
+  auto tail(size_type len) const { return make_slice(end() - len, end()); }
+
+  auto cut(size_type s, size_type e) const { return make_slice(begin() + s, begin() + e); }
+
+  auto substr(size_type pos) const { return to_sequence(cut(pos, size())); }
+
+  auto substr(size_type pos, size_type count) const { return to_sequence(cut(pos, pos + count)); }
+
+  auto subseq(size_type s, size_type e) const { return to_sequence(cut(s,e)); }
+
+  // Remove all elements of the subsequence beginning at the element
+  // pointed to by p, and return a new sequence consisting of those
+  // removed elements.
+  sequence_type pop_tail(iterator p) {
+    if (p == end()) {
+      return sequence_type{};
+    } else {
+      sequence_type the_tail(std::make_move_iterator(p), std::make_move_iterator(end()));
+      if constexpr (!std::is_trivially_destructible_v<value_type>) {
+        parallel_for(0, end() - p, [&](size_t i) { storage.destroy(&p[i]); });
+      }
+      storage.set_size(p - begin());
+      return the_tail;
+    }
+  }
+
+  // Remove the last len elements from the sequence and return
+  // a new sequence consisting of the removed elements
+  sequence_type pop_tail(size_t len) { return pop_tail(end() - len); }
+
+  // ----------------- Factory methods --------------------
+
+  // Create a sequence of length n consisting of uninitialized
+  // elements. This is potentially dangerous! Use at your own
+  // risk. For primitive types, this is mostly harmless, since
+  // the elements will essentially just be arbitrary. For
+  // non-trivial types, you must ensure that you initialize
+  // every element of the sequence before invoking any operation
+  // that might resize the sequence or destroy it.
+  //
+  // Initializing non-trivial elements must be done using an
+  // uninitialized assignment (see e.g., std::uninitialized_copy
+  // or std::uninitialized_move). Ordinary assignment will trigger
+  // the destructor of the uninitialized contents which is bad.
+  static sequence_type uninitialized(size_t n) { return sequence_type(n, _uninitialized_tag{}); }
+
+#ifdef _MSC_VER
+  #pragma warning(push)
+#pragma warning(disable : 4267)  // conversion from 'size_t' to *, possible loss of data
+#endif
+
+  // Create a sequence of length n consisting of the elements
+  // generated by f(0), f(1), ..., f(n-1)
+  template<typename F>
+  static sequence_type from_function(size_t n, F&& f, size_t granularity = 0) {
+    return sequence_type(n, std::forward<F>(f), _from_function_tag(), granularity);
+  }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+  std::vector<T> to_vector() const {
+    return {begin(), end()};
+  }
+
+ private:
+  struct _uninitialized_tag {};
+  struct _from_function_tag {};
+
+  sequence(size_t n, _uninitialized_tag) : sequence_base_type() {
+    storage.initialize_capacity(n);
+    storage.set_size(n);
+
+    // If uninitialized memory debugging is turned on, make sure that
+    // a buffer of UninitializedTracker is appropriately set to its
+    // uninitialized state.
+#ifdef PARLAY_DEBUG_UNINITIALIZED
+    if constexpr (std::is_same_v<value_type, internal::UninitializedTracker>) {
+      auto buffer = storage.data();
+      parallel_for(0, n, [&](size_t i) {
+        buffer[i].initialized = false;
+        PARLAY_ASSERT_UNINITIALIZED(buffer[i]);
+      });
+    }
+#endif
+  }
+
+  template<typename F>
+  sequence(size_t n, F&& f, _from_function_tag, size_t granularity = 0) :
+      sequence_base_type() {
+    // value_type must either be constructible from f(i), or f(i) must return a prvalue
+    // of value_type, in which case we can rely on guaranteed copy elision
+    static_assert(std::is_constructible_v<value_type, std::invoke_result_t<F&&, size_t>> ||
+                  std::is_same_v<value_type, std::invoke_result_t<F&&, size_t>>);
+
+    storage.initialize_capacity(n);
+    storage.set_size(n);
+    auto buffer = storage.data();
+    parallel_for(0, n, [&](size_t i) {
+      if constexpr (std::is_constructible_v<value_type, std::invoke_result_t<F&&, size_t>>) {
+        storage.initialize(&buffer[i], f(i));
+      }
+      else {
+        storage.initialize_with_copy_elision(&buffer[i], [&]() { return f(i); });
+      }
+    }, granularity);
+  }
+
+  // Implement initialize_default manually rather than
+  // calling initialize_fill(n, value_type()) because
+  // this allows us to store a sequence of uncopyable
+  // types provided that no reallocation ever happens.
+  void initialize_default(size_t n) {
+    storage.initialize_capacity(n);
+    auto buffer = storage.data();
+    parallel_for(0, n, [&](size_t i) {      // Calling initialize with
+      storage.initialize(buffer + i);       // no arguments performs
+    }, initialization_granularity(n));      // value initialization
+    storage.set_size(n);
+  }
+
+  void initialize_fill(size_t n, const value_type& v) {
+    storage.initialize_capacity(n);
+    auto buffer = storage.data();
+    parallel_for(0, n, [&](size_t i) {
+      storage.initialize_explicit(buffer + i, v);
+    }, copy_granularity(n));
+    storage.set_size(n);
+  }
+
+  template<typename InputIterator_>
+  void initialize_range(InputIterator_ first, InputIterator_ last, std::input_iterator_tag) {
+    for (; first != last; ++first) {
+      push_back(*first);
+    }
+  }
+
+  template<typename ForwardIterator_>
+  void initialize_range(ForwardIterator_ first, ForwardIterator_ last, std::forward_iterator_tag) {
+    auto n = std::distance(first, last);
+    storage.initialize_capacity(n);
+    auto buffer = storage.data();
+    for (size_t i = 0; first != last; i++, ++first) {
+      storage.initialize(buffer + i, *first);
+    }
+    storage.set_size(n);
+  }
+
+  template<typename RandomAccessIterator_>
+  void initialize_range(RandomAccessIterator_ first, RandomAccessIterator_ last, std::random_access_iterator_tag) {
+    auto n = std::distance(first, last);
+    storage.initialize_capacity(n);
+    auto buffer = storage.data();
+    parallel_for(0, n, [&](size_t i) {
+      storage.initialize(buffer + i, first[i]);
+    }, copy_granularity(n));
+    storage.set_size(n);
+  }
+
+  // Use tag dispatch to distinguish between the (n, value)
+  // constructor and the iterator pair constructor
+
+  template<typename Integer_>
+  void initialize_dispatch(Integer_ n, Integer_ v, std::true_type) {
+    initialize_fill(n, v);
+  }
+
+  template<typename Iterator_>
+  void initialize_dispatch(Iterator_ first, Iterator_ last, std::false_type) {
+    initialize_range(first, last, typename std::iterator_traits<Iterator_>::iterator_category());
+  }
+
+  // Use tag dispatch to distinguish between the (n, value)
+  // append operation and the iterator pair append operation
+
+  template<typename Integer_>
+  iterator append_dispatch(Integer_ first, Integer_ last, std::true_type) {
+    return append_n(first, last);
+  }
+
+  template<typename Iterator_>
+  iterator append_dispatch(Iterator_ first, Iterator_ last, std::false_type) {
+    return append_range(first, last, typename std::iterator_traits<Iterator_>::iterator_category());
+  }
+
+  iterator append_n(size_t n, const value_type& t) {
+    storage.ensure_capacity(size() + n);
+    auto it = end();
+    parallel_for(0, n, [&](size_t i) {
+      storage.initialize_explicit(it + i, t);
+    }, this->copy_granularity(n));
+    storage.set_size(size() + n);
+    return it;
+  }
+
+  // Distinguish between different types of iterators
+  // InputIterators and ForwardIterators can not be used
+  // in parallel, so they operate sequentially.
+
+  template<typename InputIterator_>
+  iterator append_range(InputIterator_ first, InputIterator_ last, std::input_iterator_tag) {
+    size_t n = 0;
+    for (; first != last; first++, n++) {
+      push_back(*first);
+    }
+    return end() - n;
+  }
+
+  template<typename ForwardIterator_>
+  iterator append_range(ForwardIterator_ first, ForwardIterator_ last, std::forward_iterator_tag) {
+    auto n = std::distance(first, last);
+    storage.ensure_capacity(size() + n);
+    auto it = end();
+    std::uninitialized_copy(first, last, it);
+    storage.set_size(size() + n);
+    return it;
+  }
+
+  template<typename RandomAccessIterator_>
+  iterator append_range(RandomAccessIterator_ first, RandomAccessIterator_ last, std::random_access_iterator_tag) {
+    auto n = std::distance(first, last);
+    storage.ensure_capacity(size() + n);
+    auto it = end();
+    parallel_for(0, n, [&](size_t i) {
+      storage.initialize(it + i, first[i]);
+    }, copy_granularity(n));
+    storage.set_size(size() + n);
+    return it;
+  }
+
+  // Use tag dispatch to distinguish between the (n, value)
+  // insert operation and the iterator pair insert operation
+
+  template<typename Integer_>
+  iterator insert_dispatch(iterator p, Integer_ n, Integer_ v, std::true_type) {
+    return insert_n(p, n, v);
+  }
+
+  template<typename Iterator_>
+  iterator insert_dispatch(iterator p, Iterator_ first, Iterator_ last, std::false_type) {
+    return insert_range(p, first, last);
+  }
+
+  iterator insert_n(iterator p, size_t n, const value_type& v) {
+    // p might be invalidated when the capacity is increased,
+    // so we have to remember where it is in the sequence
+    auto pos = p - begin();
+    storage.ensure_capacity(size() + n);
+    p = begin() + pos;
+
+    // Note that "it" is guaranteed to remain valid even after
+    // the call to move_append since we ensured that there was
+    // sufficient capacity already, so a second reallocation will
+    // never happen after this point
+    auto the_tail = pop_tail(p);
+    auto it = append_n(n, v);
+    move_append(the_tail);
+    return it;
+  }
+
+  template<typename Iterator_>
+  iterator insert_range(iterator p, Iterator_ first, Iterator_ last) {
+    auto the_tail = pop_tail(p);
+    auto it = append(first, last);
+    auto pos = it - begin();
+    move_append(the_tail);
+    return begin() + pos;
+  }
+
+  // Append the given range, moving its elements into this sequence
+  template<typename R>
+  void move_append(R&& r) {
+    append(std::make_move_iterator(std::begin(r)), std::make_move_iterator(std::end(r)));
+  }
+
+  // Return true if this sequence compares equal to the sequence
+  // beginning at other. The sequence beginning at other must be
+  // of at least the same length as this sequence.
+  template<typename Iterator_>
+  bool compare_equal(Iterator_ other, size_t granularity = 0) const {
+    if (granularity == 0) {
+      granularity = 1024 * sizeof(size_t) / sizeof(value_type);
+    }
+    auto n = size();
+    auto self = begin();
+    size_t i;
+    for (i = 0; i < (std::min)(granularity, n); i++)
+      if (!(self[i] == other[i])) return false;
+    if (i == n) return true;
+    size_t start = granularity;
+    size_t block_size = 2 * granularity;
+    bool matches = true;
+    while (start < n) {
+      size_t last = (std::min)(n, start + block_size);
+      parallel_for(start, last, [&](size_t j) {
+        if (!(self[j] == other[j])) matches = false;
+      }, granularity);
+      if (!matches) return false;
+      start += block_size;
+      block_size *= 2;
+    }
+    return matches;
+  }
+};
+
+// A short_sequence is a dynamic array supporting parallel modification operations
+// that may also perform small-size optimization. For sequences of trivial types
+// whose elements fit in 15 bytes or fewer, the sequence will be stored inline and
+// no heap allocation will be performed.
+//
+// This type is just an alias for parlay::sequence<T, Allocator, true>
+//
+// Template arguments:
+//  T:         the value type of the sequence
+//  Allocator: an allocator for type T
+//
+template<typename T, typename Allocator = internal::sequence_default_allocator<T>>
+using short_sequence = sequence<T, Allocator, true>;
+
+// A chars is an alias for a short-size optimized character sequence.
+//
+// You can think of chars as either an abbreviation of "char sequence",
+// or as a plural of char. Both make sense!
+//
+// Character sequences that fit in 15 bytes or fewer will be stored inline
+// without performing a heap allocation. Large sequences are stored on the
+// heap, and support update and query operations in parallel.
+using chars = sequence<char, internal::sequence_default_allocator<char>, true>;
+
+// Convert an arbitrary range into a sequence.
+//
+// The value type is deduced from the value type of the range, and the
+// default allocator is used.
+template<typename R>
+inline auto to_sequence(R&& r) -> sequence<range_value_type_t<R>> {
+  static_assert(is_random_access_range_v<R> || !is_block_iterable_range_v<R>,
+      "You called parlay::to_sequence on a delayed (block-iterable) range. You probably meant to call parlay::delayed::to_sequence");
+  return {std::begin(r), std::end(r)};
+}
+
+// Convert an arbitrary range into a (short) sequence
+//
+// The value type is deduced from the value type of the range, and the
+// default allocator is used.
+template<typename R>
+inline auto to_short_sequence(R&& r) -> short_sequence<range_value_type_t<R>> {
+  static_assert(is_random_access_range_v<R> || !is_block_iterable_range_v<R>,
+      "You called parlay::to_sequence on a delayed (block-iterable) range. You probably meant to call parlay::delayed::to_sequence");
+  return {std::begin(r), std::end(r)};
+}
+
+// Convert an arbitrary range into a sequence of type T, and optionally
+// specify the allocator to use for the sequence.
+template<typename T, typename Alloc = internal::sequence_default_allocator<T>, typename R>
+inline auto to_sequence(R&& r) -> sequence<T, Alloc> {
+  static_assert(is_random_access_range_v<R> || !is_block_iterable_range_v<R>,
+      "You called parlay::to_sequence on a delayed (block-iterable) range. You probably meant to call parlay::delayed::to_sequence");
+  return {std::begin(r), std::end(r)};
+}
+
+// Convert an arbitrary range into a (short) sequence of type T, and optionally
+// specify the allocator to use for the sequence.
+template<typename T, typename Alloc = internal::sequence_default_allocator<T>, typename R>
+inline auto to_short_sequence(R&& r) -> short_sequence<T, Alloc> {
+  static_assert(is_random_access_range_v<R> || !is_block_iterable_range_v<R>,
+      "You called parlay::to_sequence on a delayed (block-iterable) range. You probably meant to call parlay::delayed::to_sequence");
+  return {std::begin(r), std::end(r)};
+}
+
+// Mark sequences as trivially relocatable. A sequence is always
+// trivially relocatable as long as the allocator is, because:
+//  1) Sequences only use small-size optimization when the element
+//     type is trivial, so the buffer of trivial elements is
+//     trivially relocatable.
+//  2) Sequences that are not small-size optimized are just a
+//     pointer/length pair, which are trivially relocatable
+template<typename T, typename Alloc, bool EnableSSO>
+struct is_trivially_relocatable<sequence<T, Alloc, EnableSSO>>
+    : std::bool_constant<is_trivially_relocatable_v<Alloc>> {};
+
+
+}  // namespace parlay
+
+namespace std {
+
+// exchange the values of a and b
+template<typename T, typename Allocator, bool EnableSSO>
+inline void swap(parlay::sequence<T, Allocator, EnableSSO>& a, parlay::sequence<T, Allocator, EnableSSO>& b) {
+  a.swap(b);
+}
+
+// compute a suitable hash value for a sequence
+template<typename T, typename Allocator, bool EnableSSO>
+struct hash<parlay::sequence<T, Allocator, EnableSSO>> {
+  std::size_t operator()(parlay::sequence<T, Allocator, EnableSSO> const& s) const noexcept {
+    size_t hash = 5381;
+      for (size_t i = 0; i < s.size(); i++) {
+        hash = ((hash << 5) + hash) + parlay::hash<T>{}(s[i]);
+      }
+      return hash;
+  }
+};
+
+}  // namespace std
+
+#endif  // PARLAY_SEQUENCE_H_

--- a/third_party/parlayhash/include/parlay/slice.h
+++ b/third_party/parlayhash/include/parlay/slice.h
@@ -1,0 +1,116 @@
+// A slice is a non-owning view of a range defined by a pair
+// of iterators. Slices can be created from any range object,
+// or directly from an iterator pair. They can contain const
+// iterators, in which case the slice represents a read-only
+// view, or they can contain mutable iterators, so the slice
+// can be used to modify the underlying sequence.
+//
+// Usage:
+//
+//   // create from a range
+//   auto s = parlay::make_slice(r);  
+//
+//   // create from an iterator pair
+//   auto s = parlay::make_slice(r.begin(), r.end())
+//
+//   // supports subscripting
+//   std::cout << s[i] << std::endl;
+//
+//   // cutting out a substring
+//   auto s_mid = s.cut(from,to);
+//
+// slice satisfies the parlay::Range concept so they can be
+// used with all of Parlay's sequence primitives
+//
+
+#ifndef PARLAY_SLICE_H_
+#define PARLAY_SLICE_H_
+
+#include <cstddef>
+
+#include <iterator>
+
+#include "range.h"    // IWYU pragma: keep
+
+namespace parlay {
+
+template <typename It, typename S>  
+struct slice;
+
+// Create a slice from an explicit iterator range
+template<typename It, typename S>
+auto make_slice(It it, S s) {
+  return slice<It, S>(it, s);
+}
+
+// Create a slice from a range.
+template<typename R>
+auto make_slice(R&& r) {
+  return make_slice(std::begin(r), std::end(r));
+}
+
+// A slice is a non-owning view of a random-access range defined by an iterator pair.
+template <typename It, typename S>  
+struct slice {
+  static_assert(is_random_access_iterator_v<It>);
+  static_assert(is_sentinel_for_v<It, S>);
+
+ public:
+ 
+  // Note the distinction -- value_type is the underlying type pointed to
+  // by the iterator ignoring const-ness or reference-ness. reference is
+  // the actual type returned by dereferencing the iterator, which may
+  // not actually be a reference (for delayed sequence, it is a value)
+  using value_type = typename std::iterator_traits<It>::value_type;
+  using reference = typename std::iterator_traits<It>::reference;
+  
+  using iterator = It;
+  using sentinel = S;
+  
+  slice(iterator s, sentinel e) : s(s), e(e){};
+  
+  // Copy construction and assignment
+  slice(const slice<It,S>&) = default;
+  slice<It,S>& operator=(const slice<It,S>&) = default;
+  
+  // Return the i'th element of the sequence
+  reference operator[](size_t i) const { return s[i]; }
+  
+  // Return the size of the sequence
+  size_t size() const { return e - s; }
+  
+  // Return a slice corresponding to the subrange from
+  // positions ss to ee.
+  slice<It, It> cut(size_t ss, size_t ee) const {
+    return make_slice(s + ss, s + ee);
+  }
+  
+  // Iterator access
+  iterator begin() const { return s; }
+  sentinel end() const { return e; }
+
+ private:
+  iterator s;
+  sentinel e;
+};
+
+// Two slices are equal if they refer to the same underlying
+// range via the same pair of iterators, i.e., the iterators
+// compare equal.
+//
+// Note that comparing iterators from different underlying
+// ranges is undefined behaviour.
+template<typename Iterator, typename Sentinal>
+bool operator==(slice<Iterator, Sentinal> s1, slice<Iterator, Sentinal> s2) {
+  // Since iterators from different ranges / containers can not be
+  // compared, cppcheck detects this as a problem. Slices should only
+  // be compared with == if they refer to a subrange of the same range.
+  // Other uses are undefined behaviour.
+  
+  // cppcheck-suppress mismatchingContainerExpression
+  return s1.begin() == s2.begin() && s1.end() == s2.end();
+}
+
+}
+
+#endif  // PARLAY_SLICE_H_

--- a/third_party/parlayhash/include/parlay/thread_specific.h
+++ b/third_party/parlayhash/include/parlay/thread_specific.h
@@ -1,0 +1,464 @@
+
+#ifndef PARLAY_THREAD_SPECIFIC_H_
+#define PARLAY_THREAD_SPECIFIC_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <array>
+#include <algorithm>      // IWYU pragma: keep
+#include <atomic>
+#include <functional>
+#include <iterator>
+#include <mutex>
+#include <new>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "internal/thread_id_pool.h"
+
+#include "portability.h"
+#include "range.h"
+#include "type_traits.h"
+
+
+namespace parlay {
+
+using internal::thread_id_type;
+
+// Returns a unique thread ID for the current running thread
+// in the range of [0...num_thread_ids()).  Thread IDs are
+// guaranteed to be unique for all *live* threads, but they
+// are re-used after a thread dies and another is spawned.
+inline thread_id_type my_thread_id() {
+  return internal::get_thread_id();
+}
+
+// Return the number of thread IDs that have been assigned to
+// threads.  All thread IDs are in the range [0...num_thread_ids()).
+//
+// Important note:  Thread IDs are assigned lazily when a thread
+// first requests one.  Therefore num_thread_ids() is *not*
+// guaranteed to be as large as the number of live threads if
+// those threads have never called my_thread_id().
+inline thread_id_type num_thread_ids() {
+  return internal::get_num_thread_ids();
+}
+
+namespace internal {
+
+class ThreadListChunkData {
+
+ public:
+
+  // This is just std::bit_ceil(std::thread::hardware_concurrency()) but we don't assume C++20
+  const static inline std::size_t thread_list_chunk_size = []() {
+    std::size_t size = 4;
+    while (size < std::thread::hardware_concurrency())
+      size *= 2;
+    return size;
+  }();
+
+  // Used by ThreadSpecific which stores a chunked sequence of items that is at least as large
+  // as the number of active threads.  Given a thread ID, items are split into chunks of size:
+  //
+  //   P, P, 2P, 4P, 8P, ...
+  //
+  // where P is the lowest power of two that is at least as large as the number of hardware threads.
+  static std::size_t compute_chunk_id(thread_id_type id) {
+    std::size_t k = thread_list_chunk_size;
+    std::size_t chunk = 0;
+    while (k <= id) {
+      chunk++;
+      k *= 2;
+    }
+    return chunk;
+  }
+
+  static std::size_t compute_chunk_position(thread_id_type id, std::size_t chunk_id) {
+    if (chunk_id == 0)
+      return id;
+    else {
+      auto high_bit = thread_list_chunk_size << (chunk_id - 1);
+      assert(id & high_bit);
+      return id - high_bit;
+    }
+  }
+
+  explicit ThreadListChunkData(thread_id_type thread_id_) noexcept : thread_id(thread_id_),
+      chunk_id(compute_chunk_id(thread_id)), chunk_position(compute_chunk_position(thread_id, chunk_id)) { }
+
+  const thread_id_type thread_id;
+  const std::size_t chunk_id;
+  const std::size_t chunk_position;
+};
+
+extern inline const ThreadListChunkData& get_chunk_data() {
+  static thread_local const ThreadListChunkData data{get_thread_id()};
+  return data;
+}
+
+template<typename T>
+struct Uninitialized {
+  union {
+    alignas(64) std::monostate empty;
+    T value;
+  };
+
+  Uninitialized() noexcept { };
+
+  T& operator*() { return value; }
+
+  T* get() { return std::addressof(value); }
+
+  ~Uninitialized() { value.~T(); }
+};
+
+}  // namespace internal
+
+// A ThreadSpecific<T> stores a list of objects of type T such that there
+// is a unique object for each active thread. The list automatically grows
+// when additional threads are spawned and attempt to access it. Threads
+// may also traverse the entire list if they need to.
+//
+// By default, list elements are all value initialized, roughly meaning
+// that class types are default constructed, and builtin types are zero
+// initialized.  For custom initialization, you can pass a constructor
+// function which returns the desired value.  The constructor function
+// can take zero or one arguments.  If it takes one argument, it will be
+// passed the thread ID that it is constructing for.  Note that the
+// elements are not guaranteed to be constructed by the thread that
+// they belong to, and they may be constructed in advance of any thread
+// actually taking ownership of that ID.
+//
+// A few things to note:
+//
+// - Thread IDs are always unique for the set of currently live threads,
+//   but not unique over the course of the entire program.  A thread that
+//   dies will give up its ID to be claimed by a new thread later.
+//
+// - The list elements are *not* destroyed when the thread that "owns"
+//   them is destroyed. A new thread that reclaims a previously-used ID
+//   will find the item at that position in the same state that it was
+//   left by the previous thread.  Elements are only destroyed when the
+//   entire ThreadSpecific is destroyed.
+//
+//   Therefore, threads are responsible for manually cleaning up the
+//   contents of a ThreadSpecific and/or resetting it to a default value
+//   for the next thread that might claim the spot if they need to.
+//
+template<typename T>
+class ThreadSpecific {
+
+  // 25 chunks guarantees enough slots for any machine
+  // with up to 2^48 bytes of addressable virtual memory,
+  // assuming that threads are 8MB large.
+  static constexpr std::size_t n_chunks = 25;
+
+ public:
+
+  using reference = T&;
+  using value_type = T;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using pointer = T*;
+
+  ThreadSpecific() : constructor([](std::size_t) { return T{}; }) {
+    initialize();
+  }
+
+  template<typename F,
+      typename std::enable_if_t<std::is_invocable_v<F&> && !std::is_invocable_v<F&, std::size_t>, int> = 0>
+  explicit ThreadSpecific(F&& constructor_)
+      : constructor([f = std::forward<F>(constructor_)](std::size_t) { return f(); }) {
+    initialize();
+  }
+
+  template<typename F,
+      typename std::enable_if_t<std::is_invocable_v<F&, std::size_t>, int> = 0>
+  explicit ThreadSpecific(F&& constructor_) : constructor(std::forward<F>(constructor_)) {
+    initialize();
+  }
+
+  ThreadSpecific(const ThreadSpecific&) = delete;
+  ThreadSpecific& operator=(const ThreadSpecific&) = delete;
+  ThreadSpecific(ThreadSpecific&&) = delete;
+
+  ~ThreadSpecific() {
+    for (internal::Uninitialized<T>* chunk : chunks) {
+      delete[] chunk;
+    }
+  }
+
+  T& operator*() { return get(); }
+  T* operator->() { return std::addressof(get()); }
+
+  T& get() {
+    auto chunk_data = internal::get_chunk_data();
+    return get_by_index(chunk_data.chunk_id, chunk_data.chunk_position);
+  }
+
+  const T& operator*() const { return get(); }
+  T const* operator->() const { return std::addressof(get()); }
+
+  const T& get() const {
+    auto chunk_data = internal::get_chunk_data();
+    return get_by_index(chunk_data.chunk_id, chunk_data.chunk_position);
+  }
+
+  template<typename F>
+  void for_each(F&& f) {
+    static_assert(std::is_invocable_v<F, T&>);
+
+    auto num_threads = num_thread_ids();
+    thread_id_type tid = 0;
+    internal::Uninitialized<T>* chunk = chunks[0].load(std::memory_order_relaxed);
+
+    for (std::size_t chunk_id = 0; tid < num_threads; chunk = chunks[++chunk_id].load(std::memory_order_acquire)) {
+      auto chunk_size = get_chunk_size(chunk_id);
+      if (!chunk) PARLAY_UNLIKELY {
+        ensure_chunk_exists(chunk_id);
+        chunk = chunks[chunk_id].load(std::memory_order_relaxed);
+      }
+      for (std::size_t i = 0; tid < num_threads && i < chunk_size; i++, tid++) {
+        f(*chunk[i]);
+      }
+    }
+  }
+
+  // Allow looping over all thread's data
+  template<bool Const>
+  class iterator_t {
+    friend class ThreadSpecific<T>;
+
+    using parent_type = maybe_const_t<Const, ThreadSpecific<T>>;
+
+    iterator_t(std::size_t chunk_id_, std::size_t position_, parent_type* parent_) :
+        chunk_id(chunk_id_), position(position_), parent(parent_) { }
+
+   public:
+    using iterator_category = std::random_access_iterator_tag;
+    using reference = std::add_lvalue_reference_t<maybe_const_t<Const, T>>;
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = std::add_pointer_t<maybe_const_t<Const, T>>;
+
+    iterator_t() = default;
+
+    /* implicit */ iterator_t(const iterator_t<false>& other)  // cppcheck-suppress noExplicitConstructor    // NOLINT
+        : chunk_id(other.chunk_id), position(other.position), parent(other.parent) { }
+
+    reference operator*() const { return parent->get_by_index_nocheck(chunk_id, position); }
+
+    reference operator[](std::size_t p) const {
+      auto tmp = *this;
+      tmp += p;
+      return *tmp;
+    }
+
+    iterator_t& operator++() {
+      position++;
+      if (position == get_chunk_size(chunk_id)) {
+        if (++chunk_id < n_chunks && parent->chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+          parent->ensure_chunk_exists(chunk_id);
+        position = 0;
+      }
+      return *this;
+    }
+
+    iterator_t operator++(int) { auto tmp = *this; ++(*this); return tmp; }   //NOLINT
+
+    iterator_t& operator--() {
+      if (position == 0) {
+        position = get_chunk_size(--chunk_id) - 1;
+        if (parent->chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+          parent->ensure_chunk_exists(chunk_id);
+      }
+      else {
+        position--;
+      }
+      return *this;
+    }
+
+    iterator_t operator--(int) { auto tmp = *this; --(*this); return tmp; }   //NOLINT
+
+    iterator_t& operator+=(difference_type diff) {
+      if (diff < 0) return *this -= (-diff);
+      assert(diff >= 0);
+      position += diff;
+      if (position >= get_chunk_size(chunk_id)) {
+        do {
+          position -= get_chunk_size(chunk_id++);
+        } while (position >= get_chunk_size(chunk_id));
+        if (parent->chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+          parent->ensure_chunk_exists(chunk_id);
+      }
+      return *this;
+    }
+
+    iterator_t operator+(difference_type diff) const {
+      auto result = *this;
+      result += diff;
+      return result;
+    }
+
+    iterator_t& operator-=(difference_type diff) {
+      if (diff < 0) return *this += (-diff);
+      assert(diff >= 0);
+      auto pos = static_cast<difference_type>(position);
+      pos -= diff;
+      if (pos < 0) {
+        do {
+          pos += static_cast<difference_type>(get_chunk_size(--chunk_id));
+        } while (pos < 0);
+        if (parent->chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+          parent->ensure_chunk_exists(chunk_id);
+      }
+      assert(pos >= 0);
+      position = static_cast<std::size_t>(pos);
+      return *this;
+    }
+
+    iterator_t operator-(difference_type diff) const {
+      auto result = *this;
+      result -= diff;
+      return result;
+    }
+
+    difference_type operator-(const iterator_t& other) const {
+      if (other > *this) return -(other - *this);
+      assert(other <= *this);
+      auto result = static_cast<difference_type>(position) - static_cast<difference_type>(other.position);
+      auto chunk_id_ = other.chunk_id;
+      while (chunk_id_ < chunk_id) {
+        result += static_cast<difference_type>(get_chunk_size(chunk_id_++));
+      }
+      return result;
+    }
+
+    bool operator==(const iterator_t& other) const {
+      return chunk_id == other.chunk_id && position == other.position;
+    }
+
+    bool operator!=(const iterator_t& other) const {
+      return chunk_id != other.chunk_id || position != other.position;
+    }
+
+    bool operator<(const iterator_t& other) const {
+      return chunk_id < other.chunk_id || (chunk_id == other.chunk_id && position < other.position);
+    }
+
+    bool operator<=(const iterator_t& other) const {
+      return chunk_id < other.chunk_id || (chunk_id == other.chunk_id && position <= other.position);
+    }
+
+    bool operator>(const iterator_t& other) const {
+      return chunk_id > other.chunk_id || (chunk_id == other.chunk_id && position > other.position);
+    }
+
+    bool operator>=(const iterator_t& other) const {
+      return chunk_id > other.chunk_id || (chunk_id == other.chunk_id && position >= other.position);
+    }
+
+    friend void swap(iterator_t& left, iterator_t& right) {
+      std::swap(left.chunk_id, right.chunk_id);
+      std::swap(left.position, right.position);
+      std::swap(left.parent, right.parent);
+    }
+
+    std::size_t chunk_id{n_chunks};
+    std::size_t position{0};
+    parent_type* parent{nullptr};
+  };
+
+  using iterator = iterator_t<false>;
+  using const_iterator = iterator_t<true>;
+
+  static_assert(is_random_access_iterator_v<iterator>);
+  static_assert(is_random_access_iterator_v<const_iterator>);
+
+  [[nodiscard]] iterator begin() {
+    return iterator{0,0,this};
+  }
+
+  [[nodiscard]] const_iterator begin() const {
+    return const_iterator{0,0,this};
+  }
+
+  [[nodiscard]] iterator end() {
+    internal::ThreadListChunkData data{num_thread_ids()};
+    return iterator{data.chunk_id, data.chunk_position, this};
+  }
+
+  [[nodiscard]] const_iterator end() const {
+    internal::ThreadListChunkData data{num_thread_ids()};
+    return const_iterator{data.chunk_id, data.chunk_position, this};
+  }
+
+ private:
+
+  void initialize() {
+    internal::get_chunk_data();  //  Force static initialization before any ThreadLocals are constructed
+    chunks[0].store(new internal::Uninitialized<T>[internal::ThreadListChunkData::thread_list_chunk_size], std::memory_order_relaxed);
+    std::fill(chunks.begin() + 1, chunks.end(), nullptr);
+    auto chunk = chunks[0].load(std::memory_order_relaxed);
+    for (std::size_t i = 0; i < internal::ThreadListChunkData::thread_list_chunk_size; i++) {
+      new (static_cast<void*>(chunk[i].get())) T(constructor(i));
+    }
+  }
+
+  static std::size_t get_chunk_size(std::size_t chunk_id) {
+    assert(chunk_id < n_chunks);
+    if (chunk_id == 0) return internal::ThreadListChunkData::thread_list_chunk_size;
+    else return internal::ThreadListChunkData::thread_list_chunk_size << (chunk_id - 1);
+  }
+
+  T& get_by_index(std::size_t chunk_id, std::size_t chunk_position) {
+    if (chunk_id > 0 && chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+      ensure_chunk_exists(chunk_id);
+    return get_by_index_nocheck(chunk_id, chunk_position);
+  }
+
+  const T& get_by_index(std::size_t chunk_id, std::size_t chunk_position) const {
+    if (chunk_id > 0 && chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+    ensure_chunk_exists(chunk_id);
+    return get_by_index_nocheck(chunk_id, chunk_position);
+  }
+
+  T& get_by_index_nocheck(std::size_t chunk_id, std::size_t chunk_position) {
+    assert(chunks[chunk_id].load() != nullptr);
+    return *(chunks[chunk_id].load(std::memory_order_relaxed)[chunk_position]);
+  }
+
+  const T& get_by_index_nocheck(std::size_t chunk_id, std::size_t chunk_position) const {
+    assert(chunks[chunk_id].load() != nullptr);
+    return *(chunks[chunk_id].load(std::memory_order_relaxed)[chunk_position]);
+  }
+
+  void ensure_chunk_exists(std::size_t chunk_id) const {
+    std::lock_guard<std::mutex> lock(growing_mutex);
+    if (chunks[chunk_id].load(std::memory_order_relaxed) == nullptr) {
+      auto chunk_size = get_chunk_size(chunk_id);
+      auto chunk = new internal::Uninitialized<T>[chunk_size];
+      for (std::size_t i = 0; i < chunk_size; i++) {
+        new (static_cast<void*>(chunk[i].get())) T(constructor(chunk_size + i));
+      }
+      chunks[chunk_id].store(chunk, std::memory_order_release);
+    }
+  }
+
+  mutable std::function<T(thread_id_type)> constructor;
+  mutable std::mutex growing_mutex;
+  mutable std::array<std::atomic<internal::Uninitialized<T>*>, n_chunks> chunks;
+};
+
+static_assert(is_random_access_range_v<ThreadSpecific<int>>);
+static_assert(is_random_access_range_v<const ThreadSpecific<int>>);
+
+}  // namespace parlay
+
+
+#endif  // PARLAY_THREAD_SPECIFIC_H_

--- a/third_party/parlayhash/include/parlay/type_traits.h
+++ b/third_party/parlayhash/include/parlay/type_traits.h
@@ -1,0 +1,286 @@
+// Useful type traits used mostly internally by Parlay
+//
+// Many inspired by this video, and the following standards
+// proposals:
+//  - https://www.youtube.com/watch?v=MWBfmmg8-Yo
+//  - http://open-std.org/JTC1/SC22/WG21/docs/papers/2014/n4034.pdf
+//  - https://quuxplusone.github.io/blog/code/object-relocation-in-terms-of-move-plus-destroy-draft-7.html
+//
+// Includes:
+//  - priority_tag
+//  - is_trivial_allocator
+//  - is_trivially_relocatable / is_nothrow_relocatable
+//
+
+#ifndef PARLAY_TYPE_TRAITS_H_
+#define PARLAY_TYPE_TRAITS_H_
+
+#include <cstddef>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <utility>       // IWYU pragma: keep
+
+// IWYU pragma: no_include <iterator>
+
+namespace parlay {
+
+// Provides the member type T
+template<typename T>
+struct type_identity {
+  using type = T;
+};
+
+// Equal to the type T, i.e., the identity transformation
+template<typename T>
+using type_identity_t = typename type_identity<T>::type;
+
+// Given a pointer-to-member (object or function), returns
+// the type of the class in which the member lives
+template<typename T>
+struct member_pointer_class;
+
+template<typename T, typename U>
+struct member_pointer_class<T U::*> : public type_identity<U> {};
+
+template<typename T>
+using member_pointer_class_t = typename member_pointer_class<T>::type;
+
+// Provides the member type std::add_const_t<T> if Const is
+// true, otherwise provides the member type T
+template<bool Const, typename T>
+using maybe_const = std::conditional<Const, std::add_const_t<T>, T>;
+
+// Adds const to the given type if Const is true
+template<bool Const, typename T>
+using maybe_const_t = typename maybe_const<Const, T>::type;
+
+// Provides the member type std::decay_t<T> if Decay is
+// true, otherwise provides the member type T
+template<bool Decay, typename T>
+using maybe_decay = std::conditional<Decay, std::decay_t<T>, T>;
+
+// Decays the given type if Decay is true
+template<bool Decay, typename T>
+using maybe_decay_t = typename maybe_decay<Decay, T>::type;
+
+// Provides the member value true if the given type is an instance of std::optional
+template <typename T>
+struct is_optional : std::false_type {};
+
+template <typename T>
+struct is_optional<std::optional<T>> : std::true_type {};
+
+// true if the given type is an instance of std::optional
+template<typename T>
+inline constexpr bool is_optional_v = is_optional<T>::value;
+
+template<typename T, typename U = T>
+using is_less_than_comparable = std::conjunction<
+                                  std::is_invocable_r<bool, std::less<>, T, U>,
+                                  std::is_invocable_r<bool, std::less<>, U, T>
+                                >;
+
+template<typename T, typename U = T>
+inline constexpr bool is_less_than_comparable_v = is_less_than_comparable<T, U>::value;
+
+template<typename T, typename U = T>
+using is_equality_comparable = std::conjunction<
+                                 std::is_invocable_r<bool, std::equal_to<>, T, U>,
+                                 std::is_invocable_r<bool, std::equal_to<>, U, T>,
+                                 std::is_invocable_r<bool, std::not_equal_to<>, T, U>,
+                                 std::is_invocable_r<bool, std::not_equal_to<>, U, T>
+                               >;
+
+template<typename T, typename U = T>
+inline constexpr bool is_equality_comparable_v = is_equality_comparable<T, U>::value;
+
+// Defines a member value true if the given type BinaryOperator_ can be invoked on types
+// T1&& and T2 to yield a result of a type that is convertible to T1.
+//
+// This requirement corresponds to the needs of a left fold over the operator BinaryOperator_
+// with an identity and result type of T1, where the intermediate elements being reduced over
+// are potentially of type T2.
+template<typename BinaryOperator_, typename T1, typename T2, typename = void, typename = void>
+struct is_binary_operator_for : public std::false_type {};
+
+template<typename BinaryOperator_, typename T1, typename T2>
+struct is_binary_operator_for<BinaryOperator_, T1, T2, std::void_t<
+  std::enable_if_t< std::is_move_constructible_v<T1> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, T1&&, T1&&> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, T1&&, T2> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, T2, T2> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, T2, T1&&> >
+>, std::enable_if_t<!std::is_member_function_pointer_v<BinaryOperator_>>> : public std::true_type{};
+
+// Handle the case where BinaryOperator_ is a member function pointer
+template<typename BinaryOperator_, typename T1, typename T2>
+struct is_binary_operator_for<BinaryOperator_, T1, T2, std::void_t<
+  std::enable_if_t< std::is_move_constructible_v<T1> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, const member_pointer_class_t<BinaryOperator_>&, T1&&, T1&&> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, const member_pointer_class_t<BinaryOperator_>&, T1&&, T2> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, const member_pointer_class_t<BinaryOperator_>&, T2, T2> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, const member_pointer_class_t<BinaryOperator_>&, T2, T1&&> >
+>, std::enable_if_t<std::is_member_function_pointer_v<BinaryOperator_>>> : public std::true_type{};
+
+// True if the given type BinaryOperator_ can be invoked on types T1&& and T2 to yield a result
+// of a type that is convertible to T1. T2 defaults to T1&& if not specified.
+//
+// This requirement corresponds to the needs of a left fold over the operator BinaryOperator_
+// with an identity and result type of T1, where the intermediate elements being reduced over
+// are potentially of type T2.
+template<typename BinaryOperator_, typename T1, typename T2 = T1&&>
+inline constexpr bool is_binary_operator_for_v = is_binary_operator_for<BinaryOperator_, T1, T2>::value;
+
+// Defines the member value true if T is a pair or a tuple of length two
+template<typename T, typename = void>
+struct is_pair : public std::false_type {};
+
+template<typename T>
+struct is_pair<T, std::void_t<
+  decltype( std::get<0>(std::declval<T>()) ),
+  decltype( std::get<1>(std::declval<T>()) ),
+  std::enable_if_t< 2 == std::tuple_size_v<std::decay_t<T>> >
+>> : public std::true_type {};
+
+// True if T is a pair or a tuple of length two
+template<typename T>
+inline constexpr bool is_pair_v = is_pair<T>::value;
+
+/*  --------------------- Priority tags. -------------------------
+    Priority tags are an easy way to force template resolution to
+    pick the "best" option in the presence of multiple valid
+    choices. It works because of the facts that priority_tag<K>
+    is a subtype of priority_tag<K-1>, and template resolution
+    will always pick the most specialised option when faced with
+    a choice, so it will prefer priority_tag<K> over
+    priority_tag<K-1>
+*/
+
+template<size_t K>
+struct priority_tag : priority_tag<K-1> {};
+
+template<>
+struct priority_tag<0> {};
+
+
+/*  ----------------- Trivial allocators. ---------------------
+    Allocator-aware containers and algorithms need to know whether
+    they can construct/destruct objects directly inside memory given
+    to them by an allocator, or whether the allocator has custom
+    behaviour. Since some optimizations require us to circumvent
+    custom allocator behaviour, we need to detect when an allocator
+    does not do this.
+
+    Specifically, an allocator-aware algorithm must construct objects
+    inside memory returned by an allocator by writing
+
+    std::allocator_traits<allocator_type>::construct(allocator, p, args);
+
+    if the allocator type defines a method .construct, then this results
+    in forwarding the construction to that method. Otherwise, this just
+    results in a call to
+
+    new (p) T(std::forward<Args>(args)...)
+
+    If we wish to circumvent calling the constructor, for example,
+    for a trivially relocatable type in which we would prefer to
+    copy directly via memcpy, we must ensure that the allocator
+    does not have a custom .construct method. Otherwise, we can
+    not optimize, and must continue to use the allocator's own
+    construct method.
+
+    The same discussion is true for destruction as well.
+
+    See https://www.youtube.com/watch?v=MWBfmmg8-Yo for more info.
+*/
+
+namespace internal {
+
+// Detect the existence of the .destroy method of the type Alloc
+template<typename Alloc, typename T>
+auto trivial_allocator(Alloc& a, T* p, priority_tag<2>)
+  -> decltype(void(a.destroy(p)), std::false_type());
+
+// Detect the existence of the .construct method of the type Alloc
+template<typename Alloc, typename T>
+auto trivial_allocator(Alloc& a, T* p, priority_tag<1>)
+  -> decltype(void(a.construct(p, std::declval<T&&>())), std::false_type());
+
+// By default, if no .construct or .destroy methods are found, assume
+// that the allocator is trivial
+template<typename Alloc, typename T>
+auto trivial_allocator(Alloc& a, T* p, priority_tag<0>)
+  -> std::true_type;
+
+}  // namespace internal
+
+template<typename Alloc, typename T>
+struct is_trivial_allocator
+    : decltype(internal::trivial_allocator<Alloc, T>(std::declval<Alloc&>(), nullptr, priority_tag<2>())) {};
+
+template<typename Alloc, typename T>
+inline constexpr bool is_trivial_allocator_v = is_trivial_allocator<Alloc, T>::value;
+
+// Manually specialize std::allocator since it is trivial, but
+// some (maybe all?) implementations still provide a .construct
+// and .destroy method anyway.
+template<typename T>
+struct is_trivial_allocator<std::allocator<T>, T> : std::true_type {};
+
+/*  ----------------- Trivially relocatable. ---------------------
+    A type T is called trivially relocatable if, given a pointer
+    p to an object of type T, and a pointer q to unintialized
+    memory large enough for an object of type T, then
+
+    new (q) T(std::move(*p));
+    p->~T();
+
+    is equivalent to
+
+    std::memcpy(p, q, sizeof(T));
+
+    Any type that is trivially move constructible and trivially
+    destructible is therefore trivially relocatable. User-defined
+    types that are not obviously trivially relocatable can be
+    annotated as such by specializing the is_trivially_relocatable
+    type.
+
+    See proposal D1144R0 for copious details:
+    https://quuxplusone.github.io/blog/code/object-relocation-in-terms-of-move-plus-destroy-draft-7.html
+*/
+
+template <typename T>
+struct is_trivially_relocatable :
+        std::bool_constant<std::is_trivially_move_constructible<T>::value &&
+                           std::is_trivially_destructible<T>::value> { };
+
+template <typename T> struct is_nothrow_relocatable :
+        std::bool_constant<is_trivially_relocatable<T>::value ||
+                           (std::is_nothrow_move_constructible<T>::value &&
+                            std::is_nothrow_destructible<T>::value)> { };
+
+template<typename T>
+inline constexpr bool is_trivially_relocatable_v = is_trivially_relocatable<T>::value;
+
+template<typename T>
+inline constexpr bool is_nothrow_relocatable_v = is_nothrow_relocatable<T>::value;
+
+// The standard allocator is stateless, so it is trivially relocatable,
+// but unfortunately it is not detected as such, so we mark it manually.
+// This is important because parlay::sequence<T, Alloc> is only trivially
+// relocatable when its allocator is trivially relocatable.
+
+template<typename T>
+struct is_trivially_relocatable<std::allocator<T>> : std::true_type {};
+
+template <typename T1, typename T2>
+struct is_trivially_relocatable<std::pair<T1,T2>> : 
+    std::bool_constant<is_trivially_relocatable<T1>::value &&
+		       is_trivially_relocatable<T2>::value> {};
+
+}  // namespace parlay
+
+#endif //PARLAY_TYPE_TRAITS_H_

--- a/third_party/parlayhash/include/parlay/utilities.h
+++ b/third_party/parlayhash/include/parlay/utilities.h
@@ -1,0 +1,501 @@
+
+#ifndef PARLAY_UTILITIES_H_
+#define PARLAY_UTILITIES_H_
+
+#include <cstddef>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
+#include <array>            // IWYU pragma: keep
+#include <atomic>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+#include "portability.h"
+#include "type_traits.h"
+
+#include "internal/debug_uninitialized.h"
+
+// IWYU pragma: no_include <tuple>
+
+namespace parlay {
+
+// Obtains a pointer to an object of type T located at the address represented
+// by p. Essentially performs std::launder(reinterpret_cast<T*>(p)).
+template<typename T>
+[[nodiscard]] constexpr T* from_bytes(std::byte* p) noexcept {
+  // std::launder not available on older compilers
+#ifdef __cpp_lib_launder
+  return std::launder(reinterpret_cast<T*>(p));
+#else
+  return reinterpret_cast<T*>(p);
+#endif
+}
+
+
+template <class T>
+size_t log2_up(T);
+
+struct empty {};
+
+typedef uint32_t flags;
+const flags no_flag = 0;
+const flags fl_sequential = 1;
+const flags fl_debug = 2;
+const flags fl_time = 4;
+const flags fl_conservative = 8;
+const flags fl_inplace = 16;
+
+template <typename T>
+inline void assign_uninitialized(T& a, const type_identity_t<T>& b) {
+  PARLAY_ASSERT_UNINITIALIZED(a);
+  new (static_cast<T*>(std::addressof(a))) T(b);
+}
+
+template <typename T>
+inline auto assign_uninitialized(T& a, type_identity_t<T>&& b) {
+  PARLAY_ASSERT_UNINITIALIZED(a);
+  new (static_cast<T*>(std::addressof(a))) T(std::move(b));
+}
+
+template <typename T>
+inline void move_uninitialized(T& a, type_identity_t<T>& b) {
+  PARLAY_ASSERT_UNINITIALIZED(a);
+  new (static_cast<T*>(std::addressof(a))) T(std::move(b));
+}
+
+// Relocate a single object into uninitialized memory, leaving
+// the source memory uninitialized afterwards.
+template<typename T>
+inline void uninitialized_relocate(T* to, T* from) noexcept(is_nothrow_relocatable<T>::value) {
+  if constexpr (is_trivially_relocatable<T>::value) {
+    std::memcpy(static_cast<void*>(to), static_cast<void*>(from), sizeof(T));
+  }
+  else {
+    static_assert(std::is_move_constructible<T>::value);
+    static_assert(std::is_destructible<T>::value);
+    PARLAY_ASSERT_UNINITIALIZED(*to);
+    ::new (to) T(std::move(*from));
+    from->~T();
+    PARLAY_ASSERT_UNINITIALIZED(*from);
+  }
+}
+
+/* Hashing functions for various integer types */
+
+// a 32-bit hash function
+inline uint32_t hash32(uint32_t a) {
+  a = (a + 0x7ed55d16) + (a << 12);
+  a = (a ^ 0xc761c23c) ^ (a >> 19);
+  a = (a + 0x165667b1) + (a << 5);
+  a = (a + 0xd3a2646c) ^ (a << 9);
+  a = (a + 0xfd7046c5) + (a << 3);
+  a = (a ^ 0xb55a4f09) ^ (a >> 16);
+  return a;
+}
+
+inline uint32_t hash32_2(uint32_t a) {
+  uint32_t z = (a + 0x6D2B79F5UL);
+  z = (z ^ (z >> 15)) * (z | 1UL);
+  z ^= z + (z ^ (z >> 7)) * (z | 61UL);
+  return z ^ (z >> 14);
+}
+
+inline uint32_t hash32_3(uint32_t a) {
+  uint32_t z = a + 0x9e3779b9;
+  z ^= z >> 15;  // 16 for murmur3
+  z *= 0x85ebca6b;
+  z ^= z >> 13;
+  z *= 0xc2b2ae3d;  // 0xc2b2ae35 for murmur3
+  return z ^ (z >> 16);
+}
+
+// from numerical recipes
+inline uint64_t hash64(uint64_t u) {
+  uint64_t v = u * 3935559000370003845ul + 2691343689449507681ul;
+  v ^= v >> 21;
+  v ^= v << 37;
+  v ^= v >> 4;
+  v *= 4768777513237032717ul;
+  v ^= v << 20;
+  v ^= v >> 41;
+  v ^= v << 5;
+  return v;
+}
+
+// a slightly cheaper, but possibly not as good version
+// based on splitmix64
+inline uint64_t hash64_2(uint64_t x) {
+  x = (x ^ (x >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+  x = (x ^ (x >> 27)) * UINT64_C(0x94d049bb133111eb);
+  x = x ^ (x >> 31);
+  return x;
+}
+
+// Combine two hash values into a single hash value. Formula borrowed from Boost
+inline void hash_combine(size_t& seed, size_t v) {
+  seed ^= v + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+// parlay::hash provides a customization point for hashing that allows
+// us to override the hash for standard types, or to provide specializations
+// for standard types that do not have a std::hash specialization themselves.
+template<typename T, typename Enable = void>
+struct hash : public std::hash<T> { };
+
+template <typename T>
+struct hash<T, typename std::enable_if_t<std::is_integral_v<T>>> {
+  size_t operator()(const T& p) const {
+    return p * UINT64_C(0xbf58476d1ce4e5b9);
+  }
+};
+    
+// Hashing for std::pairs
+template<typename U, typename V>
+struct hash<std::pair<U,V>> {
+  size_t operator()(const std::pair<U,V>& p) const {
+    size_t h = parlay::hash<U>{}(p.first);
+    hash_combine(h, parlay::hash<V>{}(p.second));
+    return h;
+  }
+};
+
+template<typename V, std::size_t n>
+struct hash<std::array<V,n>> {
+  size_t operator()(const std::array<V,n>& a) const {
+    size_t h = 1;
+    for (int i=0; i < n; i++) {
+      hash_combine(h, parlay::hash<V>{}(a[i]));
+    }
+    return h;
+  }
+};
+
+/* Atomic write-add, write-min, and write-max */
+
+template <typename T, typename EV>
+inline void write_add(std::atomic<T>* a, EV b) {
+  T newV, oldV;
+  do {
+    oldV = a->load();
+    newV = oldV + b;
+  } while (!std::atomic_compare_exchange_weak(a, &oldV, newV));
+}
+
+template <typename T, typename F>
+inline bool write_min(std::atomic<T>* a, T b, F less) {
+  T c;
+  bool r = false;
+  do {
+    c = a->load();
+  } while (less(b, c) && !(r = std::atomic_compare_exchange_weak(a, &c, b)));
+  return r;
+}
+
+template <typename T, typename F>
+inline bool write_max(std::atomic<T>* a, T b, F less) {
+  T c;
+  bool r = false;
+  do {
+    c = a->load();
+  } while (less(c, b) && !(r = std::atomic_compare_exchange_weak(a, &c, b)));
+  return r;
+}
+
+// returns the log base 2 rounded up (works on ints or longs or unsigned
+// versions)
+template <class T>
+size_t log2_up(T i) {
+  assert(i > 0);
+  size_t a = 0;
+  T b = i - 1;
+  while (b > 0) {
+    b = b >> 1;
+    a++;
+  }
+  return a;
+}
+
+
+inline size_t granularity(size_t n) {
+  return (n > 100) ? static_cast<size_t>(std::ceil(std::sqrt(n))) : 100;
+}
+
+//  A copyable_function_wrapper allows an object to store a function (e.g., a lambda,
+//  or any callable object) as a member while still being default copy-assignable.
+//
+//  As long as the function type is copy constructible (which it needs to be in
+//  order to even initialize the member), this wrapper will be copy assignable.
+template<typename F>
+struct copyable_function_wrapper {
+
+  static_assert(std::is_copy_constructible_v<F>);
+
+  explicit copyable_function_wrapper(F _f) : f(std::move(_f)) {}
+
+  copyable_function_wrapper(const copyable_function_wrapper&) = default;
+  copyable_function_wrapper(copyable_function_wrapper&&)
+    noexcept(std::is_nothrow_move_constructible_v<F>) = default;
+
+  copyable_function_wrapper& operator=(const copyable_function_wrapper& other) {
+    if constexpr (std::is_copy_assignable_v<F>) {
+      f = other.f;
+    }
+    else {
+      f.~F();
+      new (std::addressof(f)) F(other.f);
+    }
+    return *this;
+  }
+
+  copyable_function_wrapper& operator=(copyable_function_wrapper&& other)
+    noexcept(std::is_nothrow_move_assignable_v<F> && std::is_nothrow_move_constructible_v<F>) {
+    if constexpr (std::is_move_assignable_v<F>) {
+      f = std::move(other.f);
+    }
+    else {
+      f.~F();
+      new (std::addressof(f)) F(std::move(other.f));
+    }
+    return *this;
+  }
+
+  ~copyable_function_wrapper() = default;
+
+  template<typename... Args>
+  PARLAY_INLINE decltype(auto) operator()(Args&&... args) noexcept(std::is_nothrow_invocable_v<F&, Args...>) {
+    static_assert(std::is_invocable_v<F&, Args...>);
+    return std::invoke(f, std::forward<Args>(args)...);
+  }
+
+  template<typename... Args>
+  PARLAY_INLINE decltype(auto) operator()(Args&&... args) const noexcept(std::is_nothrow_invocable_v<const F&, Args...>) {
+    static_assert(std::is_invocable_v<const F&, Args...>);
+    return std::invoke(f, std::forward<Args>(args)...);
+  }
+
+  // Special case for when the argument is just a size_t. This is the common case since this is what
+  // all the functions in delayed_sequence are. This should in theory make absolutely no difference
+  // compared to the templates whatsoever but for some reason it's faster???
+  PARLAY_INLINE decltype(auto) operator()(size_t i) noexcept(std::is_nothrow_invocable_v<F&, size_t>) {
+    static_assert(std::is_invocable_v<F&, size_t>);
+    return std::invoke(f, i);
+  }
+
+  PARLAY_INLINE decltype(auto) operator()(size_t i) const noexcept(std::is_nothrow_invocable_v<const F&, size_t>) {
+    static_assert(std::is_invocable_v<const F&, size_t>);
+    return std::invoke(f, i);
+  }
+
+  F* get() { return std::addressof(f); }
+  const F* get() const { return std::addressof(f); }
+
+ private:
+  F f;
+};
+
+
+/* For inplace sorting / merging, we sometimes need to move values
+   around and sometimes we want to make copies. We use tag dispatch
+   to choose between moving and copying, so that the move algorithm
+   can be written agnostic to which one it uses. We also account for
+   moving / copying between uninitialized memory.
+   
+   Usage:
+     assign_dispatch(dest, val, tag_type())
+
+   Tag types:
+    move_assign_tag:                 The value is moved assigned into dest from val
+    uninitialized_move_tag:          The value is move constructed from val into dest
+    copy_assign_tag:                 The value is copy assigned into dest from val
+    uninitialized_copy_tag:          The value is copy constructed from val into dest
+    uninitialized_relocate_tag:      The value is destructively moved from val into dest
+   
+*/   
+
+struct move_assign_tag {};
+struct uninitialized_move_tag {};
+struct copy_assign_tag {};
+struct uninitialized_copy_tag {};
+struct uninitialized_relocate_tag {};
+
+// Move dispatch -- move val into dest
+template<typename T>
+void assign_dispatch(T& dest, type_identity_t<T>& val, move_assign_tag) {
+  dest = std::move(val);
+}
+
+// Copy dispatch -- copy val into dest
+template<typename T>
+void assign_dispatch(T& dest, const type_identity_t<T>& val, copy_assign_tag) {
+  dest = val;
+}
+
+// Uninitialized move dispatch -- move construct dest with val
+template<typename T>
+void assign_dispatch(T& dest, type_identity_t<T>& val, uninitialized_move_tag) {
+  assign_uninitialized(dest, std::move(val));
+}
+
+// Uninitialized copy dispatch -- copy initialize dest with val
+template<typename T>
+void assign_dispatch(T& dest, const type_identity_t<T>& val, uninitialized_copy_tag) {
+  assign_uninitialized(dest, val);
+}
+
+// Uninitialized relocate dispatch -- destructively move val into dest
+template<typename T>
+void assign_dispatch(T& dest, T& val, uninitialized_relocate_tag) {
+  uninitialized_relocate(&dest, &val);
+}
+
+
+namespace internal {
+
+// The deleter used by unique_array / make_unique_array
+template<typename T>
+struct unique_array_deleter {
+  void operator()(T* ptr) {
+    if (ptr != nullptr) {
+      if constexpr (!std::is_trivially_destructible_v<T>) {
+        for (size_t i = 0; i < n; i++) {
+          ptr[i].~T();
+        }
+      }
+      ::operator delete (static_cast<void*>(ptr), std::align_val_t{alignof(T)});
+    }
+  }
+  size_t n;
+};
+
+}  // namespace internal
+
+// An alias of unique_ptr<T[], *custom_deleter*> as returned by make_unique_array.
+// Stores a dynamically allocated array of type T[] that is automatically freed when
+// the unique_ptr goes out of scope. Unlike regular unique_ptr<T[]>, this type with
+// make_unique_array can be used to construct an array of non-default-constructible T
+template<typename T>
+using unique_array = std::unique_ptr<T[], internal::unique_array_deleter<T>>;
+
+template<typename T>
+std::size_t size(const unique_array<T>& arr) {
+  return arr.get_deleter().n;
+}
+
+template<typename T>
+T* begin(unique_array<T>& arr) {
+  return &arr[0];
+}
+
+template<typename T>
+T* end(unique_array<T>& arr) {
+  return &arr[0] + size(arr);
+}
+
+template<typename T>
+T const* begin(const unique_array<T>& arr) {
+  return &arr[0];
+}
+
+template<typename T>
+T const* end(const unique_array<T>& arr) {
+  return &arr[0] + size(arr);
+}
+
+// Creates a unique_ptr<T[], *custom_deleter*> consisting of n objects of
+// type T initialized by T(init(i)) for i from 0 to n - 1. The objects are
+// automatically destroyed and freed when the unique_ptr goes out of scope.
+//
+// Useful in place of unique_ptr<T[]> when T is not default constructible
+// and hence make_unique<T[]> can not be used.
+template<typename T, typename F>
+auto make_unique_array(size_t n, F init) {
+  // Either T is constructible from init(i), or init(i) returns a prvalue T which means
+  // we get guaranteed copy elision and can construct T even if it isn't copyable/movable
+  static_assert(std::is_constructible_v<T, std::invoke_result_t<F&, size_t>> ||
+                std::is_same_v<T, std::invoke_result_t<F&, size_t>>);
+
+  if (n == 0) return unique_array<T>(nullptr, {0});
+  auto buffer = static_cast<std::byte*>(::operator new(n * sizeof(T), std::align_val_t{alignof(T)}));
+  auto first = new (buffer) T(init(0));
+  for (size_t i = 1; i < n; i++) {
+    new (buffer + i * sizeof(T)) T(init(i));  // NOLINT
+  }
+  return unique_array<T>(first, {n});
+}
+
+/*
+    Padded types for avoiding false sharing by over-aligning to a cache-line boundary.
+
+    parlay::padded<T> should be a drop-in replacement for T in just about any scenario,
+    without having to change the code that makes use of the T object. padded<T> can be
+    initialized with any initializer that would work on T, including copy and move
+    initialization, and any constructor of T. Assignment operations should also work.
+
+    You can also bind a padded<T> to const/non-const reference/rvalue-reference variables
+    of type T, e.g.,
+
+      padded<int> p{1};
+      int& x = p;  // refers to the padded int 1
+      x = 2;       // p now contains 2
+
+    This also applies to function parameters. For class types, you should also be able
+    to invoke overloaded operations and member functions, e.g.,
+
+      padded<std::vector<int>> v{1,2,3};
+      v.push_back(4);
+      v[0] = 42;
+
+    You can even invoke function pointers!!
+
+      padded<int(*)()> fp = &func;
+      int x = fp();
+
+    The only thing that doesn't seem to work is directly invoking member-function pointers...
+
+ */
+
+// Padded types to avoid false sharing. Takes a type T and makes its size
+// at least Size bytes by over-aligning it. Size must be a valid alignment.
+template<typename T, size_t Size = 128, typename Sfinae = void>
+struct padded;
+
+// Use user-defined conversions to pad primitive types
+template<typename T, size_t Size>
+struct alignas(Size) padded<T, Size, typename std::enable_if_t<std::is_scalar_v<T>>> {
+  padded() : x{} {};
+  /* implicit */ padded(T _x) : x(_x) { }       // cppcheck-suppress noExplicitConstructor    // NOLINT
+  /* implicit */ operator T&() & { return x; }                                                // NOLINT
+  /* implicit */ operator const T&() const& { return x; }                                     // NOLINT
+  /* implicit */ operator T&&() && { return std::move(x); }                                   // NOLINT
+  /* implicit */ operator const T&&() const&& { return std::move(x); }                        // NOLINT
+
+  // Allow padded function pointers to be directly invoked!
+  template<typename... Ts> auto operator()(Ts... args) const noexcept(std::is_nothrow_invocable_v<T, Ts...>)
+      -> std::enable_if_t<std::is_invocable_v<T, Ts...>, std::invoke_result_t<T, Ts...>> {
+    return x(std::forward<Ts>(args)...);
+  }
+
+  T x;
+};
+
+// Use inheritance to pad class types
+template<typename T, size_t Size>
+struct alignas(Size) padded<T, Size, typename std::enable_if_t<std::is_class_v<T>>> : public T {
+  static_assert(std::is_same_v<T, std::remove_cv_t<T>>,
+      "padded<T> requires T be non-const-volatile qualified. Use const padded<T> instead of padded<const T>");
+  using T::T;                                         // inherit (non-special) constructors
+  padded() = default;                                 // implement non-inherited special constructors
+  /* implicit */ padded(const T& t) : T(t) {}         // cppcheck-suppress noExplicitConstructor          // NOLINT
+  /* implicit */ padded(T&& t) : T(std::move(t)) {}   // cppcheck-suppress noExplicitConstructor          // NOLINT
+};
+
+}  // namespace parlay
+
+#endif  // PARLAY_UTILITIES_H_

--- a/third_party/parlayhash/include/parlay/worker_specific.h
+++ b/third_party/parlayhash/include/parlay/worker_specific.h
@@ -1,0 +1,181 @@
+
+#ifndef PARLAY_WORKER_SPECIFIC_H_
+#define PARLAY_WORKER_SPECIFIC_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+#include "parallel.h"
+#include "range.h"
+#include "type_traits.h"
+#include "utilities.h"
+
+#if !defined(NDEBUG) && defined(PARLAY_USING_PARLAY_SCHEDULER)
+#define PARLAY_DEBUG_WORKER_SPECIFIC
+#endif
+
+#if defined(PARLAY_DEBUG_WORKER_SPECIFIC)
+#define PARLAY_WORKER_SPECIFIC_CHECK_SCHEDULER assert(&internal::get_current_scheduler() == owning_scheduler &&  \
+  "parlay::WorkerSpecific<> must ONLY be used within the scheduler instance in which it was created.");
+#else
+#define PARLAY_WORKER_SPECIFIC_CHECK_SCHEDULER
+#endif
+
+namespace parlay {
+
+template<typename T>
+class WorkerSpecific {
+
+  struct alignas(64) data {
+    // We take the value wrapped in a function call so that we can instantiate
+    // uncopyable types from prvalues using copy elision.  Otherwise, it would
+    // not be possible to initialize uncopyable types (e.g., std::atomic)
+    template<typename F>
+    explicit data(F&& f) : x(f()) { }
+
+    data(const data&) = delete;
+    data(data&&) = delete;
+
+    T x;
+  };
+
+ public:
+
+  using reference = T&;
+  using value_type = T;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using pointer = T*;
+
+  WorkerSpecific() : WorkerSpecific([](std::size_t) { return T{}; }) { }
+
+  template<typename F,
+    std::enable_if_t<std::is_invocable_v<F&> && !std::is_invocable_v<F&, std::size_t>, int> = 0>
+  explicit WorkerSpecific(F&& f) : WorkerSpecific([f = std::forward<F>(f)](std::size_t) { return f(); }) { }
+
+  template<typename F,
+    std::enable_if_t<std::is_invocable_v<F&, std::size_t>, int> = 0>
+  explicit WorkerSpecific(F&& f) : elements(make_unique_array<data>(num_workers(),
+      [f = std::forward<F>(f)](std::size_t i) { return [&f, i]() { return f(i); }; }))
+#if defined(PARLAY_DEBUG_WORKER_SPECIFIC)
+      , owning_scheduler(std::addressof(internal::get_current_scheduler()))
+#endif
+  { }
+
+  WorkerSpecific(const WorkerSpecific&) = delete;
+  WorkerSpecific& operator=(const WorkerSpecific&) = delete;
+  WorkerSpecific(WorkerSpecific&&) = delete;
+
+  T& operator*() { return get(); }
+  T* operator->() { return std::addressof(get()); }
+  [[nodiscard]] T& get() {
+    PARLAY_WORKER_SPECIFIC_CHECK_SCHEDULER;
+    return elements[worker_id()].x;
+  }
+
+  const T& operator*() const { return get(); }
+  T const* operator->() const { return std::addressof(get()); }
+  [[nodiscard]] const T& get() const {
+    PARLAY_WORKER_SPECIFIC_CHECK_SCHEDULER;
+    return elements[worker_id()].x;
+  }
+
+  template<typename F>
+  void for_each(F&& f) {
+    std::for_each(begin(), end(), std::forward<F>(f));
+  }
+
+  // Allow looping over all thread's data
+  template<bool Const>
+  class iterator_t {
+    friend class WorkerSpecific<T>;
+
+    explicit iterator_t(data* ptr_) : ptr(ptr_) { }
+
+   public:
+    using iterator_category = std::random_access_iterator_tag;
+    using reference = std::add_lvalue_reference_t<maybe_const_t<Const, T>>;
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = std::add_pointer_t<maybe_const_t<Const, T>>;
+
+    iterator_t() : ptr(nullptr) { }
+
+    /* implicit */ iterator_t(const iterator_t<false>& other) : ptr(other.ptr) { }  // cppcheck-suppress noExplicitConstructor    // NOLINT
+
+    reference operator*() const { return ptr->x; }
+    reference operator[](std::size_t p) const { return ptr[p].x; }
+
+    iterator_t& operator++() { ptr++; return *this; }
+    iterator_t operator++(int) { auto tmp = *this; ++(*this); return tmp; }   //NOLINT
+    iterator_t& operator--() { ptr--; return *this; }
+    iterator_t operator--(int) { auto tmp = *this; --(*this); return tmp; }   //NOLINT
+
+    iterator_t& operator+=(difference_type diff) { ptr += diff; return *this; }
+    iterator_t& operator-=(difference_type diff) { ptr -= diff; return *this; }
+
+    iterator_t operator+(difference_type diff) const { return iterator_t{ptr + diff}; }
+    iterator_t operator-(difference_type diff) const { return iterator_t{ptr - diff}; }
+
+    difference_type operator-(const iterator_t& other) const { return ptr - other.ptr; }
+
+    bool operator==(const iterator_t& other) const { return ptr == other.ptr; }
+    bool operator!=(const iterator_t& other) const { return ptr != other.ptr; }
+    bool operator<(const iterator_t& other) const { return ptr < other.ptr; }
+    bool operator<=(const iterator_t& other) const { return ptr <= other.ptr; }
+    bool operator>(const iterator_t& other) const { return ptr > other.ptr; }
+    bool operator>=(const iterator_t& other) const { return ptr >= other.ptr; }
+
+    friend void swap(iterator_t& left, iterator_t& right) { std::swap(left.ptr, right.ptr); }
+
+   private:
+    maybe_const_t<Const, data>* ptr;
+  };
+
+  using iterator = iterator_t<false>;
+  using const_iterator = iterator_t<true>;
+
+  static_assert(is_random_access_iterator_v<iterator>);
+  static_assert(is_random_access_iterator_v<const_iterator>);
+
+  [[nodiscard]] iterator begin() {
+    PARLAY_WORKER_SPECIFIC_CHECK_SCHEDULER;
+    return iterator{&elements[0]};
+  }
+
+  [[nodiscard]] iterator end() {
+    PARLAY_WORKER_SPECIFIC_CHECK_SCHEDULER;
+    return iterator{&elements[0] + num_workers()};
+  }
+
+  [[nodiscard]] const_iterator begin() const {
+    PARLAY_WORKER_SPECIFIC_CHECK_SCHEDULER;
+    return const_iterator{&elements[0]};
+  }
+
+  [[nodiscard]] const_iterator end() const {
+    PARLAY_WORKER_SPECIFIC_CHECK_SCHEDULER;
+    return const_iterator{&elements[0] + num_workers()};
+  }
+
+ private:
+  unique_array<data> elements;
+
+#if defined(PARLAY_DEBUG_WORKER_SPECIFIC)
+  // In DEBUG mode only, remember the scheduler instance that this belongs to
+  internal::scheduler_type* owning_scheduler;
+#endif
+};
+
+static_assert(is_random_access_range_v<WorkerSpecific<int>>);
+static_assert(is_random_access_range_v<const WorkerSpecific<int>>);
+
+}
+
+
+#endif  // PARLAY_WORKER_SPECIFIC_H_

--- a/third_party/parlayhash/include/parlay_hash/BUILD
+++ b/third_party/parlayhash/include/parlay_hash/BUILD
@@ -1,0 +1,22 @@
+cc_library(
+    name = "epoch",
+    hdrs = ["epoch.h"],
+    deps = [
+        "@parlaylib//parlay:primitives",
+    ],
+)
+
+cc_library(
+    name = "lock",
+    hdrs = ["lock.h"],
+)
+
+cc_library(
+    name = "unordered_map",
+    hdrs = ["unordered_map.h"],
+    deps = [
+        ":epoch",
+        ":lock",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/parlayhash/include/parlay_hash/bigatomic.h
+++ b/third_party/parlayhash/include/parlay_hash/bigatomic.h
@@ -1,0 +1,95 @@
+// An implementation of big_atomic using a SeqLock.
+//
+//  Supports:
+//  - Blocking loads (loads never obstruct each-other, but can be indefinitely blocked by writers)
+//  - Blocking stores
+//  - Blocking CAS
+//
+// No additional space usage
+//
+
+#ifndef PARLAYATOMIC_H_
+#define PARLAYATOMIC_H_
+
+#include <atomic>
+#include <functional>
+#include <parlay/primitives.h>
+#include <parlay/sequence.h>
+#include <utils/lock.h>
+
+namespace parlay {
+
+template<typename V, class KeyEqual = std::equal_to<V>>
+struct alignas(32) big_atomic {
+
+  using vtype = long;
+  using tag = vtype;
+
+  std::atomic<vtype> version;
+  V val;
+
+  big_atomic(const V& v) : version(0), val(v) {}
+  big_atomic() : version(0) {}
+
+  void store_sequential(const V& v) { val = v; }
+  
+  V load() {
+    while (true) {
+      vtype ver = version.load(std::memory_order_acquire);
+      V v = val;
+      std::atomic_thread_fence(std::memory_order_acquire);
+      if ((ver & 1) == 0 && version.load(std::memory_order_relaxed) == ver) return v;
+    }
+  }
+
+  std::pair<V,tag> ll_speculative() {
+    vtype ver = version.load(std::memory_order_acquire);
+    V v = val;
+    std::atomic_thread_fence(std::memory_order_acquire);
+    return std::pair(v, ver);
+  }
+
+  std::pair<V,tag> ll() {
+    while (true) {
+      int delay = 100;
+      vtype ver = version.load(std::memory_order_acquire);
+      V v = val;
+      std::atomic_thread_fence(std::memory_order_acquire);
+      if ((ver & 1) == 0 && version.load(std::memory_order_relaxed) == ver)
+	return std::pair(v,ver);
+      for (volatile int i = 0; i < delay; i++);
+      delay = std::min(2 * delay, 1000);
+    }
+  }
+
+  bool lv(tag tg) {
+    return version.load() == tg;
+  }
+
+  bool sc(tag expected_tag, const V& v) {
+    bool result = true;
+    int delay = 100;
+    while (true) {
+      vtype ver = version.load();
+      if (ver != expected_tag) return false;
+      if (get_locks().try_lock((long)this, [&] {
+            if (version.load(std::memory_order_acquire) != expected_tag)
+              result = false;
+            else {
+              version.store(ver + 1, std::memory_order_relaxed);
+              std::atomic_thread_fence(std::memory_order_release);
+              val = v;
+              version.store(ver + 2, std::memory_order_release);
+            }
+            return true;
+          }))
+        return result;
+      for (volatile int i = 0; i < delay; i++);
+      delay = std::min(2 * delay, 2000);
+    }
+  }
+
+};
+
+}  // namespace parlay
+#endif  // PARLAYATOMIC_H_

--- a/third_party/parlayhash/include/parlay_hash/parallel.h
+++ b/third_party/parlayhash/include/parlay_hash/parallel.h
@@ -1,0 +1,36 @@
+#ifdef USE_PARLAY
+#include <parlay/primitives.h>
+#include <parlay/sequence.h>
+#include <parlay/delayed.h>
+namespace parlay {
+#define PARLAY_USE_STD_ALLOC 1
+
+  using scheduler_type = internal::scheduler_type;
+
+  template <typename F>
+  long tabulate_reduce(long n, const F& f) {
+    return parlay::reduce(parlay::delayed::tabulate(n, [&] (size_t i) {
+	     return f(i);}));
+  }
+}
+#else
+namespace parlay {
+
+  struct scheduler_type {
+    scheduler_type(int num_procs) {}
+  };
+
+  template <typename F>
+  long tabulate_reduce(long n, const F& f) {
+    long r = 0;
+    for (long i=0; i < n; i++)
+      r += f(i);
+    return r;
+  }
+  
+  template <typename F>
+  void parallel_for(long n, const F& f) {
+    for (long i=0; i < n; i++) f(i);
+  }
+}
+#endif

--- a/third_party/parlayhash/include/parlay_hash/parlay_hash.h
+++ b/third_party/parlayhash/include/parlay_hash/parlay_hash.h
@@ -1,0 +1,1181 @@
+#ifndef PARLAY_HASH_H_
+#define PARLAY_HASH_H_
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <functional>
+#include <iterator>
+#include <optional>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <utils/epoch.h>
+#include "bigatomic.h"
+#include "parallel.h"
+
+constexpr bool PrintGrow = false;
+
+namespace parlay {
+
+template <typename Entries>
+struct parlay_hash {
+  using Entry = typename Entries::Entry;
+  using K = typename Entry::Key;
+
+  // *********************************************
+  // Various parameters
+  // *********************************************
+  
+  // set to grow by factor of 8 (2^3)
+  static constexpr int log_grow_factor = 2;
+  static constexpr int grow_factor = 1 << log_grow_factor;
+
+  // groups of block_size buckets are copied over by a single thread
+  // the block size typically grows with size, but starts here
+  static constexpr long min_block_size = 4;
+
+  // buffer_size is picked so state fits in a cache line (if it can)
+  static constexpr long buffer_size = (sizeof(Entry) > 24) ? 1 : 48 / sizeof(Entry);
+
+  // log_2 of the expected number of entries in a bucket (<= buffer_size)
+  static constexpr long log_bucket_size = 
+    (buffer_size == 1) ? 0 : ((buffer_size == 2) ? 1 : ((buffer_size <= 4) ? 2 : ((buffer_size <= 8) ? 3 : 3)));
+
+  static long get_block_size(int num_bits) {
+    return num_bits < 16 ? 16 : 256; }
+
+  // The size of a bucket that causes the table to grow, i.e. if any
+  // insert causes the bucket to reach the given size, then start
+  // growing.
+  // Technically this should be something like c log (n) / log(log n))
+  // for a small constant c if each bucket is expected to hold 1
+  // element, but.... each bucket can be expected to hold more than one.
+  static long get_overflow_size(int num_bits) {
+    if constexpr (log_bucket_size == 0) return num_bits < 18 ? 10 : 16;
+    else if constexpr (log_bucket_size == 1) return num_bits < 18 ? 11 : 18;
+    else if constexpr (log_bucket_size == 2) return num_bits < 18 ? 12 : 20;
+    else if constexpr (log_bucket_size == 3) return num_bits < 18 ? 14 : 22;
+    else return num_bits < 18 ? 20 : 24;
+  }
+
+  // clear_at_end will cause the scheduler and epoch-based collector
+  // to clear their state on destruction
+  static constexpr bool default_clear_at_end = true;
+  bool clear_memory_and_scheduler_at_end;
+
+  // a reference to the scheduler (null if not to be cleared)
+  parlay::scheduler_type* sched_ref;
+
+  // *********************************************
+  // The state structure for each bucket
+  // *********************************************
+  
+  // for overflow lists for each bucket
+  struct link {
+    Entry entry;
+    link* next;
+    link(const Entry& entry, link* next) : entry(entry), next(next) { }
+  };
+
+  // for delayed reclamation of links using an epoch-based collector
+  epoch::memory_pool<link>* link_pool;
+
+  link* new_link(const Entry& entry, link* l) {
+    return link_pool->New(entry, l); }
+  void retire_link(link* l) { link_pool->Retire(l);}
+
+  // Each bucket contains a "state", which consists of a fixed size
+  // buffer of entries (buffer_size) and an overflow list.  The first
+  // buffer_size entries in the bucket are kept in the buffer, and any
+  // overflow goes to the list.  The head stores both the pointer to
+  // the overflow list (lower 56 bits) and the number of elements in
+  // the buffer, or buffer_size+1 if overfull (top 8 bits).
+  struct state {
+  public:
+    size_t list_head;
+    Entry buffer[buffer_size];
+    state() : list_head(0) {}
+    state(const Entry& e) : list_head(1ul << 48) {
+      buffer[0] = e;
+    }
+    static constexpr size_t forwarded_val = 1ul;
+    
+    size_t make_head(link* l, size_t bsize) {
+      return (((size_t) l) | (bsize << 48)); }
+
+    // update overflow list with new ptr (assumes buffer is full)
+    state(const state& s, link* ptr)
+      : list_head(make_head(ptr, buffer_size + (ptr != nullptr))) {
+      for (int i=0; i < buffer_size; i++)
+	buffer[i] = s.buffer[i];
+    }
+
+    // add entry to the bucket state (in buffer if fits, otherwise at head of overflow list)
+    template <typename NL>
+    state(const state& s, Entry e, const NL& new_link) {
+      for (int i=0; i < std::min(s.buffer_cnt(), buffer_size); i++) 
+	buffer[i] = s.buffer[i];
+      if (s.buffer_cnt() < buffer_size) {
+	buffer[s.buffer_cnt()] = e;
+	list_head = make_head(nullptr, s.buffer_cnt() + 1);
+      } else {
+	link* l = new_link(e, s.overflow_list());
+	list_head = make_head(l, buffer_size + 1);
+      }
+    }
+
+    // add entry to buffer (assumes it fits) -- specialization of above
+    state(const state& s, Entry e) : list_head(make_head(nullptr, s.buffer_cnt() + 1)) {
+      for (int i=0; i < s.buffer_cnt(); i++) 
+	buffer[i] = s.buffer[i];
+      buffer[s.buffer_cnt()] = e;
+    }
+
+    // remove buffer entry j, replace with first from overflow list (assumes there is overflow)
+    state(const state& s, link* ptr, int j)
+      : list_head(make_head(ptr->next, buffer_size + (ptr->next != nullptr))) {
+      for (int i=0; i < buffer_size; i++)
+	buffer[i] = s.buffer[i];
+      buffer[j] = Entry{ptr->entry};
+    }
+
+    // remove buffer entry j, replace with last entry in buffer (assumes no overflow)
+    state(const state& s, int j) : list_head(make_head(nullptr, s.buffer_cnt() - 1)) {
+      if (s.overflow_list() != nullptr) abort();
+      for (int i=0; i < s.buffer_cnt(); i++)
+	buffer[i] = s.buffer[i];
+      buffer[j] = buffer[s.buffer_cnt() - 1];
+    }
+
+    state(bool x) : list_head(forwarded_val) {}
+    
+    bool is_forwarded() const {return list_head == forwarded_val ;}
+
+    // number of entries in buffer, or buffer_size+1 if overflow
+    long buffer_cnt() const {return (list_head >> 48) & 255ul ;}
+
+    // number of entries in bucket (includes those in the overflow list)
+    long size() const {
+      if (buffer_cnt() <= buffer_size) return buffer_cnt();
+      return buffer_size + list_length(overflow_list());
+    }
+
+    // get the overflow list
+    link* overflow_list() const {
+      return (link*) (list_head & ((1ul << 48) - 1));}
+  };
+
+  // returns std::optional(f(entry)) for entry with given key
+  template <typename F>
+  static auto find_in_list(const link* nxt, const K& k, const F& f) {
+    using rtype = typename std::invoke_result<F,Entry>::type;
+    long cnt = 0;
+    while (nxt != nullptr && !nxt->entry.equal(k)) {
+      nxt = nxt->next;
+      cnt++;
+    }
+    if (nxt == nullptr)
+      return std::pair(std::optional<rtype>(), cnt);
+    else
+      return std::pair(std::optional<rtype>(f(nxt->entry)), 0l);
+  }
+
+  // If k is found copies list elements up to k, and keeps the old
+  // tail past k.  Returns the number of new nodes that will need to
+  // be reclaimed, the head of the new list, and the link that is removed.
+  // Returns [0, nullptr, nullptr] if k is not found
+  std::tuple<int, link*, link*> remove_from_list(link* nxt, const K& k) {
+    if (nxt == nullptr)
+      return std::tuple(0, nullptr, nullptr);
+    else if (nxt->entry.equal(k))
+      return std::tuple(1, nxt->next, nxt);
+    else {
+      auto [len, ptr, removed] = remove_from_list(nxt->next, k);
+      if (len == 0) return std::tuple(0, nullptr, nullptr);
+      return std::tuple(len + 1, new_link(nxt->entry, ptr), removed);
+    }
+  }
+
+  // update element with a given key in a list.  Uses path copying.
+  // Returns a triple consisting of the position of the key in the list (1 based),
+  // the head of the new list with the key updated, and the old link that is replaced.
+  // If the key is not found, nothing is done, the last two results are nullptr, and
+  // the first result is the length of the list.
+  template <typename Constr>
+  std::tuple<int, link*, link*> update_list(link* nxt, const K& k, const Constr& constr) {
+    if (nxt == nullptr) 
+      return std::tuple(0, nullptr, nullptr);
+    else if (nxt->entry.equal(k))
+      return std::tuple(1, link_pool->New(constr(std::optional(nxt->entry)), nxt->next), nxt);
+    else {
+      auto [len, ptr, updated] = update_list(nxt->next, k, constr);
+      if (ptr == nullptr) return std::tuple(len + 1, nullptr, nullptr);
+      return std::tuple(len + 1, link_pool->New(nxt->entry, ptr), updated);
+    }
+  }
+
+  // retires first n elements of a list, but not the entries
+  void retire_list_n(link* nxt, int n) {
+    while (n > 0) {
+      n--;
+      link* tmp = nxt->next;
+      retire_link(nxt);
+      nxt = tmp;
+    }
+  }
+
+  // Retires full list and their entries.  Used when destructing the
+  // table.
+  void retire_list_all(link* nxt) {
+    while (nxt != nullptr) {
+      link* tmp = nxt->next;
+      entries_->retire_entry(nxt->entry);
+      retire_link(nxt);
+      nxt = tmp;
+    }
+  }
+
+  // Retires full list, but not their entries. Used when copying to a
+  // new list during expansion, i.e. the entries will be in the new
+  // list and don't need to be retired.
+  void retire_list(link* nxt) {
+    while (nxt != nullptr) {
+      link* tmp = nxt->next;
+      retire_link(nxt);
+      nxt = tmp;
+    }
+  }
+
+  static long list_length(link* nxt) {
+    long len = 0;
+    while (nxt != nullptr) {
+      len++;
+      nxt = nxt->next;
+    }
+    return len;
+  }
+
+  // Find key if it is in the buffer. Return index.
+  int find_in_buffer(const state& s, const K& k) {
+    long len = s.buffer_cnt();
+    for (long i = 0; i < std::min(len, buffer_size); i++)
+      if (s.buffer[i].equal(k))
+	return i;
+    return -1;
+  }
+
+  // Apply f to all entries in the state.
+  template <typename F>
+  void static for_each_in_state(const state& s, const F& f) {
+    for (long i = 0; i < std::min(s.buffer_cnt(), buffer_size); i++)
+      f(s.buffer[i]);
+    link* l = s.overflow_list();
+    while (l != nullptr) {
+      f(l->entry);
+      l = l->next;
+    }
+  }
+    
+  // Find entry with given key if in the bucket (state).  Return
+  // optional of f applied to the entry if found, otherwise
+  // std::nullopt.
+  template <typename F>
+  auto find_in_state(const state& s, const K& k, const F& f)
+    -> std::optional<typename std::invoke_result<F,Entry>::type>
+  {
+    long len = s.buffer_cnt();
+    for (long i = 0; i < std::min(len, buffer_size); i++)
+      if (s.buffer[i].equal(k))
+	return std::optional(f(s.buffer[i]));
+    if (len <= buffer_size) return std::nullopt;
+    return find_in_list(s.overflow_list(), k, f).first;
+  }
+
+  // A bucket is just an "atomic" state.
+  // a big_atomic<x> is sort of like an std::atomic<x> but supports
+  // load-linked, store-conditional, and is efficient when the x does
+  // not fit in a machine word.
+  using bckt = big_atomic<state>;
+
+  // used for load-linked, store-conditionals
+  using tag_type = typename big_atomic<state>::tag;
+
+  // wrapper to ensure alignment
+  struct alignas(64) bucket { bckt v; };
+
+  // initialize an uninitialized bucket
+  static void initialize(bucket& bck) {
+    new (&bck.v) big_atomic<state>(state());
+  }
+
+  // *********************************************
+  // The table structures
+  // Each version increases in size, by grow_factor
+  // *********************************************
+
+  // status of a block of buckets, used when initializing and when copying to a new version
+  enum status : char {Uninit, Initializing, Empty, Working, Done};
+
+  // A single version of the table.
+  // A version includes a sequence of "size" "buckets".
+  // New versions are added as the hash table grows, and each holds a
+  // pointer to the next larger version, if one exists.
+  struct table_version {
+    std::atomic<table_version*> next; // points to next version if created
+    std::atomic<long> finished_block_count; //number of blocks finished copying
+    long num_bits;  // log_2 of size
+    size_t size; // number of buckets
+    long block_size; // size of each block used for copying
+    int overflow_size; // size of bucket to trigger next expansion
+    bucket* buckets; // sequence of buckets
+    //sequence<bucket> buckets; // sequence of buckets
+    std::atomic<status>* block_status; // status of each block while copying
+
+    // The index of a key is the highest num_bits of the lowest
+    // 48-bits of the hash value.  Using the highest num_bits ensures
+    // that when growing, a bucket will go to grow_factor contiguous
+    // buckets in the next table.
+    long get_index(const K& k) {
+      size_t h = Entry::hash(k);
+      return (h >> (48 - num_bits))  & (size-1u);}
+
+    bckt* get_bucket(const K& k) {
+      return &buckets[get_index(k)].v; }
+
+    // initial table version, n indicating size
+    table_version(long n) 
+      : next(nullptr),
+	finished_block_count(0),
+	num_bits(std::max<long>((long) std::ceil(std::log2(min_block_size-1)),
+				(long) std::ceil(std::log2(1.5*n)) - log_bucket_size)),
+	size(1ul << num_bits),
+	block_size(num_bits < 10 ? min_block_size : get_block_size(num_bits)),
+	overflow_size(get_overflow_size(num_bits))
+    {
+      //if (PrintGrow) std::cout << "initial size: " << size << std::endl;
+      buckets = (bucket*) malloc(sizeof(bucket)*size);
+      block_status = (std::atomic<status>*) malloc(sizeof(std::atomic<status>) * size/block_size);
+      parallel_for(size, [&] (long i) { initialize(buckets[i]);});
+      parallel_for(size/block_size, [&] (long i) { block_status[i] = Empty;});
+    }
+
+    // expanded table version copied from smaller version t
+    table_version(table_version* t)
+      : next(nullptr),
+	finished_block_count(0),
+	num_bits(t->num_bits + log_grow_factor),
+	size(t->size * grow_factor),
+	block_size(get_block_size(num_bits)),
+	overflow_size(get_overflow_size(num_bits))
+    {
+      buckets = (bucket*) malloc(sizeof(bucket)*size);
+      block_status = (std::atomic<status>*) malloc(sizeof(std::atomic<status>) * size/min_block_size);
+    }
+
+    ~table_version() {
+      free(buckets);
+      free(block_status);
+    }
+  };
+
+  // the current table version
+  std::atomic<table_version*> current_table_version;
+
+  // the initial table version, used for cleanup on destruction
+  table_version* initial_table_version;
+
+  // *********************************************
+  // Functions for expanding the table
+  // *********************************************
+
+  // Called when table should be expanded (i.e. when some bucket is too large).
+  // Allocates a new table version and links the old one to it.
+  void expand_table(table_version* ht) {
+    table_version* htt = current_table_version.load();
+    if (htt->next == nullptr) {
+      long n = ht->size;
+      // if fail on lock, someone else is working on it, so skip
+      get_locks().try_lock((long) ht, [&] {
+	 if (ht->next == nullptr) {
+	   ht->next = new table_version(ht);
+	   //if (PrintGrow)
+	   //  std::cout << "expand to: " << n * grow_factor << std::endl;
+	 }
+	 return true;});
+    }
+  }
+
+  // Copies a bucket into grow_factor new buckets.
+  void copy_bucket(table_version* t, table_version* next, long i) {
+    long exp_start = i * grow_factor;
+    // Clear grow_factor buckets in the next table version to put them in.
+    for (int j = exp_start; j < exp_start + grow_factor; j++)
+      initialize(next->buckets[j]); 
+    // copy bucket to grow_factor new buckets in next table version
+    while (true) {
+      // the bucket to copy
+      auto [s, tag] = t->buckets[i].v.ll();
+
+      // insert into grow_factor buckets (states) for next larger table
+      state hold[grow_factor];
+      size_t mask = grow_factor-1;
+      for_each_in_state(s, [&] (const Entry& entry) {
+	size_t idx = next->get_index(entry.get_key()) & mask;
+       	hold[idx] = state(hold[idx], entry,
+			  [&] (const Entry& e, link* l) {return new_link(e,l);});
+      });
+
+      // now store the buckets into table
+      for (int j = 0; j < grow_factor; j++)
+	next->buckets[grow_factor * i + j].v.store_sequential(hold[j]);
+
+      // try to replace original bucket with forwarded marker
+      if (t->buckets[i].v.sc(tag, state(true))) {
+	retire_list(s.overflow_list()); 
+	break;
+      }
+      
+      // If the attempt failed then someone updated bucket in the meantime so need to retry.
+      // Before retrying need to clear out already added buckets.
+      for (int j = exp_start; j < exp_start + grow_factor; j++) {
+	state ss = next->buckets[j].v.load();
+	retire_list(ss.overflow_list());
+	next->buckets[j].v.store_sequential(state());
+      }
+    }
+  }
+
+  // If copying is ongoing (i.e., next is not null), and if the the
+  // hash bucket given by hashid is not already copied, tries to copy
+  // the block_size buckets that containing hashid to the next larger
+  // table version.
+  void copy_if_needed(table_version* t, long hashid) {
+    table_version* next = t->next.load();
+    if (next != nullptr) {
+      long num_blocks = t->size/t->block_size;
+      long block_num = hashid & (num_blocks -1);
+      long start = block_num * t->block_size;
+      status st = t->block_status[block_num];
+      status old = Empty;
+      if (st == Done) return;
+
+      // if data is uninitialized, need to initialize
+      // if (st == Uninit || st == Initializing) {
+      // 	status x = Uninit;
+      // 	if (t->block_status[block_num].compare_exchange_strong(x, Working)) {
+      // 	  for (int i = start; i < start + t->block_size; i++) 
+      // 	    initialize(t->buckets[i]);
+      // 	  t->block_status[block_num] = Empty;
+      // 	} else {
+      // 	  while (t->block_status[block_num] == Initializing)
+      // 	    for (volatile int i=0; i < 100; i++);
+      // 	}
+      // }
+	
+      // This is effectively a try lock on the block_num.
+      // It blocks other updates on the buckets associated with the block.
+      else if (st == Empty &&
+	       t->block_status[block_num].compare_exchange_strong(old, Working)) {
+
+	// initialize block_status for next grow round
+	for (int i = 0; i < grow_factor; i++)
+	  next->block_status[grow_factor*block_num + i] = Empty;
+	
+	// copy block_size buckets
+	for (int i = start; i < start + t->block_size; i++) {
+	  copy_bucket(t, next, i);
+	}
+	t->block_status[block_num] = Done;
+	
+	// If all blocks have been copied then can set current table
+	// to next.  Note: this atomic fetch-and-add can be a
+	// bottleneck and is the reason the block sizes are reasonably
+	// large (e.g. 256).  A smarter combining tree could be used
+	// if smaller block sizes are needed.
+	if (++next->finished_block_count == num_blocks) {
+	  //std::cout << "expand done" << std::endl;
+	  current_table_version = next;
+	}
+      } else {
+	// If another thread is working on the block, wait until Done
+	while (t->block_status[block_num] == Working) {
+	  for (volatile int i=0; i < 100; i++);
+	}
+      }
+    }
+  }
+    
+  // *********************************************
+  // Construction and Destruction
+  // *********************************************
+
+  // Clear bucket, assuming it is not forwarded.
+  void clear_bucket(bckt* b) {
+    auto [s, tag] = b->ll();
+    if (!s.is_forwarded() && b->sc(tag, state())) {
+      for (int j=0; j < std::min(s.buffer_cnt(), buffer_size); j++) {
+	entries_->retire_entry(s.buffer[j]);
+      }
+      retire_list_all(s.overflow_list());
+    }
+  }
+
+  // Clears bucket or if the bucket is forwarded (during copying)
+  // then clear the forwarded buckets.
+  void clear_bucket_rec(table_version* t, long i) {
+    bckt* b = &(t->buckets[i].v);
+    state head = b->load();
+    if (!head.is_forwarded())
+      clear_bucket(b);
+    else {
+      table_version* next = t->next.load();
+      for (int j = 0; j < grow_factor; j++)
+	clear_bucket_rec(next, grow_factor * i + j);
+    }
+  }
+
+  void clear_buckets() {
+    table_version* ht = current_table_version.load();
+    // clear buckets from current and future versions
+    parallel_for(ht->size, [&] (size_t i) {
+	clear_bucket_rec(ht, i);});
+  }
+  
+  // Clear all memory.
+  // Reinitialize to table of size 1 if specified, and by default.
+  void clear(bool reinitialize = true) {
+    clear_buckets();
+
+    // now reclaim the arrays
+    table_version* tv = initial_table_version;
+    while (tv != nullptr) {
+      table_version* tv_next = tv->next;
+      delete tv;
+      tv = tv_next;
+    }
+    // reinitialize
+    if (reinitialize) {
+      current_table_version = new table_version(1);
+      initial_table_version = current_table_version;
+    }
+  }
+
+  Entries* entries_;
+  
+  // Creates initial table version for the given size.  The
+  // clear_at_end allows to free up the epoch-based collector's
+  // memory, and the scheduler.
+  parlay_hash(long n, Entries* entries, bool clear_at_end = default_clear_at_end)
+    : entries_(entries),
+      clear_memory_and_scheduler_at_end(clear_at_end),
+      sched_ref(clear_at_end ?
+		new parlay::scheduler_type(std::thread::hardware_concurrency()) :
+		nullptr),
+      link_pool(clear_at_end ?
+		new epoch::memory_pool<link>() :
+		&epoch::get_default_pool<link>()),
+      current_table_version(new table_version(n)),
+      initial_table_version(current_table_version.load())
+  { }
+
+  ~parlay_hash() {
+    clear(false);
+    if (clear_memory_and_scheduler_at_end) {
+      delete sched_ref;
+      delete link_pool;
+    }
+  }
+
+  // *********************************************
+  // Operations
+  // *********************************************
+
+  // Updates b, s, tag, and idx to the correct bucket, state, tag and
+  // index if the the state s is forwarded.  Is called recursively,
+  // but unlikely to go more than one level, and when not growing will
+  // return immediately.
+  void check_bucket_and_state(table_version* t, const K& k,
+			      big_atomic<state>*& b, state& s, tag_type& tag, long& idx) {
+    if (s.is_forwarded()) {
+      table_version* nxt = t->next.load();
+      idx = nxt->get_index(k);
+      b = &(nxt->buckets[idx].v);
+      std::tie(s, tag) = b->ll();
+      check_bucket_and_state(nxt, k, b, s, tag, idx);
+    }
+  }
+
+  // find in the bucket, or if forwarded (during copying) then follow
+  // through to the next table, possibly reapeatedly, although
+  // unlikely.
+  template <typename F>
+  auto find_in_bucket_rec(table_version* t, bckt* s, const K& k, const F& f)
+    -> std::optional<typename std::invoke_result<F,Entry>::type>
+  {
+    state x = s->load();
+    //if bucket is forwarded, go to next version
+    if (x.is_forwarded()) {
+      table_version* nxt = t->next.load();
+      return find_in_bucket_rec(nxt, nxt->get_bucket(k), k, f);
+    }
+    return find_in_state(x, k, f);
+  }
+
+  // Finds the entry with the key
+  // Returns an optional which is empty if the key is not in the table,
+  // and contains f(e) otherwise, where e is the entry matching the key
+  // NOTE: this is the most important function to opmitize for performance
+  // Hence one hand inline and one prefetch (not used anywhere else in code).
+  template <typename F>
+  auto Find(const K& k, const F& f)
+    -> std::optional<typename std::invoke_result<F,Entry>::type>
+  {
+    table_version* ht = current_table_version.load();
+    long idx = ht->get_index(k);
+    bckt* b = &(ht->buckets[idx].v);
+    // if entries are direct, then safe to scan the buffer without epoch protection
+    if constexpr (Entry::Direct) {
+      auto [s, tag] = b->ll();
+      if (s.is_forwarded()) 
+	check_bucket_and_state(ht, k, b, s, tag, idx);
+      for (long i = 0; i < std::min(s.buffer_cnt(), buffer_size); i++)
+	if (s.buffer[i].equal(k))
+	  return std::optional(f(s.buffer[i]));
+      // if not found and not overfull, then done
+      if (s.buffer_cnt() <= buffer_size) return std::nullopt;
+      // otherwise need to search overflow, which requires protection
+      return epoch::with_epoch([&, tag=tag, &s = s] {
+        // if state has not changed, then just search list
+	if (b->lv(tag)) return find_in_list(s.overflow_list(), k, f).first;
+	return find_in_bucket_rec(ht, b, k, f);
+      });
+    } else { // if using indirection always use protection
+      __builtin_prefetch(b); // allows read to be pipelined with epoch announcement
+      return epoch::with_epoch([&] () -> std::optional<typename std::invoke_result<F,Entry>::type> {
+	  return find_in_bucket_rec(ht, b, k, f);});
+
+
+    }
+  }
+
+  // Inserts at key, and does nothing if key already in the table.
+  // The constr function construct the entry to be inserted if needed.
+  // Returns an optional, which is empty if sucessfully inserted or
+  // contains f(e) if not, where e is the entry matching the key.
+  template <typename Constr, typename F>
+  auto Insert(const K& key, const Constr& constr, const F& f)
+    -> std::optional<typename std::invoke_result<F,Entry>::type>
+  {
+    using rtype = std::optional<typename std::invoke_result<F,Entry>::type>;
+    return epoch::with_epoch([&] () -> rtype {
+			       auto [e, flag] = insert_(key, constr);
+			       if (flag) return {};
+			       return rtype(f(e));});
+  }
+
+  template <typename Constr>
+  auto insert_(const K& key, const Constr& constr) -> std::pair<Entry, bool> {
+    table_version* ht = current_table_version.load();
+    long idx = ht->get_index(key);
+    auto b = &(ht->buckets[idx].v);
+    int delay = 200;
+    while (true) {
+      auto [s, tag] = b->ll();
+      copy_if_needed(ht, idx);
+      check_bucket_and_state(ht, key, b, s, tag, idx);
+      long len = s.buffer_cnt();
+      // if found in buffer then done
+      for (long i = 0; i < std::min(len, buffer_size); i++)
+	if (s.buffer[i].equal(key)) return std::pair(s.buffer[i], false);
+      if (len < buffer_size) { // buffer has space, insert to end of buffer
+	Entry new_e = constr();
+	if (b->sc(tag, state(s, new_e))) return std::pair(new_e, true);
+	entries_->retire_entry(new_e); // if failed need to ty again
+      } else if (len == buffer_size) { // buffer full, insert new link
+	Entry new_e = constr();
+	link* new_head = new_link(new_e, nullptr);
+	if (b->sc(tag, state(s, new_head))) 
+	  return std::pair(new_e, true);
+	entries_->retire_entry(new_head->entry); // if failed need to try again
+	retire_link(new_head);
+      } else { // buffer overfull, need to check if in list
+	auto [x, list_len] = find_in_list(s.overflow_list(), key, identity);
+	if (list_len + buffer_size > ht->overflow_size) expand_table(ht);
+	if (x.has_value()) return std::pair(*x, false); // if in list, then done
+	Entry new_e = constr();
+	link* new_head = new_link(new_e, s.overflow_list());
+	if (b->sc(tag, state(s, new_head))) // try to add to head of list
+	  return std::pair(new_e, true);
+	entries_->retire_entry(new_head->entry); // if failed need to ty again
+	retire_link(new_head);
+      }
+      // delay before trying again, only marginally helps
+      for (volatile int i=0; i < delay; i++);
+      delay = std::min(2*delay, 5000); // 1000-10000 are about equally good
+    }
+  }
+
+  template <typename Constr, typename G>
+  auto Upsert(const K& key, const Constr& constr, G& g)
+    -> std::optional<typename std::invoke_result<G,Entry>::type>
+  {
+    using rtype = std::optional<typename std::invoke_result<G,Entry>::type>;
+    table_version* ht = current_table_version.load();
+    long idx = ht->get_index(key);
+    auto b = &(ht->buckets[idx].v);
+    return epoch::with_epoch([&] () -> rtype {
+      int delay = 200;
+      while (true) {
+	auto [s, tag] = b->ll();
+	state out_s = s;
+	copy_if_needed(ht, idx);
+	check_bucket_and_state(ht, key, b, s, tag, idx);
+	long len = s.buffer_cnt();
+	bool cont = false;
+	for (long i = 0; i < std::min(len, buffer_size); i++) {
+	  if (s.buffer[i].equal(key)) {
+	    Entry new_e = constr(std::optional(s.buffer[i]));
+	    out_s.buffer[i] = new_e;
+	    if (b->sc(tag, out_s)) return g(s.buffer[i]);
+	    else {
+	      entries_->retire_entry(new_e);
+	      cont = true;
+	      break;
+	    }
+	  }
+	}
+	if (cont) continue;
+	if (len < buffer_size) { // buffer has space, insert to end of buffer
+	  Entry new_e = constr(std::optional<Entry>());
+	  if (b->sc(tag, state(s, new_e))) return std::nullopt;
+	  entries_->retire_entry(new_e); // if failed need to ty again
+	} else if (len == buffer_size) { // buffer just full, insert new link
+	  link* new_head = new_link(constr(std::optional<Entry>()), nullptr);
+	  if (b->sc(tag, state(s, new_head))) 
+	    return std::nullopt;
+	  entries_->retire_entry(new_head->entry); // if failed need to try again
+	  retire_link(new_head);
+	} else { // buffer overfull, need to check if in list
+	  link* old_head = s.overflow_list();
+	  auto [list_len, new_head, updated] = update_list(old_head, key, constr);
+	  if (new_head != nullptr) {
+	    if (b->sc(tag, state(s, new_head))) {// try to add to head of list
+	      rtype r = std::optional(g(updated->entry));
+	      retire_list_n(old_head, list_len); // retire old list
+	      return r;
+	    } else retire_list_n(new_head, list_len);
+	  } else {
+	    if (list_len + buffer_size > ht->overflow_size) expand_table(ht);
+	    new_head = new_link(constr(std::optional<Entry>()), old_head);
+	    if (b->sc(tag, state(s, new_head))) // try to add to head of list
+	      return std::nullopt;
+	    entries_->retire_entry(new_head->entry); // if failed need to ty again
+	    retire_link(new_head);
+	  }	    
+	}
+	// delay before trying again, only marginally helps
+	for (volatile int i=0; i < delay; i++);
+	delay = std::min(2*delay, 5000); // 1000-10000 are about equally good
+      }
+    });
+  }
+
+  // Removes entry with given key
+  // Returns an optional which is empty if the key is not in the table,
+  // and contains f(e) otherwise, where e is the entry that is removed.
+  template <typename F>
+  auto Remove(const K& key, const F& f)
+    -> std::optional<typename std::invoke_result<F,Entry>::type>
+  {
+    using rtype = std::optional<typename std::invoke_result<F,Entry>::type>;
+    table_version* ht = current_table_version.load();
+    long idx = ht->get_index(key);
+    auto b = &(ht->buckets[idx].v);
+    // if entries are direct safe to scan the buffer without epoch protection
+    if constexpr (Entry::Direct) {
+      auto [s, tag] = b->ll();
+      copy_if_needed(ht, idx);
+      check_bucket_and_state(ht, key, b, s, tag, idx);
+      if (s.buffer_cnt() <= buffer_size) {
+	int i = find_in_buffer(s, key);
+	if (i == -1) return std::nullopt;
+	if (b->sc(tag, state(s, i))) {
+	  rtype r = f(s.buffer[i]);
+	  entries_->retire_entry(s.buffer[i]);
+	  return r;
+	} // if sc failed, will need to try again
+      }
+    }
+    // if buffer overfull, or indirect, then need to protect
+    return epoch::with_epoch([&] () -> rtype {
+      int delay = 200;
+      while (true) {
+        auto [s, tag] = b->ll();
+	copy_if_needed(ht, idx);
+	check_bucket_and_state(ht, key, b, s, tag, idx);
+	int i = find_in_buffer(s, key);
+	if (i >= 0) { // found in buffer
+	  if (s.buffer_cnt() > buffer_size) { // need to backfill from list
+	    link* l = s.overflow_list();
+	    if (b->sc(tag, state(s, l, i))) {
+	      rtype r = f(s.buffer[i]);
+	      entries_->retire_entry(s.buffer[i]);
+	      retire_link(l);
+	      return r;
+	    } // if sc failed, will need to try again
+	  } else { // buffer not overfull, can backfill within buffer
+	    if (b->sc(tag, state(s, i))) {
+	      rtype r = f(s.buffer[i]);
+	      entries_->retire_entry(s.buffer[i]);
+	      return r;
+	    } // if sc failed, will need to try again
+	  }
+	} else { // not found in buffer
+	  if (s.buffer_cnt() <= buffer_size) // if not overful, then done
+	    return std::nullopt;
+	  auto [cnt, new_list, removed] = remove_from_list(s.overflow_list(), key);
+          if (cnt == 0) // if not found in list then done
+	    return std::nullopt;
+	  // if found, try to update with the new list that has the element removed
+          if (b->sc(tag, state(s, new_list))) { 
+	    rtype r = f(removed->entry); 
+	    entries_->retire_entry(removed->entry);
+            retire_list_n(s.overflow_list(), cnt); // retire old list
+            return r;
+          } // if sc failed, will need to try again
+          retire_list_n(new_list, cnt - 1); // failed, retire new list
+	}
+	for (volatile int i=0; i < delay; i++);
+	delay = std::min(2*delay, 5000); // 1000-10000 are about equally good
+      }
+    });
+  }
+
+  // Size of bucket, or if forwarded, then sum sizes of all forwarded
+  // buckets, recursively.
+  long bucket_size_rec(table_version* t, long i) {
+    state head = t->buckets[i].v.load();
+    if (!head.is_forwarded())
+      return  head.size();
+    else {
+      long sum = 0;
+      table_version* next = t->next.load();
+      for (int j = 0; j < grow_factor; j++)
+	sum += bucket_size_rec(next, grow_factor * i + j);
+      return sum;
+    }
+  }
+
+  long size() {
+    table_version* ht = current_table_version.load();
+    return epoch::with_epoch([&] {
+       return parlay::tabulate_reduce(ht->size, [&] (size_t i) {
+	   return bucket_size_rec(ht, i);});});
+  }
+
+  template <typename F>
+  void static for_each_bucket_rec(table_version* t, long i, const F& f) {
+    state s = t->buckets[i].v.load();
+    if (!s.is_forwarded())
+      for_each_in_state(s, f);
+    else {
+      table_version* next = t->next.load();
+      for (int j = 0; j < grow_factor; j++)
+	for_each_bucket_rec(next, grow_factor * i + j, f);
+    }
+  }
+
+  // Apply function f to all entries of the table.  Works while updates are going on, and guarantees that:
+  //   any element whose delete linearizes before the invocation will not be included
+  //   any element whose insert linearizes after the response will not be included
+  //   any element that is present from invocation to response will be included
+  // Elements that are inserted or deleted between the invocation and response might or might not appear.
+  // template <typename F>
+  // parlay::sequence<Entry> entries(const F& f) {
+  //   table_version* ht = current_table_version.load();
+  //   return epoch::with_epoch([&] {
+  //     auto s = parlay::tabulate(ht->size, [&] (size_t i) {
+  //       parlay::sequence<Entry> r;
+  // 	for_each_in_bucket_rec(ht, i, [&] (const Entry& entry) {
+  // 	  r.push_back(f(entry));});
+  // 	return r;});
+  //     return flatten(s);});
+  // }
+
+  // Applies f to all elments in table.
+  // Same pseudo-linearizable guarantee as entries and size.
+  template <typename F>
+  void for_each(const F& f) {
+    table_version* ht = current_table_version.load();
+    return epoch::with_epoch([&] {
+                               parallel_for(ht->size, [&] (long i) {
+                                   for_each_bucket_rec(ht, i, f);});});
+  }
+
+  // *********************************************
+  // Iterator
+  // *********************************************
+
+  struct Iterator {
+  public:
+    using value_type        = typename Entries::Data;
+    using iterator_category = std::forward_iterator_tag;
+    using pointer           = value_type*;
+    using reference         = value_type&;
+    using difference_type   = long;
+
+  private:
+    std::vector<Entry> entries;
+    Entry entry;
+    table_version* t;
+    int i;
+    long bucket_num;
+    bool single;
+    bool end;
+    void get_next_bucket() {
+      auto g = [&] (const Entry& e) {entries.push_back(e);};
+      while (entries.size() == 0 && ++bucket_num < t->size)
+        for_each_bucket_rec(t, bucket_num, g);
+      if (bucket_num == t->size) end = true;
+    }
+
+  public:
+    Iterator(bool end) : i(0), bucket_num(-2l), single(false), end(true) {}
+    Iterator(table_version* t) : t(t),
+      i(0), bucket_num(-1l), single(false), end(false) {
+      get_next_bucket();
+    }
+    Iterator(Entry entry) : entry(entry), single(true), end(false) {}
+    Iterator& operator++() {
+      if (single) end = true;
+      else if (++i == entries.size()) {
+	i = 0;
+	entries.clear();
+	get_next_bucket();
+      }
+      return *this;
+    }
+    Iterator& operator++(int) {
+      Iterator tmp = *this;
+      if (single) end = true;
+      else if (++i == entries.size()) {
+	i = 0;
+	entries.clear();
+	get_next_bucket();
+      }
+      return tmp;
+    }
+    template<bool D = Entry::Direct, std::enable_if_t<D, int> = 0>
+    const value_type operator*() {
+      if (single) return entry.get_entry();
+      return entries[i].get_entry();}
+
+    template<bool D = Entry::Direct, std::enable_if_t<!D, int> = 0>
+    const value_type& operator*() { 
+      if (single) return entry.get_entry();
+      return entries[i].get_entry();}
+
+    bool operator!=(const Iterator& iterator) {
+      return !(end ? iterator.end : (bucket_num == iterator.bucket_num &&
+				     i == iterator.i));
+    }
+    bool operator==(const Iterator& iterator) {
+      return !(*this != iterator);}
+  };
+
+  Iterator begin() { return Iterator(current_table_version.load());}
+  Iterator end() { return Iterator(true);}
+
+  static constexpr auto identity = [] (const Entry& entry) {return entry;};
+  static constexpr auto true_f = [] (const Entry& entry) {return true;};
+
+  
+  template <typename Constr>
+  std::pair<Iterator,bool> insert(const K& key, const Constr& constr) {
+    return epoch::with_epoch([&] {
+      auto [e,flag] = insert_(key, constr);
+      return std::pair(Iterator(e), flag);});
+  }
+
+  Iterator erase(Iterator pos) {
+    Remove(*pos.first, true_f);
+    return Iterator(true);
+  }
+
+  size_t erase(const K& key) {
+    return Remove(key, true_f).has_value();
+  }
+
+  Iterator find(const K& k) {
+    auto r = Find(k, identity);
+    if (!r.has_value()) return Iterator(true);
+    auto x = Iterator(*r);
+    return x;
+  }
+
+};
+
+  static constexpr bool default_clear_at_end = true;
+
+  // conditionally rehash if type Hash::avalanching is not defined
+  template<typename Hash, typename ignore = void>
+  struct rehash {
+    size_t operator()(size_t h) {
+      size_t x = h * UINT64_C(0xbf58476d1ce4e5b9); // linear transform
+      return (x ^ (x >> 31));  // non-linear transform
+    }};
+
+  template<typename Hash>
+  struct rehash<Hash, typename Hash::is_avalanching> {
+    size_t operator()(size_t i) {return i;}};
+
+  // Definition where entries of the hash table are stored indirectly
+  // through a pointer.  This means the entries themselves will never
+  // move, but requires a level of indirection when accessing them.
+  // Tags the high-bits of pointers with part of the hash function so
+  // one can avoid the indirection if the tags do not match.
+  // Currently used for all types that are not trivially copyable.
+  template <typename EntryData>
+  struct IndirectEntries {
+    using DataS = EntryData;
+    using Data = typename DataS::value_type;
+    using Hash = typename DataS::Hash;
+    using KeyEqual = typename DataS::KeyEqual;
+      
+    struct Entry {
+      using K = typename DataS::K;
+      using Key = std::pair<const K*,size_t>;
+      static constexpr bool Direct = false;
+      Data* ptr;
+      static Data* tag_ptr(size_t hashv, Data* data) {
+	return (Data*) (((hashv >> 48) << 48) | ((size_t) data));
+      }
+      Data* get_ptr() const {
+	return (Data*) (((size_t) ptr) & ((1ul << 48) - 1)); }
+      static unsigned long hash(const Key& k) {
+	return k.second;}
+      bool equal(const Key& k) const {
+	return (((k.second >> 48) == (((size_t) ptr) >> 48)) &&
+		KeyEqual{}(DataS::get_key(*get_ptr()), *k.first)); }
+      Key get_key() const { return make_key(DataS::get_key(*get_ptr()));}
+      Data& get_entry() const { return *get_ptr();}
+      static Key make_key(const K& key) {
+	return Key(&key, rehash<Hash>{}(Hash{}(key)));}
+      Entry(Key k, Data* data) : ptr(tag_ptr(hash(k), data)) {}
+      Entry() {}
+    };
+
+    bool clear_at_end;
+    using Key = typename Entry::Key;
+
+    // a memory pool for the entries
+    epoch::memory_pool<Data>* data_pool;
+
+    IndirectEntries(bool clear_at_end=false) 
+      : clear_at_end(clear_at_end),
+	data_pool(clear_at_end ?
+		  new epoch::memory_pool<Data>() :
+		  &epoch::get_default_pool<Data>()) {}
+    ~IndirectEntries() {
+      if (clear_at_end) { delete data_pool;}
+    }
+
+    // allocates memory for the entry
+    Entry make_entry(const Key& k, const Data& data) {
+      return Entry(k, data_pool->New(data)); }
+
+    // retires the memory for the entry
+    void retire_entry(Entry& e) {
+      data_pool->Retire(e.get_ptr()); }
+  };
+
+  // Definition where entries of the hash table are stored directly.
+  // This means the entries might be moved during updates, including
+  // insersions, removals, and resizing.  Currently used for trivially
+  // copyable types.
+  template <typename EntryData>
+  struct DirectEntries {
+    using DataS = EntryData;
+    using Data = typename DataS::value_type;
+    using Hash = typename DataS::Hash;
+    using KeyEqual = typename DataS::KeyEqual;
+    using K = typename DataS::K;
+
+    struct Entry {
+      using K = typename DataS::K;
+      using Key = K;
+      static const bool Direct = true;
+      Data data; 
+      static unsigned long hash(const Key& k) {
+	return rehash<Hash>{}(Hash{}(k));}
+      bool equal(const Key& k) const { return KeyEqual{}(get_key(), k); }
+      static Key make_key(const K& k) {return k;}
+      const K& get_key() const {return DataS::get_key(data);}
+      const Data& get_entry() const { return data;}
+      Entry(const Data& data) : data(data) {}
+      Entry() {}
+    };
+
+    DirectEntries(bool clear_at_end=false) {}
+    Entry make_entry(const K& k, const Data& data) {
+      return Entry(data); }
+
+    // retiring is a noop since no memory has been allocated for entries
+    void retire_entry(Entry& e) {}
+  };
+
+  // template <typename EntryData>
+  // struct DirectEntriesX {
+  //   using DataS = EntryData;
+  //   using Data = typename DataS::value_type;
+  //   using Hash = typename DataS::Hash;
+  //   using KeyEqual = typename DataS::KeyEqual;
+  //   using K = typename DataS::K;
+
+  //   struct Entry {
+  //     using K = typename DataS::K;
+  //     using Key = K;
+  //     static const bool Direct = true;
+  //     std::array<long,1 + (sizeof(Data)-1)/8> data;
+  //     static unsigned long hash(const Key& k) {
+  // 	return rehash<Hash>{}(Hash{}(k));}
+  //     bool equal(const Key& k) const { return KeyEqual{}(get_key(), k); }
+  //     static Key make_key(const K& k) {return k;}
+  //     const K& get_key() const { return DataS::get_key(*((Data*) &data));}
+  //     const Data& get_entry() const { return *((Data*) &data);}
+  //     Entry(const Data& d) { new (&data) Data(d); }
+  //     Entry() {}
+  //   };
+
+  //   bool clear_at_end;
+
+  //   // a memory pool for the entries
+  //   epoch::retire_pool<Data>* data_pool;
+
+  //   DirectEntriesX(bool clear_at_end=false) 
+  //     : clear_at_end(clear_at_end),
+  // 	data_pool(clear_at_end ?
+  //   		  new epoch::retire_pool<Data>() :
+  //   		  &epoch::get_default_retire_pool<Data>())
+  //   {}
+  //   ~DirectEntriesX() {
+  //     if (clear_at_end) { delete data_pool;}
+  //   }
+
+  //   // allocates memory for the entry
+  //   Entry make_entry(const K& k, const Data& data) {
+  //     return Entry(data);}
+
+  //   // retires the memory for the entry
+  //   void retire_entry(Entry& e) {
+  //     data_pool->Retire((Data*) &(e.data)); 
+  //   }
+  // };
+  
+
+}  // namespace parlay
+#endif  // PARLAY_HASH_H_

--- a/third_party/parlayhash/include/parlay_hash/unordered_map.h
+++ b/third_party/parlayhash/include/parlay_hash/unordered_map.h
@@ -1,0 +1,170 @@
+// Initial Author: Guy Blelloch
+// Developed as part of the flock library
+// 
+// A growable unordered_map using a hash table designed for scalability to large number of threads, and
+// for high contention.  On a key type K and value type V it supports:
+//
+//   unordered_map<K, V, Hash=std::hash<K>, Equal=std::equal_to<K>>(n) :
+//   constructor for table of initial size n
+//
+//   Find(const K&) -> std::optional<V> :
+//   returns value if key is found, and otherwise returns nullopt
+//
+//   Insert(const K&, const V&) -> std::optional<V> :
+//   if key not in the table it inserts the key with the given value
+//   and returns nullopt, otherwise it does not modify the table and
+//   returns the old value.
+//
+//   Remove(const K&) -> std::optional<V> :
+//   if key is in the table it removes the entry and returns its value.
+//   otherwise it does nothing and returns nullopt.
+//
+//   size() -> long : returns the size of the table.  Not linearizable with
+//   the other functions, and takes time proportional to the table size.
+//  
+//   clear() -> void : clears the table so its size is 0.
+//
+//   for_each(F f) : applies functor f to each entry of the table.
+//   f should be of type (const std::pair<K,V>&) -> void
+
+#ifndef PARLAY_UNORDERED_MAP_
+#define PARLAY_UNORDERED_MAP_
+
+#include <functional>
+#include <optional>
+#include "parlay_hash.h"
+
+namespace parlay {
+
+  // entries contain a key
+  template <typename K_, typename V_, class Hash_ = std::hash<K_>, class KeyEqual_ = std::equal_to<K_>>
+  struct MapData {
+    using K = K_;
+    using V = V_;
+    using Hash = Hash_;
+    using KeyEqual = KeyEqual_;
+    using value_type = std::pair<K,V>;
+    static const K& get_key(const value_type& x) { return x.first;}
+  };
+
+  // Generic unordered_map that can be used with direct or indirect
+  // entries depending on the template argument.
+  template <typename Entries>
+  struct unordered_map_internal {
+    using map = parlay_hash<Entries>;
+
+    Entries entries_;
+    map m;
+
+    using Entry = typename Entries::Entry;
+    using K = typename Entries::DataS::K;
+    using V = typename Entries::DataS::V;
+    using key_type = K;
+    using mapped_type = V;
+    using value_type = std::pair<K, V>;
+    using iterator = typename map::Iterator;
+
+    static constexpr auto true_f = [] (const value_type& kv) {return true;};
+    static constexpr auto identity = [] (const Entry& kv) {return kv;};
+    static constexpr auto get_value = [] (const value_type& kv) {return kv.second;};
+
+    unordered_map_internal(long n = 0, bool clear_at_end = default_clear_at_end)
+      : entries_(Entries(clear_at_end)),
+	m(map(n+1, &entries_, clear_at_end)) {}
+
+    iterator begin() { return m.begin();}
+    iterator end() { return m.end();}
+    bool empty() { return size() == 0;}
+    bool max_size() { return (1ul << 47)/sizeof(Entry);}
+    void clear() { m.clear_buckets();}
+    long size() { return m.size();}
+
+    template <typename F = decltype(identity)>
+    //auto entries(const F& f = identity) { return m.entries(f);}
+    long count(const K& k) { return (contains(k)) ? 1 : 0; }
+    bool contains(const K& k) { return Find(k, true_f).has_value();}
+
+    template <typename F = decltype(get_value)>
+    auto Find(const K& k, const F& f = get_value)
+    // -> std::optional<typename std::invoke_result<F(value_type)>::type>
+    {
+      auto g = [&] (const Entry& e) {return f(e.get_entry());};
+      return m.Find(Entry::make_key(k), g);
+    }
+
+    auto Insert(const K& key, const V& value) -> std::optional<mapped_type>
+    {
+      auto k = Entry::make_key(key);
+      auto g = [&] (const Entry& e) {return get_value(e.get_entry());};
+      return m.Insert(k, [&] {return entries_.make_entry(k, value_type(key, value));}, g);
+    }
+
+    template <typename F>
+    auto Upsert(const K& key, const F& f) -> std::optional<mapped_type>
+    {
+      auto k = Entry::make_key(key);
+      auto g = [&] (const Entry& e) {return get_value(e.get_entry());};
+      auto constr = [&] (const std::optional<Entry>& e) -> Entry {
+		      if (e.has_value())
+			return entries_.make_entry(k, value_type(key, f(std::optional(get_value((*e).get_entry())))));
+		      return entries_.make_entry(k, value_type(key, f(std::optional<V>())));
+		    };
+      return m.Upsert(k, constr, g);
+    }
+
+    template <typename F>
+    auto Insert(const K& key, const V& value, const F& f)
+    // -> std::optional<typename std::invoke_result<F(value_type)>::type>
+    {
+      auto k = Entry::make_key(key);
+      auto g = [&] (const Entry& e) {return f(e.get_entry());};
+      return m.Insert(k, [&] {return entries_.make_entry(k, value_type(key, value));}, g);
+    }
+
+    auto Remove(const K& k) -> std::optional<mapped_type>
+    {
+      auto g = [&] (const Entry& e) {return get_value(e.get_entry());};
+      return m.Remove(Entry::make_key(k), g);
+    }
+
+    template <typename F>
+    auto Remove(const K& k, const F& f)
+    //  -> std::optional<typename std::invoke_result<F(value_type)>::type>
+    {
+      auto g = [&] (const Entry& e) {return f(e.get_entry());};
+      return m.Remove(Entry::make_key(k), g);
+    }
+
+    iterator find(const K& k) { return m.find(k); }
+
+    std::pair<iterator,bool> insert(const value_type& entry) {
+      auto k = Entry::make_key(entry.first);
+      return m.insert(k, [&] {return entries_.make_entry(k, entry);});}
+
+    iterator erase(iterator pos) { return m.erase(pos); }
+    size_t erase(const K& k) { return m.erase(k); }
+
+  };
+
+  // Entries are stored directly in the bucket, avoiding a cache miss
+  // for indirection.  Entries can be moved by updates even on
+  // different keys.
+  template <typename K, typename V, class Hash = std::hash<K>, class KeyEqual = std::equal_to<K>>
+  using parlay_unordered_map_direct = unordered_map_internal<DirectEntries<MapData<K, V, Hash, KeyEqual>>>;
+
+  // Entries are stored indirectly through a pointer.  Pointers to
+  // entries wil remain valid until the entry is upserted or deleted
+  // (an upsert can be though of as a deletion followed by an
+  // insersion).
+  template <typename K, typename V, class Hash = std::hash<K>, class KeyEqual = std::equal_to<K>>
+  using parlay_unordered_map_indirect = unordered_map_internal<IndirectEntries<MapData<K, V, Hash, KeyEqual>>>;
+
+  // specialization of unordered_map to use either direct or indirect
+  // entries depending on whether K and V are trivially copyable.
+  template <typename K, typename V, class Hash = std::hash<K>, class KeyEqual = std::equal_to<K>>
+  using parlay_unordered_map = std::conditional_t<std::is_trivially_copyable_v<K> &&
+						  std::is_trivially_copyable_v<V>,
+						  parlay_unordered_map_direct<K,V,Hash,KeyEqual>,
+						  parlay_unordered_map_indirect<K,V,Hash,KeyEqual>>;
+}  // namespace parlay
+#endif  // PARLAY_BIGATOMIC_HASH_LIST

--- a/third_party/parlayhash/include/parlay_hash/unordered_set.h
+++ b/third_party/parlayhash/include/parlay_hash/unordered_set.h
@@ -1,0 +1,87 @@
+#ifndef PARLAY_UNORDERED_SET_
+#define PARLAY_UNORDERED_SET_
+
+#include <functional>
+#include <optional>
+#include "parlay_hash.h"
+#include <utils/epoch.h>
+
+namespace parlay {
+
+  // entries just contain a key
+  template <typename K_, class Hash_ = std::hash<K_>, class KeyEqual_ = std::equal_to<K_>>
+  struct SetData {
+    using K = K_;
+    using Hash = Hash_;
+    using KeyEqual = KeyEqual_;
+    using value_type = K;
+    static const K& get_key(const value_type& x) { return x;}
+  };
+
+  // Generic unordered_set that can be used with direct or indirect
+  // entries depending on the template argument.
+  template <typename Entries>
+  struct unordered_set_internal {
+    using set = parlay_hash<Entries>;
+
+    Entries entries_;
+    set m;
+
+    using Entry = typename Entries::Entry;
+    using K = typename Entries::DataS::K;
+    using key_type = K;
+    using value_type = K;
+    using iterator = typename set::Iterator;
+
+    static constexpr auto true_f = [] (const Entry& kv) {return true;};
+    static constexpr auto identity = [] (const Entry& kv) {return kv;};
+
+    unordered_set_internal(long n = 0, bool clear_at_end = default_clear_at_end)
+      : entries_(Entries(clear_at_end)),
+	m(set(n+1, &entries_, clear_at_end)) {}
+
+    iterator begin() { return m.begin();}
+    iterator end() { return m.end();}
+    bool empty() { return size() == 0;}
+    bool max_size() { return (1ul << 47)/sizeof(Entry);}
+    void clear() { m.clear_buckets();}
+    long size() { return m.size();}
+
+    template <typename F = decltype(identity)>
+    //auto entries(const F& f = identity) { return m.entries(f);}
+    long count(const K& k) { return (contains(k)) ? 1 : 0; }
+    bool contains(const K& k) { return Find(k);}
+
+    bool Find(const K& k) { return m.Find(Entry::make_key(k), true_f).has_value(); }
+    bool Insert(const K& key) 
+    {
+      auto k = Entry::make_key(key);
+      return !m.Insert(k, [&] {return entries_.make_entry(k, key);}, true_f).has_value();
+    }
+
+    bool Remove(const K& k)
+    { return m.Remove(Entry::make_key(k), true_f).has_value(); }
+
+    iterator find(const K& k) { return m.find(k); }
+
+    std::pair<iterator,bool> insert(const value_type& entry) {
+      return m.insert(entries_.make_entry(make_key(entry.first), entry)); }
+
+    iterator erase(iterator pos) { return m.erase(pos); }
+    size_t erase(const K& k) { return m.erase(k); }
+
+  };
+
+  template <typename K, class Hash = std::hash<K>, class KeyEqual = std::equal_to<K>>
+  using parlay_unordered_set_direct = unordered_set_internal<DirectEntries<SetData<K, Hash, KeyEqual>>>;
+
+  template <typename K, class Hash = std::hash<K>, class KeyEqual = std::equal_to<K>>
+  using parlay_unordered_set_indirect = unordered_set_internal<IndirectEntries<SetData<K, Hash, KeyEqual>>>;
+
+  template <typename K, class Hash = std::hash<K>, class KeyEqual = std::equal_to<K>>
+  using parlay_unordered_set = std::conditional_t<std::is_trivially_copyable_v<K>,
+						  parlay_unordered_set_direct<K, Hash, KeyEqual>,
+						  parlay_unordered_set_indirect<K, Hash, KeyEqual>>;
+}  // namespace parlay
+#endif  // PARLAY_BIGATOMIC_HASH_LIST
+

--- a/third_party/parlayhash/include/utils/epoch.h
+++ b/third_party/parlayhash/include/utils/epoch.h
@@ -1,0 +1,597 @@
+// ***************************
+// Epoch-based memory reclamation
+// Supports:
+//     epoch::with_epoch(F f),
+// which runs f within an epoch, as well as:
+//     epoch::New<T>(args...)
+//     epoch::Retire(T* a)   -- delays destruction and free
+//     epoch::Delete(T* a)   -- destructs and frees immediately
+// Retire delays destruction and free until no operation that was in a
+// with_epoch at the time it was run is still within the with_epoch.
+//
+// All operations take constant time overhead (beyond the cost of the
+// system malloc and free).
+//
+// Designed to work with C++ threads, or compatible threading
+// libraries.  In particular it uses thread_local variables, and no two
+// concurrent processes can share the same instance of the  variable.
+//
+// When NDEBUG is not set, the operations check for memory corruption
+// of the bytes immediately before and after the object, and check
+// for double retires/deletes.  Also:
+//     epoch::check_ptr(T* a)
+// will check that an object allocated using epoch::New(..) has not
+// been corrupted.
+//
+// Supports undoing retires.  This can be useful in transactional
+// system in which an operation aborts, and any retires done during
+// the operations have to be undone.  In particular Retire returns a
+// pointer to a boolean.  Running
+//    epoch::undo_retire(bool* x)
+// will undo the retire.  Must be run in same with_epoch as the retire
+// was run, otherwise it is too late to undo.  If you don't want
+// to undo retires, you can ignore this feature.
+//
+// New<T>, Retire and Delete use a shared pool for the retired lists,
+// which, although not very large, is not cleared until program
+// termination.  A private pool can be created with
+//     epoch::memory_pool<T> a;
+// which then supports a->New(args...), a->Retire(T*) and
+// a->Delete(T*).  On destruction of "a", all elements of the retired
+// lists will be destructed and freed.
+//
+// Achieves constant times overhead by incrementally taking steps.
+// In particular every Retire takes at most a constant number of
+// incremental steps towards updating the epoch and clearing the
+// retired lists.
+//
+// Developed as part of parlay project at CMU, initially for flock then
+// used for verlib, and parlayhash.
+// Current dependence on parlay is just for parlay::my_thread_id() and
+// parlay::num_thread_ids() which are from "parlay/thread_specific.h".
+// ***************************
+
+#include <atomic>
+#include <cstdlib>
+#include <functional>
+#include <list>
+#include <ostream>
+#include <vector>
+#include <type_traits>
+#include <utility>
+// Needed for parlay::my_thread_id of parlay::num_thread_ids
+#include "threads/thread_specific.h"
+
+#ifndef PARLAY_EPOCH_H_
+#define PARLAY_EPOCH_H_
+
+#ifndef NDEBUG
+// Checks for corruption of bytes before and after allocated structures, as well as double frees.
+// Requires some extra memory to pad the front and back of a structure.
+#define EpochMemCheck 1
+#endif
+//#define EpochMemCheck 1
+
+#define USE_STEPPING 1
+//#define USE_UNDO 1
+
+#ifdef USE_PARLAY_ALLOC
+#include "parlay/alloc.h"
+#endif
+
+// ***************************
+// epoch structure
+// ***************************
+
+namespace epoch {
+
+  namespace internal {
+
+  inline int worker_id() {return parlay::my_thread_id(); }
+  inline int num_workers() {return parlay::num_thread_ids();}
+  constexpr int max_num_workers = 1024;
+
+struct alignas(64) epoch_s {
+
+  // functions to run when epoch is incremented
+  std::vector<std::function<void()>> before_epoch_hooks;
+  std::vector<std::function<void()>> after_epoch_hooks;
+
+  struct alignas(64) announce_slot {
+    std::atomic<long> last;
+    announce_slot() : last(-1l) {}
+  };
+
+  std::vector<announce_slot> announcements;
+  std::atomic<long> current_epoch;
+  epoch_s() :
+    announcements(std::vector<announce_slot>(max_num_workers)),
+    current_epoch(0),
+    epoch_state(0) {}
+
+  long get_current() {
+    return current_epoch.load();
+  }
+
+  long get_my_epoch() {
+    return announcements[worker_id()].last;
+  }
+
+  void set_my_epoch(long e) {
+    announcements[worker_id()].last = e;
+  }
+
+  int announce() {
+    size_t id = worker_id();
+    assert(id < max_num_workers);
+    while (true) {
+      long current_e = get_current();
+      long tmp = current_e;
+      // apparently an exchange is faster than a store (write and fence)
+      announcements[id].last.exchange(tmp, std::memory_order_seq_cst);
+      if (get_current() == current_e) return id;
+    }
+  }
+
+  void unannounce(size_t id) {
+    announcements[id].last.store(-1l, std::memory_order_release);
+  }
+
+  // top 16 bits are used for the process id, and the bottom 48 for
+  // the epoch number
+  using state = size_t;
+  std::atomic<state> epoch_state;
+
+  // Attempts to takes num_steps checking the announcement array to
+  // see that all slots are up-to-date with the current epoch.  Once
+  // they are, the epoch is updated.  Designed to deamortize the cost
+  // of sweeping the announcement array--every thread only does
+  // constant work.
+  state update_epoch_steps(state prev_state, int num_steps) {
+    state current_state = epoch_state.load();
+    if (prev_state != current_state)
+      return current_state;
+    size_t i = current_state >> 48;
+    size_t current_e = ((1ul << 48) - 1) & current_state;
+    size_t workers = num_workers();
+    if (i == workers) {
+      for (const auto h : before_epoch_hooks) h();
+      long tmp = current_e;
+      if (current_epoch.load() == current_e &&
+	  current_epoch.compare_exchange_strong(tmp, current_e+1)) {
+	for (const auto h : after_epoch_hooks) h();
+      }
+      state new_state = current_e + 1;
+      epoch_state.compare_exchange_strong(current_state, new_state);
+      return epoch_state.load();
+    }
+    size_t j;
+    for (j = i ; j < i + num_steps && j < workers; j++)
+      if ((announcements[j].last != -1l) && announcements[j].last < current_e)
+	return current_state;
+    state new_state = (j << 48 | current_e);
+    if (epoch_state.compare_exchange_strong(current_state, new_state))
+      return new_state;
+    return current_state;
+  }
+
+  // this version does the full sweep
+  void update_epoch() {
+    long current_e = get_current();
+
+    // check if everyone is done with earlier epochs
+    int workers;
+    do {
+      workers = num_workers();
+      if (workers > max_num_workers) {
+	std::cerr << "number of threads: " << workers
+		  << ", greater than max_num_threads: " << max_num_workers << std::endl;
+	abort();
+      }
+      for (int i=0; i < workers; i++)
+	if ((announcements[i].last != -1l) && announcements[i].last < current_e)
+	  return;
+    } while (num_workers() != workers); // this is unlikely to loop
+
+    // if so then increment current epoch
+    for (const auto h : before_epoch_hooks) h();
+    if (current_epoch.compare_exchange_strong(current_e, current_e+1)) {
+      for (const auto h : after_epoch_hooks) h();
+    }
+  }
+};
+
+  // Juat one epoch structure shared by all
+  extern inline epoch_s& get_epoch() {
+    static epoch_s epoch;
+    return epoch;
+  }
+
+// ***************************
+// type specific memory pools
+// ***************************
+
+template <typename T>
+struct alignas(64) memory_pool {
+private:
+
+  struct list_entry {
+    T* ptr;
+#ifdef USE_UNDO
+    bool keep_;
+    bool keep() {return keep_;}
+    list_entry() : keep_(false) {}
+    list_entry(T* ptr) : ptr(ptr), keep_(false) {}
+#else
+    bool keep() {return false;}
+#endif
+  };
+
+  // each thread keeps one of these
+  struct alignas(256) old_current {
+    std::list<list_entry> old;  // linked list of retired items from previous epoch
+    std::list<list_entry> current; // linked list of retired items from current epoch
+    std::list<list_entry> reserve;  // linked list of items that could be destructed, but delayed so they can be reused
+    long epoch; // epoch on last retire, updated on a retire
+    long retire_count; // number of retires so far, reset on updating the epoch
+    long alloc_count;
+    epoch_s::state e_state;
+    old_current() : e_state(0), epoch(0), retire_count(0), alloc_count(0) {}
+  };
+
+  std::vector<old_current> pools;
+    
+  // wrapper used so can pad for the memory checked version
+  struct wrapper {
+#ifdef EpochMemCheck    
+    long pad;
+    std::atomic<long> head;
+    T value;
+    std::atomic<long> tail;
+#else
+    T value;
+#endif
+  };
+
+  // values used to check for corruption or double delete
+  static constexpr long default_val = 10;
+  static constexpr long deleted_val = 55;
+
+  // given a pointer to value in a wrapper, return a pointer to the wrapper.
+  wrapper* wrapper_from_value(T* p) {
+    size_t offset = ((char*) &((wrapper*) p)->value) - ((char*) p);
+    return (wrapper*) (((char*) p) - offset);
+  }
+
+  // destructs entries on a list
+  void clear_list(std::list<list_entry>& lst) {
+    for (list_entry& x : lst)
+      if (!x.keep()) {
+	x.ptr->~T();
+	free_wrapper(wrapper_from_value(x.ptr));
+      }
+    lst.clear();
+  }
+
+  void advance_epoch(int i, old_current& pid) {
+#ifndef USE_UNDO
+    int delay = 1;
+#else
+    int delay = 2;
+#endif
+    if (pid.epoch + delay < get_epoch().get_current()) {
+      pid.reserve.splice(pid.reserve.end(), pid.old);
+      pid.old = std::move(pid.current);
+      pid.epoch = get_epoch().get_current();
+    }
+    // a heuristic
+#ifdef USE_STEPPING
+    long update_threshold = 10;
+#else
+    long update_threshold = 10 * num_workers();
+#endif
+    if (++pid.retire_count == update_threshold) {
+      pid.retire_count = 0;
+#ifdef USE_STEPPING
+      pid.e_state = get_epoch().update_epoch_steps(pid.e_state, 8);
+#else
+      get_epoch().update_epoch();
+#endif
+    }
+  }
+
+#ifdef USE_PARLAY_ALLOC
+  using Allocator = parlay::type_allocator<wrapper>;
+#endif
+
+  void check_wrapper_on_destruct(wrapper* x) {
+#ifdef EpochMemCheck
+    // check nothing is corrupted or double deleted
+    if (x->head != default_val || x->tail != default_val) {
+      if (x->head == deleted_val) std::cerr << "double free" << std::endl;
+      else if (x->head != default_val)  std::cerr << "corrupted head" << x->head << std::endl;
+      if (x->tail != default_val) std::cerr << "corrupted tail: " << x->tail << std::endl;
+      abort();
+    }
+    x->head = deleted_val;
+#endif
+  }
+
+  void set_wrapper_on_construct(wrapper* x) {
+#ifdef EpochMemCheck
+    x->pad = x->head = x->tail = default_val;
+#endif
+  }
+
+  void free_wrapper(wrapper* x) {
+    check_wrapper_on_destruct(x);
+#ifdef USE_PARLAY_ALLOC
+    return Allocator::free(x);
+#else
+    return std::free(x);
+#endif
+  }
+  
+  wrapper* allocate_wrapper() {
+    auto &pid = pools[worker_id()];
+    if (!pid.reserve.empty()) {
+      list_entry x = pid.reserve.front();
+      pid.reserve.pop_front();
+      if (!x.keep()) {
+	x.ptr->~T();
+	wrapper* w = wrapper_from_value(x.ptr);
+	check_wrapper_on_destruct(w);
+	set_wrapper_on_construct(w);
+	return w;
+      }
+    }
+#ifdef USE_PARLAY_ALLOC
+    wrapper* w = Allocator::alloc();
+#else
+    wrapper* w = (wrapper*) std::malloc(sizeof(wrapper));
+#endif
+    set_wrapper_on_construct(w);
+    return w;
+  }
+
+ public:
+  memory_pool() {
+    long workers = max_num_workers;
+    pools = std::vector<old_current>(workers);
+    for (int i = 0; i < workers; i++) {
+      pools[i].retire_count = 0;
+    }
+  }
+
+  memory_pool(const memory_pool&) = delete;
+  ~memory_pool() { clear(); }
+
+  // for backwards compatibility
+  void acquire(T* p) { }
+
+  template <typename ... Args>
+  T* New(Args... args) {
+    wrapper* x = allocate_wrapper();
+    T* newv = &x->value;
+    new (newv) T(args...);
+    return newv;
+  }
+
+  // f is a function that initializes a new object before it is shared
+  template <typename F, typename ... Args>
+  T* New_Init(F f, Args... args) {
+    T* x = New(args...);
+    f(x);
+    return x;
+  }
+
+  // retire and return a pointer if want to undo the retire
+#ifdef USE_UNDO
+  bool* Retire(T* p) {
+#else
+  void Retire(T* p) {
+#endif
+    auto i = worker_id();
+    auto &pid = pools[i];
+    if (pid.reserve.size() > 500) {
+      list_entry x = pid.reserve.front();
+      if (!x.keep()) {
+	x.ptr->~T();
+	free_wrapper(wrapper_from_value(x.ptr));
+      }
+      pid.reserve.pop_front();
+    }
+    advance_epoch(i, pid);
+    pid.current.push_back(list_entry{p});
+#ifdef USE_UNDO
+    return &pid.current.back().keep_;
+#endif
+  }
+
+  // destructs and frees the object immediately
+  void Delete(T* p) {
+    p->~T();
+    free_wrapper(wrapper_from_value(p));
+  }
+
+  bool check_ptr(T* ptr, bool silent=false) {
+#ifdef EpochMemCheck
+    if (ptr == nullptr) return true;
+    wrapper* x = wrapper_from_value(ptr);
+    if (!silent) {
+      if (x->pad != default_val) std::cerr << "memory_pool, check: pad word corrupted" << x->pad << std::endl;
+      if (x->head != default_val) std::cerr << "memory_pool, check: head word corrupted" << x->head << std::endl;
+      if (x->tail != default_val) std::cerr << "memory_pool, check: tail word corrupted: " << x->tail << std::endl;
+    }
+    return (x->pad == default_val && x->head == default_val && x->tail == default_val);
+#endif
+    return true;
+  }
+
+  // Clears all the lists, to be used on termination, or could be use
+  // at a quiescent point when noone is reading any retired items.
+  void clear() {
+    // for (int i=0; i < num_workers(); i++)
+    //   std::cout << i << ": " << pools[1].old.size() << ", "
+    // 		<< pools[i].current.size() << ", "
+    // 		<< pools[i].reserve.size() << std::endl;
+    get_epoch().update_epoch();
+    for (int i=0; i < num_workers(); i++) {
+      clear_list(pools[i].old);
+      clear_list(pools[i].current);
+      clear_list(pools[i].reserve);
+    }
+    //Allocator::print_stats();
+  }
+
+  void stats() {}
+};
+  
+template <typename T>
+struct alignas(64) retire_pool {
+private:
+
+  struct list_entry {
+    char data[sizeof(T)];
+  };
+
+  // each thread keeps one of these
+  struct alignas(256) old_current {
+    std::list<list_entry> old;  // linked list of retired items from previous epoch
+    std::list<list_entry> current; // linked list of retired items from current epoch
+    long epoch; // epoch on last retire, updated on a retire
+    long retire_count; // number of retires so far, reset on updating the epoch
+    epoch_s::state e_state;
+    old_current() : e_state(0), epoch(0), retire_count(0) {}
+  };
+
+  std::vector<old_current> pools;
+
+  // destructs entries on a list
+  void clear_list(std::list<list_entry>& lst) {
+    for (list_entry& x : lst)
+      ((T*) (&(x.data)))->~T();
+    lst.clear();
+  }
+
+  void advance_epoch(int i, old_current& pid) {
+    if (pid.epoch + 1 < get_epoch().get_current()) {
+      clear_list(pid.old);
+      pid.old = std::move(pid.current);
+      pid.epoch = get_epoch().get_current();
+    }
+#ifdef USE_STEPPING
+    long update_threshold = 10;
+#else
+    long update_threshold = 10 * num_workers();
+#endif
+    if (++pid.retire_count == update_threshold) {
+      pid.retire_count = 0;
+#ifdef USE_STEPPING
+      pid.e_state = get_epoch().update_epoch_steps(pid.e_state, 8);
+#else
+      get_epoch().update_epoch();
+#endif
+    }
+  }
+
+ public:
+  retire_pool() {
+    long workers = max_num_workers;
+    pools = std::vector<old_current>(workers);
+    for (int i = 0; i < workers; i++) 
+      pools[i].retire_count = 0;
+  }
+
+  retire_pool(const retire_pool&) = delete;
+  ~retire_pool() { clear(); }
+
+  void Retire(T* p) {
+    auto i = worker_id();
+    auto &pid = pools[i];
+    advance_epoch(i, pid);
+    list_entry x;
+    strncpy(x.data, (char*) p, sizeof(T));
+    pid.current.push_back(x);
+  }
+
+  // Clears all the lists, to be used on termination, or could be use
+  // at a quiescent point when noone is reading any retired items.
+  void clear() {
+    get_epoch().update_epoch();
+    for (int i=0; i < num_workers(); i++) {
+      clear_list(pools[i].old);
+      clear_list(pools[i].current);
+    }
+  }
+
+  void stats() {}
+};
+
+} // namespace internal
+
+// ***************************
+// The public interface
+// ***************************
+  
+  // x should point to the skip field of a link
+  inline void undo_retire(bool* x) { *x = true;}
+  
+  template <typename T>
+  using memory_pool = internal::memory_pool<T>;
+
+  template <typename T>
+  extern inline memory_pool<T>& get_default_pool() {
+    static memory_pool<T> pool;
+    return pool;
+  }
+
+  template <typename T>
+  using retire_pool = internal::retire_pool<T>;
+
+  template <typename T>
+  extern inline retire_pool<T>& get_default_retire_pool() {
+    static retire_pool<T> pool;
+    return pool;
+  }
+
+  template <typename T, typename ... Args>
+  static T* New(Args... args) {
+    return get_default_pool<T>().New(std::forward<Args>(args)...);}
+
+  template <typename T>
+  static void Delete(T* p) {get_default_pool<T>().Delete(p);}
+
+  template <typename T>
+#ifdef USE_UNDO
+  static bool* Retire(T* p) {return get_default_pool<T>().Retire(p);}
+#else
+  void Retire(T* p) {return get_default_pool<T>().Retire(p);}
+#endif
+    
+  template <typename T>
+  static bool check_ptr(T* p, bool silent=false) {
+    return get_default_pool<T>().check_ptr(p, silent);}
+
+  template <typename T>
+  static void clear() {get_default_pool<T>().clear();}
+
+  //template <typename T>
+  //static void stats() {get_default_pool<T>().stats();}
+
+  template <typename Thunk>
+  auto with_epoch(Thunk f) {
+    int id = internal::get_epoch().announce();
+    if constexpr (std::is_void_v<std::invoke_result_t<Thunk>>) {
+      f();
+      internal::get_epoch().unannounce(id);
+    } else {
+      auto v = f();
+      internal::get_epoch().unannounce(id);
+      return v;
+    }
+  }
+
+} // end namespace epoch
+
+#endif //PARLAY_EPOCH_H_

--- a/third_party/parlayhash/include/utils/lock.h
+++ b/third_party/parlayhash/include/utils/lock.h
@@ -1,0 +1,67 @@
+#include <atomic>
+#include <cstddef>
+#include <vector>
+
+#ifndef PARLAYLOCK_H_
+#define PARLAYLOCK_H_
+
+namespace parlay {
+
+// creates 2^16 lock slots.
+// locks.try_lock(i, f) will hash i to the h(i) % 2^16th lock.
+// If the lock is not taken then f is run and the try_lock returns the
+// boolean result of f then releasing the lock.   Otherwise it returns false.
+struct lock_set {
+private:
+  using lck = std::atomic<bool>;
+  const int bucket_bits = 16;
+  const size_t mask = ((1ul) << bucket_bits) - 1;
+  std::vector<lck> locks;
+
+  static inline uint64_t hash64(uint64_t x) {
+    x = (x ^ (x >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)) * UINT64_C(0x94d049bb133111eb);
+    x = x ^ (x >> 31);
+    return x;
+  }
+public:
+  template <typename F>
+  bool try_lock(long i, F f) {
+    bool old = false;
+    bool result = false;
+    lck& x = locks[hash64(i) & mask];
+    if (x.compare_exchange_strong(old, true)) {
+      result = f();
+      x = false;
+    }
+    return result;
+  }
+  lock_set() : locks(std::vector<lck>(1ul << bucket_bits)) {
+    std::fill(locks.begin(), locks.end(), false);
+  }
+};
+
+  extern inline lock_set& get_locks() {
+    static lock_set locks;
+    return locks;
+  }
+
+      template <typename F>
+  auto try_loop(const F& f, int delay = 200, const int max_multiplier = 20) {
+    int multiplier = 1;
+    int cnt = 0;
+    while (true)  {
+      if (cnt++ == 10000000000ul/(delay*max_multiplier)) {
+  	std::cerr << "problably in an infinite retry loop" << std::endl;
+  	abort(); 
+      }
+      auto r = f();
+      if (r.has_value()) return *r;
+      multiplier = std::min(2*multiplier, max_multiplier);
+      for (volatile int i=0; i < delay * multiplier; i++);
+    }
+  }
+
+}
+
+#endif // PARLAYLOCK_H_

--- a/third_party/parlayhash/include/utils/threads/portability.h
+++ b/third_party/parlayhash/include/utils/threads/portability.h
@@ -1,0 +1,112 @@
+
+#ifndef PARLAY_PORTABILITY_H_
+#define PARLAY_PORTABILITY_H_
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define PARLAY_DEFINED_NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#ifdef PARLAY_DEFINED_NOMINMAX
+#undef NOMINMAX
+#endif
+#endif
+
+#include <cstdlib>
+
+#include <iostream>
+
+namespace parlay {
+
+// PARLAY_INLINE: Ask the compiler politely to inline the given function.
+#if defined(__GNUC__)
+#define PARLAY_INLINE inline  __attribute__((__always_inline__))
+#elif defined(_MSC_VER)
+#define PARLAY_INLINE __forceinline
+#else
+#define PARLAY_INLINE inline
+#endif
+
+// PARLAY_NOINLINE: Ask the compiler to *not* inline the given function
+#if defined(__GNUC__)
+#define PARLAY_NOINLINE __attribute__((__noinline__))
+#elif defined(_MSC_VER)
+#define PARLAY_NOINLINE __declspec(noinline)
+#else
+#define PARLAY_NOINLINE
+#endif
+
+// PARLAY_COLD: Ask the compiler to place the given function far away from other code
+#if defined(__GNUC__)
+#define PARLAY_COLD __attribute__((__cold__))
+#elif defined(_MSC_VER)
+#define PARLAY_COLD
+#else
+#define PARLAY_COLD
+#endif
+
+
+// PARLAY_PACKED: Ask the compiler to pack a struct into less memory by not padding
+#if defined(__GNUC__)
+#define PARLAY_PACKED __attribute__((packed))
+#else
+#define PARLAY_PACKED
+#endif
+
+// PARLAY_NO_UNIQUE_ADDR: Allow a member object to occupy no space
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(no_unique_address)
+#define PARLAY_NO_UNIQUE_ADDR [[no_unique_address]]
+#else
+#define PARLAY_NO_UNIQUE_ADDR
+#endif
+#else
+#define PARLAY_NO_UNIQUE_ADDR
+#endif
+
+// PARLAY_PREFETCH: Prefetch data into cache
+#if defined(__GNUC__)
+#define PARLAY_PREFETCH(addr, rw, locality) __builtin_prefetch ((addr), (rw), (locality))
+#elif defined(_MSC_VER)
+#define PARLAY_PREFETCH(addr, rw, locality)                                                 \
+  PreFetchCacheLine(((locality) ? PF_TEMPORAL_LEVEL_1 : PF_NON_TEMPORAL_LEVEL_ALL), (addr))
+#else
+#define PARLAY_PREFETCH(addr, rw, locality)
+#endif
+
+
+#if defined(__cplusplus) && __cplusplus >= 202002L
+#define PARLAY_LIKELY [[likely]]
+#define PARLAY_UNLIKELY [[unlikely]]
+#else
+#define PARLAY_LIKELY
+#define PARLAY_UNLIKELY
+#endif
+
+// Check for exceptions. The standard suggests __cpp_exceptions. Clang/GCC defined __EXCEPTIONS.
+// MSVC disables them with _HAS_EXCEPTIONS=0.  Might not cover obscure compilers/STLs.
+//
+// Exceptions can be explicitly disabled in Parlay with PARLAY_NO_EXCEPTIONS.
+#if !defined(PARLAY_NO_EXCEPTIONS) &&                            \
+    ((defined(__cpp_exceptions) && __cpp_exceptions != 0) ||     \
+     (defined(__EXCEPTIONS)) ||                                  \
+     (defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 1) ||       \
+     (defined(_MSC_VER) && !defined(_HAS_EXCEPTIONS)))
+#define PARLAY_EXCEPTIONS_ENABLED
+#endif
+
+template<typename Exception, typename... Args>
+[[noreturn]] PARLAY_NOINLINE PARLAY_COLD void throw_exception_or_terminate(Args&&... args) {
+#if defined(PARLAY_EXCEPTIONS_ENABLED)
+  throw Exception{std::forward<Args>(args)...};
+#else
+  std::cerr << Exception{std::forward<Args>(args)...}.what() << "\n";
+  std::terminate();
+#endif
+}
+
+
+}  // namespace parlay
+
+#endif  // PARLAY_PORTABILITY_H_

--- a/third_party/parlayhash/include/utils/threads/thread_id_pool.h
+++ b/third_party/parlayhash/include/utils/threads/thread_id_pool.h
@@ -1,0 +1,160 @@
+
+#ifndef PARLAY_INTERNAL_THREAD_ID_POOL_H_
+#define PARLAY_INTERNAL_THREAD_ID_POOL_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+namespace parlay {
+namespace internal {
+
+using thread_id_type = unsigned int;
+
+// A ThreadIdPool hands out and maintains available unique dense IDs for active threads.
+// Each thread that requests an ID will get one in the range from [0...get_num_thread_ids()).
+// When the pool runs out of available IDs, it will allocate new ones, increasing the result
+// of get_num_thread_ids().  Threads that die will return their ID to the pool for re-use by
+// a subsequently spawned thread.
+//
+// There is a global singleton instance of ThreadIdPool given by ThreadIdPool::instance(),
+// however this function is private and should not be called by the outside world. The public
+// API through which the world can access thread IDs is limited to the free functions:
+//
+// - get_thread_id() -> size_t:  Returns the thread ID of the current thread. Will assign
+//                               one if this thread doesn't have one yet.
+// - get_num_thread_ids() -> size_t:  Returns the number of unique thread IDs that have
+//                                    been handed out.
+//
+class ThreadIdPool : public std::enable_shared_from_this<ThreadIdPool> {
+
+  // Prevent public construction since this class is meant as a global singleton
+  struct private_constructor {
+    explicit private_constructor() = default;
+  };
+
+ public:
+
+  // Returns a unique thread ID for the current thread in the range [0...get_num_thread_ids())
+  friend thread_id_type get_thread_id();
+
+  // Returns the number of assigned thread IDs in the range [0...get_num_thread_ids())
+  friend thread_id_type get_num_thread_ids();
+
+
+  ~ThreadIdPool() noexcept {
+    size_t num_destroyed = 0;
+    for (auto current = available_ids.load(std::memory_order_relaxed); current; num_destroyed++) {
+      auto old = std::exchange(current, current->next);
+      delete old;
+    }
+    assert(num_destroyed == num_thread_ids.load(std::memory_order_relaxed));
+  }
+
+  // The constructor must be public since we make_shared it, but we protect it with a private parameter type
+  explicit ThreadIdPool(private_constructor) noexcept : num_thread_ids(0), available_ids(nullptr) { }
+
+  ThreadIdPool(const ThreadIdPool&) = delete;
+  ThreadIdPool& operator=(const ThreadIdPool&) = delete;
+
+ private:
+
+  // A ThreadId corresponds to a unique ID number in the range [0...num_thread_ids). When it is
+  // not in use (the thread that owned it dies), it is returned to the global pool which maintains
+  // a linked list of available ones.
+  class ThreadId {
+    friend class ThreadIdPool;
+
+    explicit ThreadId(const thread_id_type id_) noexcept : id(id_), next(nullptr) { }
+
+   public:
+    const thread_id_type id;
+   private:
+    ThreadId* next;
+  };
+
+  // A ThreadIdOwner indicates that a thread is currently in possession of the given ThreadID.
+  // Each thread has a static thread_local ThreadIdOwner containing the ID that it owns.
+  // On construction, it acquires an available ThreadID, and on destruction, it releases
+  // it back to the pool. The ThreadIdOwner stores a shared_ptr to the pool to guarantee
+  // that the pool does not get destroyed before a detached thread returns its ID.
+  class ThreadIdOwner {
+    friend class ThreadIdPool;
+
+    explicit ThreadIdOwner(ThreadIdPool& pool_)
+        : pool(pool_.shared_from_this()), node(pool->acquire()), id(node->id) { }
+
+    ~ThreadIdOwner() { pool->relinquish(node); }
+
+   private:
+    const std::shared_ptr<ThreadIdPool> pool;
+    ThreadId* const node;
+
+   public:
+    const thread_id_type id;
+  };
+
+  // Grab a free ID from the available list, or if there are none available, allocate a new one.
+  ThreadId* acquire() {
+    if (available_ids.load(std::memory_order_relaxed)) {
+      // We only take the lock if there are available IDs in the pool. In the common case
+      // where there are no relinquished IDs available for re-use we don't need the lock.
+      static std::mutex m_;
+      std::lock_guard<std::mutex> g_{m_};
+
+      ThreadId* current = available_ids.load(std::memory_order_relaxed);
+      while (current && !available_ids.compare_exchange_weak(current, current->next,
+               std::memory_order_acquire, std::memory_order_relaxed)) {}
+      if (current) { return current; }
+    }
+    return new ThreadId(num_thread_ids.fetch_add(1));
+  }
+
+  // Given the ID back to the global pool for reuse
+  void relinquish(ThreadId* p) {
+    p->next = available_ids.load(std::memory_order_relaxed);
+    while (!available_ids.compare_exchange_weak(p->next, p,
+             std::memory_order_release, std::memory_order_relaxed)) {}
+  }
+
+  static inline const ThreadIdOwner& get_local_thread_id() {
+    static const thread_local ThreadIdPool::ThreadIdOwner my_id(instance());
+    return my_id;
+  }
+
+  static inline ThreadIdPool& instance() {
+    // We hold the global thread id pool inside a shared_ptr because it is possible
+    // for threads to be spawned *before* the ID pool has been initialized, which
+    // means that they may outlive this static variable. Each ThreadId holds onto
+    // a copy of the shared_ptr to ensure that the pool stays alive long enough
+    // for the IDs to relinquish themselves back to the pool.
+    //
+    // I think it is still possible to cause a segfault by spawning a new thread
+    // *after* the static destructors have run... so please do not spawn threads
+    // inside your static destructors :)
+    static const std::shared_ptr<ThreadIdPool> pool = std::make_shared<ThreadIdPool>(private_constructor{});
+    return *pool;
+  }
+
+  std::atomic<size_t> num_thread_ids;
+  std::atomic<ThreadId*> available_ids;
+};
+
+inline thread_id_type get_thread_id() {
+  return ThreadIdPool::get_local_thread_id().id;
+}
+
+inline thread_id_type get_num_thread_ids() {
+  return ThreadIdPool::instance().num_thread_ids.load();
+}
+
+
+}  // namespace internal
+}  // namespace parlay
+
+
+#endif  // PARLAY_INTERNAL_THREAD_ID_POOL_H_

--- a/third_party/parlayhash/include/utils/threads/thread_specific.h
+++ b/third_party/parlayhash/include/utils/threads/thread_specific.h
@@ -1,0 +1,463 @@
+
+#ifndef PARLAY_THREAD_SPECIFIC_H_
+#define PARLAY_THREAD_SPECIFIC_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include <array>
+#include <algorithm>      // IWYU pragma: keep
+#include <atomic>
+#include <functional>
+#include <iterator>
+#include <mutex>
+#include <new>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "thread_id_pool.h"
+#include "portability.h"
+//#include "range.h"
+#include "type_traits.h"
+
+
+namespace parlay {
+
+using internal::thread_id_type;
+
+// Returns a unique thread ID for the current running thread
+// in the range of [0...num_thread_ids()).  Thread IDs are
+// guaranteed to be unique for all *live* threads, but they
+// are re-used after a thread dies and another is spawned.
+inline thread_id_type my_thread_id() {
+  return internal::get_thread_id();
+}
+
+// Return the number of thread IDs that have been assigned to
+// threads.  All thread IDs are in the range [0...num_thread_ids()).
+//
+// Important note:  Thread IDs are assigned lazily when a thread
+// first requests one.  Therefore num_thread_ids() is *not*
+// guaranteed to be as large as the number of live threads if
+// those threads have never called my_thread_id().
+inline thread_id_type num_thread_ids() {
+  return internal::get_num_thread_ids();
+}
+
+namespace internal {
+
+class ThreadListChunkData {
+
+ public:
+
+  // This is just std::bit_ceil(std::thread::hardware_concurrency()) but we don't assume C++20
+  const static inline std::size_t thread_list_chunk_size = []() {
+    std::size_t size = 4;
+    while (size < std::thread::hardware_concurrency())
+      size *= 2;
+    return size;
+  }();
+
+  // Used by ThreadSpecific which stores a chunked sequence of items that is at least as large
+  // as the number of active threads.  Given a thread ID, items are split into chunks of size:
+  //
+  //   P, P, 2P, 4P, 8P, ...
+  //
+  // where P is the lowest power of two that is at least as large as the number of hardware threads.
+  static std::size_t compute_chunk_id(thread_id_type id) {
+    std::size_t k = thread_list_chunk_size;
+    std::size_t chunk = 0;
+    while (k <= id) {
+      chunk++;
+      k *= 2;
+    }
+    return chunk;
+  }
+
+  static std::size_t compute_chunk_position(thread_id_type id, std::size_t chunk_id) {
+    if (chunk_id == 0)
+      return id;
+    else {
+      auto high_bit = thread_list_chunk_size << (chunk_id - 1);
+      assert(id & high_bit);
+      return id - high_bit;
+    }
+  }
+
+  explicit ThreadListChunkData(thread_id_type thread_id_) noexcept : thread_id(thread_id_),
+      chunk_id(compute_chunk_id(thread_id)), chunk_position(compute_chunk_position(thread_id, chunk_id)) { }
+
+  const thread_id_type thread_id;
+  const std::size_t chunk_id;
+  const std::size_t chunk_position;
+};
+
+extern inline const ThreadListChunkData& get_chunk_data() {
+  static thread_local const ThreadListChunkData data{get_thread_id()};
+  return data;
+}
+
+template<typename T>
+struct Uninitialized {
+  union {
+    alignas(64) std::monostate empty;
+    T value;
+  };
+
+  Uninitialized() noexcept { };
+
+  T& operator*() { return value; }
+
+  T* get() { return std::addressof(value); }
+
+  ~Uninitialized() { value.~T(); }
+};
+
+}  // namespace internal
+
+// A ThreadSpecific<T> stores a list of objects of type T such that there
+// is a unique object for each active thread. The list automatically grows
+// when additional threads are spawned and attempt to access it. Threads
+// may also traverse the entire list if they need to.
+//
+// By default, list elements are all value initialized, roughly meaning
+// that class types are default constructed, and builtin types are zero
+// initialized.  For custom initialization, you can pass a constructor
+// function which returns the desired value.  The constructor function
+// can take zero or one arguments.  If it takes one argument, it will be
+// passed the thread ID that it is constructing for.  Note that the
+// elements are not guaranteed to be constructed by the thread that
+// they belong to, and they may be constructed in advance of any thread
+// actually taking ownership of that ID.
+//
+// A few things to note:
+//
+// - Thread IDs are always unique for the set of currently live threads,
+//   but not unique over the course of the entire program.  A thread that
+//   dies will give up its ID to be claimed by a new thread later.
+//
+// - The list elements are *not* destroyed when the thread that "owns"
+//   them is destroyed. A new thread that reclaims a previously-used ID
+//   will find the item at that position in the same state that it was
+//   left by the previous thread.  Elements are only destroyed when the
+//   entire ThreadSpecific is destroyed.
+//
+//   Therefore, threads are responsible for manually cleaning up the
+//   contents of a ThreadSpecific and/or resetting it to a default value
+//   for the next thread that might claim the spot if they need to.
+//
+template<typename T>
+class ThreadSpecific {
+
+  // 25 chunks guarantees enough slots for any machine
+  // with up to 2^48 bytes of addressable virtual memory,
+  // assuming that threads are 8MB large.
+  static constexpr std::size_t n_chunks = 25;
+
+ public:
+
+  using reference = T&;
+  using value_type = T;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using pointer = T*;
+
+  ThreadSpecific() : constructor([](std::size_t) { return T{}; }) {
+    initialize();
+  }
+
+  template<typename F,
+      typename std::enable_if_t<std::is_invocable_v<F&> && !std::is_invocable_v<F&, std::size_t>, int> = 0>
+  explicit ThreadSpecific(F&& constructor_)
+      : constructor([f = std::forward<F>(constructor_)](std::size_t) { return f(); }) {
+    initialize();
+  }
+
+  template<typename F,
+      typename std::enable_if_t<std::is_invocable_v<F&, std::size_t>, int> = 0>
+  explicit ThreadSpecific(F&& constructor_) : constructor(std::forward<F>(constructor_)) {
+    initialize();
+  }
+
+  ThreadSpecific(const ThreadSpecific&) = delete;
+  ThreadSpecific& operator=(const ThreadSpecific&) = delete;
+  ThreadSpecific(ThreadSpecific&&) = delete;
+
+  ~ThreadSpecific() {
+    for (internal::Uninitialized<T>* chunk : chunks) {
+      delete[] chunk;
+    }
+  }
+
+  T& operator*() { return get(); }
+  T* operator->() { return std::addressof(get()); }
+
+  T& get() {
+    auto chunk_data = internal::get_chunk_data();
+    return get_by_index(chunk_data.chunk_id, chunk_data.chunk_position);
+  }
+
+  const T& operator*() const { return get(); }
+  T const* operator->() const { return std::addressof(get()); }
+
+  const T& get() const {
+    auto chunk_data = internal::get_chunk_data();
+    return get_by_index(chunk_data.chunk_id, chunk_data.chunk_position);
+  }
+
+  template<typename F>
+  void for_each(F&& f) {
+    static_assert(std::is_invocable_v<F, T&>);
+
+    auto num_threads = num_thread_ids();
+    thread_id_type tid = 0;
+    internal::Uninitialized<T>* chunk = chunks[0].load(std::memory_order_relaxed);
+
+    for (std::size_t chunk_id = 0; tid < num_threads; chunk = chunks[++chunk_id].load(std::memory_order_acquire)) {
+      auto chunk_size = get_chunk_size(chunk_id);
+      if (!chunk) PARLAY_UNLIKELY {
+        ensure_chunk_exists(chunk_id);
+        chunk = chunks[chunk_id].load(std::memory_order_relaxed);
+      }
+      for (std::size_t i = 0; tid < num_threads && i < chunk_size; i++, tid++) {
+        f(*chunk[i]);
+      }
+    }
+  }
+
+  // Allow looping over all thread's data
+  template<bool Const>
+  class iterator_t {
+    friend class ThreadSpecific<T>;
+
+    using parent_type = maybe_const_t<Const, ThreadSpecific<T>>;
+
+    iterator_t(std::size_t chunk_id_, std::size_t position_, parent_type* parent_) :
+        chunk_id(chunk_id_), position(position_), parent(parent_) { }
+
+   public:
+    using iterator_category = std::random_access_iterator_tag;
+    using reference = std::add_lvalue_reference_t<maybe_const_t<Const, T>>;
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = std::add_pointer_t<maybe_const_t<Const, T>>;
+
+    iterator_t() = default;
+
+    /* implicit */ iterator_t(const iterator_t<false>& other)  // cppcheck-suppress noExplicitConstructor    // NOLINT
+        : chunk_id(other.chunk_id), position(other.position), parent(other.parent) { }
+
+    reference operator*() const { return parent->get_by_index_nocheck(chunk_id, position); }
+
+    reference operator[](std::size_t p) const {
+      auto tmp = *this;
+      tmp += p;
+      return *tmp;
+    }
+
+    iterator_t& operator++() {
+      position++;
+      if (position == get_chunk_size(chunk_id)) {
+        if (++chunk_id < n_chunks && parent->chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+          parent->ensure_chunk_exists(chunk_id);
+        position = 0;
+      }
+      return *this;
+    }
+
+    iterator_t operator++(int) { auto tmp = *this; ++(*this); return tmp; }   //NOLINT
+
+    iterator_t& operator--() {
+      if (position == 0) {
+        position = get_chunk_size(--chunk_id) - 1;
+        if (parent->chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+          parent->ensure_chunk_exists(chunk_id);
+      }
+      else {
+        position--;
+      }
+      return *this;
+    }
+
+    iterator_t operator--(int) { auto tmp = *this; --(*this); return tmp; }   //NOLINT
+
+    iterator_t& operator+=(difference_type diff) {
+      if (diff < 0) return *this -= (-diff);
+      assert(diff >= 0);
+      position += diff;
+      if (position >= get_chunk_size(chunk_id)) {
+        do {
+          position -= get_chunk_size(chunk_id++);
+        } while (position >= get_chunk_size(chunk_id));
+        if (parent->chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+          parent->ensure_chunk_exists(chunk_id);
+      }
+      return *this;
+    }
+
+    iterator_t operator+(difference_type diff) const {
+      auto result = *this;
+      result += diff;
+      return result;
+    }
+
+    iterator_t& operator-=(difference_type diff) {
+      if (diff < 0) return *this += (-diff);
+      assert(diff >= 0);
+      auto pos = static_cast<difference_type>(position);
+      pos -= diff;
+      if (pos < 0) {
+        do {
+          pos += static_cast<difference_type>(get_chunk_size(--chunk_id));
+        } while (pos < 0);
+        if (parent->chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+          parent->ensure_chunk_exists(chunk_id);
+      }
+      assert(pos >= 0);
+      position = static_cast<std::size_t>(pos);
+      return *this;
+    }
+
+    iterator_t operator-(difference_type diff) const {
+      auto result = *this;
+      result -= diff;
+      return result;
+    }
+
+    difference_type operator-(const iterator_t& other) const {
+      if (other > *this) return -(other - *this);
+      assert(other <= *this);
+      auto result = static_cast<difference_type>(position) - static_cast<difference_type>(other.position);
+      auto chunk_id_ = other.chunk_id;
+      while (chunk_id_ < chunk_id) {
+        result += static_cast<difference_type>(get_chunk_size(chunk_id_++));
+      }
+      return result;
+    }
+
+    bool operator==(const iterator_t& other) const {
+      return chunk_id == other.chunk_id && position == other.position;
+    }
+
+    bool operator!=(const iterator_t& other) const {
+      return chunk_id != other.chunk_id || position != other.position;
+    }
+
+    bool operator<(const iterator_t& other) const {
+      return chunk_id < other.chunk_id || (chunk_id == other.chunk_id && position < other.position);
+    }
+
+    bool operator<=(const iterator_t& other) const {
+      return chunk_id < other.chunk_id || (chunk_id == other.chunk_id && position <= other.position);
+    }
+
+    bool operator>(const iterator_t& other) const {
+      return chunk_id > other.chunk_id || (chunk_id == other.chunk_id && position > other.position);
+    }
+
+    bool operator>=(const iterator_t& other) const {
+      return chunk_id > other.chunk_id || (chunk_id == other.chunk_id && position >= other.position);
+    }
+
+    friend void swap(iterator_t& left, iterator_t& right) {
+      std::swap(left.chunk_id, right.chunk_id);
+      std::swap(left.position, right.position);
+      std::swap(left.parent, right.parent);
+    }
+
+    std::size_t chunk_id{n_chunks};
+    std::size_t position{0};
+    parent_type* parent{nullptr};
+  };
+
+  using iterator = iterator_t<false>;
+  using const_iterator = iterator_t<true>;
+
+  //static_assert(is_random_access_iterator_v<iterator>);
+  //static_assert(is_random_access_iterator_v<const_iterator>);
+
+  [[nodiscard]] iterator begin() {
+    return iterator{0,0,this};
+  }
+
+  [[nodiscard]] const_iterator begin() const {
+    return const_iterator{0,0,this};
+  }
+
+  [[nodiscard]] iterator end() {
+    internal::ThreadListChunkData data{num_thread_ids()};
+    return iterator{data.chunk_id, data.chunk_position, this};
+  }
+
+  [[nodiscard]] const_iterator end() const {
+    internal::ThreadListChunkData data{num_thread_ids()};
+    return const_iterator{data.chunk_id, data.chunk_position, this};
+  }
+
+ private:
+
+  void initialize() {
+    internal::get_chunk_data();  //  Force static initialization before any ThreadLocals are constructed
+    chunks[0].store(new internal::Uninitialized<T>[internal::ThreadListChunkData::thread_list_chunk_size], std::memory_order_relaxed);
+    std::fill(chunks.begin() + 1, chunks.end(), nullptr);
+    auto chunk = chunks[0].load(std::memory_order_relaxed);
+    for (std::size_t i = 0; i < internal::ThreadListChunkData::thread_list_chunk_size; i++) {
+      new (static_cast<void*>(chunk[i].get())) T(constructor(i));
+    }
+  }
+
+  static std::size_t get_chunk_size(std::size_t chunk_id) {
+    assert(chunk_id < n_chunks);
+    if (chunk_id == 0) return internal::ThreadListChunkData::thread_list_chunk_size;
+    else return internal::ThreadListChunkData::thread_list_chunk_size << (chunk_id - 1);
+  }
+
+  T& get_by_index(std::size_t chunk_id, std::size_t chunk_position) {
+    if (chunk_id > 0 && chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+      ensure_chunk_exists(chunk_id);
+    return get_by_index_nocheck(chunk_id, chunk_position);
+  }
+
+  const T& get_by_index(std::size_t chunk_id, std::size_t chunk_position) const {
+    if (chunk_id > 0 && chunks[chunk_id].load(std::memory_order_acquire) == nullptr) PARLAY_UNLIKELY
+    ensure_chunk_exists(chunk_id);
+    return get_by_index_nocheck(chunk_id, chunk_position);
+  }
+
+  T& get_by_index_nocheck(std::size_t chunk_id, std::size_t chunk_position) {
+    assert(chunks[chunk_id].load() != nullptr);
+    return *(chunks[chunk_id].load(std::memory_order_relaxed)[chunk_position]);
+  }
+
+  const T& get_by_index_nocheck(std::size_t chunk_id, std::size_t chunk_position) const {
+    assert(chunks[chunk_id].load() != nullptr);
+    return *(chunks[chunk_id].load(std::memory_order_relaxed)[chunk_position]);
+  }
+
+  void ensure_chunk_exists(std::size_t chunk_id) const {
+    std::lock_guard<std::mutex> lock(growing_mutex);
+    if (chunks[chunk_id].load(std::memory_order_relaxed) == nullptr) {
+      auto chunk_size = get_chunk_size(chunk_id);
+      auto chunk = new internal::Uninitialized<T>[chunk_size];
+      for (std::size_t i = 0; i < chunk_size; i++) {
+        new (static_cast<void*>(chunk[i].get())) T(constructor(chunk_size + i));
+      }
+      chunks[chunk_id].store(chunk, std::memory_order_release);
+    }
+  }
+
+  mutable std::function<T(thread_id_type)> constructor;
+  mutable std::mutex growing_mutex;
+  mutable std::array<std::atomic<internal::Uninitialized<T>*>, n_chunks> chunks;
+};
+
+  //static_assert(is_random_access_range_v<ThreadSpecific<int>>);
+  //static_assert(is_random_access_range_v<const ThreadSpecific<int>>);
+
+}  // namespace parlay
+
+
+#endif  // PARLAY_THREAD_SPECIFIC_H_

--- a/third_party/parlayhash/include/utils/threads/type_traits.h
+++ b/third_party/parlayhash/include/utils/threads/type_traits.h
@@ -1,0 +1,286 @@
+// Useful type traits used mostly internally by Parlay
+//
+// Many inspired by this video, and the following standards
+// proposals:
+//  - https://www.youtube.com/watch?v=MWBfmmg8-Yo
+//  - http://open-std.org/JTC1/SC22/WG21/docs/papers/2014/n4034.pdf
+//  - https://quuxplusone.github.io/blog/code/object-relocation-in-terms-of-move-plus-destroy-draft-7.html
+//
+// Includes:
+//  - priority_tag
+//  - is_trivial_allocator
+//  - is_trivially_relocatable / is_nothrow_relocatable
+//
+
+#ifndef PARLAY_TYPE_TRAITS_H_
+#define PARLAY_TYPE_TRAITS_H_
+
+#include <cstddef>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <utility>       // IWYU pragma: keep
+
+// IWYU pragma: no_include <iterator>
+
+namespace parlay {
+
+// Provides the member type T
+template<typename T>
+struct type_identity {
+  using type = T;
+};
+
+// Equal to the type T, i.e., the identity transformation
+template<typename T>
+using type_identity_t = typename type_identity<T>::type;
+
+// Given a pointer-to-member (object or function), returns
+// the type of the class in which the member lives
+template<typename T>
+struct member_pointer_class;
+
+template<typename T, typename U>
+struct member_pointer_class<T U::*> : public type_identity<U> {};
+
+template<typename T>
+using member_pointer_class_t = typename member_pointer_class<T>::type;
+
+// Provides the member type std::add_const_t<T> if Const is
+// true, otherwise provides the member type T
+template<bool Const, typename T>
+using maybe_const = std::conditional<Const, std::add_const_t<T>, T>;
+
+// Adds const to the given type if Const is true
+template<bool Const, typename T>
+using maybe_const_t = typename maybe_const<Const, T>::type;
+
+// Provides the member type std::decay_t<T> if Decay is
+// true, otherwise provides the member type T
+template<bool Decay, typename T>
+using maybe_decay = std::conditional<Decay, std::decay_t<T>, T>;
+
+// Decays the given type if Decay is true
+template<bool Decay, typename T>
+using maybe_decay_t = typename maybe_decay<Decay, T>::type;
+
+// Provides the member value true if the given type is an instance of std::optional
+template <typename T>
+struct is_optional : std::false_type {};
+
+template <typename T>
+struct is_optional<std::optional<T>> : std::true_type {};
+
+// true if the given type is an instance of std::optional
+template<typename T>
+inline constexpr bool is_optional_v = is_optional<T>::value;
+
+template<typename T, typename U = T>
+using is_less_than_comparable = std::conjunction<
+                                  std::is_invocable_r<bool, std::less<>, T, U>,
+                                  std::is_invocable_r<bool, std::less<>, U, T>
+                                >;
+
+template<typename T, typename U = T>
+inline constexpr bool is_less_than_comparable_v = is_less_than_comparable<T, U>::value;
+
+template<typename T, typename U = T>
+using is_equality_comparable = std::conjunction<
+                                 std::is_invocable_r<bool, std::equal_to<>, T, U>,
+                                 std::is_invocable_r<bool, std::equal_to<>, U, T>,
+                                 std::is_invocable_r<bool, std::not_equal_to<>, T, U>,
+                                 std::is_invocable_r<bool, std::not_equal_to<>, U, T>
+                               >;
+
+template<typename T, typename U = T>
+inline constexpr bool is_equality_comparable_v = is_equality_comparable<T, U>::value;
+
+// Defines a member value true if the given type BinaryOperator_ can be invoked on types
+// T1&& and T2 to yield a result of a type that is convertible to T1.
+//
+// This requirement corresponds to the needs of a left fold over the operator BinaryOperator_
+// with an identity and result type of T1, where the intermediate elements being reduced over
+// are potentially of type T2.
+template<typename BinaryOperator_, typename T1, typename T2, typename = void, typename = void>
+struct is_binary_operator_for : public std::false_type {};
+
+template<typename BinaryOperator_, typename T1, typename T2>
+struct is_binary_operator_for<BinaryOperator_, T1, T2, std::void_t<
+  std::enable_if_t< std::is_move_constructible_v<T1> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, T1&&, T1&&> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, T1&&, T2> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, T2, T2> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, T2, T1&&> >
+>, std::enable_if_t<!std::is_member_function_pointer_v<BinaryOperator_>>> : public std::true_type{};
+
+// Handle the case where BinaryOperator_ is a member function pointer
+template<typename BinaryOperator_, typename T1, typename T2>
+struct is_binary_operator_for<BinaryOperator_, T1, T2, std::void_t<
+  std::enable_if_t< std::is_move_constructible_v<T1> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, const member_pointer_class_t<BinaryOperator_>&, T1&&, T1&&> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, const member_pointer_class_t<BinaryOperator_>&, T1&&, T2> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, const member_pointer_class_t<BinaryOperator_>&, T2, T2> >,
+  std::enable_if_t< std::is_invocable_r_v<T1, BinaryOperator_, const member_pointer_class_t<BinaryOperator_>&, T2, T1&&> >
+>, std::enable_if_t<std::is_member_function_pointer_v<BinaryOperator_>>> : public std::true_type{};
+
+// True if the given type BinaryOperator_ can be invoked on types T1&& and T2 to yield a result
+// of a type that is convertible to T1. T2 defaults to T1&& if not specified.
+//
+// This requirement corresponds to the needs of a left fold over the operator BinaryOperator_
+// with an identity and result type of T1, where the intermediate elements being reduced over
+// are potentially of type T2.
+template<typename BinaryOperator_, typename T1, typename T2 = T1&&>
+inline constexpr bool is_binary_operator_for_v = is_binary_operator_for<BinaryOperator_, T1, T2>::value;
+
+// Defines the member value true if T is a pair or a tuple of length two
+template<typename T, typename = void>
+struct is_pair : public std::false_type {};
+
+template<typename T>
+struct is_pair<T, std::void_t<
+  decltype( std::get<0>(std::declval<T>()) ),
+  decltype( std::get<1>(std::declval<T>()) ),
+  std::enable_if_t< 2 == std::tuple_size_v<std::decay_t<T>> >
+>> : public std::true_type {};
+
+// True if T is a pair or a tuple of length two
+template<typename T>
+inline constexpr bool is_pair_v = is_pair<T>::value;
+
+/*  --------------------- Priority tags. -------------------------
+    Priority tags are an easy way to force template resolution to
+    pick the "best" option in the presence of multiple valid
+    choices. It works because of the facts that priority_tag<K>
+    is a subtype of priority_tag<K-1>, and template resolution
+    will always pick the most specialised option when faced with
+    a choice, so it will prefer priority_tag<K> over
+    priority_tag<K-1>
+*/
+
+template<size_t K>
+struct priority_tag : priority_tag<K-1> {};
+
+template<>
+struct priority_tag<0> {};
+
+
+/*  ----------------- Trivial allocators. ---------------------
+    Allocator-aware containers and algorithms need to know whether
+    they can construct/destruct objects directly inside memory given
+    to them by an allocator, or whether the allocator has custom
+    behaviour. Since some optimizations require us to circumvent
+    custom allocator behaviour, we need to detect when an allocator
+    does not do this.
+
+    Specifically, an allocator-aware algorithm must construct objects
+    inside memory returned by an allocator by writing
+
+    std::allocator_traits<allocator_type>::construct(allocator, p, args);
+
+    if the allocator type defines a method .construct, then this results
+    in forwarding the construction to that method. Otherwise, this just
+    results in a call to
+
+    new (p) T(std::forward<Args>(args)...)
+
+    If we wish to circumvent calling the constructor, for example,
+    for a trivially relocatable type in which we would prefer to
+    copy directly via memcpy, we must ensure that the allocator
+    does not have a custom .construct method. Otherwise, we can
+    not optimize, and must continue to use the allocator's own
+    construct method.
+
+    The same discussion is true for destruction as well.
+
+    See https://www.youtube.com/watch?v=MWBfmmg8-Yo for more info.
+*/
+
+namespace internal {
+
+// Detect the existence of the .destroy method of the type Alloc
+template<typename Alloc, typename T>
+auto trivial_allocator(Alloc& a, T* p, priority_tag<2>)
+  -> decltype(void(a.destroy(p)), std::false_type());
+
+// Detect the existence of the .construct method of the type Alloc
+template<typename Alloc, typename T>
+auto trivial_allocator(Alloc& a, T* p, priority_tag<1>)
+  -> decltype(void(a.construct(p, std::declval<T&&>())), std::false_type());
+
+// By default, if no .construct or .destroy methods are found, assume
+// that the allocator is trivial
+template<typename Alloc, typename T>
+auto trivial_allocator(Alloc& a, T* p, priority_tag<0>)
+  -> std::true_type;
+
+}  // namespace internal
+
+template<typename Alloc, typename T>
+struct is_trivial_allocator
+    : decltype(internal::trivial_allocator<Alloc, T>(std::declval<Alloc&>(), nullptr, priority_tag<2>())) {};
+
+template<typename Alloc, typename T>
+inline constexpr bool is_trivial_allocator_v = is_trivial_allocator<Alloc, T>::value;
+
+// Manually specialize std::allocator since it is trivial, but
+// some (maybe all?) implementations still provide a .construct
+// and .destroy method anyway.
+template<typename T>
+struct is_trivial_allocator<std::allocator<T>, T> : std::true_type {};
+
+/*  ----------------- Trivially relocatable. ---------------------
+    A type T is called trivially relocatable if, given a pointer
+    p to an object of type T, and a pointer q to unintialized
+    memory large enough for an object of type T, then
+
+    new (q) T(std::move(*p));
+    p->~T();
+
+    is equivalent to
+
+    std::memcpy(p, q, sizeof(T));
+
+    Any type that is trivially move constructible and trivially
+    destructible is therefore trivially relocatable. User-defined
+    types that are not obviously trivially relocatable can be
+    annotated as such by specializing the is_trivially_relocatable
+    type.
+
+    See proposal D1144R0 for copious details:
+    https://quuxplusone.github.io/blog/code/object-relocation-in-terms-of-move-plus-destroy-draft-7.html
+*/
+
+template <typename T>
+struct is_trivially_relocatable :
+        std::bool_constant<std::is_trivially_move_constructible<T>::value &&
+                           std::is_trivially_destructible<T>::value> { };
+
+template <typename T> struct is_nothrow_relocatable :
+        std::bool_constant<is_trivially_relocatable<T>::value ||
+                           (std::is_nothrow_move_constructible<T>::value &&
+                            std::is_nothrow_destructible<T>::value)> { };
+
+template<typename T>
+inline constexpr bool is_trivially_relocatable_v = is_trivially_relocatable<T>::value;
+
+template<typename T>
+inline constexpr bool is_nothrow_relocatable_v = is_nothrow_relocatable<T>::value;
+
+// The standard allocator is stateless, so it is trivially relocatable,
+// but unfortunately it is not detected as such, so we mark it manually.
+// This is important because parlay::sequence<T, Alloc> is only trivially
+// relocatable when its allocator is trivially relocatable.
+
+template<typename T>
+struct is_trivially_relocatable<std::allocator<T>> : std::true_type {};
+
+template <typename T1, typename T2>
+struct is_trivially_relocatable<std::pair<T1,T2>> : 
+    std::bool_constant<is_trivially_relocatable<T1>::value &&
+		       is_trivially_relocatable<T2>::value> {};
+
+}  // namespace parlay
+
+#endif //PARLAY_TYPE_TRAITS_H_


### PR DESCRIPTION
Vendors [ParlayHash](https://github.com/cmuparlay/parlayhash) — no reliable conan package — as the second candidate backend for the mempool concurrent map (selected via the `mempool_backend` option from #495; the mempool that uses it comes in a follow-up PR).

- Header-only, MIT (© 2023 cmuparlay). Pinned commit `081408ba6111ce78b5add9129f8d902fa2fea58f` (2025-08-19), documented in `third_party/parlayhash/README.md`.
- Only the subtree `parlay_hash/unordered_map.h` needs: `parlay_hash/` + `parlay/` + `utils/`. Excluded: `old_parlay_hash/` and editor scratch files.
- Added `third_party/*` to `exports_sources` so the headers are packaged by conan.

No-op for the default `cfm` build (nothing includes these headers yet). Part of the mempool project (#491).