### PR TITLE
mempool: wire the mempool into the organizers (admit / evict)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,20 @@ endif()
 
 message(STATUS "Knuth: Cryptocurrency: ${CURRENCY}")
 
+# Mempool backing map: cfm (boost::concurrent_flat_map) | parlay (ParlayHash).
+# Set at the root so the define (and, for parlay, the vendored include) reach
+# every module that includes block_chain.hpp — not only blockchain.
+set(KTH_MEMPOOL_BACKEND "cfm" CACHE STRING "Mempool backing map (cfm|parlay).")
+if (${KTH_MEMPOOL_BACKEND} STREQUAL "cfm")
+    add_definitions(-DKTH_MEMPOOL_BACKEND_CFM)
+elseif (${KTH_MEMPOOL_BACKEND} STREQUAL "parlay")
+    add_definitions(-DKTH_MEMPOOL_BACKEND_PARLAY)
+    include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/third_party/parlayhash/include)
+else()
+    message(FATAL_ERROR "Invalid mempool backend: ${KTH_MEMPOOL_BACKEND} (expected cfm|parlay)")
+endif()
+message(STATUS "Knuth: Mempool backend: ${KTH_MEMPOOL_BACKEND}")
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -29,6 +29,7 @@
 #include <kth/blockchain/header_index.hpp>
 #include <kth/blockchain/pools/block_organizer.hpp>
 #include <kth/blockchain/pools/branch.hpp>
+#include <kth/blockchain/pools/mempool.hpp>
 #include <kth/blockchain/pools/mempool_transaction_summary.hpp>
 #include <kth/blockchain/pools/transaction_organizer.hpp>
 #include <kth/blockchain/populate/populate_chain_state.hpp>
@@ -216,6 +217,11 @@ struct KB_API block_chain {
     /// state, keyed by transaction hash. Replaces the old mutable
     /// `transaction::validation` member.
     transaction_validation_store& transaction_validations() const;
+
+    /// The unconfirmed-transaction mempool. Owned here; the organizers admit to
+    /// it (tx accept) and evict from it (block connect / reorg).
+    blockchain::mempool& mempool_ref();
+    blockchain::mempool const& mempool_ref() const;
 
     // =========================================================================
     // SUBSCRIPTIONS
@@ -473,6 +479,8 @@ private:
     // constructed with a reference to this store.
     mutable block_validation_store block_validations_;
     mutable transaction_validation_store transaction_validations_;
+
+    blockchain::mempool mempool_;
 
     transaction_organizer transaction_organizer_;
     block_organizer block_organizer_;

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -736,6 +736,14 @@ transaction_validation_store& block_chain::transaction_validations() const {
     return transaction_validations_;
 }
 
+blockchain::mempool& block_chain::mempool_ref() {
+    return mempool_;
+}
+
+blockchain::mempool const& block_chain::mempool_ref() const {
+    return mempool_;
+}
+
 code block_chain::set_chain_state(domain::chain::chain_state::ptr previous) {
     unique_lock lock(pool_state_mutex_);
     pool_state_ = chain_state_populator_.populate(previous);

--- a/src/blockchain/src/pools/block_organizer.cpp
+++ b/src/blockchain/src/pools/block_organizer.cpp
@@ -241,6 +241,12 @@ bool block_organizer::stop() {
     block_pool_.prune(branch->top_height());
     block_pool_.add(out_blocks);
 
+    // Update the mempool for the reorganization: evict the newly-confirmed
+    // (incoming) transactions and their conflicts; re-admit of the disconnected
+    // (outgoing) transactions is tracked in #498. Common case: a single new
+    // block extending the tip (out_blocks empty) => plain removal.
+    chain_.mempool_ref().update_for_reorg(out_blocks, branch->blocks());
+
 
     // v3 reorg block order is reverse of v2, branch.back() is the new top.
     notify(branch->height(), branch->blocks(), out_blocks);

--- a/src/blockchain/src/pools/transaction_organizer.cpp
+++ b/src/blockchain/src/pools/transaction_organizer.cpp
@@ -5,7 +5,9 @@
 #include <kth/blockchain/pools/transaction_organizer.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <expected>
 #include <functional>
 #include <memory>
@@ -240,15 +242,24 @@ bool transaction_organizer::stop() {
         co_return error::success;
     }
 
-#if ! defined(KTH_DB_READONLY)
     //#########################################################################
-    auto push_ec = co_await chain_.push(tx);
-    if (push_ec) {
+    // Admit to the mempool. The tx is already validated (accept / fee / dust /
+    // connect above); this only records it. add() enforces first-seen: it
+    // returns false on a double-spend conflict with a pooled tx (or a duplicate).
+    auto const seen = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
+    auto const admitted = chain_.mempool_ref().add(mempool_entry{
+        tx,
+        tx->fees(),
+        static_cast<uint32_t>(tx->serialized_size(true)),
+        static_cast<uint32_t>(tx->signature_operations(true, false)),
+        seen});
+    if ( ! admitted) {
         mutex_.unlock_low_priority();
-        co_return push_ec;
+        co_return error::double_spend_mempool;
     }
     //#########################################################################
-#endif
 
     mutex_.unlock_low_priority();
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Integrates the new mempool (#500) into the validation flow so it is actually populated and drained on a running node.

- **`block_chain`** owns the mempool as a real member (not `mutable`), exposed via a non-const `mempool_ref()` for mutation and a `const` overload for reads.
- **`transaction_organizer::organize`** — an accepted transaction (already validated: accept / fee / dust / connect) is added to the mempool with its policy metadata (fee, serialized size, sigops). `add()` enforces first-seen; a double-spend conflict or duplicate returns `error::double_spend_mempool`. This replaces the `abort()` stub that stood in for the removed LMDB tx sink — receiving a transaction no longer aborts.
- **`block_organizer::organize`** — after the reorganization commits, `update_for_reorg(outgoing, incoming)` evicts the newly-confirmed transactions and their conflicts. Common case (one new block, nothing disconnected) is a plain removal.
- The `mempool_backend` define (and, for parlay, the vendored include) is set at the **root CMakeLists** so it reaches every module that includes `block_chain.hpp` (node / node-exe / c-api), not just blockchain.

Builds green in both `cfm` and `parlay`; full-tree conan build + integration link.

**Follow-ups:** reimplement the mempool reader functions and chained-tx prevout resolution into the validator (#491), then A/B measure cfm vs parlay on a running node. Part of #491.