### PR TITLE
mempool: cache per-tx sigchecks in the mempool entry

### DIFF
--- a/src/blockchain/include/kth/blockchain/pools/mempool.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool.hpp
@@ -27,7 +27,7 @@ struct mempool_entry {
     transaction_const_ptr tx;
     uint64_t fee;
     uint32_t size;
-    uint32_t sigops;
+    uint32_t sigchecks;
     uint64_t time_seen;
 };
 

--- a/src/blockchain/include/kth/blockchain/validate/validate_transaction.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/validate_transaction.hpp
@@ -7,18 +7,22 @@
 
 #include <atomic>
 #include <cstddef>
+#include <expected>
 
 #include <kth/blockchain/define.hpp>
 #include <kth/blockchain/pools/branch.hpp>
 #include <kth/blockchain/populate/populate_transaction.hpp>
 #include <kth/blockchain/settings.hpp>
 #include <kth/domain.hpp>
+#include <kth/infrastructure/handlers.hpp>
 
 #include <asio/any_io_executor.hpp>
 #include <asio/awaitable.hpp>
 
 
 namespace kth::blockchain {
+
+using kth::awaitable_expected;
 
 // Forward declaration
 struct block_chain;
@@ -38,8 +42,10 @@ struct KB_API validate_transaction {
     [[nodiscard]]
     ::asio::awaitable<code> accept(transaction_const_ptr tx) const;
 
+    // Runs script validation across all inputs; on success yields the tx's
+    // total sigchecks (BCH), which the organizer caches in the mempool entry.
     [[nodiscard]]
-    ::asio::awaitable<code> connect(transaction_const_ptr tx) const;
+    awaitable_expected<size_t> connect(transaction_const_ptr tx) const;
 
 protected:
     inline
@@ -48,7 +54,8 @@ protected:
     }
 
 private:
-    code connect_inputs_sync(transaction_const_ptr tx, domain::script_flags_t flags, size_t bucket, size_t buckets) const;
+    // Yields this bucket's sigchecks total, or the first script/validation error.
+    std::expected<size_t, code> connect_inputs_sync(transaction_const_ptr tx, domain::script_flags_t flags, size_t bucket, size_t buckets) const;
 
     // These are thread safe.
     std::atomic<bool> stopped_;

--- a/src/blockchain/src/pools/transaction_organizer.cpp
+++ b/src/blockchain/src/pools/transaction_organizer.cpp
@@ -115,7 +115,7 @@ bool transaction_organizer::stop() {
     }
 
     // Checks that include script validation.
-    ec = co_await validator_.connect(tx);
+    auto const connected = co_await validator_.connect(tx);
 
     chain_.transaction_validations().erase(tx->hash());
 
@@ -123,7 +123,7 @@ bool transaction_organizer::stop() {
         co_return error::service_stopped;
     }
 
-    co_return ec;
+    co_return connected ? error::success : connected.error();
 }
 
 // DSProof Organize sequence.
@@ -215,8 +215,8 @@ bool transaction_organizer::stop() {
         co_return error::dusty_transaction;
     }
 
-    // Checks that include script validation.
-    ec = co_await validator_.connect(tx);
+    // Checks that include script validation; on success yields the tx sigchecks.
+    auto const connected = co_await validator_.connect(tx);
 
     if (stopped()) {
         erase_tx_validation();
@@ -224,10 +224,10 @@ bool transaction_organizer::stop() {
         co_return error::service_stopped;
     }
 
-    if (ec) {
+    if ( ! connected) {
         erase_tx_validation();
         mutex_.unlock_low_priority();
-        co_return ec;
+        co_return connected.error();
     }
 
     // TODO: create a simulated validation path that does not block others.
@@ -253,7 +253,7 @@ bool transaction_organizer::stop() {
         tx,
         tx->fees(),
         static_cast<uint32_t>(tx->serialized_size(true)),
-        static_cast<uint32_t>(tx->signature_operations(true, false)),
+        static_cast<uint32_t>(*connected),
         seen});
     if ( ! admitted) {
         mutex_.unlock_low_priority();

--- a/src/blockchain/src/validate/validate_transaction.cpp
+++ b/src/blockchain/src/validate/validate_transaction.cpp
@@ -8,8 +8,10 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <expected>
 #include <functional>
 #include <memory>
+#include <utility>
 
 #include <kth/blockchain/interface/block_chain.hpp>
 #include <kth/blockchain/pools/branch.hpp>
@@ -121,7 +123,7 @@ void validate_transaction::stop()
 //-----------------------------------------------------------------------------
 // These checks require chain state, block state and perform script validation.
 
-::asio::awaitable<code> validate_transaction::connect(transaction_const_ptr tx) const {
+awaitable_expected<size_t> validate_transaction::connect(transaction_const_ptr tx) const {
     domain::chain::chain_state::ptr state_ptr;
     chain_.transaction_validations().visit(tx->hash(), [&](auto const& tv){ state_ptr = tv.state; });
     KTH_ASSERT(state_ptr);
@@ -130,73 +132,78 @@ void validate_transaction::stop()
 
     // Return if there are no inputs to validate (will fail later).
     if (total_inputs == 0) {
-        co_return error::success;
+        co_return 0u;
     }
 
     auto const buckets = std::min(threads_, total_inputs);
     KTH_ASSERT(buckets != 0);
 
-    // Use a channel to collect results from parallel tasks
-    using result_channel = ::asio::experimental::concurrent_channel<void(std::error_code, code)>;
+    // Use a channel to collect each bucket's {sigchecks | error} result.
+    using bucket_result = std::expected<size_t, code>;
+    using result_channel = ::asio::experimental::concurrent_channel<void(std::error_code, bucket_result)>;
     auto channel = std::make_shared<result_channel>(executor_, buckets);
 
     // Launch parallel tasks
     for (size_t bucket = 0; bucket < buckets; ++bucket) {
         ::asio::post(executor_, [this, tx, flags, bucket, buckets, channel]() {
-            auto result = connect_inputs_sync(tx, flags, bucket, buckets);
-            channel->try_send(std::error_code{}, result);
+            channel->try_send(std::error_code{}, connect_inputs_sync(tx, flags, bucket, buckets));
         });
     }
 
-    // Wait for all results - return first error or success if all succeed
+    // Wait for all results - return first error, or the summed sigchecks.
     code final_result = error::success;
+    size_t total_sigchecks = 0;
     for (size_t i = 0; i < buckets; ++i) {
         auto [ec, result] = co_await channel->async_receive(::asio::as_tuple(::asio::use_awaitable));
         if (ec) {
             // Channel error - shouldn't happen
-            co_return error::operation_failed;
+            co_return std::unexpected(error::operation_failed);
         }
-        if (result != error::success && final_result == error::success) {
-            final_result = result;
+        if ( ! result) {
+            if (final_result == error::success) {
+                final_result = result.error();
+            }
+        } else {
+            total_sigchecks += *result;
         }
     }
 
-    co_return final_result;
+    if (final_result != error::success) {
+        co_return std::unexpected(final_result);
+    }
+    co_return total_sigchecks;
 }
 
-code validate_transaction::connect_inputs_sync(transaction_const_ptr tx, script_flags_t flags, size_t bucket, size_t buckets) const {
+std::expected<size_t, code> validate_transaction::connect_inputs_sync(transaction_const_ptr tx, script_flags_t flags, size_t bucket, size_t buckets) const {
     KTH_ASSERT(bucket < buckets);
 
-#if defined(KTH_CURRENCY_BCH)
-    size_t tx_sigchecks = 0;
-#endif
-
+    size_t sigchecks = 0;
     auto const& inputs = tx->inputs();
 
     for (auto input_index = bucket; input_index < inputs.size(); input_index = ceiling_add(input_index, buckets)) {
         if (stopped()) {
-            return error::service_stopped;
+            return std::unexpected(error::service_stopped);
         }
 
         auto const& prevout = inputs[input_index].previous_output();
 
         if ( ! prevout.validation.cache.is_valid()) {
-            return error::missing_previous_output;
+            return std::unexpected(error::missing_previous_output);
         }
 
         auto res = validate_input::verify_script(*tx, input_index, flags);
         if (res.first != error::success) {
-            return res.first;
+            return std::unexpected(res.first);
         }
 
 #if defined(KTH_CURRENCY_BCH)
-        tx_sigchecks += res.second;
-        if (tx_sigchecks > max_tx_sigchecks) {
-            return error::transaction_sigchecks_limit;
+        sigchecks += res.second;
+        if (sigchecks > max_tx_sigchecks) {
+            return std::unexpected(error::transaction_sigchecks_limit);
         }
 #endif
     }
-    return error::success;
+    return sigchecks;
 }
 
 } // namespace kth::blockchain

--- a/src/blockchain/test/mempool_test.cpp
+++ b/src/blockchain/test/mempool_test.cpp
@@ -88,7 +88,7 @@ mempool_entry entry_for(transaction_const_ptr const& tx, uint64_t tag) {
         tx,
         /*fee*/      1000u + tag,
         /*size*/     static_cast<uint32_t>(tx->serialized_size(true)),
-        /*sigops*/   1u,
+        /*sigchecks*/ 1u,
         /*time_seen*/ tag};
 }
 


### PR DESCRIPTION
Script validation already computes each transaction's total sigchecks in `validate_transaction::connect` (summed across the parallel input buckets) but discarded it, returning only a `code`. This threads it out so the block-template builder (next PR) has the correct per-tx accounting without re-running the interpreter.

- `connect` now yields the sigchecks total on success (`awaitable_expected<size_t>`); `connect_inputs_sync` returns `{code, sigchecks}` per bucket.
- The organizer records the total in the mempool entry at admission.
- `mempool_entry`'s unused legacy `sigops` field (populated from `signature_operations`, never read) becomes `sigchecks` — the unit BCH block validation enforces (`dynamic_max_block_sigchecks`).

Local build + mempool tests green (cfm backend). Change is backend-agnostic (does not touch `mempool_map`).