### PR TITLE
node: move p2p_node from the network module to the node module

### DIFF
--- a/src/c-api/src/node/settings.cpp
+++ b/src/c-api/src/node/settings.cpp
@@ -14,7 +14,7 @@
 #include <kth/domain/multi_crypto_support.hpp>
 
 #if ! defined(__EMSCRIPTEN__)
-#include <kth/network/p2p_node.hpp>
+#include <kth/node/p2p_node.hpp>
 #endif
 
 // ---------------------------------------------------------------------------
@@ -28,7 +28,7 @@ kth_currency_t kth_node_settings_get_currency() {
 kth_network_t kth_node_settings_get_network(kth_node_t exec) {
 
     kth_p2p_t p2p_node = kth_node_get_p2p(exec);
-    auto const& node = *static_cast<kth::network::p2p_node*>(p2p_node);
+    auto const& node = *static_cast<kth::node::p2p_node*>(p2p_node);
 
     auto const& sett = node.network_settings();
     auto id = sett.identifier;

--- a/src/c-api/src/p2p/p2p.cpp
+++ b/src/c-api/src/p2p/p2p.cpp
@@ -4,14 +4,14 @@
 
 #include <kth/capi/p2p/p2p.h>
 
-#include <kth/network/p2p_node.hpp>
+#include <kth/node/p2p_node.hpp>
 #include <kth/capi/helpers.hpp>
 
 namespace {
 
 inline
-kth::network::p2p_node& p2p_cast(kth_p2p_t p2p) {
-    return *static_cast<kth::network::p2p_node*>(p2p);
+kth::node::p2p_node& p2p_cast(kth_p2p_t p2p) {
+    return *static_cast<kth::node::p2p_node*>(p2p);
 }
 
 } /* end of anonymous namespace */

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -99,15 +99,12 @@ set(kth_headers
   include/kth/network/peer_database.hpp
   include/kth/network/peer_session.hpp
   include/kth/network/peer_manager.hpp
-  include/kth/network/p2p_node.hpp
   include/kth/network/protocols_coro.hpp
   include/kth/network/settings.hpp
   include/kth/network.hpp
   include/kth/network/hosts.hpp  # Legacy - will be replaced by peer_database
 
   # Message handlers (one per message type)
-  include/kth/network/handlers/ping.hpp
-  include/kth/network/handlers/pong.hpp
 
   # =========================================================================
   # LEGACY FILES - MOVED TO deprecated/ FOLDER
@@ -146,7 +143,6 @@ set(kth_headers
 set(kth_sources
   src/banlist.cpp
   src/net_permissions.cpp
-  src/p2p_node.cpp
   src/peer_database.cpp
   src/peer_session.cpp
   src/peer_manager.cpp
@@ -155,8 +151,6 @@ set(kth_sources
   src/hosts.cpp  # Legacy - will be replaced by peer_database
 
   # Message handlers (one per message type)
-  src/handlers/ping.cpp
-  src/handlers/pong.cpp
 
   # =========================================================================
   # LEGACY FILES - MOVED TO deprecated/ FOLDER
@@ -228,7 +222,6 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   find_package(Catch2 3 REQUIRED)
 
   add_executable(kth_network_test
-    test/p2p_node.cpp
     test/peer_database.cpp
     test/peer_manager.cpp
     test/peer_session.cpp

--- a/src/network/include/kth/network.hpp
+++ b/src/network/include/kth/network.hpp
@@ -22,7 +22,6 @@
 #include <kth/network/peer_manager.hpp>
 #include <kth/network/peer_session.hpp>
 #include <kth/network/protocols_coro.hpp>
-#include <kth/network/p2p_node.hpp>
 
 // Legacy networking - COMMENTED OUT (coroutine migration cleanup)
 // These are replaced by p2p_node + peer_session + peer_manager + protocols_coro

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -143,6 +143,12 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     src/full_node.cpp
     src/executor/executor.cpp
 
+    # P2P node orchestration (moved from the network module: it bridges
+    # networking and the blockchain, which only the node module depends on).
+    src/p2p_node.cpp
+    src/handlers/ping.cpp
+    src/handlers/pong.cpp
+
     src/utility/reservation.cpp
     src/utility/reservations.cpp
 
@@ -167,6 +173,9 @@ set(kth_sources
 
 set(kth_headers
   include/kth/node.hpp
+  include/kth/node/p2p_node.hpp
+  include/kth/node/handlers/ping.hpp
+  include/kth/node/handlers/pong.hpp
   include/kth/node/configuration.hpp
   include/kth/node/user_agent.hpp
   include/kth/node/executor/executor.hpp
@@ -240,6 +249,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/header_list.cpp
           test/main.cpp
           test/node.cpp
+          test/p2p_node.cpp
           test/performance.cpp
           test/reservation.cpp
           test/reservations.cpp

--- a/src/node/include/kth/node/full_node.hpp
+++ b/src/node/include/kth/node/full_node.hpp
@@ -10,7 +10,7 @@
 // =============================================================================
 //
 // This class represents a complete Bitcoin full node that combines:
-// - P2P networking (via network::p2p_node composition) [non-WASM only]
+// - P2P networking (via kth::node::p2p_node composition) [non-WASM only]
 // - Blockchain storage and validation (via blockchain::block_chain)
 //
 // ARCHITECTURE:
@@ -128,7 +128,7 @@ public:
 #if ! defined(__EMSCRIPTEN__)
     /// P2P network node.
     [[nodiscard]]
-    kth::network::p2p_node& network();
+    kth::node::p2p_node& network();
 #endif
 
     // Thread pools
@@ -199,7 +199,7 @@ private:
     // Core components (composition, not inheritance)
 #if ! defined(__EMSCRIPTEN__)
     kth::network::settings network_settings_;  // Own copy, allows modification (e.g., user_agent)
-    kth::network::p2p_node network_;
+    kth::node::p2p_node network_;
 #endif
     blockchain::block_chain chain_;
 };

--- a/src/node/include/kth/node/handlers/ping.hpp
+++ b/src/node/include/kth/node/handlers/ping.hpp
@@ -11,7 +11,8 @@
 
 #include <asio/awaitable.hpp>
 
-namespace kth::network {
+namespace kth::node {
+using namespace kth::network;
 
 enum class message_result;
 
@@ -26,6 +27,6 @@ KN_API ::asio::awaitable<message_result> handle(
 
 } // namespace handlers::ping
 
-} // namespace kth::network
+} // namespace kth::node
 
 #endif // KTH_NETWORK_HANDLERS_PING_HPP

--- a/src/node/include/kth/node/handlers/pong.hpp
+++ b/src/node/include/kth/node/handlers/pong.hpp
@@ -11,7 +11,8 @@
 
 #include <asio/awaitable.hpp>
 
-namespace kth::network {
+namespace kth::node {
+using namespace kth::network;
 
 enum class message_result;
 
@@ -26,6 +27,6 @@ KN_API ::asio::awaitable<message_result> handle(
 
 } // namespace handlers::pong
 
-} // namespace kth::network
+} // namespace kth::node
 
 #endif // KTH_NETWORK_HANDLERS_PONG_HPP

--- a/src/node/include/kth/node/p2p_node.hpp
+++ b/src/node/include/kth/node/p2p_node.hpp
@@ -34,7 +34,8 @@
 #include <asio/steady_timer.hpp>
 #include <asio/thread_pool.hpp>
 
-namespace kth::network {
+namespace kth::node {
+using namespace kth::network;
 
 using kth::awaitable_expected;
 
@@ -393,6 +394,6 @@ private:
     std::unique_ptr<concurrent_channel<peer_notification>> peer_notification_channel_;
 };
 
-} // namespace kth::network
+} // namespace kth::node
 
 #endif // KTH_NETWORK_P2P_NODE_HPP

--- a/src/node/include/kth/node/sync/orchestrator.hpp
+++ b/src/node/include/kth/node/sync/orchestrator.hpp
@@ -8,7 +8,7 @@
 #include <asio/awaitable.hpp>
 
 #include <kth/blockchain.hpp>
-#include <kth/network/p2p_node.hpp>
+#include <kth/node/p2p_node.hpp>
 #include <kth/node/sync/messages.hpp>
 
 namespace kth::node::sync {
@@ -38,7 +38,7 @@ namespace kth::node::sync {
 ::asio::awaitable<void> sync_orchestrator(
     blockchain::block_chain& chain,
     blockchain::header_organizer& organizer,
-    network::p2p_node& network
+    kth::node::p2p_node& network
 );
 
 } // namespace kth::node::sync

--- a/src/node/src/full_node.cpp
+++ b/src/node/src/full_node.cpp
@@ -308,7 +308,7 @@ block_chain& full_node::chain_kth() {
 }
 
 #if ! defined(__EMSCRIPTEN__)
-kth::network::p2p_node& full_node::network() {
+kth::node::p2p_node& full_node::network() {
     return network_;
 }
 #endif

--- a/src/node/src/handlers/ping.cpp
+++ b/src/node/src/handlers/ping.cpp
@@ -2,12 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <kth/network/handlers/ping.hpp>
+#include <kth/node/handlers/ping.hpp>
 
 #include <kth/domain.hpp>
-#include <kth/network/p2p_node.hpp>
+#include <kth/node/p2p_node.hpp>
 
-namespace kth::network::handlers::ping {
+namespace kth::node::handlers::ping {
+using namespace kth::network;
 
 ::asio::awaitable<message_result> handle(
     peer_session& peer,
@@ -26,4 +27,4 @@ namespace kth::network::handlers::ping {
     co_return message_result::handled;
 }
 
-} // namespace kth::network::handlers::ping
+} // namespace kth::node::handlers::ping

--- a/src/node/src/handlers/pong.cpp
+++ b/src/node/src/handlers/pong.cpp
@@ -2,12 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <kth/network/handlers/pong.hpp>
+#include <kth/node/handlers/pong.hpp>
 
 #include <kth/domain.hpp>
-#include <kth/network/p2p_node.hpp>
+#include <kth/node/p2p_node.hpp>
 
-namespace kth::network::handlers::pong {
+namespace kth::node::handlers::pong {
+using namespace kth::network;
 
 ::asio::awaitable<message_result> handle(
     peer_session& peer,
@@ -24,4 +25,4 @@ namespace kth::network::handlers::pong {
     co_return message_result::handled;
 }
 
-} // namespace kth::network::handlers::pong
+} // namespace kth::node::handlers::pong

--- a/src/node/src/p2p_node.cpp
+++ b/src/node/src/p2p_node.cpp
@@ -2,16 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <kth/network/p2p_node.hpp>
+#include <kth/node/p2p_node.hpp>
 
-#include <kth/network/handlers/ping.hpp>
-#include <kth/network/handlers/pong.hpp>
+#include <kth/node/handlers/ping.hpp>
+#include <kth/node/handlers/pong.hpp>
 
 #include <asio/experimental/awaitable_operators.hpp>
 #include <asio/use_awaitable.hpp>
 #include <fmt/format.h>
 
-namespace kth::network {
+namespace kth::node {
+using namespace kth::network;
 
 using namespace ::asio::experimental::awaitable_operators;
 using namespace std::chrono_literals;
@@ -1307,4 +1308,4 @@ uint64_t p2p_node::generate_ping_nonce() {
     return pseudo_random::generate<uint64_t>(1, max_uint64);
 }
 
-} // namespace kth::network
+} // namespace kth::node

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -127,7 +127,7 @@ static
 ::asio::awaitable<void> sync_orchestrator(
     blockchain::block_chain& chain,
     blockchain::header_organizer& organizer,
-    network::p2p_node& network
+    kth::node::p2p_node& network
 ) {
     auto executor = co_await ::asio::this_coro::executor;
 
@@ -226,7 +226,7 @@ static
                 }
 
                 // Demultiplex based on event type
-                if (notification.event == network::peer_event_type::connected) {
+                if (notification.event == kth::node::peer_event_type::connected) {
                     if (!peer_provider_input.try_send(std::error_code{}, new_peer{notification.peer})) {
                         spdlog::warn("[peer_bridge] Channel full, new_peer dropped for {}",
                             notification.peer->authority_with_agent());

--- a/src/node/test/p2p_node.cpp
+++ b/src/node/test/p2p_node.cpp
@@ -9,6 +9,7 @@
 #include <test_helpers.hpp>
 
 #include <kth/network.hpp>
+#include <kth/node/p2p_node.hpp>
 
 #include <asio/co_spawn.hpp>
 #include <asio/detached.hpp>
@@ -17,6 +18,7 @@
 
 using namespace kth;
 using namespace kth::network;
+using namespace kth::node;
 using namespace std::chrono_literals;
 
 // =============================================================================


### PR DESCRIPTION
The v1.0 coroutine rewrite (#151, 2026-06-18) put the whole P2P **orchestration** — the accept loop, the peer supervisor, and the message **dispatch / serving** — inside the `network` module. But serving messages needs blockchain access (BIP-35 `mempool` → inv, `getdata` for blocks/txs), and only the `node` module depends on both `network` and `blockchain`; the network module cannot (and should not) depend on blockchain.

**Move** `p2p_node`, the message dispatcher / `message_result`, and the `ping`/`pong` handlers to the `node` module (namespace `kth::network` → `kth::node`). The connection-level primitives (`peer_session`, `peer_manager`, `protocols_coro`, `peer_database`) **stay** in `network`, which `p2p_node` uses via `using namespace kth::network`.

This mirrors the **net / net_processing** split in BCHN/Core and lets the node bridge networking to the chain (prerequisite for the BIP-35 `mempool` → inv reply).

Pure relocation, no behavior change. `network` + `node` + `node-exe` + `c-api` build; node tests pass (158 assertions); node-exe runs.