### PR TITLE
c-api: expose the mempool query readers on the chain interface

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -414,13 +414,13 @@ struct KB_API block_chain {
     void fill_tx_list_from_mempool(domain::message::compact_block const& block, size_t& mempool_count, std::vector<domain::chain::transaction>& txn_available, std::unordered_map<uint64_t, uint16_t> const& shorttxids) const;
 
     // Mempool query readers, backing the typical BCH JSON-RPC mempool calls.
-    std::vector<hash_digest> get_mempool_txids() const;                                              // getrawmempool
+    hash_list get_mempool_txids() const;                                                             // getrawmempool
     blockchain::mempool_totals get_mempool_info() const;                                             // getmempoolinfo
     std::optional<mempool_entry_info> get_mempool_entry(hash_digest const& txid) const;              // getmempoolentry
-    std::vector<hash_digest> get_mempool_depends(hash_digest const& txid) const;                     // getmempoolentry.depends
-    std::vector<hash_digest> get_mempool_spentby(hash_digest const& txid) const;                     // getmempoolentry.spentby
-    std::vector<hash_digest> get_mempool_ancestors(hash_digest const& txid) const;                   // getmempoolancestors
-    std::vector<hash_digest> get_mempool_descendants(hash_digest const& txid) const;                 // getmempooldescendants
+    hash_list get_mempool_depends(hash_digest const& txid) const;                                    // getmempoolentry.depends
+    hash_list get_mempool_spentby(hash_digest const& txid) const;                                    // getmempoolentry.spentby
+    hash_list get_mempool_ancestors(hash_digest const& txid) const;                                  // getmempoolancestors
+    hash_list get_mempool_descendants(hash_digest const& txid) const;                                // getmempooldescendants
 
     // Persist the mempool to <datadir>/mempool.dat (called on shutdown; also
     // backs a future savemempool). Returns false on I/O error.

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1519,7 +1519,7 @@ block_chain::fetch_mempool(size_t count_limit, uint64_t /*minimum_fee*/) const {
     co_return std::make_shared<domain::message::inventory>(std::move(*inv));
 }
 
-std::vector<hash_digest> block_chain::get_mempool_txids() const {
+hash_list block_chain::get_mempool_txids() const {
     return mempool_.all_txids();
 }
 
@@ -1535,19 +1535,19 @@ std::optional<mempool_entry_info> block_chain::get_mempool_entry(hash_digest con
     return mempool_entry_info{e->fee, e->size, e->time_seen};
 }
 
-std::vector<hash_digest> block_chain::get_mempool_depends(hash_digest const& txid) const {
+hash_list block_chain::get_mempool_depends(hash_digest const& txid) const {
     return mempool_.parents(txid);
 }
 
-std::vector<hash_digest> block_chain::get_mempool_spentby(hash_digest const& txid) const {
+hash_list block_chain::get_mempool_spentby(hash_digest const& txid) const {
     return mempool_.children(txid);
 }
 
-std::vector<hash_digest> block_chain::get_mempool_ancestors(hash_digest const& txid) const {
+hash_list block_chain::get_mempool_ancestors(hash_digest const& txid) const {
     return mempool_.ancestors(txid);
 }
 
-std::vector<hash_digest> block_chain::get_mempool_descendants(hash_digest const& txid) const {
+hash_list block_chain::get_mempool_descendants(hash_digest const& txid) const {
     return mempool_.descendants(txid);
 }
 

--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -256,6 +256,7 @@ set(kth_sources
         src/chain/chain_async.cpp
         src/chain/chain_other.cpp
         src/chain/chain_sync.cpp
+        src/chain/chain_mempool.cpp
 
         src/domain/message/compact_block.cpp
         src/domain/message/double_spend_proof.cpp
@@ -427,6 +428,9 @@ set(kth_headers
     include/kth/capi/chain/chain.h
     include/kth/capi/chain/chain_sync.h
     include/kth/capi/chain/chain_other.h
+    include/kth/capi/chain/chain_mempool.h
+    include/kth/capi/chain/mempool_totals.h
+    include/kth/capi/chain/mempool_entry_info.h
     include/kth/capi/domain/chain/stealth_compact.h
     include/kth/capi/domain/chain/history_compact_list.h
     include/kth/capi/domain/chain/stealth_compact_list.h
@@ -631,6 +635,10 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     # public symbol the snippet references drifts.
     add_executable(kth_readme_c_compile_check test/readme_c_compile_check.c)
     target_link_libraries(kth_readme_c_compile_check PRIVATE ${PROJECT_NAME})
+
+    # Chain-interface mempool readers — compile + link signature check.
+    add_executable(kth_chain_mempool_compile_check test/chain/chain_mempool_compile_check.c)
+    target_link_libraries(kth_chain_mempool_compile_check PRIVATE ${PROJECT_NAME})
 
     # README C snippet — runtime smoke. Same flow as the README but
     # adapted for CI: regtest network, fresh temp data dir, 16 MiB DB

--- a/src/c-api/include/kth/capi/chain/chain.h
+++ b/src/c-api/include/kth/capi/chain/chain.h
@@ -6,6 +6,7 @@
 #define KTH_CAPI_CHAIN_CHAIN_H_
 
 #include <kth/capi/chain/chain_async.h>
+#include <kth/capi/chain/chain_mempool.h>
 #include <kth/capi/chain/chain_other.h>
 #include <kth/capi/chain/chain_sync.h>
 

--- a/src/c-api/include/kth/capi/chain/chain_mempool.h
+++ b/src/c-api/include/kth/capi/chain/chain_mempool.h
@@ -1,0 +1,99 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_CHAIN_MEMPOOL_H_
+#define KTH_CAPI_CHAIN_CHAIN_MEMPOOL_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/chain/mempool_entry_info.h>
+#include <kth/capi/chain/mempool_totals.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Getters
+
+/** @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`. */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_get_mempool_txids(kth_chain_t self);
+
+KTH_EXPORT
+kth_mempool_totals_t kth_chain_get_mempool_info(kth_chain_t self);
+
+
+// Operations
+
+/** @param txid Borrowed input; must be non-null. Read during the call; ownership of `txid` stays with the caller. */
+KTH_EXPORT
+kth_bool_t kth_chain_get_mempool_entry(kth_chain_t self, kth_hash_t const* txid, kth_mempool_entry_info_t* out);
+
+/** @warning `txid` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
+KTH_EXPORT
+kth_bool_t kth_chain_get_mempool_entry_unsafe(kth_chain_t self, uint8_t const* txid, kth_mempool_entry_info_t* out);
+
+/**
+ * @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`.
+ * @param txid Borrowed input; must be non-null. Read during the call; ownership of `txid` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_get_mempool_depends(kth_chain_t self, kth_hash_t const* txid);
+
+/**
+ * @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`.
+ * @warning `txid` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_get_mempool_depends_unsafe(kth_chain_t self, uint8_t const* txid);
+
+/**
+ * @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`.
+ * @param txid Borrowed input; must be non-null. Read during the call; ownership of `txid` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_get_mempool_spentby(kth_chain_t self, kth_hash_t const* txid);
+
+/**
+ * @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`.
+ * @warning `txid` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_get_mempool_spentby_unsafe(kth_chain_t self, uint8_t const* txid);
+
+/**
+ * @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`.
+ * @param txid Borrowed input; must be non-null. Read during the call; ownership of `txid` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_get_mempool_ancestors(kth_chain_t self, kth_hash_t const* txid);
+
+/**
+ * @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`.
+ * @warning `txid` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_get_mempool_ancestors_unsafe(kth_chain_t self, uint8_t const* txid);
+
+/**
+ * @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`.
+ * @param txid Borrowed input; must be non-null. Read during the call; ownership of `txid` stays with the caller.
+ */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_get_mempool_descendants(kth_chain_t self, kth_hash_t const* txid);
+
+/**
+ * @return Owned `kth_hash_list_mut_t`. Caller must release with `kth_core_hash_list_destruct`.
+ * @warning `txid` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_hash_list_mut_t kth_chain_get_mempool_descendants_unsafe(kth_chain_t self, uint8_t const* txid);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_CHAIN_CHAIN_MEMPOOL_H_

--- a/src/c-api/include/kth/capi/chain/mempool_entry_info.h
+++ b/src/c-api/include/kth/capi/chain/mempool_entry_info.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_MEMPOOL_ENTRY_INFO_H_
+#define KTH_CAPI_CHAIN_MEMPOOL_ENTRY_INFO_H_
+
+#include <stdint.h>
+
+typedef struct kth_mempool_entry_info {
+    uint64_t fee;
+    uint32_t size;
+    uint64_t time;
+} kth_mempool_entry_info_t;
+
+#endif // KTH_CAPI_CHAIN_MEMPOOL_ENTRY_INFO_H_

--- a/src/c-api/include/kth/capi/chain/mempool_totals.h
+++ b/src/c-api/include/kth/capi/chain/mempool_totals.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_MEMPOOL_TOTALS_H_
+#define KTH_CAPI_CHAIN_MEMPOOL_TOTALS_H_
+
+#include <stdint.h>
+
+typedef struct kth_mempool_totals {
+    size_t size;
+    uint64_t bytes;
+    uint64_t total_fee;
+} kth_mempool_totals_t;
+
+#endif // KTH_CAPI_CHAIN_MEMPOOL_TOTALS_H_

--- a/src/c-api/src/chain/chain_mempool.cpp
+++ b/src/c-api/src/chain/chain_mempool.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/chain/chain_mempool.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/blockchain/interface/block_chain.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::blockchain::block_chain;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Getters
+
+kth_hash_list_mut_t kth_chain_get_mempool_txids(kth_chain_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::leak_list<kth::hash_digest>(kth::cpp_ref<cpp_t>(self).get_mempool_txids());
+}
+
+kth_mempool_totals_t kth_chain_get_mempool_info(kth_chain_t self) {
+    KTH_PRECONDITION(self != nullptr);
+    return kth::to_c_struct<kth_mempool_totals_t>(kth::cpp_ref<cpp_t>(self).get_mempool_info());
+}
+
+
+// Operations
+
+kth_bool_t kth_chain_get_mempool_entry(kth_chain_t self, kth_hash_t const* txid, kth_mempool_entry_info_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid->hash);
+    auto const result = kth::cpp_ref<cpp_t>(self).get_mempool_entry(txid_cpp);
+    if ( ! result) return kth::bool_to_int(false);
+    *out = kth::to_c_struct<kth_mempool_entry_info_t>(*result);
+    return kth::bool_to_int(true);
+}
+
+kth_bool_t kth_chain_get_mempool_entry_unsafe(kth_chain_t self, uint8_t const* txid, kth_mempool_entry_info_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid);
+    auto const result = kth::cpp_ref<cpp_t>(self).get_mempool_entry(txid_cpp);
+    if ( ! result) return kth::bool_to_int(false);
+    *out = kth::to_c_struct<kth_mempool_entry_info_t>(*result);
+    return kth::bool_to_int(true);
+}
+
+kth_hash_list_mut_t kth_chain_get_mempool_depends(kth_chain_t self, kth_hash_t const* txid) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid->hash);
+    return kth::leak_list<kth::hash_digest>(kth::cpp_ref<cpp_t>(self).get_mempool_depends(txid_cpp));
+}
+
+kth_hash_list_mut_t kth_chain_get_mempool_depends_unsafe(kth_chain_t self, uint8_t const* txid) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid);
+    return kth::leak_list<kth::hash_digest>(kth::cpp_ref<cpp_t>(self).get_mempool_depends(txid_cpp));
+}
+
+kth_hash_list_mut_t kth_chain_get_mempool_spentby(kth_chain_t self, kth_hash_t const* txid) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid->hash);
+    return kth::leak_list<kth::hash_digest>(kth::cpp_ref<cpp_t>(self).get_mempool_spentby(txid_cpp));
+}
+
+kth_hash_list_mut_t kth_chain_get_mempool_spentby_unsafe(kth_chain_t self, uint8_t const* txid) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid);
+    return kth::leak_list<kth::hash_digest>(kth::cpp_ref<cpp_t>(self).get_mempool_spentby(txid_cpp));
+}
+
+kth_hash_list_mut_t kth_chain_get_mempool_ancestors(kth_chain_t self, kth_hash_t const* txid) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid->hash);
+    return kth::leak_list<kth::hash_digest>(kth::cpp_ref<cpp_t>(self).get_mempool_ancestors(txid_cpp));
+}
+
+kth_hash_list_mut_t kth_chain_get_mempool_ancestors_unsafe(kth_chain_t self, uint8_t const* txid) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid);
+    return kth::leak_list<kth::hash_digest>(kth::cpp_ref<cpp_t>(self).get_mempool_ancestors(txid_cpp));
+}
+
+kth_hash_list_mut_t kth_chain_get_mempool_descendants(kth_chain_t self, kth_hash_t const* txid) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid->hash);
+    return kth::leak_list<kth::hash_digest>(kth::cpp_ref<cpp_t>(self).get_mempool_descendants(txid_cpp));
+}
+
+kth_hash_list_mut_t kth_chain_get_mempool_descendants_unsafe(kth_chain_t self, uint8_t const* txid) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(txid != nullptr);
+    auto const txid_cpp = kth::hash_to_cpp(txid);
+    return kth::leak_list<kth::hash_digest>(kth::cpp_ref<cpp_t>(self).get_mempool_descendants(txid_cpp));
+}
+
+} // extern "C"

--- a/src/c-api/test/chain/chain_mempool_compile_check.c
+++ b/src/c-api/test/chain/chain_mempool_compile_check.c
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Compile + link check for the generated mempool query readers on the chain
+// interface (kth_chain_get_mempool_*). These need a running node to execute,
+// so like the rest of the chain interface they are not unit-tested at runtime;
+// this file fails the build if any public signature drifts. The behavioral
+// coverage lives at the C++ level (mempool graph-query tests).
+
+#include <kth/capi.h>
+#include <kth/capi/chain/chain_mempool.h>
+
+static void mempool_readers_sig_check(kth_chain_t chain, kth_hash_t const* txid) {
+    kth_hash_list_mut_t txids = kth_chain_get_mempool_txids(chain);
+    kth_mempool_totals_t info = kth_chain_get_mempool_info(chain);
+
+    kth_mempool_entry_info_t entry;
+    kth_bool_t found = kth_chain_get_mempool_entry(chain, txid, &entry);
+
+    kth_hash_list_mut_t depends = kth_chain_get_mempool_depends(chain, txid);
+    kth_hash_list_mut_t spentby = kth_chain_get_mempool_spentby(chain, txid);
+    kth_hash_list_mut_t ancestors = kth_chain_get_mempool_ancestors(chain, txid);
+    kth_hash_list_mut_t descendants = kth_chain_get_mempool_descendants(chain, txid);
+
+    (void)txids; (void)info; (void)found; (void)entry;
+    (void)depends; (void)spentby; (void)ancestors; (void)descendants;
+}
+
+int main(void) {
+    // Referenced but never called: forces linkage of every symbol above
+    // without needing a live chain handle.
+    void (*ref)(kth_chain_t, kth_hash_t const*) = &mempool_readers_sig_check;
+    (void)ref;
+    return 0;
+}


### PR DESCRIPTION
Exposes the BCH mempool query readers (#508) through the C-API, on the chain interface via the `kth_chain_t` handle — the `kth_chain_` prefix freed by #509.

| C function | returns | RPC |
|---|---|---|
| `kth_chain_get_mempool_txids` | `kth_hash_list_mut_t` | getrawmempool |
| `kth_chain_get_mempool_info` | `kth_mempool_totals_t` | getmempoolinfo |
| `kth_chain_get_mempool_entry` | `kth_bool_t` + out param | getmempoolentry |
| `kth_chain_get_mempool_depends` / `_spentby` | `kth_hash_list_mut_t` | entry depends / spentby |
| `kth_chain_get_mempool_ancestors` / `_descendants` | `kth_hash_list_mut_t` | getmempoolancestors / descendants |

- Two by-value POD result structs: `kth_mempool_totals_t {size, bytes, total_fee}` and `kth_mempool_entry_info_t {fee, size, time}`. The optional entry is a nullable `kth_bool_t fn(..., out)`.
- The `block_chain` readers now return `hash_list` (the domain typedef for `std::vector<hash_digest>`).
- Adds a compile+link signature check (the chain interface needs a running node, so it isn't runtime-tested here; behavioral coverage is at the C++ level).

c-api library + tests build and pass (2790 assertions, 735 cases).