### PR TITLE
node: add getblocktemplatelight JSON-RPC method

### DIFF
--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -67,7 +67,31 @@ counterpart.
 | JSON-RPC method | C-API function | C++ (`block_chain`) |
 |---|---|---|
 | `getblockcount` | `kth_chain_sync_last_height` | `fetch_last_height().block` |
+| `getblocktemplatelight` | `kth_chain_async_fetch_mining_template` _(pending)_ | `fetch_mining_template()` |
 
-_More methods land per phase: mining (`getblocktemplate`, `submitblock`,
+_More methods land per phase: mining (`submitblocklight`, `submitblock`,
 `getmininginfo`), mempool (`getrawmempool`, `getmempoolentry`, ...), and
 blockchain/raw-tx (`getblock`, `getrawtransaction`, `sendrawtransaction`, ...)._
+
+## Mining: getblocktemplatelight
+
+Returns the next-block template **without** the transaction list. The selected
+transactions are cached server-side under `job_id`; a later `submitblocklight`
+(pending) reconstructs the full block from the miner's solved header + coinbase
+alone, so transactions never travel over the wire.
+
+Response fields: `version`, `previousblockhash`, `height`, `coinbasevalue`
+(subsidy + selected fees), `target`, `bits`, `mintime` (MTP + 1), `curtime`,
+`sizelimit`, `sigchecklimit`, `noncerange`, `mutable`, and `job_id`.
+
+Job cache config (mirrors bitcoind `-gbtcachesize` / `-gbtstoretime`):
+
+```ini
+rpc.gbt_cache_size = 10     # recent jobs kept
+rpc.gbt_store_time = 3600   # seconds before a job expires
+```
+
+> The template is rebuilt on every call (no per-tip cache yet). `tools/rpc_bench.py`
+> load-tests the miner-polling side; a faithful benchmark also simulates
+> transactions and blocks arriving (mempool churn + tip changes), which needs the
+> submit paths added in later phases.

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -403,6 +403,11 @@ struct KB_API block_chain {
     [[nodiscard]] awaitable_expected<blockchain::block_template>
     fetch_template() const;
 
+    // Full mining template (header fields + coinbase value + tx selection) for
+    // getblocktemplate[light]. C-API counterpart: kth_chain_async_fetch_mining_template.
+    [[nodiscard]] awaitable_expected<blockchain::mining_template>
+    fetch_mining_template() const;
+
     [[nodiscard]] awaitable_expected<inventory_ptr>
     fetch_mempool(size_t count_limit, uint64_t minimum_fee) const;
 

--- a/src/blockchain/include/kth/blockchain/pools/block_template.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/block_template.hpp
@@ -47,6 +47,23 @@ struct block_template_context {
 KB_API
 block_template build_block_template(mempool const& pool, block_template_context const& ctx);
 
+// A full mining template: the transaction selection plus every header-level field
+// a miner needs to assemble and solve the next block. This is what the getblock-
+// template / getblocktemplatelight RPC and its C-API counterpart serialize. The
+// caller builds a coinbase paying `coinbase_value` and prepends it to `selection`.
+struct mining_template {
+    uint32_t version;                   // suggested block version
+    hash_digest previous_block_hash;    // tip hash (big-endian display is caller's job)
+    size_t height;                      // template height (tip + 1)
+    uint32_t bits;                      // required work, compact nBits
+    uint32_t min_time;                  // earliest valid timestamp (MTP + 1)
+    uint32_t current_time;              // suggested timestamp (clamped to >= min_time)
+    uint64_t coinbase_value;            // subsidy(height) + selected fees, in satoshis
+    uint64_t size_limit;                // consensus max block size
+    uint64_t sigchecks_limit;           // consensus max block sigchecks
+    block_template selection;           // CTOR-ordered txs + totals (no coinbase)
+};
+
 } // namespace kth::blockchain
 
 #endif

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1497,6 +1497,57 @@ block_chain::fetch_template() const {
         state->median_time_past()});
 }
 
+awaitable_expected<blockchain::mining_template>
+block_chain::fetch_mining_template() const {
+    if (stopped()) {
+        co_return std::unexpected(error::service_stopped);
+    }
+
+    auto const state = chain_state();
+    if ( ! state) {
+        co_return std::unexpected(error::not_found);
+    }
+
+    auto const height = state->height();
+
+    auto selection = build_block_template(mempool_, block_template_context{
+        state->dynamic_max_block_size(),
+        state->dynamic_max_block_sigchecks(),
+        height,
+        state->median_time_past()});
+
+    // Previous block hash = the tip, i.e. the block one below the template height.
+    hash_digest previous = null_hash;
+    if (height > 0) {
+        auto const prev = get_block_hash(height - 1);
+        if ( ! prev) {
+            co_return std::unexpected(error::not_found);
+        }
+        previous = *prev;
+    }
+
+    auto const min_time = state->median_time_past() + 1;
+    auto const current_time = std::max(min_time,
+        static_cast<uint32_t>(zulu_time()));
+
+    auto const coinbase_value = selection.total_fees +
+        domain::chain::block::subsidy(height, true);
+
+    // 0x20000000: the BIP9 version base. BCH has no active version-bits signaling,
+    // and miners routinely override this, so it is only a sensible default.
+    co_return blockchain::mining_template{
+        0x20000000U,
+        previous,
+        height,
+        state->work_required(),
+        min_time,
+        current_time,
+        coinbase_value,
+        state->dynamic_max_block_size(),
+        state->dynamic_max_block_sigchecks(),
+        std::move(selection)};
+}
+
 awaitable_expected<inventory_ptr>
 block_chain::fetch_mempool(size_t count_limit, uint64_t /*minimum_fee*/) const {
     if (stopped()) {

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -167,6 +167,7 @@ if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     ${kth_sources_just_legacy}
     src/rpc/json.cpp
     src/rpc/dispatch.cpp
+    src/rpc/job_store.cpp
     src/rpc/methods.cpp
     src/rpc/server.cpp
   )
@@ -207,6 +208,7 @@ set(kth_headers
   include/kth/node/rpc/error.hpp
   include/kth/node/rpc/json.hpp
   include/kth/node/rpc/dispatch.hpp
+  include/kth/node/rpc/job_store.hpp
   include/kth/node/rpc/server.hpp
 
   # CSP-based sync system
@@ -284,7 +286,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 
   # JSON-RPC unit tests build only when the server is compiled in.
   if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    target_sources(kth_node_test PRIVATE test/rpc_json.cpp)
+    target_sources(kth_node_test PRIVATE test/rpc_json.cpp test/rpc_job_store.cpp)
   endif()
 
   target_include_directories(kth_node_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)

--- a/src/node/include/kth/node/rpc/dispatch.hpp
+++ b/src/node/include/kth/node/rpc/dispatch.hpp
@@ -22,11 +22,20 @@ class block_chain;
 
 namespace kth::node::rpc {
 
+struct job_store;
+
+// Shared state a handler may reach: the chain and the getblocktemplatelight job
+// cache. Passed by reference; owned by the server for the connection's lifetime.
+struct method_context {
+    blockchain::block_chain& chain;
+    job_store& jobs;
+};
+
 // A method handler serializes the JSON-RPC "result" fragment for `req`, or
 // returns an rpc_error. It runs on the RPC coroutine and may co_await the chain.
 using handler_fn = std::function<
     ::asio::awaitable<std::expected<std::string, rpc_error>>(
-        blockchain::block_chain&, request const&)>;
+        method_context&, request const&)>;
 
 // Routes a parsed JSON-RPC request to its registered handler and wraps the
 // outcome (or any error) in a JSON-RPC response envelope.
@@ -36,7 +45,7 @@ struct dispatcher {
 
     // Parse `body`, invoke the matching handler, and return the full response body.
     [[nodiscard]] ::asio::awaitable<std::string>
-    handle(blockchain::block_chain& chain, std::string_view body) const;
+    handle(method_context& ctx, std::string_view body) const;
 
 private:
     boost::unordered_flat_map<std::string, handler_fn> methods_;

--- a/src/node/include/kth/node/rpc/job_store.hpp
+++ b/src/node/include/kth/node/rpc/job_store.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_RPC_JOB_STORE_HPP
+#define KTH_NODE_RPC_JOB_STORE_HPP
+
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <boost/unordered/unordered_flat_map.hpp>
+
+#include <kth/blockchain/pools/block_template.hpp>
+
+namespace kth::node::rpc {
+
+// Stores the transaction selection behind each getblocktemplatelight job so a
+// later submitblocklight can reconstruct the full block from the miner's solved
+// header + coinbase alone (transactions never travel over the wire). Bounded by
+// count (gbtcachesize) with insertion-order eviction and a TTL (gbtstoretime).
+// Thread-safe: RPC handlers run on the shared asio executor.
+struct job_store {
+    job_store(std::size_t max_jobs, std::uint32_t ttl_seconds);
+
+    // Store `txs` under a content-derived job id (hex) and return it. Re-adding
+    // the same selection yields the same id (idempotent).
+    std::string add(std::vector<transaction_const_ptr> txs);
+
+    // The transactions for `job_id`, or nullopt if unknown or expired. Used by
+    // submitblocklight (F1b).
+    std::optional<std::vector<transaction_const_ptr>> get(std::string const& job_id) const;
+
+private:
+    struct entry {
+        std::vector<transaction_const_ptr> txs;
+        std::uint32_t created;
+    };
+
+    void evict_locked();
+
+    mutable std::mutex mutex_;
+    boost::unordered_flat_map<std::string, entry> jobs_;
+    std::deque<std::string> order_;   // insertion order, for count eviction
+    std::size_t max_jobs_;
+    std::uint32_t ttl_seconds_;
+};
+
+} // namespace kth::node::rpc
+
+#endif // KTH_NODE_RPC_JOB_STORE_HPP

--- a/src/node/include/kth/node/rpc/server.hpp
+++ b/src/node/include/kth/node/rpc/server.hpp
@@ -13,6 +13,7 @@
 #include <asio/ip/tcp.hpp>
 
 #include <kth/node/rpc/dispatch.hpp>
+#include <kth/node/rpc/job_store.hpp>
 #include <kth/node/settings.hpp>
 
 namespace kth::blockchain {
@@ -39,6 +40,7 @@ private:
     rpc_settings const& settings_;
     blockchain::block_chain& chain_;
     dispatcher dispatcher_;
+    job_store jobs_;
     // Plaintext "user:password" (or "__cookie__:token") the Authorization header
     // must decode to.
     std::string expected_credentials_;

--- a/src/node/include/kth/node/settings.hpp
+++ b/src/node/include/kth/node/settings.hpp
@@ -31,6 +31,11 @@ struct KND_API rpc_settings {
     /// the auto-generated .cookie file (bitcoind-style).
     std::string user;
     std::string password;
+    /// getblocktemplatelight job cache: how many recent jobs to keep, and for how
+    /// long (seconds) before a job expires. Mirrors bitcoind -gbtcachesize /
+    /// -gbtstoretime.
+    uint32_t gbt_cache_size;
+    uint32_t gbt_store_time;
 };
 
 /// Common database configuration settings, properties not thread safe.

--- a/src/node/src/parser.cpp
+++ b/src/node/src/parser.cpp
@@ -265,6 +265,10 @@ void add_settings(CLI::App& app, configuration& cfg) {
         "JSON-RPC HTTP Basic-Auth user (empty uses the .cookie file).");
     app.add_option("--rpc.password", cfg.rpc.password,
         "JSON-RPC HTTP Basic-Auth password.");
+    app.add_option("--rpc.gbt_cache_size", cfg.rpc.gbt_cache_size,
+        "getblocktemplatelight jobs to keep cached (default 10).");
+    app.add_option("--rpc.gbt_store_time", cfg.rpc.gbt_store_time,
+        "Seconds to keep a getblocktemplatelight job (default 3600).");
 }
 
 // Read KTH_* env vars once and, for the subset of names that map to CLI11

--- a/src/node/src/rpc/dispatch.cpp
+++ b/src/node/src/rpc/dispatch.cpp
@@ -21,7 +21,7 @@ bool dispatcher::has(std::string_view method) const {
 }
 
 ::asio::awaitable<std::string>
-dispatcher::handle(blockchain::block_chain& chain, std::string_view body) const {
+dispatcher::handle(method_context& ctx, std::string_view body) const {
     auto const req = parse_request(body);
     if ( ! req) {
         co_return build_error("null", req.error().code, req.error().message);
@@ -33,7 +33,7 @@ dispatcher::handle(blockchain::block_chain& chain, std::string_view body) const 
             "Method not found");
     }
 
-    auto const result = co_await it->second(chain, *req);
+    auto const result = co_await it->second(ctx, *req);
     if ( ! result) {
         co_return build_error(req->id, result.error().code, result.error().message);
     }

--- a/src/node/src/rpc/job_store.cpp
+++ b/src/node/src/rpc/job_store.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/rpc/job_store.hpp>
+
+#include <utility>
+
+#include <kth/infrastructure/formats/base_16.hpp>
+#include <kth/infrastructure/math/hash.hpp>
+#include <kth/infrastructure/utility/data.hpp>
+#include <kth/infrastructure/utility/timer.hpp>
+
+namespace kth::node::rpc {
+
+job_store::job_store(std::size_t max_jobs, std::uint32_t ttl_seconds)
+    : max_jobs_(max_jobs == 0 ? 1 : max_jobs)
+    , ttl_seconds_(ttl_seconds)
+{}
+
+std::string job_store::add(std::vector<transaction_const_ptr> txs) {
+    // Content-derived id: double-SHA256 over the concatenated txids.
+    data_chunk material;
+    material.reserve(txs.size() * hash_size);
+    for (auto const& tx : txs) {
+        auto const h = tx->hash();
+        material.insert(material.end(), h.begin(), h.end());
+    }
+    auto const job_id = encode_base16(bitcoin_hash(material));
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto const now = static_cast<std::uint32_t>(zulu_time());
+    auto const [it, inserted] = jobs_.try_emplace(job_id, entry{std::move(txs), now});
+    if (inserted) {
+        order_.push_back(job_id);
+    } else {
+        it->second.created = now; // refresh TTL on re-add
+    }
+    evict_locked();
+    return job_id;
+}
+
+std::optional<std::vector<transaction_const_ptr>>
+job_store::get(std::string const& job_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto const it = jobs_.find(job_id);
+    if (it == jobs_.end()) {
+        return std::nullopt;
+    }
+    auto const now = static_cast<std::uint32_t>(zulu_time());
+    if (now - it->second.created > ttl_seconds_) {
+        return std::nullopt;
+    }
+    return it->second.txs;
+}
+
+// Requires mutex_ held. Drops expired jobs and enforces the count bound.
+void job_store::evict_locked() {
+    auto const now = static_cast<std::uint32_t>(zulu_time());
+    while ( ! order_.empty()) {
+        auto const& oldest = order_.front();
+        auto const it = jobs_.find(oldest);
+        bool const expired = it != jobs_.end() &&
+            now - it->second.created > ttl_seconds_;
+        if (jobs_.size() <= max_jobs_ && ! expired && it != jobs_.end()) {
+            break;
+        }
+        if (it != jobs_.end()) {
+            jobs_.erase(it);
+        }
+        order_.pop_front();
+    }
+}
+
+} // namespace kth::node::rpc

--- a/src/node/src/rpc/methods.cpp
+++ b/src/node/src/rpc/methods.cpp
@@ -4,25 +4,45 @@
 
 #include <cstdint>
 #include <expected>
+#include <iomanip>
+#include <sstream>
 #include <string>
 
 #include <asio/awaitable.hpp>
 
 #include <kth/blockchain/interface/block_chain.hpp>
+#include <kth/domain/chain/compact.hpp>
+#include <kth/infrastructure/formats/base_16.hpp>
 
 #include <kth/node/rpc/dispatch.hpp>
 #include <kth/node/rpc/error.hpp>
+#include <kth/node/rpc/job_store.hpp>
 #include <kth/node/rpc/json.hpp>
 
 namespace kth::node::rpc {
 
 namespace {
 
+// 256-bit value as a 64-char, zero-padded, big-endian hex string (the GBT target
+// format).
+std::string to_hex256(uint256_t const& value) {
+    std::ostringstream os;
+    os << std::hex << std::setfill('0') << std::setw(64) << value;
+    return os.str();
+}
+
+// Compact nBits as an 8-char hex string (the GBT bits format).
+std::string bits_to_hex(std::uint32_t bits) {
+    std::ostringstream os;
+    os << std::hex << std::setfill('0') << std::setw(8) << bits;
+    return os.str();
+}
+
 // getblockcount -> the height of the most-work fully-validated block.
 // C-API counterpart: kth_chain_sync_last_height (see docs/json-rpc.md).
 ::asio::awaitable<std::expected<std::string, rpc_error>>
-get_block_count(blockchain::block_chain& chain, request const& /*req*/) {
-    auto const heights = co_await chain.fetch_last_height();
+get_block_count(method_context& ctx, request const& /*req*/) {
+    auto const heights = co_await ctx.chain.fetch_last_height();
     if ( ! heights) {
         co_return std::unexpected(from_code(heights.error()));
     }
@@ -32,10 +52,51 @@ get_block_count(blockchain::block_chain& chain, request const& /*req*/) {
     co_return w.str();
 }
 
+// getblocktemplatelight -> the next-block template minus the transactions, which
+// are cached under `job_id` for a later submitblocklight to reassemble.
+// C-API counterpart: kth_chain_async_fetch_mining_template (see docs/json-rpc.md).
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_block_template_light(method_context& ctx, request const& /*req*/) {
+    auto const tmpl = co_await ctx.chain.fetch_mining_template();
+    if ( ! tmpl) {
+        co_return std::unexpected(from_code(tmpl.error()));
+    }
+
+    auto const job_id = ctx.jobs.add(tmpl->selection.txs);
+
+    // Expand compact bits to the 256-bit target. from_compact only fails on an
+    // overflowing encoding, which a chain-produced nBits never is.
+    std::string target_hex(64, '0');
+    if (auto const target = domain::chain::compact::from_compact(tmpl->bits)) {
+        target_hex = to_hex256(target->big());
+    }
+
+    writer w;
+    w.begin_object();
+    w.field("version", static_cast<std::int64_t>(tmpl->version));
+    w.field("previousblockhash", encode_hash(tmpl->previous_block_hash));
+    w.field("height", static_cast<std::int64_t>(tmpl->height));
+    w.field("coinbasevalue", static_cast<std::uint64_t>(tmpl->coinbase_value));
+    w.field("target", target_hex);
+    w.field("bits", bits_to_hex(tmpl->bits));
+    w.field("mintime", static_cast<std::int64_t>(tmpl->min_time));
+    w.field("curtime", static_cast<std::int64_t>(tmpl->current_time));
+    w.field("sizelimit", static_cast<std::uint64_t>(tmpl->size_limit));
+    w.field("sigchecklimit", static_cast<std::uint64_t>(tmpl->sigchecks_limit));
+    w.field("noncerange", "00000000ffffffff");
+    w.key("mutable").begin_array()
+        .value("time").value("transactions").value("prevblock")
+        .end_array();
+    w.field("job_id", job_id);
+    w.end_object();
+    co_return w.str();
+}
+
 } // namespace
 
 void register_builtin_methods(dispatcher& d) {
     d.add("getblockcount", get_block_count);
+    d.add("getblocktemplatelight", get_block_template_light);
 }
 
 } // namespace kth::node::rpc

--- a/src/node/src/rpc/server.cpp
+++ b/src/node/src/rpc/server.cpp
@@ -161,7 +161,8 @@ std::string random_token() {
 
 server::server(rpc_settings const& settings, blockchain::block_chain& chain)
     : settings_(settings)
-    , chain_(chain) {
+    , chain_(chain)
+    , jobs_(settings.gbt_cache_size, settings.gbt_store_time) {
     register_builtin_methods(dispatcher_);
 
     if ( ! settings_.user.empty() || ! settings_.password.empty()) {
@@ -225,7 +226,8 @@ bool server::authorized(std::string_view authorization_header) const {
             co_return;
         }
 
-        std::string const response = co_await dispatcher_.handle(chain_, ctx.body);
+        method_context mctx{chain_, jobs_};
+        std::string const response = co_await dispatcher_.handle(mctx, ctx.body);
         co_await write_response(socket, 200, "OK", response, ctx.keep_alive);
         if ( ! ctx.keep_alive) {
             co_return;

--- a/src/node/src/settings.cpp
+++ b/src/node/src/settings.cpp
@@ -34,6 +34,8 @@ rpc_settings::rpc_settings()
     , port(8332)
     , user()
     , password()
+    , gbt_cache_size(10)
+    , gbt_store_time(3600)
 {}
 
 } // namespace kth::node

--- a/src/node/test/rpc_job_store.cpp
+++ b/src/node/test/rpc_job_store.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <memory>
+#include <vector>
+
+#include <kth/domain.hpp>
+#include <kth/node/rpc/job_store.hpp>
+
+using namespace kth;
+using namespace kth::node::rpc;
+
+namespace {
+
+// Distinct transactions (by locktime) yield distinct txids -> distinct job ids.
+transaction_const_ptr make_tx(uint32_t locktime) {
+    return std::make_shared<domain::message::transaction>(
+        domain::chain::transaction{1u, locktime, {}, {}});
+}
+
+std::vector<transaction_const_ptr> txs(std::initializer_list<uint32_t> locktimes) {
+    std::vector<transaction_const_ptr> out;
+    for (auto lt : locktimes) {
+        out.push_back(make_tx(lt));
+    }
+    return out;
+}
+
+} // namespace
+
+// Start Test Suite: rpc job_store tests
+
+TEST_CASE("job_store add then get roundtrips", "[rpc job_store]") {
+    job_store store(10, 3600);
+    auto const id = store.add(txs({1, 2}));
+    auto const got = store.get(id);
+    REQUIRE(got.has_value());
+    REQUIRE(got->size() == 2u);
+}
+
+TEST_CASE("job_store add is idempotent for equal selections", "[rpc job_store]") {
+    job_store store(10, 3600);
+    auto const a = store.add(txs({7, 8, 9}));
+    auto const b = store.add(txs({7, 8, 9}));
+    REQUIRE(a == b);
+}
+
+TEST_CASE("job_store distinct selections get distinct ids", "[rpc job_store]") {
+    job_store store(10, 3600);
+    REQUIRE(store.add(txs({1})) != store.add(txs({2})));
+}
+
+TEST_CASE("job_store returns nullopt for unknown id", "[rpc job_store]") {
+    job_store store(10, 3600);
+    REQUIRE_FALSE(store.get("deadbeef").has_value());
+}
+
+TEST_CASE("job_store evicts the oldest past the count bound", "[rpc job_store]") {
+    job_store store(/*max_jobs*/ 2, /*ttl*/ 3600);
+    auto const first = store.add(txs({1}));
+    store.add(txs({2}));
+    store.add(txs({3}));       // pushes the count to 3 -> evicts `first`
+    REQUIRE_FALSE(store.get(first).has_value());
+}

--- a/tools/rpc_bench.py
+++ b/tools/rpc_bench.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016-present Knuth Project developers.
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Saturation load generator for the Knuth JSON-RPC server.
+
+N concurrent clients each fire RPC requests back-to-back over a kept-alive
+connection for a fixed duration; reports throughput and latency percentiles.
+
+This is the miner-polling HALF of a realistic mining benchmark. A faithful bench
+is a network SIMULATION: transactions arriving (mempool churn), blocks arriving
+(tip advances, which invalidates the template), and miners polling GBT at the
+same time -- only then does the per-call template rebuild actually cost anything
+(an empty mempool makes getblocktemplatelight as cheap as getblockcount). Driving
+the tx/block inflow needs sendrawtransaction + submitblock, added in later PRs;
+until then this measures the polling side alone.
+
+Dependency-free (stdlib only). Example:
+
+    tools/rpc_bench.py --url http://127.0.0.1:8332/ --user u --password p \\
+        --method getblocktemplatelight --concurrency 16 --duration 10
+"""
+
+import argparse
+import base64
+import http.client
+import json
+import statistics
+import threading
+import time
+from urllib.parse import urlparse
+
+
+def worker(args, auth, stop_at, out):
+    """Fire requests until stop_at; append per-request latencies (seconds)."""
+    u = urlparse(args.url)
+    body = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "method": args.method, "params": []}
+    ).encode()
+    headers = {
+        "Authorization": "Basic " + auth,
+        "Content-Type": "application/json",
+        "Connection": "keep-alive",
+    }
+    latencies, errors = [], 0
+    conn = http.client.HTTPConnection(u.hostname, u.port or 8332, timeout=30)
+    while time.monotonic() < stop_at:
+        t0 = time.monotonic()
+        try:
+            conn.request("POST", u.path or "/", body=body, headers=headers)
+            resp = conn.getresponse()
+            payload = resp.read()
+            if resp.status != 200 or b'"error":null' not in payload:
+                errors += 1
+            latencies.append(time.monotonic() - t0)
+        except Exception:
+            errors += 1
+            try:
+                conn.close()
+            except Exception:
+                pass
+            conn = http.client.HTTPConnection(u.hostname, u.port or 8332, timeout=30)
+    conn.close()
+    out.append((latencies, errors))
+
+
+def pct(values, p):
+    if not values:
+        return 0.0
+    k = max(0, min(len(values) - 1, int(round((p / 100.0) * (len(values) - 1)))))
+    return sorted(values)[k]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--url", default="http://127.0.0.1:8332/")
+    ap.add_argument("--user", default="")
+    ap.add_argument("--password", default="")
+    ap.add_argument("--method", default="getblocktemplatelight")
+    ap.add_argument("--concurrency", type=int, default=8)
+    ap.add_argument("--duration", type=float, default=10.0)
+    args = ap.parse_args()
+
+    auth = base64.b64encode(f"{args.user}:{args.password}".encode()).decode()
+
+    results, threads = [], []
+    lock_free = []  # each thread appends its own tuple; list append is atomic in CPython
+    stop_at = time.monotonic() + args.duration
+    wall0 = time.monotonic()
+    for _ in range(args.concurrency):
+        t = threading.Thread(target=worker, args=(args, auth, stop_at, lock_free))
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+    wall = time.monotonic() - wall0
+
+    all_lat = [x for lats, _ in lock_free for x in lats]
+    errors = sum(e for _, e in lock_free)
+    total = len(all_lat)
+
+    print(f"method       : {args.method}")
+    print(f"concurrency  : {args.concurrency}")
+    print(f"duration     : {wall:.2f} s")
+    print(f"requests     : {total}  (errors: {errors})")
+    print(f"throughput   : {total / wall:.0f} req/s")
+    if all_lat:
+        ms = lambda s: s * 1000.0
+        print(f"latency mean : {ms(statistics.fmean(all_lat)):.2f} ms")
+        print(f"latency p50  : {ms(pct(all_lat, 50)):.2f} ms")
+        print(f"latency p90  : {ms(pct(all_lat, 90)):.2f} ms")
+        print(f"latency p99  : {ms(pct(all_lat, 99)):.2f} ms")
+        print(f"latency max  : {ms(max(all_lat)):.2f} ms")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the light block-template RPC — the first mining method — on top of the JSON-RPC foundation (#516).

## What

`getblocktemplatelight` returns the next-block template **without** the transaction list. The selected transactions are cached server-side under a `job_id` so a later `submitblocklight` (follow-up) can reconstruct the full block from the miner's solved header + coinbase alone — transactions never travel over the wire.

## Core (blockchain)

`block_chain::fetch_mining_template()` returns a new `mining_template`:

```cpp
struct mining_template {
    uint32_t version; hash_digest previous_block_hash; size_t height;
    uint32_t bits; uint32_t min_time; uint32_t current_time;
    uint64_t coinbase_value; uint64_t size_limit; uint64_t sigchecks_limit;
    block_template selection;   // CTOR-ordered txs + totals (no coinbase)
};
```

Assembled from `chain_state()` (height, MTP, `work_required()`, dynamic limits), the mempool selection (`build_block_template`, #503–#505), the tip hash, and the block subsidy.

## Server (node)

- A thread-safe, bounded, TTL'd `job_store` keyed by a content hash of the selection (`rpc.gbt_cache_size` / `rpc.gbt_store_time`, mirroring bitcoind `-gbtcachesize` / `-gbtstoretime`).
- Handlers now receive a `method_context { chain, jobs }`.
- The handler serializes the template (compact `bits` expanded to the 256-bit `target`) and returns the `job_id`.

Verified against genesis (`height` 1, genesis `previousblockhash`, `1d00ffff` bits, 50 BCH subsidy, correct target).

## Deliberate scope

- **No per-tip template cache** — the template is rebuilt on every call. Optimizing this (after studying BCHN's approach) is a dedicated follow-up PR; the saturation benchmark will drive it with numbers.
- `tools/rpc_bench.py` load-tests the miner-polling side. A faithful mining benchmark is a full network simulation (transactions + blocks arriving + miners polling); driving the inflow needs the submit paths added later.
- **C-API counterpart** (`kth_chain_async_fetch_mining_template`) follows in its own generator PR — the same C++-then-C-API split used for the mempool (#508 → #510).

## Tests

`job_store` add/get/idempotency/eviction. Node suite green (RPC on and off).