### PR TITLE
mempool: add mempool query readers for the BCH JSON-RPC mempool calls

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <functional>
 #include <expected>
+#include <optional>
 #include <vector>
 
 #include <kth/infrastructure/utility/atomic.hpp>
@@ -46,6 +47,14 @@ namespace kth::blockchain {
 
 using kth::awaitable_expected;
 using database::heights_t;
+
+// One pooled transaction's own metadata (== BCHN getmempoolentry scalars; its
+// depends / spentby are separate list queries).
+struct mempool_entry_info {
+    uint64_t fee;   // satoshis
+    uint32_t size;  // serialized bytes
+    uint64_t time;  // time first seen (unix seconds)
+};
 
 /// Unified blockchain interface.
 /// Thread safety: get_* methods are NOT thread safe, fetch_* methods are thread safe.
@@ -403,6 +412,15 @@ struct KB_API block_chain {
 
     mempool_mini_hash_map get_mempool_mini_hash_map(domain::message::compact_block const& block) const;
     void fill_tx_list_from_mempool(domain::message::compact_block const& block, size_t& mempool_count, std::vector<domain::chain::transaction>& txn_available, std::unordered_map<uint64_t, uint16_t> const& shorttxids) const;
+
+    // Mempool query readers, backing the typical BCH JSON-RPC mempool calls.
+    std::vector<hash_digest> get_mempool_txids() const;                                              // getrawmempool
+    blockchain::mempool_totals get_mempool_info() const;                                             // getmempoolinfo
+    std::optional<mempool_entry_info> get_mempool_entry(hash_digest const& txid) const;              // getmempoolentry
+    std::vector<hash_digest> get_mempool_depends(hash_digest const& txid) const;                     // getmempoolentry.depends
+    std::vector<hash_digest> get_mempool_spentby(hash_digest const& txid) const;                     // getmempoolentry.spentby
+    std::vector<hash_digest> get_mempool_ancestors(hash_digest const& txid) const;                   // getmempoolancestors
+    std::vector<hash_digest> get_mempool_descendants(hash_digest const& txid) const;                 // getmempooldescendants
 
     // Persist the mempool to <datadir>/mempool.dat (called on shutdown; also
     // backs a future savemempool). Returns false on I/O error.

--- a/src/blockchain/include/kth/blockchain/pools/mempool.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <vector>
 
 #include <kth/domain.hpp>
 
@@ -29,6 +30,14 @@ struct mempool_entry {
     uint32_t size;
     uint32_t sigchecks;
     uint64_t time_seen;
+};
+
+// Aggregate figures over the whole pool (== the BCHN getmempoolinfo fields KTH
+// backs). Computed on demand by summary().
+struct mempool_totals {
+    std::size_t size;   // number of transactions
+    uint64_t bytes;     // sum of serialized sizes
+    uint64_t total_fee; // sum of fees (satoshis)
 };
 
 // The BCH mempool: unconfirmed transactions in two concurrent maps —
@@ -79,6 +88,24 @@ struct mempool {
     // Fetch a pooled transaction by id (null if absent).
     transaction_const_ptr get(hash_digest const& txid) const;
 
+    // Copy a pooled entry (tx + policy metadata) by id, or nullopt if absent.
+    std::optional<mempool_entry> entry(hash_digest const& txid) const;
+
+    // Read-only graph queries over the pool (mirror BCHN CTxMemPool). `parents`
+    // / `children` are the direct in-mempool adjacency (== BCHN depends /
+    // spentby); `ancestors` / `descendants` are their transitive closures. All
+    // exclude `txid` itself and are de-duplicated. Empty if txid is not pooled.
+    std::vector<hash_digest> parents(hash_digest const& txid) const;
+    std::vector<hash_digest> children(hash_digest const& txid) const;
+    std::vector<hash_digest> ancestors(hash_digest const& txid) const;
+    std::vector<hash_digest> descendants(hash_digest const& txid) const;
+
+    // The ids of every pooled transaction (== BCHN getrawmempool).
+    std::vector<hash_digest> all_txids() const;
+
+    // Aggregate size / bytes / total_fee over the pool (== getmempoolinfo).
+    mempool_totals summary() const;
+
     // Visit every pooled entry. Snapshot-ish under concurrency (an entry added
     // or removed during the walk may or may not be seen) — fine for the
     // read-only listing/relay queries that use it.
@@ -100,6 +127,12 @@ private:
     // Remove a tx and, transitively, every pool tx that spends its outputs
     // (the rare invalid/conflict path).
     void remove_recursive(hash_digest const& txid);
+
+    // Direct in-mempool adjacency, un-instrumented (the public parents/children
+    // wrap these with stats; the ancestors/descendants traversal reuses them so
+    // the internal walk is not counted as top-level calls).
+    std::vector<hash_digest> parents_of(hash_digest const& txid) const;
+    std::vector<hash_digest> children_of(hash_digest const& txid) const;
 
     mempool_map<hash_digest, mempool_entry, salted_txid_hasher> pool_;
     mempool_map<outpoint_key, hash_digest, salted_outpoint_hasher> spent_by_;

--- a/src/blockchain/include/kth/blockchain/pools/mempool_stats.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool_stats.hpp
@@ -33,12 +33,36 @@ struct mempool_stats {
     std::atomic<uint64_t> resolve_hits{0};
     std::atomic<uint64_t> resolve_time_ns{0};
 
+    // Query readers (JSON-RPC-facing: getrawmempool / getmempoolentry /
+    // getmempoolinfo / getmempoolancestors / getmempooldescendants).
+    std::atomic<uint64_t> entry_calls{0};
+    std::atomic<uint64_t> entry_time_ns{0};
+    std::atomic<uint64_t> parents_calls{0};
+    std::atomic<uint64_t> parents_time_ns{0};
+    std::atomic<uint64_t> children_calls{0};
+    std::atomic<uint64_t> children_time_ns{0};
+    std::atomic<uint64_t> ancestors_calls{0};
+    std::atomic<uint64_t> ancestors_time_ns{0};
+    std::atomic<uint64_t> descendants_calls{0};
+    std::atomic<uint64_t> descendants_time_ns{0};
+    std::atomic<uint64_t> txids_calls{0};
+    std::atomic<uint64_t> txids_time_ns{0};
+    std::atomic<uint64_t> info_calls{0};
+    std::atomic<uint64_t> info_time_ns{0};
+
     void reset_all() {
         add_calls = 0; add_inserted = 0; add_rejected_duplicate = 0;
         add_rejected_conflict = 0; add_time_ns = 0;
         remove_for_block_calls = 0; removed_confirmed = 0; removed_conflict = 0;
         remove_time_ns = 0;
         resolve_calls = 0; resolve_hits = 0; resolve_time_ns = 0;
+        entry_calls = 0; entry_time_ns = 0;
+        parents_calls = 0; parents_time_ns = 0;
+        children_calls = 0; children_time_ns = 0;
+        ancestors_calls = 0; ancestors_time_ns = 0;
+        descendants_calls = 0; descendants_time_ns = 0;
+        txids_calls = 0; txids_time_ns = 0;
+        info_calls = 0; info_time_ns = 0;
     }
 };
 

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1519,6 +1519,38 @@ block_chain::fetch_mempool(size_t count_limit, uint64_t /*minimum_fee*/) const {
     co_return std::make_shared<domain::message::inventory>(std::move(*inv));
 }
 
+std::vector<hash_digest> block_chain::get_mempool_txids() const {
+    return mempool_.all_txids();
+}
+
+blockchain::mempool_totals block_chain::get_mempool_info() const {
+    return mempool_.summary();
+}
+
+std::optional<mempool_entry_info> block_chain::get_mempool_entry(hash_digest const& txid) const {
+    auto const e = mempool_.entry(txid);
+    if ( ! e) {
+        return std::nullopt;
+    }
+    return mempool_entry_info{e->fee, e->size, e->time_seen};
+}
+
+std::vector<hash_digest> block_chain::get_mempool_depends(hash_digest const& txid) const {
+    return mempool_.parents(txid);
+}
+
+std::vector<hash_digest> block_chain::get_mempool_spentby(hash_digest const& txid) const {
+    return mempool_.children(txid);
+}
+
+std::vector<hash_digest> block_chain::get_mempool_ancestors(hash_digest const& txid) const {
+    return mempool_.ancestors(txid);
+}
+
+std::vector<hash_digest> block_chain::get_mempool_descendants(hash_digest const& txid) const {
+    return mempool_.descendants(txid);
+}
+
 std::filesystem::path block_chain::mempool_dat_path() const {
     return database_.internal_db_dir.parent_path() / "mempool.dat";
 }

--- a/src/blockchain/src/pools/mempool.cpp
+++ b/src/blockchain/src/pools/mempool.cpp
@@ -4,11 +4,15 @@
 
 #include <kth/blockchain/pools/mempool.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <optional>
 #include <utility>
 #include <vector>
+
+#include <boost/unordered/unordered_flat_set.hpp>
 
 #include <kth/infrastructure/utility/pseudo_random.hpp>
 
@@ -195,6 +199,149 @@ transaction_const_ptr mempool::get(hash_digest const& txid) const {
 
 std::size_t mempool::size() const {
     return pool_.size();
+}
+
+std::optional<mempool_entry> mempool::entry(hash_digest const& txid) const {
+    KTH_STATS_INCREMENT(stats_, entry_calls);
+    KTH_STATS_TIME_START(entry);
+
+    std::optional<mempool_entry> result;
+    pool_.visit(txid, [&](mempool_entry const& e) {
+        result = e;
+    });
+
+    KTH_STATS_TIME_ADD(stats_, entry, entry_time_ns);
+    return result;
+}
+
+// Direct adjacency, un-instrumented (see header). Read pool_ / spent_by_ once
+// each; de-duplicate with a linear scan (input/output counts are small).
+std::vector<hash_digest> mempool::parents_of(hash_digest const& txid) const {
+    std::vector<hash_digest> result;
+    pool_.visit(txid, [&](mempool_entry const& e) {
+        for (auto const& in : e.tx->inputs()) {
+            auto const& p = in.previous_output().hash();
+            if (std::find(result.begin(), result.end(), p) == result.end() && contains(p)) {
+                result.push_back(p);
+            }
+        }
+    });
+    return result;
+}
+
+std::vector<hash_digest> mempool::children_of(hash_digest const& txid) const {
+    std::vector<hash_digest> result;
+    pool_.visit(txid, [&](mempool_entry const& e) {
+        auto const outputs = static_cast<uint32_t>(e.tx->outputs().size());
+        for (uint32_t index = 0; index < outputs; ++index) {
+            spent_by_.visit(outpoint_key{txid, index}, [&](hash_digest const& c) {
+                if (std::find(result.begin(), result.end(), c) == result.end()) {
+                    result.push_back(c);
+                }
+            });
+        }
+    });
+    return result;
+}
+
+std::vector<hash_digest> mempool::parents(hash_digest const& txid) const {
+    KTH_STATS_INCREMENT(stats_, parents_calls);
+    KTH_STATS_TIME_START(parents);
+    auto result = parents_of(txid);
+    KTH_STATS_TIME_ADD(stats_, parents, parents_time_ns);
+    return result;
+}
+
+std::vector<hash_digest> mempool::children(hash_digest const& txid) const {
+    KTH_STATS_INCREMENT(stats_, children_calls);
+    KTH_STATS_TIME_START(children);
+    auto result = children_of(txid);
+    KTH_STATS_TIME_ADD(stats_, children, children_time_ns);
+    return result;
+}
+
+namespace {
+// The txid is already a uniform digest; the low 8 bytes make a fine key hash.
+struct digest_hasher {
+    std::size_t operator()(hash_digest const& h) const {
+        std::size_t out;
+        std::memcpy(&out, h.data(), sizeof(out));
+        return out;
+    }
+};
+
+// Breadth-first transitive closure of `step` (parents_of / children_of) from
+// `txid`, excluding `txid`, de-duplicated. O(V+E) with O(1) hashed dedup — no
+// node is revisited, which bounds the walk even without a chain limit.
+template <typename Step>
+std::vector<hash_digest> closure(hash_digest const& txid, Step&& step) {
+    std::vector<hash_digest> result;
+    boost::unordered_flat_set<hash_digest, digest_hasher> seen;
+    auto stack = step(txid);
+    for (auto const& h : stack) {
+        seen.insert(h);
+    }
+    while ( ! stack.empty()) {
+        auto const cur = stack.back();
+        stack.pop_back();
+        result.push_back(cur);
+        for (auto const& next : step(cur)) {
+            if (seen.insert(next).second) {
+                stack.push_back(next);
+            }
+        }
+    }
+    return result;
+}
+} // namespace
+
+std::vector<hash_digest> mempool::ancestors(hash_digest const& txid) const {
+    KTH_STATS_INCREMENT(stats_, ancestors_calls);
+    KTH_STATS_TIME_START(ancestors);
+    auto result = closure(txid, [this](hash_digest const& h) { return parents_of(h); });
+    KTH_STATS_TIME_ADD(stats_, ancestors, ancestors_time_ns);
+    return result;
+}
+
+std::vector<hash_digest> mempool::descendants(hash_digest const& txid) const {
+    KTH_STATS_INCREMENT(stats_, descendants_calls);
+    KTH_STATS_TIME_START(descendants);
+    auto result = closure(txid, [this](hash_digest const& h) { return children_of(h); });
+    KTH_STATS_TIME_ADD(stats_, descendants, descendants_time_ns);
+    return result;
+}
+
+std::vector<hash_digest> mempool::all_txids() const {
+    KTH_STATS_INCREMENT(stats_, txids_calls);
+    KTH_STATS_TIME_START(txids);
+
+    std::vector<hash_digest> result;
+    result.reserve(pool_.size());
+    pool_.for_each([&](hash_digest const& txid, mempool_entry const&) {
+        result.push_back(txid);
+    });
+
+    KTH_STATS_TIME_ADD(stats_, txids, txids_time_ns);
+    return result;
+}
+
+mempool_totals mempool::summary() const {
+    KTH_STATS_INCREMENT(stats_, info_calls);
+    KTH_STATS_TIME_START(info);
+
+    // On-demand O(n) scan. If getmempoolinfo is ever polled hard over a huge
+    // pool, maintain running byte/fee totals in add/remove instead — but the
+    // totals are informational (nothing consensus/mining depends on them) so
+    // this stays simple until a profile says otherwise.
+    mempool_totals totals{0, 0, 0};
+    pool_.for_each([&](hash_digest const&, mempool_entry const& e) {
+        ++totals.size;
+        totals.bytes += e.size;
+        totals.total_fee += e.fee;
+    });
+
+    KTH_STATS_TIME_ADD(stats_, info, info_time_ns);
+    return totals;
 }
 
 } // namespace kth::blockchain

--- a/src/blockchain/test/mempool_test.cpp
+++ b/src/blockchain/test/mempool_test.cpp
@@ -19,6 +19,7 @@
 #include <kth/blockchain/pools/mempool.hpp>
 #include <kth/domain.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <map>
@@ -292,6 +293,91 @@ TEST_CASE("mempool update_for_reorg evicts for incoming blocks", "[mempool][seri
     CHECK_FALSE(mp.contains(b.hash()));
     CHECK(mp.contains(other.hash()));
     CHECK(mp.size() == 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Graph queries (entry / parents / children / ancestors / descendants)
+// ---------------------------------------------------------------------------
+
+namespace {
+// Sort a copy so graph-query results can be compared irrespective of order.
+std::vector<hash_digest> sorted(std::vector<hash_digest> v) {
+    std::sort(v.begin(), v.end());
+    return v;
+}
+} // namespace
+
+TEST_CASE("mempool entry returns metadata or nullopt", "[mempool][serial]") {
+    mempool mp(1, 2);
+    auto const tx = make_tx({op(1, 0)}, 1, 1);
+    mp.add(entry_for(tx, 7));
+
+    auto const e = mp.entry(tx.hash());
+    REQUIRE(e.has_value());
+    CHECK(e->tx->hash() == tx.hash());
+    CHECK(e->time_seen == 7u);
+
+    CHECK_FALSE(mp.entry(make_hash(999)).has_value());
+}
+
+TEST_CASE("mempool parents and children give direct adjacency", "[mempool][serial]") {
+    mempool mp(1, 2);
+    // parent has 2 outputs; child spends output 0; grandchild spends child's 0.
+    auto const parent = make_tx({op(1, 0)}, 2, 1);
+    auto const child = make_tx({output_point{parent.hash(), 0}}, 1, 2);
+    auto const grandchild = make_tx({output_point{child.hash(), 0}}, 1, 3);
+    mp.add(entry_for(parent, 1));
+    mp.add(entry_for(child, 2));
+    mp.add(entry_for(grandchild, 3));
+
+    CHECK(mp.parents(child.hash()) == std::vector<hash_digest>{parent.hash()});
+    CHECK(mp.children(parent.hash()) == std::vector<hash_digest>{child.hash()});
+    CHECK(mp.children(child.hash()) == std::vector<hash_digest>{grandchild.hash()});
+    // Endpoints: parent has no in-pool parent, grandchild has no child.
+    CHECK(mp.parents(parent.hash()).empty());
+    CHECK(mp.children(grandchild.hash()).empty());
+    // A confirmed/absent prevout is not an in-pool parent.
+    CHECK(mp.parents(parent.hash()).empty());
+}
+
+TEST_CASE("mempool ancestors and descendants give transitive closure", "[mempool][serial]") {
+    mempool mp(1, 2);
+    auto const parent = make_tx({op(1, 0)}, 2, 1);
+    auto const child = make_tx({output_point{parent.hash(), 0}}, 1, 2);
+    auto const grandchild = make_tx({output_point{child.hash(), 0}}, 1, 3);
+    mp.add(entry_for(parent, 1));
+    mp.add(entry_for(child, 2));
+    mp.add(entry_for(grandchild, 3));
+
+    CHECK(sorted(mp.ancestors(grandchild.hash())) == sorted({parent.hash(), child.hash()}));
+    CHECK(mp.ancestors(child.hash()) == std::vector<hash_digest>{parent.hash()});
+    CHECK(mp.ancestors(parent.hash()).empty());
+
+    CHECK(sorted(mp.descendants(parent.hash())) == sorted({child.hash(), grandchild.hash()}));
+    CHECK(mp.descendants(child.hash()) == std::vector<hash_digest>{grandchild.hash()});
+    CHECK(mp.descendants(grandchild.hash()).empty());
+}
+
+TEST_CASE("mempool parents/children de-duplicate multi-output spends", "[mempool][serial]") {
+    mempool mp(1, 2);
+    // parent has 2 outputs; child spends BOTH (0 and 1) -> counted once each way.
+    auto const parent = make_tx({op(1, 0)}, 2, 1);
+    auto const child = make_tx(
+        {output_point{parent.hash(), 0}, output_point{parent.hash(), 1}}, 1, 2);
+    mp.add(entry_for(parent, 1));
+    mp.add(entry_for(child, 2));
+
+    CHECK(mp.parents(child.hash()) == std::vector<hash_digest>{parent.hash()});
+    CHECK(mp.children(parent.hash()) == std::vector<hash_digest>{child.hash()});
+}
+
+TEST_CASE("mempool graph queries are empty for absent txid", "[mempool][serial]") {
+    mempool mp(1, 2);
+    auto const missing = make_hash(12345);
+    CHECK(mp.parents(missing).empty());
+    CHECK(mp.children(missing).empty());
+    CHECK(mp.ancestors(missing).empty());
+    CHECK(mp.descendants(missing).empty());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds the C++ read surface behind the typical BCH mempool JSON-RPC calls, so the mempool can be inspected (and later exposed through the C-API): `getrawmempool`, `getmempoolentry`, `getmempoolinfo`, `getmempoolancestors`, `getmempooldescendants`.

### mempool graph primitives (read-only, mirror BCHN `CTxMemPool`)
- `entry(txid)` — copy a pooled entry (tx + fee/size/sigchecks/time) or `nullopt`.
- `parents` / `children` — direct in-mempool adjacency (== BCHN `depends` / `spentby`), derived from the tx inputs and the `spent_by_` index; de-duplicated.
- `ancestors` / `descendants` — their transitive closures.

### block_chain readers (thin forwarders + aggregation)
| method | RPC |
|---|---|
| `get_mempool_txids` | getrawmempool |
| `get_mempool_info` `{size, bytes, total_fee}` | getmempoolinfo |
| `get_mempool_entry` `{fee, size, time}` | getmempoolentry |
| `get_mempool_depends` / `get_mempool_spentby` | getmempoolentry.depends / .spentby |
| `get_mempool_ancestors` / `get_mempool_descendants` | getmempoolancestors / getmempooldescendants |

`testmempoolaccept` is already served by `transaction_validate`; `savemempool` by `dump_mempool_to_disk` (#507). `getmempoolinfo`'s usage/maxmempool fields are omitted until mempool eviction/caps land.

### Tests
mempool graph-query cases: `entry`, direct and transitive adjacency, multi-output-spend de-duplication, and empty results for an absent txid. Full blockchain suite green (992 assertions), node builds. Backend-agnostic (uses the mempool_map `visit` surface).