### PR TITLE
node: serve the BIP-35 mempool message with an inv of pooled txs

### DIFF
--- a/src/node/include/kth/node/p2p_node.hpp
+++ b/src/node/include/kth/node/p2p_node.hpp
@@ -215,6 +215,15 @@ public:
     void set_top_block(infrastructure::config::checkpoint const& top);
     void set_top_block(infrastructure::config::checkpoint&& top);
 
+    /// Register a message handler injected by the node. This is how chain-backed
+    /// replies (e.g. the BIP-35 `mempool` -> inv) are served: the node owns the
+    /// bridge to the blockchain and supplies the handler, so p2p_node itself
+    /// stays chain-agnostic (the network layer must not know about the chain).
+    template <typename Message>
+    void register_message_handler(typed_message_handler_fn<Message> handler) {
+        dispatcher_.register_handler<Message>(std::move(handler));
+    }
+
     // Manual connections
     // -------------------------------------------------------------------------
 

--- a/src/node/src/full_node.cpp
+++ b/src/node/src/full_node.cpp
@@ -105,6 +105,18 @@ full_node::~full_node() {
     // the network comes up, so peers can be served from a warm mempool.
     co_await chain_.load_mempool_from_disk();
 
+    // Serve BIP-35 `mempool` -> inv. The node is the bridge: it injects a
+    // chain-backed handler into the network layer, which stays chain-agnostic.
+    network_.register_message_handler<domain::message::memory_pool>(
+        [this](peer_session& peer, domain::message::memory_pool const&)
+            -> ::asio::awaitable<message_result> {
+            auto const inv = co_await chain_.fetch_mempool(50000, 0);
+            if (inv && *inv) {
+                co_await peer.send(**inv);
+            }
+            co_return message_result::handled;
+        });
+
 #if ! defined(__EMSCRIPTEN__)
     // Start the P2P network
     auto ec = co_await network_.start();


### PR DESCRIPTION
A peer's `mempool` request went unanswered (the coroutine networking had no handler for it — the last of the post-handshake gaps). Reply with an inv of the pooled transactions.

**Architecture — the node is the bridge.** The reply needs the chain, but the network layer must stay chain-agnostic. So:
- `p2p_node` exposes `register_message_handler<Message>()` (forwarding to its dispatcher).
- `full_node` injects a `memory_pool` handler that captures the chain and answers via `fetch_mempool` → `inv`.

`p2p_node` never sees the chain (no chain reference, no blockchain include).

Verified with `tools/p2p_probe.py`: the node now returns an `inv` in response to `mempool` (empty during IBD, populated once the mempool fills). This completes the BCHN-parity post-handshake surface (getaddr → addr, sendheaders/sendcmpct/feefilter, mempool → inv).

Builds: node + node-exe. Node runs and answers the probe.