### PR TITLE
mempool: implement the BCH mempool (concurrent maps, cfm/parlay backends)

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -59,6 +59,8 @@ if (${KTH_MEMPOOL_BACKEND} STREQUAL "cfm")
   add_definitions(-DKTH_MEMPOOL_BACKEND_CFM)
 elseif (${KTH_MEMPOOL_BACKEND} STREQUAL "parlay")
   add_definitions(-DKTH_MEMPOOL_BACKEND_PARLAY)
+  # Vendored, header-only; SYSTEM so its deprecation warnings stay out of KTH.
+  include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/parlayhash/include)
 else()
   message(FATAL_ERROR "Invalid mempool backend: ${KTH_MEMPOOL_BACKEND} (expected cfm|parlay)")
 endif()
@@ -177,6 +179,7 @@ set(kth_sources_just_legacy
   src/pools/branch.cpp
   src/pools/header_organizer.cpp
   src/pools/transaction_organizer.cpp
+  src/pools/mempool.cpp
   src/pools/mempool_transaction_summary.cpp
   src/populate/populate_base.cpp
   src/populate/populate_block.cpp
@@ -220,7 +223,11 @@ set(kth_headers
   include/kth/blockchain/validate/validate_input.hpp
   include/kth/blockchain/validate/validate_transaction.hpp
   include/kth/blockchain/pools/block_entry.hpp
+  include/kth/blockchain/pools/mempool.hpp
   include/kth/blockchain/pools/mempool_config.hpp
+  include/kth/blockchain/pools/mempool_hashers.hpp
+  include/kth/blockchain/pools/mempool_map.hpp
+  include/kth/blockchain/pools/mempool_stats.hpp
   include/kth/blockchain/pools/mempool_transaction_summary.hpp
   include/kth/blockchain/pools/block_organizer.hpp
   include/kth/blockchain/pools/branch.hpp
@@ -287,6 +294,7 @@ if (ENABLE_TEST)
         test/block_pool.cpp
         test/branch.cpp
         test/validate_transaction.cpp
+        test/mempool_test.cpp
     )
 
     # Disabled until ported to v1.0 APIs:

--- a/src/blockchain/include/kth/blockchain/pools/mempool.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool.hpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_POOLS_MEMPOOL_HPP
+#define KTH_BLOCKCHAIN_POOLS_MEMPOOL_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+#include <kth/domain.hpp>
+
+#include <kth/blockchain/define.hpp>
+#include <kth/blockchain/pools/mempool_hashers.hpp>
+#include <kth/blockchain/pools/mempool_map.hpp>
+#include <kth/blockchain/pools/mempool_stats.hpp>
+
+namespace kth::blockchain {
+
+// One unconfirmed transaction plus the policy metadata computed at admission.
+// Holds the tx by shared_ptr (== BCHN CTransactionRef): the pool owns it, and
+// prevout resolution / queries copy the shared_ptr out (a refcount bump), never
+// the transaction, and it stays alive across concurrent eviction.
+struct mempool_entry {
+    transaction_const_ptr tx;
+    uint64_t fee;
+    uint32_t size;
+    uint32_t sigops;
+    uint64_t time_seen;
+};
+
+// The BCH mempool: unconfirmed transactions in two concurrent maps —
+//   pool_     : txid    -> entry                (the pool)
+//   spent_by_ : outpoint-> spending txid        (== BCHN mapNextTx)
+// No CPFP, no ancestor/descendant fee graph, no unconfirmed chain limit. The
+// spent_by_ index gives O(1) first-seen double-spend detection and conflict /
+// descendant eviction; the descendant set is derived from spent_by_ (an evicted
+// tx's outputs are looked up there), so no separate child graph is kept.
+//
+// Concurrency model: writes (add / remove_for_block / update_for_reorg) are
+// serialised by the organizers' shared prioritized_mutex, so they need no
+// internal locking; reads (resolve / queries) run concurrently with them, which
+// is what the concurrent map backend is for. The operations are plain
+// synchronous methods — they are CPU/memory work on the maps with no I/O, so
+// they are called directly inside the organizer coroutines without co_await.
+struct mempool {
+    // Production (cfm) uses a per-node random salt for the hashers; the
+    // explicit-salt ctor is for tests / reproducibility.
+    mempool();
+    mempool(uint64_t k0, uint64_t k1);
+
+    // Admission of an already-validated transaction (scripts/fees checked by
+    // the organizer). Returns false if the txid is already present or if any
+    // input double-spends an outpoint already spent in the pool (first-seen).
+    bool add(mempool_entry entry);
+
+    // A block was connected: remove its transactions (now confirmed) and any
+    // pool transaction that conflicts with them (recursively, with descendants).
+    void remove_for_block(domain::chain::block const& block);
+
+    // A reorg happened: re-admit transactions from the disconnected blocks that
+    // are not in the new chain, then apply remove_for_block for the new blocks.
+    void update_for_reorg(block_const_ptr_list_const_ptr outgoing,
+                          block_const_ptr_list_const_ptr incoming);
+
+    // CCoinsViewMemPool-style prevout resolution for chained transactions: if
+    // `outpoint` is an output of a pool transaction, returns it; otherwise
+    // nullopt and the caller falls back to the confirmed UTXO set (UTXO-Z).
+    // Takes point (the base of output_point) — the outpoint's validation cache
+    // is deliberately not part of the key/lookup.
+    std::optional<domain::chain::output>
+    resolve(domain::chain::point const& outpoint) const;
+
+    bool contains(hash_digest const& txid) const;
+    std::size_t size() const;
+
+    mempool_stats const& stats() const { return stats_; }
+
+private:
+    // Erase one tx from pool_ and release its input-outpoint claims in
+    // spent_by_. Non-recursive: descendants are untouched.
+    void remove_entry(hash_digest const& txid);
+
+    // Remove a tx and, transitively, every pool tx that spends its outputs
+    // (the rare invalid/conflict path).
+    void remove_recursive(hash_digest const& txid);
+
+    mempool_map<hash_digest, mempool_entry, salted_txid_hasher> pool_;
+    mempool_map<outpoint_key, hash_digest, salted_outpoint_hasher> spent_by_;
+    mempool_stats stats_;
+};
+
+} // namespace kth::blockchain
+
+#endif // KTH_BLOCKCHAIN_POOLS_MEMPOOL_HPP

--- a/src/blockchain/include/kth/blockchain/pools/mempool_hashers.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool_hashers.hpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_POOLS_MEMPOOL_HASHERS_HPP
+#define KTH_BLOCKCHAIN_POOLS_MEMPOOL_HASHERS_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include <kth/infrastructure/math/sip_hash.hpp>
+
+namespace kth::blockchain {
+
+// A plain, default-constructible outpoint identity (txid + output index) used
+// as the spent_by_ map key. We do NOT use domain::chain::point: it is
+// valid-by-construction (no default ctor), which the ParlayHash backend cannot
+// accept as a key (it default-constructs its entries). This mirrors BCHN using
+// a plain COutPoint as the mapNextTx key.
+struct outpoint_key {
+    hash_digest hash{};
+    uint32_t index{};
+    friend bool operator==(outpoint_key const&, outpoint_key const&) = default;
+};
+
+// SipHash-based, salted hashers for the mempool keys — the Bitcoin Core / BCHN
+// SaltedTxidHasher / SaltedOutpointHasher pattern. txids and outpoints already
+// embed a uniform cryptographic hash, so no general-purpose mixing is needed;
+// the per-node-random salt (k0,k1) makes bucket assignment unpredictable and
+// defeats algorithmic-complexity (hash-flooding) DoS from adversarial P2P
+// transactions.
+//
+// Production (boost::concurrent_flat_map) constructs these with a per-mempool
+// random salt via the explicit ctor. The default ctor carries a FIXED salt,
+// used only by backends that default-construct the hasher and cannot take an
+// instance — ParlayHash, a measurement-only backend never exposed to
+// adversaries.
+// TODO(mempool): if ParlayHash ever ships to production, give it a real
+// per-node salt (it would need to accept a hasher instance).
+
+inline constexpr uint64_t mempool_hash_default_k0 = 0x9E3779B97F4A7C15ull;
+inline constexpr uint64_t mempool_hash_default_k1 = 0xBF58476D1CE4E5B9ull;
+
+struct salted_txid_hasher {
+    using is_avalanching = std::true_type;  // SipHash output is well-distributed.
+
+    uint64_t k0 = mempool_hash_default_k0;
+    uint64_t k1 = mempool_hash_default_k1;
+
+    salted_txid_hasher() = default;
+    salted_txid_hasher(uint64_t k0_, uint64_t k1_) : k0(k0_), k1(k1_) {}
+
+    std::size_t operator()(hash_digest const& txid) const {
+        return static_cast<std::size_t>(sip_hash_uint256(k0, k1, txid));
+    }
+};
+
+struct salted_outpoint_hasher {
+    using is_avalanching = std::true_type;
+
+    uint64_t k0 = mempool_hash_default_k0;
+    uint64_t k1 = mempool_hash_default_k1;
+
+    salted_outpoint_hasher() = default;
+    salted_outpoint_hasher(uint64_t k0_, uint64_t k1_) : k0(k0_), k1(k1_) {}
+
+    std::size_t operator()(outpoint_key const& outpoint) const {
+        return static_cast<std::size_t>(
+            sip_hash_uint256_extra(k0, k1, outpoint.hash, outpoint.index));
+    }
+};
+
+} // namespace kth::blockchain
+
+#endif // KTH_BLOCKCHAIN_POOLS_MEMPOOL_HASHERS_HPP

--- a/src/blockchain/include/kth/blockchain/pools/mempool_map.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool_map.hpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_POOLS_MEMPOOL_MAP_HPP
+#define KTH_BLOCKCHAIN_POOLS_MEMPOOL_MAP_HPP
+
+#include <concepts>
+#include <cstddef>
+#include <functional>
+#include <utility>
+
+#include <kth/blockchain/pools/mempool_config.hpp>
+
+#if defined(KTH_MEMPOOL_BACKEND_PARLAY)
+#include <parlay_hash/unordered_map.h>
+#else
+#include <boost/container_hash/hash.hpp>
+#include <boost/unordered/concurrent_flat_map.hpp>
+#endif
+
+namespace kth::blockchain {
+
+// Backend-native default hash: boost::hash for CFM, std::hash for ParlayHash.
+// (We intentionally do NOT force std::hash on both.)
+#if defined(KTH_MEMPOOL_BACKEND_PARLAY)
+template <typename Key>
+using mempool_default_hash = std::hash<Key>;
+#else
+template <typename Key>
+using mempool_default_hash = boost::hash<Key>;
+#endif
+
+// Callback constraints for the read paths.
+template <typename Fn, typename Value>
+concept value_reader = std::invocable<Fn, Value const&>;
+
+template <typename Fn, typename Key, typename Value>
+concept entry_reader = std::invocable<Fn, Key const&, Value const&>;
+
+// A thin, compile-time-selected concurrent hash map for the mempool. Exactly
+// one backend is compiled in (see mempool_config.hpp and the `mempool_backend`
+// conan option); there is no run-time switching. The surface is intentionally
+// minimal and uniform across backends — richer per-backend returns (e.g. an
+// erase count) are deliberately normalised to keep callers backend-agnostic:
+//
+//   try_insert(k, v)  -> insert if absent; true iff inserted (first-seen)
+//   visit(k, fn)      -> if present, fn(Value const&) in place; true iff found
+//   erase(k)          -> true iff an element was removed
+//   for_each(fn)      -> fn(Key const&, Value const&) for every element
+//   size()            -> element count
+template <typename Key,
+          typename Value,
+          typename Hash = mempool_default_hash<Key>,
+          typename Eq = std::equal_to<Key>>
+    requires std::invocable<Hash, Key const&>
+          && std::predicate<Eq, Key const&, Key const&>
+struct mempool_map {
+
+#if defined(KTH_MEMPOOL_BACKEND_PARLAY)
+    using backend = parlay::parlay_unordered_map<Key, Value, Hash, Eq>;
+
+    // ParlayHash default-constructs its Hash internally, so a supplied hasher
+    // instance is ignored here (the parlay backend uses the hasher's fixed
+    // default salt — it is measurement-only).
+    explicit mempool_map(std::size_t initial_capacity = 0, Hash const& = Hash{})
+        : map_(static_cast<long>(initial_capacity)) {}
+
+    bool try_insert(Key const& key, Value value) {
+        return ! map_.Insert(key, std::move(value)).has_value();
+    }
+
+    template <typename Fn>
+        requires value_reader<Fn, Value>
+    bool visit(Key const& key, Fn&& fn) const {
+        return map_.Find(key, [&](auto const& entry) {
+            fn(entry.second);   // Parlay passes the {key, value} entry.
+            return 0;           // Find requires a return value; discarded.
+        }).has_value();
+    }
+
+    bool erase(Key const& key) {
+        return map_.Remove(key).has_value();
+    }
+
+    template <typename Fn>
+        requires entry_reader<Fn, Key, Value>
+    void for_each(Fn&& fn) const {
+        for (auto const& [k, v] : map_) {
+            fn(k, v);
+        }
+    }
+
+    std::size_t size() const {
+        return static_cast<std::size_t>(map_.size());
+    }
+
+private:
+    // `mutable`: ParlayHash's Find/size are non-const, but the mempool's read
+    // paths (visit/for_each/size) are const.
+    mutable backend map_;
+
+#else // KTH_MEMPOOL_BACKEND_CFM
+    using backend = boost::concurrent_flat_map<Key, Value, Hash, Eq>;
+
+    explicit mempool_map(std::size_t initial_capacity = 0, Hash const& hash = Hash{})
+        : map_(initial_capacity, hash) {}
+
+    bool try_insert(Key const& key, Value value) {
+        return map_.emplace(key, std::move(value));
+    }
+
+    template <typename Fn>
+        requires value_reader<Fn, Value>
+    bool visit(Key const& key, Fn&& fn) const {
+        return map_.cvisit(key, [&](auto const& kv) {
+            fn(kv.second);
+        }) != 0;
+    }
+
+    bool erase(Key const& key) {
+        return map_.erase(key) != 0;
+    }
+
+    template <typename Fn>
+        requires entry_reader<Fn, Key, Value>
+    void for_each(Fn&& fn) const {
+        map_.cvisit_all([&](auto const& kv) {
+            fn(kv.first, kv.second);
+        });
+    }
+
+    std::size_t size() const {
+        return map_.size();
+    }
+
+private:
+    // No `mutable`: boost::concurrent_flat_map's cvisit/cvisit_all/size are const.
+    backend map_;
+#endif
+};
+
+} // namespace kth::blockchain
+
+#endif // KTH_BLOCKCHAIN_POOLS_MEMPOOL_MAP_HPP

--- a/src/blockchain/include/kth/blockchain/pools/mempool_stats.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool_stats.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_POOLS_MEMPOOL_STATS_HPP
+#define KTH_BLOCKCHAIN_POOLS_MEMPOOL_STATS_HPP
+
+#include <atomic>
+#include <cstdint>
+
+#include <kth/infrastructure/utility/stats.hpp>
+
+namespace kth::blockchain {
+
+// Per-mempool counters/timers, gated by KTH_WITH_STATS (see stats.hpp). Used to
+// compare the two map backends (cfm vs parlay) on a running node.
+struct mempool_stats {
+    // Admission.
+    std::atomic<uint64_t> add_calls{0};
+    std::atomic<uint64_t> add_inserted{0};
+    std::atomic<uint64_t> add_rejected_duplicate{0};
+    std::atomic<uint64_t> add_rejected_conflict{0};
+    std::atomic<uint64_t> add_time_ns{0};
+
+    // Block connect / reorg eviction.
+    std::atomic<uint64_t> remove_for_block_calls{0};
+    std::atomic<uint64_t> removed_confirmed{0};
+    std::atomic<uint64_t> removed_conflict{0};
+    std::atomic<uint64_t> remove_time_ns{0};
+
+    // Prevout resolution (chained-tx overlay).
+    std::atomic<uint64_t> resolve_calls{0};
+    std::atomic<uint64_t> resolve_hits{0};
+    std::atomic<uint64_t> resolve_time_ns{0};
+
+    void reset_all() {
+        add_calls = 0; add_inserted = 0; add_rejected_duplicate = 0;
+        add_rejected_conflict = 0; add_time_ns = 0;
+        remove_for_block_calls = 0; removed_confirmed = 0; removed_conflict = 0;
+        remove_time_ns = 0;
+        resolve_calls = 0; resolve_hits = 0; resolve_time_ns = 0;
+    }
+};
+
+} // namespace kth::blockchain
+
+#endif // KTH_BLOCKCHAIN_POOLS_MEMPOOL_STATS_HPP

--- a/src/blockchain/src/pools/mempool.cpp
+++ b/src/blockchain/src/pools/mempool.cpp
@@ -1,0 +1,192 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/blockchain/pools/mempool.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <kth/infrastructure/utility/pseudo_random.hpp>
+
+namespace kth::blockchain {
+
+using namespace kth::domain::chain;
+
+namespace {
+// Bucket hint for the concurrent maps. The pool grows as needed; this just
+// avoids early rehashing on a busy node.
+constexpr std::size_t initial_capacity = std::size_t(1) << 16;
+} // namespace
+
+// The mempool is lock-free: it relies on the concurrent maps' per-key atomic
+// operations, not on the organizers' mutex. Writes are (today) still serialised
+// by that mutex, but the logic below is correct without it — see the header.
+
+mempool::mempool()
+    : mempool(pseudo_random::generate<uint64_t>(),
+              pseudo_random::generate<uint64_t>()) {}
+
+mempool::mempool(uint64_t k0, uint64_t k1)
+    : pool_(initial_capacity, salted_txid_hasher{k0, k1})
+    , spent_by_(initial_capacity, salted_outpoint_hasher{k0, k1}) {}
+
+bool mempool::add(mempool_entry entry) {
+    KTH_STATS_TIME_START(add);
+    KTH_STATS_INCREMENT(stats_, add_calls);
+
+    auto const& tx = *entry.tx;
+    auto const txid = tx.hash();
+
+    // First-seen: atomically claim every spent outpoint. On any conflict, roll
+    // back the claims already made and reject.
+    std::vector<outpoint_key> reserved;
+    reserved.reserve(tx.inputs().size());
+    for (auto const& in : tx.inputs()) {
+        auto const& op = in.previous_output();
+        outpoint_key const key{op.hash(), op.index()};
+        if ( ! spent_by_.try_insert(key, txid)) {
+            for (auto const& k : reserved) {
+                spent_by_.erase(k);
+            }
+            KTH_STATS_INCREMENT(stats_, add_rejected_conflict);
+            KTH_STATS_TIME_ADD(stats_, add, add_time_ns);
+            return false;
+        }
+        reserved.push_back(key);
+    }
+
+    // Commit the transaction; release the claims if it is a duplicate.
+    if ( ! pool_.try_insert(txid, std::move(entry))) {
+        for (auto const& k : reserved) {
+            spent_by_.erase(k);
+        }
+        KTH_STATS_INCREMENT(stats_, add_rejected_duplicate);
+        KTH_STATS_TIME_ADD(stats_, add, add_time_ns);
+        return false;
+    }
+
+    KTH_STATS_INCREMENT(stats_, add_inserted);
+    KTH_STATS_TIME_ADD(stats_, add, add_time_ns);
+    return true;
+}
+
+void mempool::remove_entry(hash_digest const& txid) {
+    transaction_const_ptr tx;
+    bool const found = pool_.visit(txid, [&](mempool_entry const& e) {
+        tx = e.tx;
+    });
+    if ( ! found) {
+        return;
+    }
+
+    for (auto const& in : tx->inputs()) {
+        auto const& op = in.previous_output();
+        spent_by_.erase(outpoint_key{op.hash(), op.index()});
+    }
+    pool_.erase(txid);
+}
+
+void mempool::remove_recursive(hash_digest const& txid) {
+    transaction_const_ptr tx;
+    bool const found = pool_.visit(txid, [&](mempool_entry const& e) {
+        tx = e.tx;
+    });
+    if ( ! found) {
+        return;
+    }
+
+    // Evict every pool tx that spends an output of this one (its descendants),
+    // depth-first, before erasing this tx.
+    auto const outputs = static_cast<uint32_t>(tx->outputs().size());
+    for (uint32_t index = 0; index < outputs; ++index) {
+        outpoint_key const out{txid, index};
+        hash_digest child;
+        bool const has_child = spent_by_.visit(out, [&](hash_digest const& c) {
+            child = c;
+        });
+        if (has_child) {
+            remove_recursive(child);
+        }
+    }
+
+    remove_entry(txid);
+}
+
+void mempool::remove_for_block(domain::chain::block const& block) {
+    KTH_STATS_INCREMENT(stats_, remove_for_block_calls);
+    KTH_STATS_TIME_START(rmv);
+
+    for (auto const& tx : block.transactions()) {
+        auto const txid = tx.hash();
+
+        // Rare path: a confirmed tx may double-spend an outpoint claimed by a
+        // DIFFERENT pool tx; that pool tx is now invalid — evict it and its
+        // descendants.
+        for (auto const& in : tx.inputs()) {
+            auto const& op = in.previous_output();
+            outpoint_key const key{op.hash(), op.index()};
+            hash_digest spender;
+            bool const found = spent_by_.visit(key, [&](hash_digest const& s) {
+                spender = s;
+            });
+            if (found && spender != txid) {
+                remove_recursive(spender);
+                KTH_STATS_INCREMENT(stats_, removed_conflict);
+            }
+        }
+
+        // Normal path: the block confirmed this tx; drop it (non-recursive —
+        // its children now spend on-chain outputs and stay valid).
+        remove_entry(txid);
+        KTH_STATS_INCREMENT(stats_, removed_confirmed);
+    }
+
+    KTH_STATS_TIME_ADD(stats_, rmv, remove_time_ns);
+}
+
+void mempool::update_for_reorg(block_const_ptr_list_const_ptr /*outgoing*/,
+                               block_const_ptr_list_const_ptr incoming) {
+    // Evict for the new (connected) chain.
+    if (incoming) {
+        for (auto const& block : *incoming) {
+            remove_for_block(*block);
+        }
+    }
+
+    // TODO(mempool): re-admit transactions from the disconnected (`outgoing`)
+    // blocks that are not in the new chain — they become unconfirmed again.
+    // They must be re-validated against the new tip and their fee/size/sigops
+    // recomputed before re-entry (parents before children). Deferred; this is
+    // the rare path and the common flow does not depend on it. See issue #498.
+}
+
+std::optional<output> mempool::resolve(point const& outpoint) const {
+    KTH_STATS_INCREMENT(stats_, resolve_calls);
+
+    std::optional<output> result;
+    pool_.visit(outpoint.hash(), [&](mempool_entry const& e) {
+        auto const& outputs = e.tx->outputs();
+        if (outpoint.index() < outputs.size()) {
+            result = outputs[outpoint.index()];
+        }
+    });
+
+    if (result) {
+        KTH_STATS_INCREMENT(stats_, resolve_hits);
+    }
+    return result;
+}
+
+bool mempool::contains(hash_digest const& txid) const {
+    return pool_.visit(txid, [](mempool_entry const&) {});
+}
+
+std::size_t mempool::size() const {
+    return pool_.size();
+}
+
+} // namespace kth::blockchain

--- a/src/blockchain/test/mempool_test.cpp
+++ b/src/blockchain/test/mempool_test.cpp
@@ -1,0 +1,477 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Rigorous correctness tests for the BCH mempool (kth::blockchain::mempool).
+//
+// Two layers:
+//   1. Serial correctness — deterministic, single-threaded, asserts exact
+//      expected states (first-seen, duplicate, confirm-keeps-descendants,
+//      conflict-evicts-descendants-recursively, prevout overlay resolution).
+//   2. Concurrent stress — N threads doing random add / remove_for_block /
+//      resolve / contains over a deterministic key space that deliberately
+//      contains conflicts and chains. After a quiescent barrier we check the
+//      first-seen safety invariant and size/contained consistency via the
+//      public API. Intended to be run under TSan / ASan+UBSan.
+
+#include <test_helpers.hpp>
+
+#include <kth/blockchain/pools/mempool.hpp>
+#include <kth/domain.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <random>
+#include <set>
+#include <thread>
+#include <vector>
+
+using namespace kth;
+using namespace kth::domain::chain;
+using kth::blockchain::mempool;
+using kth::blockchain::mempool_entry;
+
+namespace {
+
+// A distinct, deterministic 32-byte hash for a given seed. Synthetic prevout
+// hashes never collide with real txids (which come out of double-SHA256).
+hash_digest make_hash(uint64_t seed) {
+    hash_digest h{};
+    for (int i = 0; i < 8; ++i) {
+        h[i] = static_cast<uint8_t>(seed >> (8 * i));
+    }
+    // Sprinkle a couple more bytes so seeds that differ only in high bits still
+    // produce well-separated hashes.
+    h[16] = static_cast<uint8_t>(seed >> 5);
+    h[31] = static_cast<uint8_t>(seed >> 11);
+    return h;
+}
+
+output_point op(uint64_t seed, uint32_t index) {
+    return output_point{make_hash(seed), index};
+}
+
+// Build a syntactically-valid transaction whose inputs point at `prevouts` and
+// which has `num_outputs` trivial outputs. `tag` makes otherwise-identical txs
+// distinct (distinct outputs => distinct txid), so txs that deliberately share
+// an input outpoint still get different txids.
+transaction make_tx(std::vector<output_point> const& prevouts,
+                    uint32_t num_outputs,
+                    uint64_t tag) {
+    input::list ins;
+    ins.reserve(prevouts.size());
+    for (auto const& po : prevouts) {
+        ins.emplace_back(po, script{}, 0xffffffffu);
+    }
+
+    output::list outs;
+    outs.reserve(num_outputs);
+    for (uint32_t i = 0; i < num_outputs; ++i) {
+        output o;
+        o.set_value(1000u + tag * 100u + i);
+        o.set_script(script{});
+        outs.push_back(std::move(o));
+    }
+
+    return transaction{1u, 0u, std::move(ins), std::move(outs)};
+}
+
+transaction_const_ptr as_ptr(transaction const& tx) {
+    return std::make_shared<domain::message::transaction>(tx);
+}
+
+mempool_entry entry_for(transaction_const_ptr const& tx, uint64_t tag) {
+    return mempool_entry{
+        tx,
+        /*fee*/      1000u + tag,
+        /*size*/     static_cast<uint32_t>(tx->serialized_size(true)),
+        /*sigops*/   1u,
+        /*time_seen*/ tag};
+}
+
+mempool_entry entry_for(transaction const& tx, uint64_t tag) {
+    return entry_for(as_ptr(tx), tag);
+}
+
+block make_block(std::vector<transaction> const& txs) {
+    return block{header{}, transaction::list(txs.begin(), txs.end())};
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Serial correctness
+// ---------------------------------------------------------------------------
+
+TEST_CASE("mempool add then query", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+
+    auto const tx = make_tx({op(1, 0)}, 2, /*tag*/ 1);
+    auto const txid = tx.hash();
+
+    REQUIRE(mp.add(entry_for(tx, 1)));
+    REQUIRE(mp.contains(txid));
+    REQUIRE(mp.size() == 1u);
+
+    auto const r0 = mp.resolve(point{txid, 0});
+    REQUIRE(r0.has_value());
+    CHECK(r0->value() == tx.outputs()[0].value());
+
+    auto const r1 = mp.resolve(point{txid, 1});
+    REQUIRE(r1.has_value());
+    CHECK(r1->value() == tx.outputs()[1].value());
+
+    // Out-of-range output index -> nullopt.
+    CHECK_FALSE(mp.resolve(point{txid, 2}).has_value());
+    // Unknown txid -> nullopt.
+    CHECK_FALSE(mp.resolve(point{make_hash(999), 0}).has_value());
+}
+
+TEST_CASE("mempool first-seen rejects conflicting input", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+
+    auto const a = make_tx({op(1, 0)}, 1, 1);
+    auto const b = make_tx({op(1, 0)}, 1, 2);  // spends the SAME outpoint as a
+    REQUIRE(a.hash() != b.hash());
+
+    REQUIRE(mp.add(entry_for(a, 1)));
+    // b double-spends op(1,0), already claimed by a -> rejected, not admitted.
+    REQUIRE_FALSE(mp.add(entry_for(b, 2)));
+    CHECK(mp.contains(a.hash()));
+    CHECK_FALSE(mp.contains(b.hash()));
+    CHECK(mp.size() == 1u);
+}
+
+TEST_CASE("mempool first-seen conflict rolls back partial claims", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+
+    // a spends P. b spends {Q, P}: Q is free, P is taken by a. b must be
+    // rejected AND its speculative claim on Q must be rolled back, so a later
+    // tx c spending Q can still be admitted.
+    auto const P = op(1, 0);
+    auto const Q = op(2, 0);
+    auto const a = make_tx({P}, 1, 1);
+    auto const b = make_tx({Q, P}, 1, 2);
+    auto const c = make_tx({Q}, 1, 3);
+
+    REQUIRE(mp.add(entry_for(a, 1)));
+    REQUIRE_FALSE(mp.add(entry_for(b, 2)));
+    // Q must be free again:
+    REQUIRE(mp.add(entry_for(c, 3)));
+    CHECK(mp.contains(a.hash()));
+    CHECK(mp.contains(c.hash()));
+    CHECK_FALSE(mp.contains(b.hash()));
+    CHECK(mp.size() == 2u);
+}
+
+TEST_CASE("mempool rejects duplicate txid", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+
+    auto const a = make_tx({op(1, 0)}, 1, 1);
+    REQUIRE(mp.add(entry_for(a, 1)));
+    // Same content => same txid => rejected on re-add. State unchanged.
+    REQUIRE_FALSE(mp.add(entry_for(a, 1)));
+    CHECK(mp.contains(a.hash()));
+    CHECK(mp.size() == 1u);
+
+    // A zero-input tx (exercises the pool_-duplicate path directly, since there
+    // are no outpoints to conflict on).
+    auto const z = make_tx({}, 1, 42);
+    REQUIRE(mp.add(entry_for(z, 42)));
+    REQUIRE_FALSE(mp.add(entry_for(z, 42)));
+    CHECK(mp.size() == 2u);
+}
+
+TEST_CASE("mempool remove_for_block drops confirmed tx", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+
+    auto const a = make_tx({op(1, 0)}, 1, 1);
+    REQUIRE(mp.add(entry_for(a, 1)));
+    REQUIRE(mp.size() == 1u);
+
+    mp.remove_for_block(make_block({a}));
+    CHECK_FALSE(mp.contains(a.hash()));
+    CHECK(mp.size() == 0u);
+
+    // The input outpoint must be released, so a different tx spending it is now
+    // admissible (it was confirmed/on-chain but the pool index must be clean).
+    auto const a2 = make_tx({op(1, 0)}, 1, 2);
+    CHECK(mp.add(entry_for(a2, 2)));
+}
+
+TEST_CASE("mempool normal confirm keeps descendants", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+
+    // A spends external P; B spends A's output {A,0}.
+    auto const a = make_tx({op(1, 0)}, 1, 1);
+    auto const b = make_tx({output_point{a.hash(), 0}}, 1, 2);
+
+    REQUIRE(mp.add(entry_for(a, 1)));
+    REQUIRE(mp.add(entry_for(b, 2)));
+    REQUIRE(mp.size() == 2u);
+
+    // A is confirmed in a block. Its output is now on-chain, so B stays valid
+    // and MUST remain in the pool (non-recursive removal).
+    mp.remove_for_block(make_block({a}));
+    CHECK_FALSE(mp.contains(a.hash()));
+    CHECK(mp.contains(b.hash()));
+    CHECK(mp.size() == 1u);
+}
+
+TEST_CASE("mempool conflict evicts descendants recursively", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+
+    // Chain A -> B -> C in the pool.
+    auto const a = make_tx({op(1, 0)}, 1, 1);            // spends external P
+    auto const b = make_tx({output_point{a.hash(), 0}}, 1, 2);     // spends {A,0}
+    auto const c = make_tx({output_point{b.hash(), 0}}, 1, 3);     // spends {B,0}
+
+    REQUIRE(mp.add(entry_for(a, 1)));
+    REQUIRE(mp.add(entry_for(b, 2)));
+    REQUIRE(mp.add(entry_for(c, 3)));
+    REQUIRE(mp.size() == 3u);
+
+    // A block tx X double-spends P (A's input) but is itself NOT in the pool.
+    // A conflicts with X => A is invalid, and B and C (descendants) go with it.
+    auto const x = make_tx({op(1, 0)}, 1, 99);
+    REQUIRE(x.hash() != a.hash());
+
+    mp.remove_for_block(make_block({x}));
+    CHECK_FALSE(mp.contains(a.hash()));
+    CHECK_FALSE(mp.contains(b.hash()));
+    CHECK_FALSE(mp.contains(c.hash()));
+    CHECK(mp.size() == 0u);
+}
+
+TEST_CASE("mempool resolve overlays chained parent output", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+
+    auto const a = make_tx({op(1, 0)}, 2, 1);
+    auto const b = make_tx({output_point{a.hash(), 1}}, 1, 2);  // spends A's output #1
+
+    REQUIRE(mp.add(entry_for(a, 1)));
+    REQUIRE(mp.add(entry_for(b, 2)));
+
+    // Resolving B's parent outpoint {A,1} must return A's output #1.
+    auto const r = mp.resolve(point{a.hash(), 1});
+    REQUIRE(r.has_value());
+    CHECK(r->value() == a.outputs()[1].value());
+
+    // Unknown outpoint -> nullopt.
+    CHECK_FALSE(mp.resolve(point{make_hash(123456), 0}).has_value());
+}
+
+TEST_CASE("mempool update_for_reorg evicts for incoming blocks", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+
+    auto const a = make_tx({op(1, 0)}, 1, 1);
+    auto const b = make_tx({output_point{a.hash(), 0}}, 1, 2);  // child of A
+    auto const other = make_tx({op(5, 0)}, 1, 3);
+    // X conflicts with A (same input P), not in the pool.
+    auto const x = make_tx({op(1, 0)}, 1, 99);
+
+    REQUIRE(mp.add(entry_for(a, 1)));
+    REQUIRE(mp.add(entry_for(b, 2)));
+    REQUIRE(mp.add(entry_for(other, 3)));
+    REQUIRE(mp.size() == 3u);
+
+    // Build incoming = one block containing X.
+    auto blk = std::make_shared<domain::message::block>(
+        header{}, transaction::list{x});
+    auto list = std::make_shared<domain::message::block::const_ptr_list>();
+    list->push_back(blk);
+    block_const_ptr_list_const_ptr incoming = list;
+
+    mp.update_for_reorg(nullptr, incoming);
+
+    // A (and its descendant B) evicted by the conflict; `other` untouched.
+    CHECK_FALSE(mp.contains(a.hash()));
+    CHECK_FALSE(mp.contains(b.hash()));
+    CHECK(mp.contains(other.hash()));
+    CHECK(mp.size() == 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent stress
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// One candidate transaction the workers may add/remove/query.
+struct candidate {
+    transaction tx;
+    hash_digest txid;
+    transaction_const_ptr ptr;
+    uint64_t tag;
+    std::vector<std::pair<hash_digest, uint32_t>> inpoints;  // spent outpoints
+};
+
+// Deterministic key space with deliberate conflicts and chains:
+//   - `groups` independent groups.
+//   - Each group has a "root" set of txs that all spend from a small shared
+//     pool of base outpoints -> many first-seen conflicts.
+//   - Plus chained children that spend a root's output -> descendant chains.
+std::vector<candidate> build_candidates(std::size_t groups) {
+    std::vector<candidate> out;
+    uint64_t tag = 1;
+
+    for (std::size_t g = 0; g < groups; ++g) {
+        uint64_t const base = 1'000'000ull * (g + 1);
+
+        // 4 base outpoints shared within the group.
+        std::vector<output_point> const bases = {
+            op(base + 1, 0), op(base + 2, 0),
+            op(base + 3, 0), op(base + 4, 0)};
+
+        std::vector<hash_digest> roots;
+
+        // 6 root txs, each spending 2 of the base outpoints in overlapping
+        // combinations -> guaranteed conflicts among them.
+        static constexpr int combos[6][2] = {
+            {0, 1}, {1, 2}, {2, 3}, {3, 0}, {0, 2}, {1, 3}};
+        for (auto const& combo : combos) {
+            auto tx = make_tx({bases[combo[0]], bases[combo[1]]}, 2, tag);
+            candidate c;
+            c.txid = tx.hash();
+            for (auto const& in : tx.inputs()) {
+                auto const& o = in.previous_output();
+                c.inpoints.emplace_back(o.hash(), o.index());
+            }
+            roots.push_back(c.txid);
+            c.ptr = as_ptr(tx);
+            c.tx = std::move(tx);
+            c.tag = tag++;
+            out.push_back(std::move(c));
+        }
+
+        // 6 children, each spending output 0 of a distinct root -> chains.
+        for (auto const& root : roots) {
+            auto tx = make_tx({output_point{root, 0}}, 1, tag);
+            candidate c;
+            c.txid = tx.hash();
+            for (auto const& in : tx.inputs()) {
+                auto const& o = in.previous_output();
+                c.inpoints.emplace_back(o.hash(), o.index());
+            }
+            c.ptr = as_ptr(tx);
+            c.tx = std::move(tx);
+            c.tag = tag++;
+            out.push_back(std::move(c));
+        }
+    }
+
+    return out;
+}
+
+void run_concurrent(unsigned n_threads) {
+    constexpr std::size_t groups = 24;
+    constexpr int ops_per_thread = 40'000;
+
+    auto const cands = build_candidates(groups);
+
+    // Sanity: all candidate txids distinct (so size()==contained-count holds).
+    {
+        std::set<hash_digest> ids;
+        for (auto const& c : cands) {
+            ids.insert(c.txid);
+        }
+        REQUIRE(ids.size() == cands.size());
+    }
+
+    mempool mp{0xA5A5A5A5u, 0x5A5A5A5Au};
+
+    std::atomic<bool> go{false};
+    std::vector<std::thread> threads;
+    threads.reserve(n_threads);
+
+    for (unsigned t = 0; t < n_threads; ++t) {
+        threads.emplace_back([&, t] {
+            std::mt19937_64 rng(0xC0FFEEu + t);
+            std::uniform_int_distribution<std::size_t> pick(0, cands.size() - 1);
+            std::uniform_int_distribution<int> what(0, 99);
+
+            while ( ! go.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (int i = 0; i < ops_per_thread; ++i) {
+                int const roll = what(rng);
+                auto const& c = cands[pick(rng)];
+
+                if (roll < 55) {
+                    // add (fresh entry sharing the tx's shared_ptr)
+                    mp.add(entry_for(c.ptr, c.tag));
+                } else if (roll < 70) {
+                    // remove_for_block of a small block containing this tx
+                    mp.remove_for_block(make_block({c.tx}));
+                } else if (roll < 85) {
+                    // resolve one of this tx's outputs
+                    (void)mp.resolve(point{c.txid, 0});
+                } else {
+                    // contains
+                    (void)mp.contains(c.txid);
+                }
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_release);
+    for (auto& th : threads) {
+        th.join();
+    }
+
+    // ---- Quiescent invariant checks (public API only) ----
+
+    // 1) size() must equal the number of candidates currently contained.
+    std::size_t contained_count = 0;
+    std::vector<candidate const*> contained;
+    for (auto const& c : cands) {
+        if (mp.contains(c.txid)) {
+            ++contained_count;
+            contained.push_back(&c);
+        }
+    }
+    CHECK(mp.size() == contained_count);
+
+    // 2) First-seen safety: no two currently-contained txs may spend the same
+    //    outpoint.
+    std::map<std::pair<hash_digest, uint32_t>, hash_digest> owner;
+    bool disjoint = true;
+    std::pair<hash_digest, uint32_t> clash_point{};
+    for (auto const* c : contained) {
+        for (auto const& ip : c->inpoints) {
+            auto const [it, inserted] = owner.emplace(ip, c->txid);
+            if ( ! inserted) {
+                disjoint = false;
+                clash_point = ip;
+            }
+        }
+    }
+    INFO("threads=" << n_threads
+         << " contained=" << contained_count
+         << " clash_index=" << clash_point.second);
+    CHECK(disjoint);
+
+    // 3) Every contained tx must resolve its output 0 (pool overlay consistent
+    //    with membership).
+    for (auto const* c : contained) {
+        CHECK(mp.resolve(point{c->txid, 0}).has_value());
+    }
+}
+
+} // namespace
+
+TEST_CASE("mempool concurrent stress 8 threads", "[mempool][concurrent]") {
+    run_concurrent(8);
+}
+
+TEST_CASE("mempool concurrent stress 16 threads", "[mempool][concurrent]") {
+    run_concurrent(16);
+}
+
+TEST_CASE("mempool concurrent stress 32 threads", "[mempool][concurrent]") {
+    run_concurrent(32);
+}


### PR DESCRIPTION
The new BCH mempool — the core data structure and operations. Stacked on #499 (ParlayHash vendoring); retarget to master once #499 merges.

## What

- **`mempool_map<K,V,Hash>`** — a thin struct over the compile-time-selected concurrent map (`boost::concurrent_flat_map` or ParlayHash, via the `mempool_backend` flag from #495). Uniform surface (`try_insert`/`visit`/`erase`/`for_each`/`size`); the backend `#if` lives in this one file; concept-constrained callbacks.
- **Salted SipHash hashers** — the BCHN/Core `SaltedTxidHasher`/`SaltedOutpointHasher` pattern over kth’s `sip_hash_uint256(_extra)`. Per-node random salt for the cfm backend; fixed fallback for ParlayHash (which default-constructs the hasher). `outpoint_key` is a plain default-constructible POD — the domain `point` is valid-by-construction, which ParlayHash cannot use as a key.
- **`mempool`** — two concurrent maps: `pool_` (txid → entry) and `spent_by_` (outpoint → spending txid, == BCHN `mapNextTx`). Lock-free via the maps’ per-key atomics: `add` reserves each spent outpoint (first-seen) with rollback, then commits; `remove_for_block` drops confirmed txs non-recursively and recursively evicts conflicts + descendants (derived from `spent_by_`, no child graph); `resolve` overlays pool outputs (CCoinsViewMemPool-style, UTXO-Z fallback). `KTH_WITH_STATS` instrumented.

## Correctness

`test/mempool_test.cpp`: 9 serial-correctness cases (including *normal-confirm-keeps-descendants* and *conflict-evicts-recursively*) + 3 concurrent-stress cases. Verified **TSan / ASan / UBSan clean**, first-seen safety holds under 8/16/32 threads with **no external lock**. Full `kth_blockchain_test` (106 cases) passes. Builds green in both `cfm` and `parlay` configs.

## Not in this PR

Wiring into `transaction_organizer` / `block_organizer` / `block_chain` (the #491 abort()-stubbed functions) and the on-node A/B measurement — follow-up. `update_for_reorg` re-admit → #498; lock-free orphan reconciliation → #497.

Part of #491.