### PR TITLE
mempool: resolve unconfirmed-parent prevouts from the mempool (chained txs)

### DIFF
--- a/src/blockchain/include/kth/blockchain/populate/populate_base.hpp
+++ b/src/blockchain/include/kth/blockchain/populate/populate_base.hpp
@@ -28,7 +28,9 @@ protected:
 
     void populate_duplicate(size_t maximum_height, domain::chain::transaction const& tx, bool require_confirmed) const;
     void populate_pooled(domain::chain::transaction const& tx, uint32_t height) const;
-    void populate_prevout(size_t maximum_height, domain::chain::output_point const& outpoint, bool require_confirmed) const;
+    // median_time_past (tip's MTP) is used only for a prevout resolved from the
+    // mempool. Block validation (require_confirmed) never consults the mempool.
+    void populate_prevout(size_t maximum_height, domain::chain::output_point const& outpoint, bool require_confirmed, uint32_t median_time_past) const;
 
     // Thread pool executor for parallel operations
     executor_type executor_;

--- a/src/blockchain/include/kth/blockchain/populate/populate_transaction.hpp
+++ b/src/blockchain/include/kth/blockchain/populate/populate_transaction.hpp
@@ -30,7 +30,7 @@ public:
     ::asio::awaitable<code> populate(transaction_const_ptr tx) const;
 
 protected:
-    code populate_inputs_sync(transaction_const_ptr tx, size_t chain_height, size_t bucket, size_t buckets) const;
+    code populate_inputs_sync(transaction_const_ptr tx, size_t chain_height, uint32_t median_time_past, size_t bucket, size_t buckets) const;
 
 private:
 };

--- a/src/blockchain/src/populate/populate_base.cpp
+++ b/src/blockchain/src/populate/populate_base.cpp
@@ -47,7 +47,7 @@ void populate_base::populate_pooled(domain::chain::transaction const& tx, uint32
 // Unspent outputs are cached by the store. If the cache is large enough this
 // may never hit the file system. However on high RAM systems the file system
 // is faster than the cache due to reduced paging of the memory-mapped file.
-void populate_base::populate_prevout(size_t branch_height, output_point const& outpoint, bool require_confirmed) const {
+void populate_base::populate_prevout(size_t branch_height, output_point const& outpoint, bool require_confirmed, uint32_t median_time_past) const {
     // The previous output will be cached on the input's outpoint.
     auto& prevout = outpoint.validation;
 
@@ -61,9 +61,25 @@ void populate_base::populate_prevout(size_t branch_height, output_point const& o
         return;
     }
 
-    //TODO(fernando): check the value of the parameters: branch_height and require_confirmed
+    // branch_height is the validation height; get_utxo bounds the prevout to one
+    // created at/below it (used by the spend check below too). require_confirmed
+    // = confirmed-only (blocks) vs also-mempool (tx, handled in the miss branch).
     auto const utxo = chain_.get_utxo(outpoint, branch_height);
     if ( ! utxo) {
+        // Chained tx: the prevout may be an unconfirmed parent's output in the
+        // mempool (tx-validation path only). Model the mempool coin as "confirms
+        // next block" (BCHN MEMPOOL_HEIGHT): height = branch_height + 1 and the
+        // tip's MTP make is_locked's relative age == 0. spent stays false —
+        // first-seen is enforced at admission (spent_by_).
+        if ( ! require_confirmed) {
+            if (auto out = chain_.mempool_ref().resolve(outpoint)) {
+                prevout.cache = std::move(*out);
+                prevout.height = branch_height + 1u;
+                prevout.median_time_past = median_time_past;
+                prevout.coinbase = false;
+                prevout.from_mempool = true;
+            }
+        }
         return;
     }
     prevout.cache = utxo->output;

--- a/src/blockchain/src/populate/populate_block.cpp
+++ b/src/blockchain/src/populate/populate_block.cpp
@@ -178,7 +178,7 @@ void populate_block::populate_transaction_inputs(branch::const_ptr branch, domai
 
         auto const& input = inputs[input_index];
         auto const& prevout = input.previous_output();
-        populate_base::populate_prevout(branch_height, prevout, true);  //Populate from Database
+        populate_base::populate_prevout(branch_height, prevout, true, 0);  //Populate from Database (no mempool consult during block validation)
         populate_prevout(branch, prevout, branch_utxo);                 //Populate from the Blocks in the Branch
 
         if (first_height <= chain_top) {

--- a/src/blockchain/src/populate/populate_transaction.cpp
+++ b/src/blockchain/src/populate/populate_transaction.cpp
@@ -40,6 +40,7 @@ populate_transaction::populate_transaction(executor_type executor, size_t thread
     // Chain state is for the next block, so always > 0.
     KTH_ASSERT(state->height() > 0);
     auto const chain_height = state->height() - 1u;
+    auto const median_time_past = state->median_time_past();
 
     //*************************************************************************
     // CONSENSUS:
@@ -75,8 +76,8 @@ populate_transaction::populate_transaction(executor_type executor, size_t thread
 
     // Launch parallel tasks
     for (size_t bucket = 0; bucket < buckets; ++bucket) {
-        ::asio::post(executor_, [this, tx, chain_height, bucket, buckets, channel]() {
-            auto result = populate_inputs_sync(tx, chain_height, bucket, buckets);
+        ::asio::post(executor_, [this, tx, chain_height, median_time_past, bucket, buckets, channel]() {
+            auto result = populate_inputs_sync(tx, chain_height, median_time_past, bucket, buckets);
             channel->try_send(std::error_code{}, result);
         });
     }
@@ -97,14 +98,15 @@ populate_transaction::populate_transaction(executor_type executor, size_t thread
     co_return final_result;
 }
 
-code populate_transaction::populate_inputs_sync(transaction_const_ptr tx, size_t chain_height, size_t bucket, size_t buckets) const {
+code populate_transaction::populate_inputs_sync(transaction_const_ptr tx, size_t chain_height, uint32_t median_time_past, size_t bucket, size_t buckets) const {
     KTH_ASSERT(bucket < buckets);
     auto const& inputs = tx->inputs();
 
     for (auto input_index = bucket; input_index < inputs.size(); input_index = ceiling_add(input_index, buckets)) {
         auto const& input = inputs[input_index];
         auto const& prevout = input.previous_output();
-        populate_prevout(chain_height, prevout, false);
+        // Tx-validation path: allow unconfirmed (mempool) parents.
+        populate_prevout(chain_height, prevout, false, median_time_past);
 
 
     }


### PR DESCRIPTION
Lets a transaction spending an output of an **unconfirmed parent** still in the mempool validate. Previously chained transactions were rejected with *missing input* — the `output_point::validation.from_mempool` infrastructure existed but was never wired (the old code even carried the `BUGBUG: tx pool ... no double spend limitation` note).

## What

In `populate_base::populate_prevout`, when the confirmed UTXO lookup misses **and** unconfirmed spends are allowed (the tx-validation path, `require_confirmed == false`), consult `mempool.resolve()`. Block validation never consults the mempool.

**Mempool-coin semantics (cross-checked vs BCHN v29):** BCHN's `CCoinsViewMemPool::GetCoin` returns `Coin(output, MEMPOOL_HEIGHT=0x7FFFFFFF, coinbase=false)` and special-cases `MEMPOOL_HEIGHT` in the sequence-lock check → `prevheight = tip+1` ("confirms next block"). KTH's `input::is_locked` instead computes `age = block_height - prevout.height` (with `block_height == branch_height + 1`) and asserts `block_height >= prevout.height` — so storing `0x7FFFFFFF` would blow the assert. We store **`height = branch_height + 1`** and the tip's **`median_time_past`**, giving the same `age == 0` result with no special case. `from_mempool = true`, `coinbase = false`, `spent = false` (first-seen double-spend is enforced at admission by `spent_by_`, closing the old BUGBUG). The tip MTP is threaded through `populate()` → `populate_inputs_sync`.

## Also

Resolves the `branch_height` / `require_confirmed` TODO in `populate_prevout`: `require_confirmed` was a **dead parameter** and now carries its intended confirmed-only vs. also-mempool meaning; `branch_height` is the validation height that bounds the UTXO lookup and the confirmed-spend check.

Builds green in **cfm** and **parlay**. A full validation-level mirror test vs BCHN is a follow-up (needs block_chain integration-test infrastructure). Part of #491.