### PR TITLE
mempool: assemble the block template from the mempool (GBT)

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -180,6 +180,7 @@ set(kth_sources_just_legacy
   src/pools/header_organizer.cpp
   src/pools/transaction_organizer.cpp
   src/pools/mempool.cpp
+  src/pools/block_template.cpp
   src/pools/mempool_transaction_summary.cpp
   src/populate/populate_base.cpp
   src/populate/populate_block.cpp
@@ -223,6 +224,7 @@ set(kth_headers
   include/kth/blockchain/validate/validate_input.hpp
   include/kth/blockchain/validate/validate_transaction.hpp
   include/kth/blockchain/pools/block_entry.hpp
+  include/kth/blockchain/pools/block_template.hpp
   include/kth/blockchain/pools/mempool.hpp
   include/kth/blockchain/pools/mempool_config.hpp
   include/kth/blockchain/pools/mempool_hashers.hpp
@@ -295,6 +297,7 @@ if (ENABLE_TEST)
         test/branch.cpp
         test/validate_transaction.cpp
         test/mempool_test.cpp
+        test/block_template_test.cpp
     )
 
     # Disabled until ported to v1.0 APIs:

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -29,6 +29,7 @@
 #include <kth/blockchain/header_index.hpp>
 #include <kth/blockchain/pools/block_organizer.hpp>
 #include <kth/blockchain/pools/branch.hpp>
+#include <kth/blockchain/pools/block_template.hpp>
 #include <kth/blockchain/pools/mempool.hpp>
 #include <kth/blockchain/pools/mempool_transaction_summary.hpp>
 #include <kth/blockchain/pools/transaction_organizer.hpp>
@@ -390,7 +391,7 @@ struct KB_API block_chain {
     // MEMPOOL / TRANSACTION POOL
     // =========================================================================
 
-    [[nodiscard]] awaitable_expected<std::pair<merkle_block_ptr, size_t>>
+    [[nodiscard]] awaitable_expected<blockchain::block_template>
     fetch_template() const;
 
     [[nodiscard]] awaitable_expected<inventory_ptr>

--- a/src/blockchain/include/kth/blockchain/pools/block_template.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/block_template.hpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_POOLS_BLOCK_TEMPLATE_HPP
+#define KTH_BLOCKCHAIN_POOLS_BLOCK_TEMPLATE_HPP
+
+#include <cstdint>
+#include <vector>
+
+#include <kth/domain.hpp>
+
+#include <kth/blockchain/define.hpp>
+#include <kth/blockchain/pools/mempool.hpp>
+
+namespace kth::blockchain {
+
+// The transactions selected for the next block plus the totals a caller needs
+// to finish the block. `txs` excludes the coinbase and is CTOR-ordered (txid
+// ascending), so the caller prepends its own coinbase at index 0. `total_fees`
+// gives the coinbase value (subsidy + total_fees); the size / sigchecks totals
+// cover only the selected txs (the coinbase reserve is accounted separately
+// during selection).
+struct block_template {
+    std::vector<transaction_const_ptr> txs;
+    uint64_t total_fees;
+    uint64_t total_size;
+    uint64_t total_sigchecks;
+};
+
+// Everything the builder needs about the block being assembled, taken from the
+// chain state of the tip's next block. Kept as plain scalars so the builder is a
+// pure function of (mempool, context), independent of chain_state.
+struct block_template_context {
+    uint64_t max_block_size;        // consensus block size limit
+    uint64_t max_block_sigchecks;   // consensus block sigchecks limit
+    size_t height;                  // template height (tip + 1)
+    uint32_t median_time_past;      // tip's MTP (BIP113 finality time)
+};
+
+// Assemble a block template from the mempool, mirroring BCHN's BlockAssembler
+// (miner.cpp addTxs): order candidates by individual fee-rate and add each once
+// all its in-mempool parents are in, so the result is dependency-complete under
+// CTOR without CPFP / ancestor-package scoring. Enforces the block size and
+// sigchecks limits (with a coinbase reserve) and per-tx finality at the
+// template height.
+KB_API
+block_template build_block_template(mempool const& pool, block_template_context const& ctx);
+
+} // namespace kth::blockchain
+
+#endif

--- a/src/blockchain/include/kth/blockchain/pools/transaction_organizer.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/transaction_organizer.hpp
@@ -64,9 +64,6 @@ struct KB_API transaction_organizer {
     void unsubscribe_ds_proof(ds_proof_broadcaster::channel_ptr const& channel);
 
     [[nodiscard]]
-    awaitable_expected<std::pair<merkle_block_ptr, size_t>> fetch_template() const;
-
-    [[nodiscard]]
     awaitable_expected<inventory_ptr> fetch_mempool(size_t maximum) const;
 
     [[nodiscard]]

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1476,9 +1476,22 @@ block_chain::fetch_ds_proof(hash_digest const& hash) const {
 // Tracked in issue #491.
 // ############################################################################
 
-awaitable_expected<std::pair<merkle_block_ptr, size_t>>
+awaitable_expected<blockchain::block_template>
 block_chain::fetch_template() const {
-    mempool_not_implemented("block_chain::fetch_template");
+    if (stopped()) {
+        co_return std::unexpected(error::service_stopped);
+    }
+
+    auto const state = chain_state();
+    if ( ! state) {
+        co_return std::unexpected(error::not_found);
+    }
+
+    co_return build_block_template(mempool_, block_template_context{
+        state->dynamic_max_block_size(),
+        state->dynamic_max_block_sigchecks(),
+        state->height(),
+        state->median_time_past()});
 }
 
 awaitable_expected<inventory_ptr>

--- a/src/blockchain/src/pools/block_template.cpp
+++ b/src/blockchain/src/pools/block_template.cpp
@@ -1,0 +1,198 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/blockchain/pools/block_template.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+#include <queue>
+#include <unordered_map>
+#include <vector>
+
+#include <kth/domain.hpp>
+
+namespace kth::blockchain {
+
+using namespace kd::chain;
+
+namespace {
+
+// The tx hash is already a uniform digest; the low 8 bytes make a fine key hash.
+struct digest_hasher {
+    size_t operator()(hash_digest const& h) const {
+        size_t out;
+        std::memcpy(&out, h.data(), sizeof(out));
+        return out;
+    }
+};
+
+// Coinbase reserve, matching BCHN BlockAssembler::resetBlock (miner.cpp).
+constexpr uint64_t coinbase_size_reserve = 1000;
+constexpr uint64_t coinbase_sigchecks_reserve = 100;
+
+// Give up adding once the block is nearly full and a run of candidates in a row
+// have all failed the size/sigchecks test (BCHN's MAX_CONSECUTIVE_FAILURES).
+constexpr int max_consecutive_failures = 1000;
+
+// CTOR: ascending reverse-byte (little-endian display) lexicographic txid order,
+// matching domain::chain::block::is_canonical_ordered.
+bool canonical_less(transaction_const_ptr const& a, transaction_const_ptr const& b) {
+    auto const& ha = a->hash();
+    auto const& hb = b->hash();
+    return std::lexicographical_compare(ha.rbegin(), ha.rend(), hb.rbegin(), hb.rend());
+}
+
+} // namespace
+
+block_template build_block_template(mempool const& pool, block_template_context const& ctx) {
+    // 1. Point-in-time snapshot of the pool. The mempool is lock-free, so we copy
+    //    the entries out (cheap: shared_ptr + a few ints) and build the template
+    //    from a self-consistent view instead of querying the live maps.
+    std::vector<mempool_entry> entries;
+    entries.reserve(pool.size());
+    pool.for_each([&](mempool_entry const& e) { entries.push_back(e); });
+
+    auto const n = entries.size();
+
+    block_template result{};
+    if (n == 0) {
+        return result;
+    }
+
+    // 2. txid -> snapshot index.
+    std::unordered_map<hash_digest, uint32_t, digest_hasher> index;
+    index.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+        index.emplace(entries[i].tx->hash(), i);
+    }
+
+    // 3. In-mempool parent / child adjacency, derived from the snapshot inputs
+    //    (a prevout whose txid is in the pool is an unconfirmed parent). Parents
+    //    are de-duplicated so a tx spending two outputs of one parent counts it
+    //    once; children are the inverse edges.
+    std::vector<std::vector<uint32_t>> parents(n);
+    std::vector<std::vector<uint32_t>> children(n);
+    for (uint32_t i = 0; i < n; ++i) {
+        for (auto const& in : entries[i].tx->inputs()) {
+            auto it = index.find(in.previous_output().hash());
+            if (it == index.end()) {
+                continue;
+            }
+            auto const parent = it->second;
+            if (std::find(parents[i].begin(), parents[i].end(), parent) == parents[i].end()) {
+                parents[i].push_back(parent);
+                children[parent].push_back(i);
+            }
+        }
+    }
+
+    // 4. Order candidates by individual fee-rate (fee/size), descending. Fee-rate
+    //    ordering is mining policy, not consensus, so a double key is fine; ties
+    //    break on txid for a deterministic template.
+    std::vector<double> feerate(n);
+    for (uint32_t i = 0; i < n; ++i) {
+        feerate[i] = entries[i].size != 0
+            ? static_cast<double>(entries[i].fee) / static_cast<double>(entries[i].size)
+            : 0.0;
+    }
+    std::vector<uint32_t> order(n);
+    std::iota(order.begin(), order.end(), 0u);
+    std::sort(order.begin(), order.end(), [&](uint32_t a, uint32_t b) {
+        if (feerate[a] != feerate[b]) {
+            return feerate[a] > feerate[b];
+        }
+        return canonical_less(entries[a].tx, entries[b].tx);
+    });
+
+    // 5. Greedy selection with the BCHN skip/backlog scheme: a child is only added
+    //    after all its in-mempool parents, so the selected set is dependency-
+    //    complete even though the order is by individual fee-rate.
+    auto const max_size = ctx.max_block_size;
+    auto const max_sigchecks = ctx.max_block_sigchecks;
+    auto const height = ctx.height;
+    auto const mtp = ctx.median_time_past;
+
+    std::vector<uint32_t> missing(n);   // in-mempool parents not yet added
+    for (uint32_t i = 0; i < n; ++i) {
+        missing[i] = static_cast<uint32_t>(parents[i].size());
+    }
+    std::vector<char> included(n, 0);
+    std::vector<char> skipped(n, 0);
+    std::queue<uint32_t> backlog;
+
+    uint64_t block_size = coinbase_size_reserve;
+    uint64_t block_sigchecks = coinbase_sigchecks_reserve;
+    int consecutive_failed = 0;
+
+    size_t cursor = 0;
+    while ( ! backlog.empty() || cursor < n) {
+        uint32_t i;
+        bool from_backlog = false;
+        if ( ! backlog.empty()) {
+            i = backlog.front();
+            backlog.pop();
+            from_backlog = true;
+        } else {
+            i = order[cursor++];
+        }
+
+        if (included[i]) {
+            continue;
+        }
+
+        // Defer a child until all its parents are in the block (backlog items are
+        // enqueued only once that holds).
+        if ( ! from_backlog && missing[i] != 0) {
+            skipped[i] = 1;
+            continue;
+        }
+
+        auto const& e = entries[i];
+
+        // Block resource limits (BCHN TestTx uses >=).
+        if (block_size + e.size >= max_size || block_sigchecks + e.sigchecks >= max_sigchecks) {
+            if (++consecutive_failed > max_consecutive_failures && block_size > max_size - coinbase_size_reserve) {
+                break;
+            }
+            continue;
+        }
+
+        // Absolute finality at the template height (BIP113 uses the tip's MTP).
+        if ( ! e.tx->is_final(height, mtp)) {
+            continue;
+        }
+
+        consecutive_failed = 0;
+        included[i] = 1;
+        block_size += e.size;
+        block_sigchecks += e.sigchecks;
+        result.total_fees += e.fee;
+        result.total_size += e.size;
+        result.total_sigchecks += e.sigchecks;
+
+        // A child becomes a candidate once its last parent is added; if it was
+        // already passed over by the cursor, re-queue it via the backlog.
+        for (auto const child : children[i]) {
+            if (--missing[child] == 0 && skipped[child]) {
+                backlog.push(child);
+            }
+        }
+    }
+
+    // 6. Emit the selected txs in CTOR order (coinbase is prepended by the caller).
+    result.txs.reserve(result.total_size != 0 ? n : 0);
+    for (uint32_t i = 0; i < n; ++i) {
+        if (included[i]) {
+            result.txs.push_back(entries[i].tx);
+        }
+    }
+    std::sort(result.txs.begin(), result.txs.end(), canonical_less);
+
+    return result;
+}
+
+} // namespace kth::blockchain

--- a/src/blockchain/src/pools/transaction_organizer.cpp
+++ b/src/blockchain/src/pools/transaction_organizer.cpp
@@ -301,14 +301,6 @@ void transaction_organizer::unsubscribe_ds_proof(ds_proof_broadcaster::channel_p
 // Queries.
 //-----------------------------------------------------------------------------
 
-awaitable_expected<std::pair<merkle_block_ptr, size_t>>
-transaction_organizer::fetch_template() const {
-    // TODO(mempool): block-template assembly (GBT) needs the new mempool.
-    // The old transaction_pool stub was removed; wire this to the rebuilt
-    // fee-prioritized mempool once it lands.
-    co_return std::unexpected(error::not_implemented);
-}
-
 awaitable_expected<inventory_ptr>
 transaction_organizer::fetch_mempool(size_t maximum) const {
     // TODO(mempool): serve the P2P `mempool` message from the new mempool.

--- a/src/blockchain/test/block_template_test.cpp
+++ b/src/blockchain/test/block_template_test.cpp
@@ -1,0 +1,257 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Tests for the block-template builder (kth::blockchain::build_block_template):
+// fee-rate ordering, block size / sigchecks limits with coinbase reserve,
+// parent-before-child dependency completeness, CTOR ordering, and finality.
+
+#include <test_helpers.hpp>
+
+#include <kth/blockchain/pools/block_template.hpp>
+#include <kth/blockchain/pools/mempool.hpp>
+#include <kth/domain.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <vector>
+
+using namespace kth;
+using namespace kth::domain::chain;
+using kth::blockchain::mempool;
+using kth::blockchain::mempool_entry;
+using kth::blockchain::block_template;
+using kth::blockchain::block_template_context;
+using kth::blockchain::build_block_template;
+
+namespace {
+
+hash_digest make_hash(uint64_t seed) {
+    hash_digest h{};
+    for (int i = 0; i < 8; ++i) {
+        h[i] = static_cast<uint8_t>(seed >> (8 * i));
+    }
+    h[16] = static_cast<uint8_t>(seed >> 5);
+    h[31] = static_cast<uint8_t>(seed >> 11);
+    return h;
+}
+
+output_point op(uint64_t seed, uint32_t index) {
+    return output_point{make_hash(seed), index};
+}
+
+// Build a syntactically-valid tx. `sequence`/`locktime` default to final.
+transaction make_tx(std::vector<output_point> const& prevouts,
+                    uint32_t num_outputs,
+                    uint64_t tag,
+                    uint32_t locktime = 0u,
+                    uint32_t sequence = 0xffffffffu) {
+    input::list ins;
+    ins.reserve(prevouts.size());
+    for (auto const& po : prevouts) {
+        ins.emplace_back(po, script{}, sequence);
+    }
+
+    output::list outs;
+    outs.reserve(num_outputs);
+    for (uint32_t i = 0; i < num_outputs; ++i) {
+        output o;
+        o.set_value(1000u + tag * 100u + i);
+        o.set_script(script{});
+        outs.push_back(std::move(o));
+    }
+
+    return transaction{1u, locktime, std::move(ins), std::move(outs)};
+}
+
+transaction_const_ptr as_ptr(transaction const& tx) {
+    return std::make_shared<domain::message::transaction>(tx);
+}
+
+mempool_entry make_entry(transaction_const_ptr const& tx, uint64_t fee, uint32_t size, uint32_t sigchecks) {
+    return mempool_entry{tx, fee, size, sigchecks, /*time_seen*/ 0u};
+}
+
+// A generous context: nothing is limited unless a test tightens it.
+block_template_context unlimited_ctx() {
+    return block_template_context{
+        /*max_block_size*/      1'000'000'000ull,
+        /*max_block_sigchecks*/ 1'000'000'000ull,
+        /*height*/              100u,
+        /*median_time_past*/    1'000'000u};
+}
+
+// CTOR predicate: reverse-byte (display) lexicographic txid ascending.
+bool canonical_less(transaction_const_ptr const& a, transaction_const_ptr const& b) {
+    auto const& ha = a->hash();
+    auto const& hb = b->hash();
+    return std::lexicographical_compare(ha.rbegin(), ha.rend(), hb.rbegin(), hb.rend());
+}
+
+// Invariants every valid template must hold: the selected txs are CTOR-ordered
+// and free of duplicates. Per-test cases assert the chain-specific parent /
+// child completeness where the structure is known.
+void check_template_invariants(block_template const& tpl) {
+    REQUIRE(std::is_sorted(tpl.txs.begin(), tpl.txs.end(), canonical_less));
+
+    std::set<hash_digest> present;
+    for (auto const& tx : tpl.txs) {
+        present.insert(tx->hash());
+    }
+    REQUIRE(present.size() == tpl.txs.size());
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+
+TEST_CASE("block_template: empty pool yields empty template", "[block_template]") {
+    mempool pool(0x1111u, 0x2222u);
+    auto const tpl = build_block_template(pool, unlimited_ctx());
+
+    REQUIRE(tpl.txs.empty());
+    REQUIRE(tpl.total_fees == 0u);
+    REQUIRE(tpl.total_size == 0u);
+    REQUIRE(tpl.total_sigchecks == 0u);
+}
+
+TEST_CASE("block_template: includes all independent txs, CTOR-ordered, totals summed", "[block_template]") {
+    mempool pool(0x1111u, 0x2222u);
+
+    std::vector<transaction_const_ptr> txs;
+    for (uint64_t i = 0; i < 5; ++i) {
+        auto tx = as_ptr(make_tx({op(1000 + i, 0)}, 1, i));
+        txs.push_back(tx);
+        REQUIRE(pool.add(make_entry(tx, /*fee*/ 100u * (i + 1), /*size*/ 200u, /*sigchecks*/ 3u)));
+    }
+
+    auto const tpl = build_block_template(pool, unlimited_ctx());
+
+    REQUIRE(tpl.txs.size() == 5u);
+    check_template_invariants(tpl);
+    REQUIRE(tpl.total_size == 5u * 200u);
+    REQUIRE(tpl.total_sigchecks == 5u * 3u);
+    REQUIRE(tpl.total_fees == (100u + 200u + 300u + 400u + 500u));
+}
+
+TEST_CASE("block_template: size limit selects highest fee-rate first", "[block_template]") {
+    mempool pool(0x1111u, 0x2222u);
+
+    // Three independent txs, size 100 each, fee-rates 3 / 2 / 1.
+    auto hi = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto mid = as_ptr(make_tx({op(2, 0)}, 1, 2));
+    auto lo = as_ptr(make_tx({op(3, 0)}, 1, 3));
+    REQUIRE(pool.add(make_entry(hi,  /*fee*/ 300u, /*size*/ 100u, 1u)));
+    REQUIRE(pool.add(make_entry(mid, /*fee*/ 200u, /*size*/ 100u, 1u)));
+    REQUIRE(pool.add(make_entry(lo,  /*fee*/ 100u, /*size*/ 100u, 1u)));
+
+    // Coinbase reserve is 1000; budget for exactly two 100-byte txs (>= rejects the third).
+    auto ctx = unlimited_ctx();
+    ctx.max_block_size = 1000u + 250u;
+
+    auto const tpl = build_block_template(pool, ctx);
+
+    REQUIRE(tpl.txs.size() == 2u);
+    check_template_invariants(tpl);
+    REQUIRE(tpl.total_size == 200u);
+    REQUIRE(tpl.total_fees == 500u);   // 300 + 200; the fee-100 tx is dropped.
+
+    std::set<hash_digest> present;
+    for (auto const& tx : tpl.txs) present.insert(tx->hash());
+    REQUIRE(present.count(hi->hash()) == 1u);
+    REQUIRE(present.count(mid->hash()) == 1u);
+    REQUIRE(present.count(lo->hash()) == 0u);
+}
+
+TEST_CASE("block_template: sigchecks limit caps selection", "[block_template]") {
+    mempool pool(0x1111u, 0x2222u);
+
+    auto a = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto b = as_ptr(make_tx({op(2, 0)}, 1, 2));
+    auto c = as_ptr(make_tx({op(3, 0)}, 1, 3));
+    REQUIRE(pool.add(make_entry(a, 300u, 100u, /*sigchecks*/ 40u)));
+    REQUIRE(pool.add(make_entry(b, 200u, 100u, /*sigchecks*/ 40u)));
+    REQUIRE(pool.add(make_entry(c, 100u, 100u, /*sigchecks*/ 40u)));
+
+    // Reserve 100 sigchecks; budget for exactly two 40-sigcheck txs.
+    auto ctx = unlimited_ctx();
+    ctx.max_block_sigchecks = 100u + 100u;
+
+    auto const tpl = build_block_template(pool, ctx);
+
+    REQUIRE(tpl.txs.size() == 2u);
+    REQUIRE(tpl.total_sigchecks == 80u);
+}
+
+TEST_CASE("block_template: child added only after its parent (dependency completeness)", "[block_template]") {
+    mempool pool(0x1111u, 0x2222u);
+
+    // Parent: low fee-rate. Child: high fee-rate, spends the parent's output 0.
+    auto parent = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto child  = as_ptr(make_tx({output_point{parent->hash(), 0}}, 1, 2));
+
+    REQUIRE(pool.add(make_entry(parent, /*fee*/ 100u, /*size*/ 100u, 1u)));
+    REQUIRE(pool.add(make_entry(child,  /*fee*/ 900u, /*size*/ 100u, 1u)));
+
+    auto const tpl = build_block_template(pool, unlimited_ctx());
+
+    REQUIRE(tpl.txs.size() == 2u);
+    check_template_invariants(tpl);
+
+    // Both present, and the parent precedes the child in CTOR only if its txid
+    // sorts first — but regardless, the child is never present without the parent.
+    std::set<hash_digest> present;
+    for (auto const& tx : tpl.txs) present.insert(tx->hash());
+    REQUIRE(present.count(parent->hash()) == 1u);
+    REQUIRE(present.count(child->hash()) == 1u);
+}
+
+TEST_CASE("block_template: child dropped when parent does not fit", "[block_template]") {
+    mempool pool(0x1111u, 0x2222u);
+
+    // A big independent high-fee tx eats the budget; a small parent+child chain
+    // cannot fit, so neither the parent nor its child may appear.
+    auto big    = as_ptr(make_tx({op(9, 0)}, 1, 9));
+    auto parent = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto child  = as_ptr(make_tx({output_point{parent->hash(), 0}}, 1, 2));
+
+    REQUIRE(pool.add(make_entry(big,    /*fee*/ 10'000u, /*size*/ 200u, 1u)));
+    REQUIRE(pool.add(make_entry(parent, /*fee*/ 50u,     /*size*/ 200u, 1u)));
+    REQUIRE(pool.add(make_entry(child,  /*fee*/ 40u,     /*size*/ 200u, 1u)));
+
+    // Reserve 1000; budget for exactly one 200-byte tx.
+    auto ctx = unlimited_ctx();
+    ctx.max_block_size = 1000u + 350u;
+
+    auto const tpl = build_block_template(pool, ctx);
+
+    check_template_invariants(tpl);
+    std::set<hash_digest> present;
+    for (auto const& tx : tpl.txs) present.insert(tx->hash());
+    REQUIRE(present.count(big->hash()) == 1u);
+    // Child must never appear without its parent.
+    if (present.count(child->hash()) == 1u) {
+        REQUIRE(present.count(parent->hash()) == 1u);
+    }
+}
+
+TEST_CASE("block_template: non-final tx is excluded", "[block_template]") {
+    mempool pool(0x1111u, 0x2222u);
+
+    auto final_tx = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    // locktime as a future height with a non-final input sequence => not final
+    // at the template height (ctx.height == 100).
+    auto non_final = as_ptr(make_tx({op(2, 0)}, 1, 2, /*locktime*/ 100000u, /*sequence*/ 0u));
+
+    REQUIRE(pool.add(make_entry(final_tx,  100u, 100u, 1u)));
+    REQUIRE(pool.add(make_entry(non_final, 900u, 100u, 1u)));
+
+    auto const tpl = build_block_template(pool, unlimited_ctx());
+
+    std::set<hash_digest> present;
+    for (auto const& tx : tpl.txs) present.insert(tx->hash());
+    REQUIRE(present.count(final_tx->hash()) == 1u);
+    REQUIRE(present.count(non_final->hash()) == 0u);
+}


### PR DESCRIPTION
Implements block-template assembly (`getblocktemplate`) against the new mempool, mirroring BCHN's `BlockAssembler` (`miner.cpp` `addTxs`).

**Stacked on #504** (per-tx sigchecks caching) — review/merge that first.

### Selection (mirrors BCHN)
- Snapshot the lock-free pool via `for_each`, derive in-mempool parent/child adjacency locally from the snapshot, and order candidates by **individual fee-rate**.
- A tx is added only once all its in-mempool parents are in (skip/backlog scheme), so the selected set is **dependency-complete under CTOR** — no CPFP / ancestor-package scoring (removed from BCHN years ago).
- Enforces block **size** and **sigchecks** limits (with a coinbase reserve) and per-tx **finality** at the template height; emits the result in **CTOR** order (coinbase prepended by the caller).

### API
- `build_block_template(mempool const&, block_template_context const&)` takes plain limit/height/MTP scalars, so it is a pure function of `(mempool, context)` — independent of `chain_state` and directly unit-testable.
- `block_chain::fetch_template` (previously `abort()`ing) builds the context from `chain_state` and returns a `block_template { txs (sans coinbase, CTOR-ordered), total_fees, total_size, total_sigchecks }`.
- Removes the dead `transaction_organizer::fetch_template` stub (no callers).

### Tests
`block_template_test.cpp`: empty pool, CTOR ordering + totals, size and sigchecks limits, parent-before-child completeness, child-dropped-when-parent-doesn't-fit, finality exclusion.

Local build (blockchain lib + tests + node) and the full blockchain suite green (cfm backend). Change does not touch backend-specific `mempool_map` code, so it is backend-agnostic.

### Follow-ups (not in this PR)
- A configurable *generated* block size (BCHN's `-blockmaxsize`); currently caps at the consensus size minus the coinbase reserve.
- Validation-level mirror test vs BCHN for a full chained template (needs integration infra).