### PR TITLE
mempool: persist the mempool to disk across restarts (mempool.dat)

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -297,6 +297,7 @@ if (ENABLE_TEST)
         test/branch.cpp
         test/validate_transaction.cpp
         test/mempool_test.cpp
+        test/mempool_persistence_test.cpp
         test/block_template_test.cpp
     )
 

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -404,6 +404,15 @@ struct KB_API block_chain {
     mempool_mini_hash_map get_mempool_mini_hash_map(domain::message::compact_block const& block) const;
     void fill_tx_list_from_mempool(domain::message::compact_block const& block, size_t& mempool_count, std::vector<domain::chain::transaction>& txn_available, std::unordered_map<uint64_t, uint16_t> const& shorttxids) const;
 
+    // Persist the mempool to <datadir>/mempool.dat (called on shutdown; also
+    // backs a future savemempool). Returns false on I/O error.
+    bool dump_mempool_to_disk() const;
+
+    // Re-admit the persisted mempool through normal validation against the
+    // current tip (called on startup, after the chain is up). Now-invalid /
+    // confirmed / conflicting transactions are dropped. Returns the count admitted.
+    [[nodiscard]] ::asio::awaitable<size_t> load_mempool_from_disk();
+
     // =========================================================================
     // FILTERS
     // =========================================================================
@@ -457,6 +466,9 @@ private:
     bool finish_read(handle sequence, Handler handler, Args... args) const;
 
     code set_chain_state(domain::chain::chain_state::ptr previous);
+
+    // <datadir>/mempool.dat — sibling of the blocks/ and utxoz/ directories.
+    std::filesystem::path mempool_dat_path() const;
 
     // Thread safe members
     std::atomic<bool> stopped_;

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -293,6 +293,9 @@ bool block_chain::stop() {
 
 bool block_chain::close() {
     auto const result = stop();
+    // Persist the mempool now that admission is quiesced and before the DB dir
+    // is torn down (the path is a plain sibling of the DB, still valid here).
+    dump_mempool_to_disk();
     priority_pool_.join();
     utxoz_db_.close();
     return result && database_.close();
@@ -1514,6 +1517,39 @@ block_chain::fetch_mempool(size_t count_limit, uint64_t /*minimum_fee*/) const {
     }
 
     co_return std::make_shared<domain::message::inventory>(std::move(*inv));
+}
+
+std::filesystem::path block_chain::mempool_dat_path() const {
+    return database_.internal_db_dir.parent_path() / "mempool.dat";
+}
+
+bool block_chain::dump_mempool_to_disk() const {
+    // Snapshot the pool; the database module owns the on-disk format.
+    std::vector<database::mempool_stored_tx> txs;
+    txs.reserve(mempool_.size());
+    mempool_.for_each([&](mempool_entry const& e) {
+        txs.push_back({e.tx, e.time_seen});
+    });
+    return database::store_mempool(mempool_dat_path(), std::move(txs));
+}
+
+::asio::awaitable<size_t> block_chain::load_mempool_from_disk() {
+    auto const persisted = database::load_mempool(mempool_dat_path());
+
+    size_t admitted = 0;
+    for (auto const& p : persisted) {
+        // Re-validate against the current tip and admit (recomputes fee/size/
+        // sigchecks, enforces first-seen). Now-invalid txs are simply dropped.
+        auto const ec = co_await organize(p.tx);
+        if ( ! ec) {
+            ++admitted;
+        }
+    }
+
+    if ( ! persisted.empty()) {
+        spdlog::info("[blockchain] Re-admitted {}/{} persisted mempool transactions", admitted, persisted.size());
+    }
+    co_return admitted;
 }
 
 namespace {

--- a/src/blockchain/test/mempool_persistence_test.cpp
+++ b/src/blockchain/test/mempool_persistence_test.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Round-trip tests for mempool.dat persistence (kth::database::store_mempool /
+// load_mempool): serialization fidelity, time_seen ordering, and graceful
+// handling of a missing / corrupt file. Lives in the blockchain test suite
+// because the database module has no active test target of its own.
+
+#include <test_helpers.hpp>
+
+#include <kth/database/mempool_store.hpp>
+#include <kth/domain.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <vector>
+
+using namespace kth;
+using namespace kth::domain::chain;
+using kth::database::mempool_stored_tx;
+using kth::database::store_mempool;
+using kth::database::load_mempool;
+
+namespace {
+
+hash_digest make_hash(uint64_t seed) {
+    hash_digest h{};
+    for (int i = 0; i < 8; ++i) {
+        h[i] = static_cast<uint8_t>(seed >> (8 * i));
+    }
+    h[16] = static_cast<uint8_t>(seed >> 5);
+    h[31] = static_cast<uint8_t>(seed >> 11);
+    return h;
+}
+
+output_point op(uint64_t seed, uint32_t index) {
+    return output_point{make_hash(seed), index};
+}
+
+transaction make_tx(std::vector<output_point> const& prevouts, uint32_t num_outputs, uint64_t tag) {
+    input::list ins;
+    ins.reserve(prevouts.size());
+    for (auto const& po : prevouts) {
+        ins.emplace_back(po, script{}, 0xffffffffu);
+    }
+    output::list outs;
+    outs.reserve(num_outputs);
+    for (uint32_t i = 0; i < num_outputs; ++i) {
+        output o;
+        o.set_value(1000u + tag * 100u + i);
+        o.set_script(script{});
+        outs.push_back(std::move(o));
+    }
+    return transaction{1u, 0u, std::move(ins), std::move(outs)};
+}
+
+transaction_const_ptr as_ptr(transaction const& tx) {
+    return std::make_shared<domain::message::transaction>(tx);
+}
+
+mempool_stored_tx stored(transaction_const_ptr const& tx, uint64_t time_seen) {
+    return mempool_stored_tx{tx, time_seen};
+}
+
+// A per-test unique temp path that is removed on scope exit.
+struct temp_dat {
+    std::filesystem::path path;
+    explicit temp_dat(char const* name)
+        : path(std::filesystem::temp_directory_path() / name) {
+        std::filesystem::remove(path);
+    }
+    ~temp_dat() {
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+        std::filesystem::remove(path.string() + ".new", ec);
+    }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+
+TEST_CASE("mempool persistence: empty set round-trips to empty", "[mempool_persistence]") {
+    temp_dat dat("kth_mp_persist_empty.dat");
+
+    REQUIRE(store_mempool(dat.path, {}));
+    auto const loaded = load_mempool(dat.path);
+    REQUIRE(loaded.empty());
+}
+
+TEST_CASE("mempool persistence: round-trips txs, ordered by time_seen", "[mempool_persistence]") {
+    temp_dat dat("kth_mp_persist_rt.dat");
+
+    auto a = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto b = as_ptr(make_tx({op(2, 0)}, 1, 2));
+    auto c = as_ptr(make_tx({op(3, 0)}, 1, 3));
+
+    // Deliberately out-of-order time_seen; store must write them sorted ascending.
+    std::vector<mempool_stored_tx> txs{stored(a, 300u), stored(b, 100u), stored(c, 200u)};
+    REQUIRE(store_mempool(dat.path, txs));
+
+    auto const loaded = load_mempool(dat.path);
+    REQUIRE(loaded.size() == 3u);
+    REQUIRE(loaded[0].time_seen == 100u);
+    REQUIRE(loaded[1].time_seen == 200u);
+    REQUIRE(loaded[2].time_seen == 300u);
+    REQUIRE(loaded[0].tx->hash() == b->hash());
+    REQUIRE(loaded[1].tx->hash() == c->hash());
+    REQUIRE(loaded[2].tx->hash() == a->hash());
+}
+
+TEST_CASE("mempool persistence: tx content survives the round-trip", "[mempool_persistence]") {
+    temp_dat dat("kth_mp_persist_content.dat");
+
+    auto tx = as_ptr(make_tx({op(7, 0), op(8, 1)}, 3, 42));
+    REQUIRE(store_mempool(dat.path, {stored(tx, 555u)}));
+
+    auto const loaded = load_mempool(dat.path);
+    REQUIRE(loaded.size() == 1u);
+    // Equal txid == equal serialization (txid is the double-SHA256 of the tx).
+    REQUIRE(loaded[0].tx->hash() == tx->hash());
+    REQUIRE(loaded[0].tx->inputs().size() == 2u);
+    REQUIRE(loaded[0].tx->outputs().size() == 3u);
+    REQUIRE(loaded[0].time_seen == 555u);
+}
+
+TEST_CASE("mempool persistence: missing file loads to empty", "[mempool_persistence]") {
+    auto const missing = std::filesystem::temp_directory_path() / "kth_mp_persist_does_not_exist.dat";
+    std::filesystem::remove(missing);
+    auto const loaded = load_mempool(missing);
+    REQUIRE(loaded.empty());
+}
+
+TEST_CASE("mempool persistence: corrupt file loads to empty without throwing", "[mempool_persistence]") {
+    temp_dat dat("kth_mp_persist_corrupt.dat");
+    {
+        std::ofstream out(dat.path, std::ios::binary | std::ios::trunc);
+        char const garbage[] = "not a valid mempool.dat header at all";
+        out.write(garbage, sizeof(garbage));
+    }
+    auto const loaded = load_mempool(dat.path);
+    REQUIRE(loaded.empty());
+}

--- a/src/database/CMakeLists.txt
+++ b/src/database/CMakeLists.txt
@@ -126,6 +126,7 @@ set(kth_sources_just_kth
     src/flat_file_seq.cpp
     src/block_undo.cpp
     src/block_store.cpp
+    src/mempool_store.cpp
     src/header_index.cpp
 )
 
@@ -144,6 +145,7 @@ set(kth_headers
   include/kth/database/flat_file_seq.hpp
   include/kth/database/block_undo.hpp
   include/kth/database/block_store.hpp
+  include/kth/database/mempool_store.hpp
   include/kth/database/databases/block_database.ipp
   include/kth/database/databases/property_code.hpp
   include/kth/database/databases/internal_database.ipp

--- a/src/database/include/kth/database.hpp
+++ b/src/database/include/kth/database.hpp
@@ -15,6 +15,7 @@
 #include <kth/domain.hpp>
 #include <kth/database/data_base.hpp>
 #include <kth/database/define.hpp>
+#include <kth/database/mempool_store.hpp>
 #include <kth/database/settings.hpp>
 #include <kth/database/store.hpp>
 #include <kth/database/databases/internal_database.hpp>

--- a/src/database/include/kth/database/mempool_store.hpp
+++ b/src/database/include/kth/database/mempool_store.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_DATABASE_MEMPOOL_STORE_HPP
+#define KTH_DATABASE_MEMPOOL_STORE_HPP
+
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+#include <kth/domain.hpp>
+
+#include <kth/database/define.hpp>
+
+namespace kth::database {
+
+// One transaction as stored in mempool.dat, with the time it was first seen.
+struct mempool_stored_tx {
+    transaction_const_ptr tx;
+    uint64_t time_seen;
+};
+
+// Serialize the transactions to `file`, written atomically (temp sibling +
+// rename-over). Entries are ordered by time_seen ascending so parents
+// (first-seen earlier) precede their children on reload. Returns false on any
+// I/O error. Format: version + count + [tx, time_seen] per entry.
+KD_API
+bool store_mempool(std::filesystem::path const& file, std::vector<mempool_stored_tx> txs);
+
+// Read a mempool.dat written by store_mempool, in file order (time_seen
+// ascending). Empty on a missing / corrupt / wrong-version file (logged; the
+// caller just starts without a persisted mempool).
+KD_API
+std::vector<mempool_stored_tx> load_mempool(std::filesystem::path const& file);
+
+} // namespace kth::database
+
+#endif // KTH_DATABASE_MEMPOOL_STORE_HPP

--- a/src/database/src/mempool_store.cpp
+++ b/src/database/src/mempool_store.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/database/mempool_store.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
+
+#include <spdlog/spdlog.h>
+
+namespace kth::database {
+
+using namespace kth::domain::chain;
+
+namespace {
+// Bumped whenever the on-disk layout changes; a mismatch is ignored on load.
+constexpr uint64_t mempool_dump_version = 1;
+} // namespace
+
+bool store_mempool(std::filesystem::path const& file, std::vector<mempool_stored_tx> txs) {
+    // Order by time_seen so parents (first-seen earlier) precede their children
+    // on reload and re-admit cleanly.
+    std::sort(txs.begin(), txs.end(),
+        [](mempool_stored_tx const& a, mempool_stored_tx const& b) {
+            return a.time_seen < b.time_seen;
+        });
+
+    // Exact buffer size: version + count, then per tx (serialized tx + time).
+    size_t total = sizeof(uint64_t) * 2;
+    for (auto const& e : txs) {
+        total += e.tx->serialized_size(true) + sizeof(uint64_t);
+    }
+
+    data_chunk buffer(total);
+    byte_writer writer(buffer);
+    if ( ! writer.write_little_endian<uint64_t>(mempool_dump_version)) return false;
+    if ( ! writer.write_little_endian<uint64_t>(static_cast<uint64_t>(txs.size()))) return false;
+    for (auto const& e : txs) {
+        if ( ! e.tx->to_data(writer, true)) return false;
+        if ( ! writer.write_little_endian<uint64_t>(e.time_seen)) return false;
+    }
+
+    // Write to a sibling temp then rename over, so a crash mid-write never
+    // leaves a truncated mempool.dat.
+    auto const tmp = file.string() + ".new";
+    {
+        std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+        if ( ! out) {
+            spdlog::warn("[database] could not open {} for writing", tmp);
+            return false;
+        }
+        out.write(reinterpret_cast<char const*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
+        out.flush();
+        if ( ! out) {
+            spdlog::warn("[database] failed to write {}", tmp);
+            return false;
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::rename(tmp, file, ec);
+    if (ec) {
+        spdlog::warn("[database] failed to rename {} -> {}: {}", tmp, file.string(), ec.message());
+        std::filesystem::remove(tmp, ec);
+        return false;
+    }
+
+    spdlog::info("[database] dumped {} mempool transactions to {}", txs.size(), file.string());
+    return true;
+}
+
+std::vector<mempool_stored_tx> load_mempool(std::filesystem::path const& file) {
+    std::vector<mempool_stored_tx> result;
+
+    std::error_code ec;
+    if ( ! std::filesystem::exists(file, ec) || ec) {
+        return result;  // no persisted mempool; not an error
+    }
+
+    std::ifstream in(file, std::ios::binary | std::ios::ate);
+    if ( ! in) {
+        spdlog::warn("[database] could not open {} for reading", file.string());
+        return result;
+    }
+    auto const size = static_cast<std::streamsize>(in.tellg());
+    in.seekg(0);
+    data_chunk buffer(static_cast<size_t>(std::max<std::streamsize>(size, 0)));
+    if (size > 0 && ! in.read(reinterpret_cast<char*>(buffer.data()), size)) {
+        spdlog::warn("[database] failed to read {}", file.string());
+        return result;
+    }
+
+    byte_reader reader(buffer);
+    auto const version = reader.read_little_endian<uint64_t>();
+    if ( ! version || *version != mempool_dump_version) {
+        spdlog::warn("[database] {}: missing or unsupported mempool dump version", file.string());
+        return result;
+    }
+    auto const count = reader.read_little_endian<uint64_t>();
+    if ( ! count) {
+        return result;
+    }
+
+    result.reserve(static_cast<size_t>(*count));
+    for (uint64_t i = 0; i < *count; ++i) {
+        auto tx = transaction::from_data(reader, true);
+        if ( ! tx) {
+            spdlog::warn("[database] {}: corrupt transaction at {}/{}; stopping", file.string(), i, *count);
+            break;
+        }
+        auto const time = reader.read_little_endian<uint64_t>();
+        if ( ! time) {
+            spdlog::warn("[database] {}: truncated after transaction {}; stopping", file.string(), i);
+            break;
+        }
+        result.push_back({std::make_shared<domain::message::transaction>(std::move(*tx)), *time});
+    }
+
+    spdlog::info("[database] read {} mempool transactions from {}", result.size(), file.string());
+    return result;
+}
+
+} // namespace kth::database

--- a/src/node/src/full_node.cpp
+++ b/src/node/src/full_node.cpp
@@ -101,6 +101,10 @@ full_node::~full_node() {
         co_return error::operation_failed;
     }
 
+    // Reload the persisted mempool (re-validated against the current tip) before
+    // the network comes up, so peers can be served from a warm mempool.
+    co_await chain_.load_mempool_from_disk();
+
 #if ! defined(__EMSCRIPTEN__)
     // Start the P2P network
     auto ec = co_await network_.start();


### PR DESCRIPTION
Adds Core/BCHN-style mempool persistence so unconfirmed transactions survive a node restart. This is the prerequisite for exposing the mempool through the C-API / JSON-RPC (and unblocks a future `savemempool`).

### Serialization (`pools/mempool_persistence`)
- `dump_mempool(pool, path)` — serializes each pooled tx with its `time_seen` to `<datadir>/mempool.dat`, written **atomically** (temp sibling + rename-over). Entries are ordered by `time_seen` ascending so parents (first-seen earlier) precede their children on reload.
- `load_mempool(path)` — reads it back; a missing / corrupt / wrong-version file loads to empty (logged; the node just starts cold). Format: `version + count + [tx, time_seen]` per entry. No prioritisation deltas (KTH has no `prioritisetransaction`).

### Lifecycle wiring
- `block_chain::dump_mempool_to_disk()` — called from `close()`, after admission is quiesced by `stop()` and while the DB dir path is still valid. Also backs a future `savemempool`.
- `block_chain::load_mempool_from_disk()` — an awaitable that re-admits each persisted tx through `organize()`, **re-validating against the current tip** (BCHN semantics): now-invalid / confirmed / conflicting txs are dropped and fee/size/sigchecks recomputed.
- `full_node::start()` reloads the mempool right after the chain is up and before the network starts, so peers are served from a warm mempool.

### Tests
`mempool_persistence_test`: empty round-trip, `time_seen` ordering, content fidelity (txid + structure), and graceful handling of missing / corrupt files.

Local build (blockchain + node) and full blockchain suite green (993 assertions, cfm backend). Backend-agnostic (uses only the mempool's public `for_each`/`size` + domain serialization).