### PR TITLE
node: add an optional JSON-RPC server (foundation)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -73,6 +73,7 @@ class KthRecipe(KnuthConanFileV2):
         "with_qrencode": [True, False],
         "with_jemalloc": [True, False],
         "with_stats": [True, False],
+        "rpc": [True, False],
         "embed_utxo_bloom": [True, False],
         "utxoz_compact": [True, False],
         "asio_standalone": [True, False],
@@ -124,6 +125,7 @@ class KthRecipe(KnuthConanFileV2):
         # For now, keep disabled until a proper solution is implemented.
         "with_jemalloc": False,
         "with_stats": False,
+        "rpc": False,
         "embed_utxo_bloom": False,
         "utxoz_compact": False,
         "asio_standalone": True,
@@ -200,6 +202,12 @@ class KthRecipe(KnuthConanFileV2):
         # TODO(2026-02-02): Check if simdjson adds WASM support in future versions
         if self.settings.os != "Emscripten":
             self.requires("simdjson/4.2.2", transitive_headers=True, transitive_libs=True)
+
+        # llhttp (Node.js HTTP parser) backs the optional JSON-RPC server. It is a
+        # sans-io codec driven by the node's existing standalone-asio I/O loop, so
+        # it is only pulled in when the RPC server is compiled (and never for WASM).
+        if self.options.rpc and self.settings.os != "Emscripten":
+            self.requires("llhttp/9.3.0", transitive_headers=True, transitive_libs=True)
 
         if self.options.with_png:
             self.requires("libpng/1.6.58", transitive_headers=True, transitive_libs=True)
@@ -296,6 +304,7 @@ class KthRecipe(KnuthConanFileV2):
         tc.variables["KTH_WITH_QRENCODE"] = option_on_off(self.options.with_qrencode)
         tc.variables["KTH_WITH_JEMALLOC"] = option_on_off(self.options.with_jemalloc)
         tc.variables["KTH_WITH_STATS"] = option_on_off(self.options.with_stats)
+        tc.variables["KTH_WITH_RPC"] = option_on_off(self.options.rpc)
         tc.variables["KTH_EMBED_UTXO_BLOOM"] = option_on_off(self.options.embed_utxo_bloom)
         tc.variables["KTH_UTXOZ_COMPACT_MODE"] = option_on_off(self.options.utxoz_compact)
         tc.variables["KTH_ASIO_STANDALONE"] = option_on_off(self.options.asio_standalone)
@@ -369,6 +378,9 @@ class KthRecipe(KnuthConanFileV2):
 
         # Define mempool-backend macro based on option (cfm | parlay)
         mempool_backend_define = f"KTH_MEMPOOL_BACKEND_{str(self.options.mempool_backend).upper()}"
+
+        # The JSON-RPC server (node module) is compiled only when the rpc option is on.
+        rpc_defines = ["KTH_WITH_RPC"] if self.options.rpc else []
 
         # Define STATIC macros when building static libraries
         static_defines = []
@@ -494,7 +506,7 @@ class KthRecipe(KnuthConanFileV2):
         self.cpp_info.components["node"].libs = ["node"]
         self.cpp_info.components["node"].names["cmake_find_package"] = "node"
         self.cpp_info.components["node"].names["cmake_find_package_multi"] = "node"
-        self.cpp_info.components["node"].defines = [currency_define, mempool_backend_define] + static_defines
+        self.cpp_info.components["node"].defines = [currency_define, mempool_backend_define] + rpc_defines + static_defines
         # Node depends on blockchain and optionally network (if not Emscripten).
         # ftxui is consumed by the node-exe TUI dashboard (executable, not a
         # library component); listing it here keeps Conan 2's strict
@@ -504,6 +516,8 @@ class KthRecipe(KnuthConanFileV2):
         if self.settings.os != "Emscripten":
             node_requires.append("network")
             node_requires.append("ftxui::ftxui")
+        if self.options.rpc and self.settings.os != "Emscripten":
+            node_requires.append("llhttp::llhttp")
         self.cpp_info.components["node"].requires = node_requires
         
         # Optional components

--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -1,0 +1,73 @@
+# JSON-RPC interface
+
+Knuth exposes an optional JSON-RPC-over-HTTP interface, compatible in shape with
+the Bitcoin Cash Node / Bitcoin Core RPC that mining and wallet tooling expects.
+
+The JSON-RPC server and the C-API are two frontends over the same C++ core
+(`kth::blockchain::block_chain`). **Every JSON-RPC method has a C-API
+counterpart**; the [equivalence table](#method-equivalences) below is the source
+of truth for that mapping.
+
+## Building
+
+The server is **off by default** and gated at compile time:
+
+```
+conanfile option  rpc=True   →   CMake KTH_WITH_RPC   →   #if defined(KTH_WITH_RPC)
+```
+
+The transport uses [llhttp](https://github.com/nodejs/llhttp) (the Node.js HTTP
+parser, sans-io) fed by the node's existing standalone-asio coroutine loop, plus
+[simdjson](https://github.com/simdjson/simdjson) for both request parsing and
+response serialization. `llhttp` is only pulled in when the `rpc` option is enabled.
+
+## Running
+
+The server is also **off at runtime by default**. Enable it in the config file:
+
+```ini
+rpc.enabled  = true
+rpc.bind     = 127.0.0.1   # localhost only by default
+rpc.port     = 8332
+rpc.user     = myuser      # HTTP Basic-Auth; empty => .cookie file
+rpc.password = mypass
+```
+
+Starting a build without RPC support but with `rpc.enabled = true` logs a warning
+and continues without the server.
+
+### Authentication
+
+HTTP Basic-Auth, bitcoind-style:
+
+- If `rpc.user` / `rpc.password` are set, clients authenticate with those.
+- Otherwise the server generates a random token and writes `__cookie__:<token>`
+  to a `.cookie` file; clients read it (e.g. `curl --user $(cat .cookie)`).
+
+Unauthenticated requests get `401 Unauthorized`. Only `POST` is accepted.
+
+### Example
+
+```bash
+curl --user myuser:mypass -H 'content-type: application/json' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"getblockcount","params":[]}' \
+     http://127.0.0.1:8332/
+# => {"result":0,"error":null,"id":1}
+```
+
+Responses use the Bitcoin envelope `{"result":..., "error":..., "id":...}`. Error
+codes follow Bitcoin Core (`-32700` parse error, `-32601` method not found, ...).
+
+## Method equivalences
+
+Each row maps a JSON-RPC method to its C-API function and the underlying C++
+`block_chain` method. New methods must be added here together with their C-API
+counterpart.
+
+| JSON-RPC method | C-API function | C++ (`block_chain`) |
+|---|---|---|
+| `getblockcount` | `kth_chain_sync_last_height` | `fetch_last_height().block` |
+
+_More methods land per phase: mining (`getblocktemplate`, `submitblock`,
+`getmininginfo`), mempool (`getrawmempool`, `getmempoolentry`, ...), and
+blockchain/raw-tx (`getblock`, `getrawtransaction`, `sendrawtransaction`, ...)._

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -160,6 +160,18 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   )
 endif()
 
+# Optional JSON-RPC server (llhttp transport). Compiled only when KTH_WITH_RPC is
+# set (conan option rpc) and never for WebAssembly.
+if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  set(kth_sources_just_legacy
+    ${kth_sources_just_legacy}
+    src/rpc/json.cpp
+    src/rpc/dispatch.cpp
+    src/rpc/methods.cpp
+    src/rpc/server.cpp
+  )
+endif()
+
 if (NOT JUST_KTH_SOURCES)
   set(kth_sources
     ${kth_sources_just_legacy}
@@ -190,6 +202,12 @@ set(kth_headers
   include/kth/node/settings.hpp
   include/kth/node/full_node.hpp
   include/kth/node/parser.hpp
+
+  # Optional JSON-RPC server (compiled only when KTH_WITH_RPC is set).
+  include/kth/node/rpc/error.hpp
+  include/kth/node/rpc/json.hpp
+  include/kth/node/rpc/dispatch.hpp
+  include/kth/node/rpc/server.hpp
 
   # CSP-based sync system
   include/kth/node/sync.hpp
@@ -233,6 +251,13 @@ if (MINGW)
   target_link_libraries(${PROJECT_NAME} PUBLIC ws2_32 wsock32)
 endif()
 
+# JSON-RPC server: link the llhttp HTTP parser and enable the feature macro.
+if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  find_package(llhttp REQUIRED)
+  target_link_libraries(${PROJECT_NAME} PUBLIC llhttp::llhttp)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC -DKTH_WITH_RPC)
+endif()
+
 _group_sources(${PROJECT_NAME} "${CMAKE_CURRENT_LIST_DIR}")
 
 # Tests
@@ -256,6 +281,11 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/settings.cpp
           test/utility.cpp
           test/utility.hpp)
+
+  # JSON-RPC unit tests build only when the server is compiled in.
+  if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    target_sources(kth_node_test PRIVATE test/rpc_json.cpp)
+  endif()
 
   target_include_directories(kth_node_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)
 

--- a/src/node/include/kth/node/configuration.hpp
+++ b/src/node/include/kth/node/configuration.hpp
@@ -34,7 +34,7 @@ namespace kth::node {
 /// Full node configuration, thread safe.
 struct KND_API configuration {
     configuration(domain::config::network net);
-    configuration(configuration const& other);
+    configuration(configuration const& other) = default;
 
     /// Options.
     bool help;
@@ -53,6 +53,7 @@ struct KND_API configuration {
 
     /// Settings.
     node::settings node;
+    node::rpc_settings rpc;
     blockchain::settings chain;
     database::settings database;
 #if ! defined(__EMSCRIPTEN__)

--- a/src/node/include/kth/node/full_node.hpp
+++ b/src/node/include/kth/node/full_node.hpp
@@ -51,6 +51,10 @@
 #include <kth/node/configuration.hpp>
 #include <kth/node/define.hpp>
 
+#if defined(KTH_WITH_RPC) && ! defined(__EMSCRIPTEN__)
+#include <kth/node/rpc/server.hpp>
+#endif
+
 #include <asio/awaitable.hpp>
 
 namespace kth::node {
@@ -202,6 +206,10 @@ private:
     kth::node::p2p_node network_;
 #endif
     blockchain::block_chain chain_;
+    node::rpc_settings rpc_settings_;  // Own copy; outlives the RPC server.
+#if defined(KTH_WITH_RPC) && ! defined(__EMSCRIPTEN__)
+    std::unique_ptr<rpc::server> rpc_server_;
+#endif
 };
 
 } // namespace kth::node

--- a/src/node/include/kth/node/rpc/dispatch.hpp
+++ b/src/node/include/kth/node/rpc/dispatch.hpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_RPC_DISPATCH_HPP
+#define KTH_NODE_RPC_DISPATCH_HPP
+
+#include <expected>
+#include <functional>
+#include <string>
+#include <string_view>
+
+#include <asio/awaitable.hpp>
+#include <boost/unordered/unordered_flat_map.hpp>
+
+#include <kth/node/rpc/error.hpp>
+#include <kth/node/rpc/json.hpp>
+
+namespace kth::blockchain {
+class block_chain;
+} // namespace kth::blockchain
+
+namespace kth::node::rpc {
+
+// A method handler serializes the JSON-RPC "result" fragment for `req`, or
+// returns an rpc_error. It runs on the RPC coroutine and may co_await the chain.
+using handler_fn = std::function<
+    ::asio::awaitable<std::expected<std::string, rpc_error>>(
+        blockchain::block_chain&, request const&)>;
+
+// Routes a parsed JSON-RPC request to its registered handler and wraps the
+// outcome (or any error) in a JSON-RPC response envelope.
+struct dispatcher {
+    void add(std::string method, handler_fn handler);
+    [[nodiscard]] bool has(std::string_view method) const;
+
+    // Parse `body`, invoke the matching handler, and return the full response body.
+    [[nodiscard]] ::asio::awaitable<std::string>
+    handle(blockchain::block_chain& chain, std::string_view body) const;
+
+private:
+    boost::unordered_flat_map<std::string, handler_fn> methods_;
+};
+
+// Register the built-in methods on `d` (getblockcount, ...).
+void register_builtin_methods(dispatcher& d);
+
+} // namespace kth::node::rpc
+
+#endif // KTH_NODE_RPC_DISPATCH_HPP

--- a/src/node/include/kth/node/rpc/error.hpp
+++ b/src/node/include/kth/node/rpc/error.hpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_RPC_ERROR_HPP
+#define KTH_NODE_RPC_ERROR_HPP
+
+#include <string>
+#include <utility>
+
+#include <kth/infrastructure/error.hpp>
+
+namespace kth::node::rpc {
+
+// JSON-RPC error codes are a distinct, EXTERNAL protocol namespace: the
+// negative-thousands values are fixed by JSON-RPC / Bitcoin Core / BCHN and are
+// what miner and wallet tooling matches on the wire. They deliberately do not
+// live in the system-wide `kth::code` enum (which stays an internal concern);
+// internal failures are bridged in via from_code() below.
+enum class error_code : int {
+    invalid_request  = -32600,
+    method_not_found = -32601,
+    invalid_params   = -32602,
+    internal_error   = -32603,
+    parse_error      = -32700,
+    // Application-level (Bitcoin RPC_MISC_ERROR family).
+    misc_error       = -1,
+};
+
+// A JSON-RPC error carried as data (not thrown): handlers return
+// std::expected<std::string, rpc_error>, so the error path stays exception-free.
+struct rpc_error {
+    int code;
+    std::string message;
+};
+
+// Build an rpc_error from a well-known JSON-RPC code.
+inline rpc_error make_error(error_code code, std::string message) {
+    return {static_cast<int>(code), std::move(message)};
+}
+
+// Bridge a system error (kth::code) to a JSON-RPC error at the RPC boundary: an
+// internal failure surfaces as internal_error carrying the system message.
+inline rpc_error from_code(kth::code const& ec) {
+    return {static_cast<int>(error_code::internal_error), ec.message()};
+}
+
+} // namespace kth::node::rpc
+
+#endif // KTH_NODE_RPC_ERROR_HPP

--- a/src/node/include/kth/node/rpc/json.hpp
+++ b/src/node/include/kth/node/rpc/json.hpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_RPC_JSON_HPP
+#define KTH_NODE_RPC_JSON_HPP
+
+#include <cstdint>
+#include <expected>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <simdjson.h>
+
+#include <kth/node/rpc/error.hpp>
+
+namespace kth::node::rpc {
+
+// A parsed JSON-RPC request. `params` and `id` hold the raw JSON text of those
+// members (owned copies) so handlers can re-parse params on demand and the
+// dispatcher can echo the id back verbatim (number, string, or null).
+struct request {
+    std::string method;
+    std::string params;         // raw JSON of "params" ("" when absent)
+    std::string id = "null";    // raw JSON of "id"     ("null" when absent)
+};
+
+// Parse a JSON-RPC request body. On failure returns the rpc_error to report:
+// parse_error for malformed JSON, invalid_request when "method" is missing.
+std::expected<request, rpc_error> parse_request(std::string_view body);
+
+// Build the response envelopes. `result_raw` / `id_raw` are already-serialized
+// JSON fragments and are emitted verbatim.
+std::string build_success(std::string_view id_raw, std::string_view result_raw);
+std::string build_error(std::string_view id_raw, int code, std::string_view message);
+
+// Ergonomic wrapper over simdjson's low-level string_builder. It owns comma and
+// colon placement plus object/array nesting, so a handler only describes the
+// shape of its result. All RPC result serialization goes through this (simdjson).
+struct writer {
+    writer();
+
+    writer& begin_object();
+    writer& end_object();
+    writer& begin_array();
+    writer& end_array();
+
+    // Object key. The next value() call supplies its value.
+    writer& key(std::string_view k);
+
+    // Scalar values (quoted+escaped for strings; verbatim for value_raw).
+    writer& value(std::string_view s);
+    writer& value(char const* s);
+    writer& value(bool b);
+    writer& value(std::int64_t n);
+    writer& value(std::uint64_t n);
+    writer& value(double d);
+    writer& value_raw(std::string_view raw_json);
+    writer& value_null();
+
+    // key + value in one call.
+    template <typename T>
+    writer& field(std::string_view k, T const& v) {
+        key(k);
+        value(v);
+        return *this;
+    }
+    writer& field_raw(std::string_view k, std::string_view raw_json) {
+        key(k);
+        value_raw(raw_json);
+        return *this;
+    }
+
+    // Finalize to an owned JSON string.
+    std::string str();
+
+private:
+    void pre_value();
+
+    simdjson::builder::string_builder b_;
+    std::vector<bool> first_;   // per nesting level: is the next element the first?
+    bool after_key_ = false;    // a key() was just written; value follows a colon
+};
+
+} // namespace kth::node::rpc
+
+#endif // KTH_NODE_RPC_JSON_HPP

--- a/src/node/include/kth/node/rpc/server.hpp
+++ b/src/node/include/kth/node/rpc/server.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_RPC_SERVER_HPP
+#define KTH_NODE_RPC_SERVER_HPP
+
+#include <string>
+#include <string_view>
+
+#include <asio/any_io_executor.hpp>
+#include <asio/awaitable.hpp>
+#include <asio/ip/tcp.hpp>
+
+#include <kth/node/rpc/dispatch.hpp>
+#include <kth/node/settings.hpp>
+
+namespace kth::blockchain {
+class block_chain;
+} // namespace kth::blockchain
+
+namespace kth::node::rpc {
+
+// A minimal JSON-RPC-over-HTTP/1.1 server. It runs on the node's existing
+// standalone-asio executor (no second runtime), parses requests with llhttp,
+// and routes them through the dispatcher. Started only when rpc.enabled is true
+// and the build defines KTH_WITH_RPC.
+struct server {
+    server(rpc_settings const& settings, blockchain::block_chain& chain);
+
+    // Bind the listener and accept connections until the executor is stopped.
+    // Intended to be co_spawned. Returns on a fatal bind error or shutdown.
+    ::asio::awaitable<void> run(::asio::any_io_executor executor);
+
+private:
+    ::asio::awaitable<void> serve_connection(::asio::ip::tcp::socket socket);
+    [[nodiscard]] bool authorized(std::string_view authorization_header) const;
+
+    rpc_settings const& settings_;
+    blockchain::block_chain& chain_;
+    dispatcher dispatcher_;
+    // Plaintext "user:password" (or "__cookie__:token") the Authorization header
+    // must decode to.
+    std::string expected_credentials_;
+};
+
+} // namespace kth::node::rpc
+
+#endif // KTH_NODE_RPC_SERVER_HPP

--- a/src/node/include/kth/node/settings.hpp
+++ b/src/node/include/kth/node/settings.hpp
@@ -6,12 +6,32 @@
 #define KTH_NODE_SETTINGS_HPP
 
 #include <cstdint>
+#include <string>
+
 #include <kth/domain.hpp>
 #include <kth/infrastructure/display_mode.hpp>
 #include <kth/infrastructure/utility/asio.hpp>
 #include <kth/node/define.hpp>
 
 namespace kth::node {
+
+/// JSON-RPC server settings. Always present so config parsing is uniform; the
+/// server itself is only compiled when KTH_WITH_RPC is defined and only started
+/// when `enabled` is true.
+struct KND_API rpc_settings {
+    rpc_settings();
+
+    /// Runtime on/off switch (config: rpc.enabled).
+    bool enabled;
+    /// Address to bind the RPC listener to (default 127.0.0.1 — localhost only).
+    std::string bind;
+    /// TCP port for the RPC listener (default 8332).
+    uint16_t port;
+    /// HTTP Basic-Auth credentials. When both are empty the server falls back to
+    /// the auto-generated .cookie file (bitcoind-style).
+    std::string user;
+    std::string password;
+};
 
 /// Common database configuration settings, properties not thread safe.
 struct KND_API settings {

--- a/src/node/src/configuration.cpp
+++ b/src/node/src/configuration.cpp
@@ -31,23 +31,4 @@ configuration::configuration(domain::config::network net)
 #endif
 {}
 
-// Copy constructor.
-configuration::configuration(configuration const& other)
-    : help(other.help)
-#if ! defined(KTH_DB_READONLY)
-    , initchain(other.initchain)
-    , init_and_run(other.init_and_run)
-#endif
-    , settings(other.settings)
-    , version(other.version)
-    , net(other.net)
-    , file(other.file)
-    , node(other.node)
-    , chain(other.chain)
-    , database(other.database)
-#if ! defined(__EMSCRIPTEN__)
-    , network(other.network)
-#endif
-{}
-
 } // namespace kth::node

--- a/src/node/src/full_node.cpp
+++ b/src/node/src/full_node.cpp
@@ -49,6 +49,7 @@ full_node::full_node(configuration const& configuration)
         network_type_,
         configuration.network.relay_transactions
     )
+    , rpc_settings_(configuration.rpc)
 #else
     : node_settings_(configuration.node)
     , chain_settings_(configuration.chain)
@@ -58,6 +59,7 @@ full_node::full_node(configuration const& configuration)
         configuration.database,
         network_type_
     )
+    , rpc_settings_(configuration.rpc)
 #endif
 {
 #if ! defined(__EMSCRIPTEN__)
@@ -124,6 +126,21 @@ full_node::~full_node() {
         spdlog::error("[node] Failure starting network: {}", ec.message());
         (void)chain_.stop();
         co_return ec;
+    }
+#endif
+
+#if defined(KTH_WITH_RPC) && ! defined(__EMSCRIPTEN__)
+    if (rpc_settings_.enabled) {
+        auto rpc_executor = network_.thread_pool().get_executor();
+        rpc_server_ = std::make_unique<rpc::server>(rpc_settings_, chain_);
+        ::asio::co_spawn(rpc_executor, rpc_server_->run(rpc_executor), ::asio::detached);
+    } else {
+        spdlog::info("[node] JSON-RPC server disabled (rpc.enabled=false).");
+    }
+#elif ! defined(__EMSCRIPTEN__)
+    if (rpc_settings_.enabled) {
+        spdlog::warn("[node] rpc.enabled=true but this build has no JSON-RPC support "
+            "(compile with the with_rpc option).");
     }
 #endif
 

--- a/src/node/src/parser.cpp
+++ b/src/node/src/parser.cpp
@@ -254,6 +254,17 @@ void add_settings(CLI::App& app, configuration& cfg) {
         cfg.node.display, parse_display_mode,
         "Display mode (tui, log, daemon).");
 
+    // [rpc]
+    app.add_option("--rpc.enabled",  cfg.rpc.enabled,
+        "Enable the JSON-RPC server (requires a build with RPC support).");
+    app.add_option("--rpc.bind",     cfg.rpc.bind,
+        "Address the JSON-RPC listener binds to (default 127.0.0.1).");
+    app.add_option("--rpc.port",     cfg.rpc.port,
+        "TCP port for the JSON-RPC listener (default 8332).");
+    app.add_option("--rpc.user",     cfg.rpc.user,
+        "JSON-RPC HTTP Basic-Auth user (empty uses the .cookie file).");
+    app.add_option("--rpc.password", cfg.rpc.password,
+        "JSON-RPC HTTP Basic-Auth password.");
 }
 
 // Read KTH_* env vars once and, for the subset of names that map to CLI11

--- a/src/node/src/rpc/dispatch.cpp
+++ b/src/node/src/rpc/dispatch.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/rpc/dispatch.hpp>
+
+#include <utility>
+
+#include <kth/blockchain/interface/block_chain.hpp>
+
+#include <kth/node/rpc/error.hpp>
+
+namespace kth::node::rpc {
+
+void dispatcher::add(std::string method, handler_fn handler) {
+    methods_.insert_or_assign(std::move(method), std::move(handler));
+}
+
+bool dispatcher::has(std::string_view method) const {
+    return methods_.find(std::string(method)) != methods_.end();
+}
+
+::asio::awaitable<std::string>
+dispatcher::handle(blockchain::block_chain& chain, std::string_view body) const {
+    auto const req = parse_request(body);
+    if ( ! req) {
+        co_return build_error("null", req.error().code, req.error().message);
+    }
+
+    auto const it = methods_.find(req->method);
+    if (it == methods_.end()) {
+        co_return build_error(req->id, static_cast<int>(error_code::method_not_found),
+            "Method not found");
+    }
+
+    auto const result = co_await it->second(chain, *req);
+    if ( ! result) {
+        co_return build_error(req->id, result.error().code, result.error().message);
+    }
+    co_return build_success(req->id, *result);
+}
+
+} // namespace kth::node::rpc

--- a/src/node/src/rpc/json.cpp
+++ b/src/node/src/rpc/json.cpp
@@ -1,0 +1,198 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/rpc/json.hpp>
+
+#include <string>
+#include <string_view>
+
+namespace kth::node::rpc {
+
+namespace {
+
+// Copy the raw JSON text of an on-demand value into `out`. Returns false if the
+// value could not be materialized.
+bool copy_raw(simdjson::ondemand::value value, std::string& out) {
+    std::string_view raw;
+    if (value.raw_json().get(raw) != simdjson::SUCCESS) {
+        return false;
+    }
+    out.assign(raw);
+    return true;
+}
+
+} // namespace
+
+std::expected<request, rpc_error> parse_request(std::string_view body) {
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string padded(body);
+
+    simdjson::ondemand::document doc;
+    if (parser.iterate(padded).get(doc) != simdjson::SUCCESS) {
+        return std::unexpected(make_error(error_code::parse_error, "Parse error"));
+    }
+
+    // "method" is mandatory and must be a string.
+    std::string_view method;
+    if (doc["method"].get_string().get(method) != simdjson::SUCCESS) {
+        return std::unexpected(
+            make_error(error_code::invalid_request, "Missing or invalid 'method'"));
+    }
+
+    request req;
+    req.method.assign(method);
+
+    // "params" is optional (any JSON type) — kept as raw text for the handler.
+    simdjson::ondemand::value params;
+    if (doc["params"].get(params) == simdjson::SUCCESS) {
+        copy_raw(params, req.params);
+    }
+
+    // "id" is optional; echoed back verbatim. Absent => "null" (default).
+    simdjson::ondemand::value id;
+    if (doc["id"].get(id) == simdjson::SUCCESS) {
+        copy_raw(id, req.id);
+    }
+
+    return req;
+}
+
+std::string build_success(std::string_view id_raw, std::string_view result_raw) {
+    writer w;
+    w.begin_object();
+    w.field_raw("result", result_raw.empty() ? "null" : result_raw);
+    w.key("error").value_null();
+    w.field_raw("id", id_raw.empty() ? "null" : id_raw);
+    w.end_object();
+    return w.str();
+}
+
+std::string build_error(std::string_view id_raw, int code, std::string_view message) {
+    writer w;
+    w.begin_object();
+    w.key("result").value_null();
+    w.key("error").begin_object();
+    w.field("code", static_cast<std::int64_t>(code));
+    w.field("message", message);
+    w.end_object();
+    w.field_raw("id", id_raw.empty() ? "null" : id_raw);
+    w.end_object();
+    return w.str();
+}
+
+// ---- writer ---------------------------------------------------------------
+
+writer::writer() = default;
+
+void writer::pre_value() {
+    if (after_key_) {
+        after_key_ = false;
+        return;
+    }
+    if ( ! first_.empty()) {
+        if ( ! first_.back()) {
+            b_.append_comma();
+        }
+        first_.back() = false;
+    }
+}
+
+writer& writer::begin_object() {
+    pre_value();
+    b_.start_object();
+    first_.push_back(true);
+    return *this;
+}
+
+writer& writer::end_object() {
+    b_.end_object();
+    if ( ! first_.empty()) {
+        first_.pop_back();
+    }
+    return *this;
+}
+
+writer& writer::begin_array() {
+    pre_value();
+    b_.start_array();
+    first_.push_back(true);
+    return *this;
+}
+
+writer& writer::end_array() {
+    b_.end_array();
+    if ( ! first_.empty()) {
+        first_.pop_back();
+    }
+    return *this;
+}
+
+writer& writer::key(std::string_view k) {
+    if ( ! first_.empty()) {
+        if ( ! first_.back()) {
+            b_.append_comma();
+        }
+        first_.back() = false;
+    }
+    b_.escape_and_append_with_quotes(k);
+    b_.append_colon();
+    after_key_ = true;
+    return *this;
+}
+
+writer& writer::value(std::string_view s) {
+    pre_value();
+    b_.escape_and_append_with_quotes(s);
+    return *this;
+}
+
+writer& writer::value(char const* s) {
+    return value(std::string_view(s));
+}
+
+writer& writer::value(bool b) {
+    pre_value();
+    b_.append_raw(b ? "true" : "false");
+    return *this;
+}
+
+writer& writer::value(std::int64_t n) {
+    pre_value();
+    b_.append(n);
+    return *this;
+}
+
+writer& writer::value(std::uint64_t n) {
+    pre_value();
+    b_.append(n);
+    return *this;
+}
+
+writer& writer::value(double d) {
+    pre_value();
+    b_.append(d);
+    return *this;
+}
+
+writer& writer::value_raw(std::string_view raw_json) {
+    pre_value();
+    b_.append_raw(raw_json);
+    return *this;
+}
+
+writer& writer::value_null() {
+    pre_value();
+    b_.append_raw("null");
+    return *this;
+}
+
+std::string writer::str() {
+    std::string_view sv;
+    if (b_.view().get(sv) != simdjson::SUCCESS) {
+        return "null";
+    }
+    return std::string(sv);
+}
+
+} // namespace kth::node::rpc

--- a/src/node/src/rpc/methods.cpp
+++ b/src/node/src/rpc/methods.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <cstdint>
+#include <expected>
+#include <string>
+
+#include <asio/awaitable.hpp>
+
+#include <kth/blockchain/interface/block_chain.hpp>
+
+#include <kth/node/rpc/dispatch.hpp>
+#include <kth/node/rpc/error.hpp>
+#include <kth/node/rpc/json.hpp>
+
+namespace kth::node::rpc {
+
+namespace {
+
+// getblockcount -> the height of the most-work fully-validated block.
+// C-API counterpart: kth_chain_sync_last_height (see docs/json-rpc.md).
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_block_count(blockchain::block_chain& chain, request const& /*req*/) {
+    auto const heights = co_await chain.fetch_last_height();
+    if ( ! heights) {
+        co_return std::unexpected(from_code(heights.error()));
+    }
+
+    writer w;
+    w.value(static_cast<std::uint64_t>(heights->block));
+    co_return w.str();
+}
+
+} // namespace
+
+void register_builtin_methods(dispatcher& d) {
+    d.add("getblockcount", get_block_count);
+}
+
+} // namespace kth::node::rpc

--- a/src/node/src/rpc/server.cpp
+++ b/src/node/src/rpc/server.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/rpc/server.hpp>
+
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <random>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#include <asio/as_tuple.hpp>
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/ip/address.hpp>
+#include <asio/use_awaitable.hpp>
+#include <asio/write.hpp>
+
+#include <llhttp.h>
+#include <spdlog/spdlog.h>
+
+#include <kth/blockchain/interface/block_chain.hpp>
+#include <kth/infrastructure/formats/base_64.hpp>
+#include <kth/infrastructure/utility/data.hpp>
+
+namespace kth::node::rpc {
+
+namespace {
+
+// ---- HTTP request accumulation (llhttp callbacks) -------------------------
+
+bool iequals(std::string_view a, std::string_view b) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (std::tolower(static_cast<unsigned char>(a[i])) !=
+            std::tolower(static_cast<unsigned char>(b[i]))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+struct parse_ctx {
+    std::string field;
+    std::string value;
+    bool reading_value = false;
+    std::string authorization;
+    std::string body;
+    bool complete = false;
+    unsigned method = 0;
+    bool keep_alive = true;
+
+    void commit_header() {
+        if (iequals(field, "authorization")) {
+            authorization = value;
+        }
+        field.clear();
+        value.clear();
+    }
+};
+
+int on_header_field(llhttp_t* p, char const* at, std::size_t len) {
+    auto* c = static_cast<parse_ctx*>(p->data);
+    if (c->reading_value) {
+        c->commit_header();
+        c->reading_value = false;
+    }
+    c->field.append(at, len);
+    return 0;
+}
+
+int on_header_value(llhttp_t* p, char const* at, std::size_t len) {
+    auto* c = static_cast<parse_ctx*>(p->data);
+    c->value.append(at, len);
+    c->reading_value = true;
+    return 0;
+}
+
+int on_headers_complete(llhttp_t* p) {
+    auto* c = static_cast<parse_ctx*>(p->data);
+    if (c->reading_value) {
+        c->commit_header();
+        c->reading_value = false;
+    }
+    return 0;
+}
+
+int on_body(llhttp_t* p, char const* at, std::size_t len) {
+    static_cast<parse_ctx*>(p->data)->body.append(at, len);
+    return 0;
+}
+
+int on_message_complete(llhttp_t* p) {
+    auto* c = static_cast<parse_ctx*>(p->data);
+    c->complete = true;
+    c->method = llhttp_get_method(p);
+    c->keep_alive = llhttp_should_keep_alive(p) != 0;
+    return 0;
+}
+
+void init_parser(llhttp_t& parser, llhttp_settings_t& settings, parse_ctx& ctx) {
+    llhttp_settings_init(&settings);
+    settings.on_header_field = on_header_field;
+    settings.on_header_value = on_header_value;
+    settings.on_headers_complete = on_headers_complete;
+    settings.on_body = on_body;
+    settings.on_message_complete = on_message_complete;
+    llhttp_init(&parser, HTTP_REQUEST, &settings);
+    parser.data = &ctx;
+}
+
+// ---- HTTP response --------------------------------------------------------
+
+::asio::awaitable<void> write_response(
+    ::asio::ip::tcp::socket& socket,
+    int status,
+    std::string_view reason,
+    std::string_view body,
+    bool keep_alive,
+    std::string_view extra_headers = {}) {
+
+    std::string out;
+    out.reserve(body.size() + 160);
+    out += "HTTP/1.1 ";
+    out += std::to_string(status);
+    out += ' ';
+    out += reason;
+    out += "\r\nContent-Type: application/json\r\nContent-Length: ";
+    out += std::to_string(body.size());
+    out += "\r\nConnection: ";
+    out += keep_alive ? "keep-alive" : "close";
+    out += "\r\n";
+    out += extra_headers;
+    out += "\r\n";
+    out += body;
+
+    co_await ::asio::async_write(socket, ::asio::buffer(out),
+        ::asio::as_tuple(::asio::use_awaitable));
+}
+
+std::string random_token() {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<int> dist(0, 15);
+    static constexpr char hex[] = "0123456789abcdef";
+    std::string token;
+    token.reserve(64);
+    for (int i = 0; i < 64; ++i) {
+        token.push_back(hex[dist(gen)]);
+    }
+    return token;
+}
+
+} // namespace
+
+server::server(rpc_settings const& settings, blockchain::block_chain& chain)
+    : settings_(settings)
+    , chain_(chain) {
+    register_builtin_methods(dispatcher_);
+
+    if ( ! settings_.user.empty() || ! settings_.password.empty()) {
+        expected_credentials_ = settings_.user + ":" + settings_.password;
+    } else {
+        // bitcoind-style cookie: "__cookie__:<random>" written to ./.cookie.
+        expected_credentials_ = "__cookie__:" + random_token();
+        std::ofstream cookie(".cookie", std::ios::trunc);
+        cookie << expected_credentials_;
+        spdlog::info("[rpc] using generated auth cookie (./.cookie)");
+    }
+}
+
+bool server::authorized(std::string_view authorization_header) const {
+    constexpr std::string_view prefix = "Basic ";
+    if ( ! authorization_header.starts_with(prefix)) {
+        return false;
+    }
+    data_chunk decoded;
+    if ( ! decode_base64(decoded, authorization_header.substr(prefix.size()))) {
+        return false;
+    }
+    std::string_view const got(
+        reinterpret_cast<char const*>(decoded.data()), decoded.size());
+    return got == expected_credentials_;
+}
+
+::asio::awaitable<void> server::serve_connection(::asio::ip::tcp::socket socket) {
+    std::array<char, 8192> buffer;
+    for (;;) {
+        parse_ctx ctx;
+        llhttp_t parser;
+        llhttp_settings_t settings;
+        init_parser(parser, settings, ctx);
+
+        while ( ! ctx.complete) {
+            auto [ec, n] = co_await socket.async_read_some(
+                ::asio::buffer(buffer), ::asio::as_tuple(::asio::use_awaitable));
+            if (ec || n == 0) {
+                co_return; // client closed or read error
+            }
+            if (llhttp_execute(&parser, buffer.data(), n) != HPE_OK) {
+                co_await write_response(socket, 400, "Bad Request",
+                    R"({"result":null,"error":{"code":-32700,"message":"Parse error"},"id":null})",
+                    false);
+                co_return;
+            }
+        }
+
+        if ( ! authorized(ctx.authorization)) {
+            co_await write_response(socket, 401, "Unauthorized",
+                R"({"result":null,"error":{"code":-1,"message":"unauthorized"},"id":null})",
+                false, "WWW-Authenticate: Basic realm=\"kth\"\r\n");
+            co_return;
+        }
+
+        if (ctx.method != HTTP_POST) {
+            co_await write_response(socket, 405, "Method Not Allowed",
+                R"({"result":null,"error":{"code":-32600,"message":"Only POST is supported"},"id":null})",
+                false);
+            co_return;
+        }
+
+        std::string const response = co_await dispatcher_.handle(chain_, ctx.body);
+        co_await write_response(socket, 200, "OK", response, ctx.keep_alive);
+        if ( ! ctx.keep_alive) {
+            co_return;
+        }
+    }
+}
+
+::asio::awaitable<void> server::run(::asio::any_io_executor executor) {
+    using ::asio::ip::tcp;
+
+    std::error_code ec;
+    auto const address = ::asio::ip::make_address(settings_.bind, ec);
+    if (ec) {
+        spdlog::error("[rpc] invalid bind address '{}': {}", settings_.bind, ec.message());
+        co_return;
+    }
+
+    tcp::endpoint const endpoint(address, settings_.port);
+    tcp::acceptor acceptor(executor);
+    acceptor.open(endpoint.protocol(), ec);
+    if (ec) {
+        spdlog::error("[rpc] failed to open acceptor: {}", ec.message());
+        co_return;
+    }
+    acceptor.set_option(tcp::acceptor::reuse_address(true), ec);
+    acceptor.bind(endpoint, ec);
+    if (ec) {
+        spdlog::error("[rpc] failed to bind {}:{}: {}", settings_.bind, settings_.port,
+            ec.message());
+        co_return;
+    }
+    acceptor.listen(tcp::socket::max_listen_connections, ec);
+    if (ec) {
+        spdlog::error("[rpc] failed to listen: {}", ec.message());
+        co_return;
+    }
+
+    spdlog::info("[rpc] JSON-RPC server listening on {}:{}", settings_.bind, settings_.port);
+
+    for (;;) {
+        auto [aec, socket] = co_await acceptor.async_accept(
+            ::asio::as_tuple(::asio::use_awaitable));
+        if (aec) {
+            if (aec == ::asio::error::operation_aborted) {
+                co_return;
+            }
+            continue;
+        }
+        ::asio::co_spawn(executor, serve_connection(std::move(socket)), ::asio::detached);
+    }
+}
+
+} // namespace kth::node::rpc

--- a/src/node/src/settings.cpp
+++ b/src/node/src/settings.cpp
@@ -28,4 +28,12 @@ duration settings::block_latency() const {
     return seconds(block_latency_seconds);
 }
 
+rpc_settings::rpc_settings()
+    : enabled(false)
+    , bind("127.0.0.1")
+    , port(8332)
+    , user()
+    , password()
+{}
+
 } // namespace kth::node

--- a/src/node/test/rpc_json.cpp
+++ b/src/node/test/rpc_json.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <kth/node/rpc/json.hpp>
+
+using namespace kth::node::rpc;
+
+// Start Test Suite: rpc json tests
+
+TEST_CASE("writer scalar number", "[rpc json]") {
+    writer w;
+    w.value(static_cast<std::uint64_t>(42));
+    REQUIRE(w.str() == "42");
+}
+
+TEST_CASE("writer object with mixed fields", "[rpc json]") {
+    writer w;
+    w.begin_object();
+    w.field("name", "kth");
+    w.field("height", static_cast<std::int64_t>(7));
+    w.field("ok", true);
+    w.end_object();
+    REQUIRE(w.str() == R"({"name":"kth","height":7,"ok":true})");
+}
+
+TEST_CASE("writer nested array of objects", "[rpc json]") {
+    writer w;
+    w.begin_object();
+    w.key("items").begin_array();
+    w.begin_object().field("id", static_cast<std::int64_t>(1)).end_object();
+    w.begin_object().field("id", static_cast<std::int64_t>(2)).end_object();
+    w.end_array();
+    w.end_object();
+    REQUIRE(w.str() == R"({"items":[{"id":1},{"id":2}]})");
+}
+
+TEST_CASE("writer escapes strings", "[rpc json]") {
+    writer w;
+    w.value(std::string_view("a\"b\\c"));
+    REQUIRE(w.str() == R"("a\"b\\c")");
+}
+
+TEST_CASE("parse_request extracts method params id", "[rpc json]") {
+    auto req = parse_request(R"({"jsonrpc":"2.0","id":7,"method":"getblockcount","params":[1,2]})");
+    REQUIRE(req.has_value());
+    REQUIRE(req->method == "getblockcount");
+    REQUIRE(req->params == "[1,2]");
+    REQUIRE(req->id == "7");
+}
+
+TEST_CASE("parse_request defaults id to null", "[rpc json]") {
+    auto req = parse_request(R"({"method":"getblockcount"})");
+    REQUIRE(req.has_value());
+    REQUIRE(req->id == "null");
+    REQUIRE(req->params.empty());
+}
+
+TEST_CASE("parse_request echoes string id verbatim", "[rpc json]") {
+    auto req = parse_request(R"({"method":"m","id":"abc"})");
+    REQUIRE(req.has_value());
+    REQUIRE(req->id == "\"abc\"");
+}
+
+TEST_CASE("parse_request rejects malformed json", "[rpc json]") {
+    REQUIRE_FALSE(parse_request("{bad").has_value());
+}
+
+TEST_CASE("parse_request rejects missing method", "[rpc json]") {
+    REQUIRE_FALSE(parse_request(R"({"id":1})").has_value());
+}
+
+TEST_CASE("build_success wraps result", "[rpc json]") {
+    REQUIRE(build_success("1", "0") == R"({"result":0,"error":null,"id":1})");
+}
+
+TEST_CASE("build_error wraps code and message", "[rpc json]") {
+    REQUIRE(build_error("null", -32601, "Method not found") ==
+        R"({"result":null,"error":{"code":-32601,"message":"Method not found"},"id":null})");
+}


### PR DESCRIPTION
First phase of the JSON-RPC interface: the server foundation, proven end-to-end with a single method.

## What
An optional JSON-RPC-over-HTTP server, **off by default** and gated twice:
- **compile time**: conan `with_rpc` → CMake `KTH_WITH_RPC` → `#if defined(KTH_WITH_RPC)`
- **runtime**: `rpc.enabled` config key

The JSON-RPC server and the C-API are two frontends over the same C++ `block_chain` core, so **every method has a C-API counterpart** (documented in `docs/json-rpc.md`).

## Stack
Chosen to stay on the node's existing async model with no second runtime:
- **I/O**: the standalone-asio coroutine loop already used by the network module
- **HTTP**: [llhttp](https://github.com/nodejs/llhttp) (Node.js parser, sans-io), pulled in only when `with_rpc` is on
- **JSON**: simdjson for both parsing and serialization (a small `writer` wraps simdjson's low-level builder)
- **Auth**: bitcoind-style HTTP Basic (`rpc.user`/`rpc.password`, or a generated `.cookie`)

## Method shipped
`getblockcount` → `block_chain::fetch_last_height().block`. Its C-API counterpart already exists (`kth_chain_sync_last_height`), which is what validates the shared-core design. This proves the whole path: accept → parse → auth → dispatch → serialize.

Config keys live under `[rpc]` (`rpc.enabled/bind/port/user/password`).

## Also
Drops the hand-written `configuration` copy constructor (`= default`). It was silently omitting members — the newly added `rpc` settings group exposed the bug (a copied configuration reset `rpc.enabled` to false). Defaulting it means new settings groups can't be forgotten.

## Verification
End-to-end via `curl` against a local node:
- `getblockcount` → `{"result":0,"error":null,"id":1}`
- `401` on bad/absent auth, `405` on non-POST
- `-32601` method-not-found, `-32700` parse error, string `id` echoed verbatim
- 2000 concurrent requests handled without issue

Unit tests: `test/rpc_json.cpp` (writer, request parsing, envelopes). Node test suite green with RPC **on and off**.

Note: default CI builds with `with_rpc=False`, so it does not compile the RPC path; a dedicated `with_rpc` CI job would exercise it (follow-up).

Later phases: mining (`getblocktemplate`, `submitblock`, `getmininginfo`) + a miner-saturation benchmark, then mempool and blockchain/raw-tx methods.