### PR TITLE
node: add submitblocklight JSON-RPC method

### DIFF
--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -68,10 +68,11 @@ counterpart.
 |---|---|---|
 | `getblockcount` | `kth_chain_sync_last_height` | `fetch_last_height().block` |
 | `getblocktemplatelight` | `kth_chain_async_fetch_mining_template` _(pending)_ | `fetch_mining_template()` |
+| `submitblocklight` | `kth_chain_async_organize_block` _(pending)_ | `organize(block)` |
 
-_More methods land per phase: mining (`submitblocklight`, `submitblock`,
-`getmininginfo`), mempool (`getrawmempool`, `getmempoolentry`, ...), and
-blockchain/raw-tx (`getblock`, `getrawtransaction`, `sendrawtransaction`, ...)._
+_More methods land per phase: mining (`submitblock`, `getmininginfo`), mempool
+(`getrawmempool`, `getmempoolentry`, ...), and blockchain/raw-tx (`getblock`,
+`getrawtransaction`, `sendrawtransaction`, ...)._
 
 ## Mining: getblocktemplatelight
 
@@ -95,3 +96,13 @@ rpc.gbt_store_time = 3600   # seconds before a job expires
 > load-tests the miner-polling side; a faithful benchmark also simulates
 > transactions and blocks arriving (mempool churn + tip changes), which needs the
 > submit paths added in later phases.
+
+## Mining: submitblocklight
+
+`submitblocklight ["hexdata", "job_id"]` closes the light-template loop. `hexdata`
+is the solved block carrying just the header and the coinbase; the node looks up
+`job_id`, splices the cached selection after the coinbase, and submits the
+reconstructed block to the chain. Returns the Bitcoin `submitblock` result: `null`
+when accepted, otherwise a reject-reason string (e.g. `"duplicate block"`,
+`"high-hash"`). Malformed input (missing args, bad hex, undecodable block, unknown
+or expired `job_id`) is a JSON-RPC `-32602` error instead.

--- a/src/blockchain/include/kth/blockchain/pools/block_template.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/block_template.hpp
@@ -64,6 +64,15 @@ struct mining_template {
     block_template selection;           // CTOR-ordered txs + totals (no coinbase)
 };
 
+// Assemble a mining_template from the next-block parameters and the selection.
+// Pure (no chain access), so it is unit-tested directly: min_time = MTP + 1,
+// current_time = max(min_time, now), coinbase_value = subsidy(height) + fees.
+KB_API
+mining_template make_mining_template(
+    uint32_t version, hash_digest const& previous_block_hash, size_t height,
+    uint32_t bits, uint32_t median_time_past, uint32_t now,
+    uint64_t size_limit, uint64_t sigchecks_limit, block_template selection);
+
 } // namespace kth::blockchain
 
 #endif

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1526,26 +1526,18 @@ block_chain::fetch_mining_template() const {
         previous = *prev;
     }
 
-    auto const min_time = state->median_time_past() + 1;
-    auto const current_time = std::max(min_time,
-        static_cast<uint32_t>(zulu_time()));
-
-    auto const coinbase_value = selection.total_fees +
-        domain::chain::block::subsidy(height, true);
-
     // 0x20000000: the BIP9 version base. BCH has no active version-bits signaling,
     // and miners routinely override this, so it is only a sensible default.
-    co_return blockchain::mining_template{
+    co_return make_mining_template(
         0x20000000U,
         previous,
         height,
         state->work_required(),
-        min_time,
-        current_time,
-        coinbase_value,
+        state->median_time_past(),
+        static_cast<uint32_t>(zulu_time()),
         state->dynamic_max_block_size(),
         state->dynamic_max_block_sigchecks(),
-        std::move(selection)};
+        std::move(selection));
 }
 
 awaitable_expected<inventory_ptr>

--- a/src/blockchain/src/pools/block_template.cpp
+++ b/src/blockchain/src/pools/block_template.cpp
@@ -195,4 +195,25 @@ block_template build_block_template(mempool const& pool, block_template_context 
     return result;
 }
 
+mining_template make_mining_template(
+    uint32_t version, hash_digest const& previous_block_hash, size_t height,
+    uint32_t bits, uint32_t median_time_past, uint32_t now,
+    uint64_t size_limit, uint64_t sigchecks_limit, block_template selection) {
+
+    auto const min_time = median_time_past + 1;
+    auto const coinbase_value = selection.total_fees + block::subsidy(height, true);
+
+    return mining_template{
+        version,
+        previous_block_hash,
+        height,
+        bits,
+        min_time,
+        std::max(min_time, now),
+        coinbase_value,
+        size_limit,
+        sigchecks_limit,
+        std::move(selection)};
+}
+
 } // namespace kth::blockchain

--- a/src/blockchain/test/block_template_test.cpp
+++ b/src/blockchain/test/block_template_test.cpp
@@ -25,6 +25,8 @@ using kth::blockchain::mempool_entry;
 using kth::blockchain::block_template;
 using kth::blockchain::block_template_context;
 using kth::blockchain::build_block_template;
+using kth::blockchain::mining_template;
+using kth::blockchain::make_mining_template;
 
 namespace {
 
@@ -254,4 +256,46 @@ TEST_CASE("block_template: non-final tx is excluded", "[block_template]") {
     for (auto const& tx : tpl.txs) present.insert(tx->hash());
     REQUIRE(present.count(final_tx->hash()) == 1u);
     REQUIRE(present.count(non_final->hash()) == 0u);
+}
+
+// ---------------------------------------------------------------------------
+// make_mining_template: the pure header-field assembly (subsidy, times).
+
+TEST_CASE("make_mining_template computes min_time as MTP + 1", "[block_template]") {
+    auto const t = make_mining_template(0x20000000u, null_hash, 1u, 0x1d00ffffu,
+        /*mtp*/ 1000u, /*now*/ 5000u, 32000000u, 226950u, block_template{});
+    REQUIRE(t.min_time == 1001u);
+}
+
+TEST_CASE("make_mining_template clamps current_time up to min_time", "[block_template]") {
+    // now behind MTP+1 -> clamped to min_time.
+    auto const behind = make_mining_template(0x20000000u, null_hash, 1u, 0x1d00ffffu,
+        /*mtp*/ 4000u, /*now*/ 100u, 32000000u, 226950u, block_template{});
+    REQUIRE(behind.current_time == 4001u);
+
+    // now ahead of MTP+1 -> used as-is.
+    auto const ahead = make_mining_template(0x20000000u, null_hash, 1u, 0x1d00ffffu,
+        /*mtp*/ 1000u, /*now*/ 9000u, 32000000u, 226950u, block_template{});
+    REQUIRE(ahead.current_time == 9000u);
+}
+
+TEST_CASE("make_mining_template coinbase value is subsidy plus fees", "[block_template]") {
+    block_template selection{};
+    selection.total_fees = 1234u;
+    auto const t = make_mining_template(0x20000000u, null_hash, /*height*/ 1u,
+        0x1d00ffffu, 1000u, 5000u, 32000000u, 226950u, std::move(selection));
+    // Height 1 subsidy is 50 BCH.
+    REQUIRE(t.coinbase_value == 5000000000ull + 1234u);
+}
+
+TEST_CASE("make_mining_template passes the header fields through", "[block_template]") {
+    auto const t = make_mining_template(0x20000000u, null_hash, /*height*/ 7u,
+        0x1d00ffffu, 1000u, 5000u, /*size*/ 32000000u, /*sigchecks*/ 226950u,
+        block_template{});
+    REQUIRE(t.version == 0x20000000u);
+    REQUIRE(t.previous_block_hash == null_hash);
+    REQUIRE(t.height == 7u);
+    REQUIRE(t.bits == 0x1d00ffffu);
+    REQUIRE(t.size_limit == 32000000u);
+    REQUIRE(t.sigchecks_limit == 226950u);
 }

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -168,6 +168,7 @@ if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     src/rpc/json.cpp
     src/rpc/dispatch.cpp
     src/rpc/job_store.cpp
+    src/rpc/mining.cpp
     src/rpc/methods.cpp
     src/rpc/server.cpp
   )
@@ -209,6 +210,7 @@ set(kth_headers
   include/kth/node/rpc/json.hpp
   include/kth/node/rpc/dispatch.hpp
   include/kth/node/rpc/job_store.hpp
+  include/kth/node/rpc/mining.hpp
   include/kth/node/rpc/server.hpp
 
   # CSP-based sync system
@@ -286,7 +288,8 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 
   # JSON-RPC unit tests build only when the server is compiled in.
   if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    target_sources(kth_node_test PRIVATE test/rpc_json.cpp test/rpc_job_store.cpp)
+    target_sources(kth_node_test PRIVATE
+      test/rpc_json.cpp test/rpc_job_store.cpp test/rpc_mining.cpp)
   endif()
 
   target_include_directories(kth_node_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)

--- a/src/node/include/kth/node/rpc/json.hpp
+++ b/src/node/include/kth/node/rpc/json.hpp
@@ -30,6 +30,11 @@ struct request {
 // parse_error for malformed JSON, invalid_request when "method" is missing.
 std::expected<request, rpc_error> parse_request(std::string_view body);
 
+// Positional params (a JSON array) decoded as strings. A missing/empty params,
+// a non-array, or a non-string element each yields an empty string in that slot;
+// handlers validate arity and emptiness themselves.
+std::vector<std::string> params_strings(std::string_view params_json);
+
 // Build the response envelopes. `result_raw` / `id_raw` are already-serialized
 // JSON fragments and are emitted verbatim.
 std::string build_success(std::string_view id_raw, std::string_view result_raw);

--- a/src/node/include/kth/node/rpc/mining.hpp
+++ b/src/node/include/kth/node/rpc/mining.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_RPC_MINING_HPP
+#define KTH_NODE_RPC_MINING_HPP
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <kth/blockchain/pools/block_template.hpp>
+#include <kth/domain/chain/header.hpp>
+#include <kth/domain/chain/transaction.hpp>
+#include <kth/domain/message/block.hpp>
+
+// The pure (chain-free) logic behind the mining RPCs, split out so it can be
+// unit-tested without a live block_chain: the handlers are just fetch/submit
+// glue around these.
+
+namespace kth::node::rpc {
+
+// Serialize a mining template as the getblocktemplatelight "result" object
+// (compact bits expanded to the 256-bit target, hashes in display order),
+// tagged with `job_id`.
+std::string render_mining_template(
+    blockchain::mining_template const& tmpl, std::string_view job_id);
+
+// Reassemble the full block a submitblocklight refers to: the miner's coinbase
+// first, then the job's cached selection (CTOR order preserved).
+domain::message::block assemble_block(
+    domain::chain::header const& header,
+    domain::chain::transaction const& coinbase,
+    std::vector<transaction_const_ptr> const& job_txs);
+
+} // namespace kth::node::rpc
+
+#endif // KTH_NODE_RPC_MINING_HPP

--- a/src/node/src/rpc/json.cpp
+++ b/src/node/src/rpc/json.cpp
@@ -58,6 +58,38 @@ std::expected<request, rpc_error> parse_request(std::string_view body) {
     return req;
 }
 
+std::vector<std::string> params_strings(std::string_view params_json) {
+    std::vector<std::string> out;
+    if (params_json.empty()) {
+        return out;
+    }
+
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string padded(params_json);
+
+    simdjson::ondemand::document doc;
+    if (parser.iterate(padded).get(doc) != simdjson::SUCCESS) {
+        return out;
+    }
+
+    simdjson::ondemand::array arr;
+    if (doc.get_array().get(arr) != simdjson::SUCCESS) {
+        return out;
+    }
+
+    for (auto element : arr) {
+        simdjson::ondemand::value value;
+        std::string_view text;
+        if (element.get(value) == simdjson::SUCCESS &&
+            value.get_string().get(text) == simdjson::SUCCESS) {
+            out.emplace_back(text);
+        } else {
+            out.emplace_back();
+        }
+    }
+    return out;
+}
+
 std::string build_success(std::string_view id_raw, std::string_view result_raw) {
     writer w;
     w.begin_object();

--- a/src/node/src/rpc/methods.cpp
+++ b/src/node/src/rpc/methods.cpp
@@ -4,39 +4,25 @@
 
 #include <cstdint>
 #include <expected>
-#include <iomanip>
-#include <sstream>
+#include <memory>
 #include <string>
 
 #include <asio/awaitable.hpp>
 
 #include <kth/blockchain/interface/block_chain.hpp>
-#include <kth/domain/chain/compact.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/data.hpp>
 
 #include <kth/node/rpc/dispatch.hpp>
 #include <kth/node/rpc/error.hpp>
 #include <kth/node/rpc/job_store.hpp>
 #include <kth/node/rpc/json.hpp>
+#include <kth/node/rpc/mining.hpp>
 
 namespace kth::node::rpc {
 
 namespace {
-
-// 256-bit value as a 64-char, zero-padded, big-endian hex string (the GBT target
-// format).
-std::string to_hex256(uint256_t const& value) {
-    std::ostringstream os;
-    os << std::hex << std::setfill('0') << std::setw(64) << value;
-    return os.str();
-}
-
-// Compact nBits as an 8-char hex string (the GBT bits format).
-std::string bits_to_hex(std::uint32_t bits) {
-    std::ostringstream os;
-    os << std::hex << std::setfill('0') << std::setw(8) << bits;
-    return os.str();
-}
 
 // getblockcount -> the height of the most-work fully-validated block.
 // C-API counterpart: kth_chain_sync_last_height (see docs/json-rpc.md).
@@ -63,32 +49,55 @@ get_block_template_light(method_context& ctx, request const& /*req*/) {
     }
 
     auto const job_id = ctx.jobs.add(tmpl->selection.txs);
+    co_return render_mining_template(*tmpl, job_id);
+}
 
-    // Expand compact bits to the 256-bit target. from_compact only fails on an
-    // overflowing encoding, which a chain-produced nBits never is.
-    std::string target_hex(64, '0');
-    if (auto const target = domain::chain::compact::from_compact(tmpl->bits)) {
-        target_hex = to_hex256(target->big());
+// submitblocklight -> reconstruct the full block from the miner's solved header +
+// coinbase and the cached job selection, then submit it to the chain. Returns
+// (Bitcoin submitblock semantics) null on accept, or a reject-reason string.
+// C-API counterpart: kth_chain_async_organize_block (see docs/json-rpc.md).
+::asio::awaitable<std::expected<std::string, rpc_error>>
+submit_block_light(method_context& ctx, request const& req) {
+    auto const args = params_strings(req.params);
+    if (args.size() < 2 || args[0].empty() || args[1].empty()) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "submitblocklight requires [hexdata, job_id]"));
     }
 
+    auto const raw = decode_base16(args[0]);
+    if ( ! raw) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "hexdata is not valid hex"));
+    }
+
+    // The submitted block carries the solved header and just the coinbase.
+    byte_reader reader(*raw);
+    auto header_and_coinbase = domain::message::block::from_data(reader, 0u);
+    if ( ! header_and_coinbase || header_and_coinbase->transactions().empty()) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "hexdata is not a decodable block with a coinbase"));
+    }
+
+    auto const job = ctx.jobs.get(args[1]);
+    if ( ! job) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "job_id not found or expired"));
+    }
+
+    // Reassemble: coinbase (from the miner) followed by the cached selection.
+    auto const block = std::make_shared<domain::message::block>(assemble_block(
+        header_and_coinbase->header(),
+        header_and_coinbase->transactions().front(),
+        *job));
+
+    auto const ec = co_await ctx.chain.organize(block);
+
     writer w;
-    w.begin_object();
-    w.field("version", static_cast<std::int64_t>(tmpl->version));
-    w.field("previousblockhash", encode_hash(tmpl->previous_block_hash));
-    w.field("height", static_cast<std::int64_t>(tmpl->height));
-    w.field("coinbasevalue", static_cast<std::uint64_t>(tmpl->coinbase_value));
-    w.field("target", target_hex);
-    w.field("bits", bits_to_hex(tmpl->bits));
-    w.field("mintime", static_cast<std::int64_t>(tmpl->min_time));
-    w.field("curtime", static_cast<std::int64_t>(tmpl->current_time));
-    w.field("sizelimit", static_cast<std::uint64_t>(tmpl->size_limit));
-    w.field("sigchecklimit", static_cast<std::uint64_t>(tmpl->sigchecks_limit));
-    w.field("noncerange", "00000000ffffffff");
-    w.key("mutable").begin_array()
-        .value("time").value("transactions").value("prevblock")
-        .end_array();
-    w.field("job_id", job_id);
-    w.end_object();
+    if (ec) {
+        w.value(ec.message()); // BIP22-style reject reason
+    } else {
+        w.value_null();        // accepted
+    }
     co_return w.str();
 }
 
@@ -97,6 +106,7 @@ get_block_template_light(method_context& ctx, request const& /*req*/) {
 void register_builtin_methods(dispatcher& d) {
     d.add("getblockcount", get_block_count);
     d.add("getblocktemplatelight", get_block_template_light);
+    d.add("submitblocklight", submit_block_light);
 }
 
 } // namespace kth::node::rpc

--- a/src/node/src/rpc/mining.cpp
+++ b/src/node/src/rpc/mining.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/rpc/mining.hpp>
+
+#include <cstdint>
+#include <iomanip>
+#include <sstream>
+#include <utility>
+
+#include <kth/domain/chain/compact.hpp>
+#include <kth/infrastructure/formats/base_16.hpp>
+
+#include <kth/node/rpc/json.hpp>
+
+namespace kth::node::rpc {
+
+namespace {
+
+// 256-bit value as a 64-char, zero-padded, big-endian hex string (GBT target).
+std::string to_hex256(uint256_t const& value) {
+    std::ostringstream os;
+    os << std::hex << std::setfill('0') << std::setw(64) << value;
+    return os.str();
+}
+
+// Compact nBits as an 8-char hex string (GBT bits).
+std::string bits_to_hex(std::uint32_t bits) {
+    std::ostringstream os;
+    os << std::hex << std::setfill('0') << std::setw(8) << bits;
+    return os.str();
+}
+
+} // namespace
+
+std::string render_mining_template(
+    blockchain::mining_template const& tmpl, std::string_view job_id) {
+
+    // Expand compact bits to the 256-bit target. from_compact only fails on an
+    // overflowing encoding, which a chain-produced nBits never is.
+    std::string target_hex(64, '0');
+    if (auto const target = domain::chain::compact::from_compact(tmpl.bits)) {
+        target_hex = to_hex256(target->big());
+    }
+
+    writer w;
+    w.begin_object();
+    w.field("version", static_cast<std::int64_t>(tmpl.version));
+    w.field("previousblockhash", encode_hash(tmpl.previous_block_hash));
+    w.field("height", static_cast<std::int64_t>(tmpl.height));
+    w.field("coinbasevalue", static_cast<std::uint64_t>(tmpl.coinbase_value));
+    w.field("target", target_hex);
+    w.field("bits", bits_to_hex(tmpl.bits));
+    w.field("mintime", static_cast<std::int64_t>(tmpl.min_time));
+    w.field("curtime", static_cast<std::int64_t>(tmpl.current_time));
+    w.field("sizelimit", static_cast<std::uint64_t>(tmpl.size_limit));
+    w.field("sigchecklimit", static_cast<std::uint64_t>(tmpl.sigchecks_limit));
+    w.field("noncerange", "00000000ffffffff");
+    w.key("mutable").begin_array()
+        .value("time").value("transactions").value("prevblock")
+        .end_array();
+    w.field("job_id", job_id);
+    w.end_object();
+    return w.str();
+}
+
+domain::message::block assemble_block(
+    domain::chain::header const& header,
+    domain::chain::transaction const& coinbase,
+    std::vector<transaction_const_ptr> const& job_txs) {
+
+    domain::chain::transaction::list txs;
+    txs.reserve(1 + job_txs.size());
+    txs.push_back(coinbase);
+    for (auto const& tx : job_txs) {
+        txs.push_back(*tx); // slice message::transaction -> chain::transaction
+    }
+    return domain::message::block(header, std::move(txs));
+}
+
+} // namespace kth::node::rpc

--- a/src/node/test/rpc_json.cpp
+++ b/src/node/test/rpc_json.cpp
@@ -80,3 +80,23 @@ TEST_CASE("build_error wraps code and message", "[rpc json]") {
     REQUIRE(build_error("null", -32601, "Method not found") ==
         R"({"result":null,"error":{"code":-32601,"message":"Method not found"},"id":null})");
 }
+
+TEST_CASE("params_strings reads a string array", "[rpc json]") {
+    auto const p = params_strings(R"(["aa","bb"])");
+    REQUIRE(p.size() == 2u);
+    REQUIRE(p[0] == "aa");
+    REQUIRE(p[1] == "bb");
+}
+
+TEST_CASE("params_strings yields empty slots for non-strings", "[rpc json]") {
+    auto const p = params_strings(R"([1,"x"])");
+    REQUIRE(p.size() == 2u);
+    REQUIRE(p[0].empty());
+    REQUIRE(p[1] == "x");
+}
+
+TEST_CASE("params_strings tolerates empty and non-array params", "[rpc json]") {
+    REQUIRE(params_strings("").empty());
+    REQUIRE(params_strings("[]").empty());
+    REQUIRE(params_strings("{}").empty());
+}

--- a/src/node/test/rpc_mining.cpp
+++ b/src/node/test/rpc_mining.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <memory>
+#include <vector>
+
+#include <kth/domain.hpp>
+#include <kth/node/rpc/mining.hpp>
+
+using namespace kth;
+using namespace kth::node::rpc;
+
+namespace {
+
+transaction_const_ptr make_tx(uint32_t locktime) {
+    return std::make_shared<domain::message::transaction>(
+        domain::chain::transaction{1u, locktime, {}, {}});
+}
+
+} // namespace
+
+// Start Test Suite: rpc mining tests
+
+TEST_CASE("render_mining_template serializes the GBT-light fields", "[rpc mining]") {
+    blockchain::mining_template tmpl{
+        /*version*/ 0x20000000u,
+        /*previous_block_hash*/ null_hash,
+        /*height*/ 5u,
+        /*bits*/ 0x1d00ffffu,
+        /*min_time*/ 1000u,
+        /*current_time*/ 2000u,
+        /*coinbase_value*/ 5000000000ULL,
+        /*size_limit*/ 32000000u,
+        /*sigchecks_limit*/ 226950u,
+        /*selection*/ blockchain::block_template{}};
+
+    REQUIRE(render_mining_template(tmpl, "testjob") ==
+        R"({"version":536870912,)"
+        R"("previousblockhash":"0000000000000000000000000000000000000000000000000000000000000000",)"
+        R"("height":5,"coinbasevalue":5000000000,)"
+        R"("target":"00000000ffff0000000000000000000000000000000000000000000000000000",)"
+        R"("bits":"1d00ffff","mintime":1000,"curtime":2000,)"
+        R"("sizelimit":32000000,"sigchecklimit":226950,)"
+        R"("noncerange":"00000000ffffffff",)"
+        R"("mutable":["time","transactions","prevblock"],)"
+        R"("job_id":"testjob"})");
+}
+
+TEST_CASE("assemble_block puts the coinbase first then the job selection", "[rpc mining]") {
+    domain::chain::transaction coinbase{1u, 0u, {}, {}};
+    std::vector<transaction_const_ptr> job{make_tx(11), make_tx(22)};
+
+    auto const block = assemble_block(domain::chain::header{}, coinbase, job);
+
+    REQUIRE(block.transactions().size() == 3u);
+    REQUIRE(block.transactions()[0].hash() == coinbase.hash());
+    REQUIRE(block.transactions()[1].hash() == job[0]->hash());
+    REQUIRE(block.transactions()[2].hash() == job[1]->hash());
+}
+
+TEST_CASE("assemble_block with an empty selection is coinbase-only", "[rpc mining]") {
+    domain::chain::transaction coinbase{1u, 7u, {}, {}};
+    auto const block = assemble_block(domain::chain::header{}, coinbase, {});
+    REQUIRE(block.transactions().size() == 1u);
+    REQUIRE(block.transactions()[0].hash() == coinbase.hash());
+}


### PR DESCRIPTION
Closes the light block-template loop opened by getblocktemplatelight (#517).

## What

`submitblocklight ["hexdata", "job_id"]`:
1. `hexdata` is the miner's solved block carrying just the header and the coinbase.
2. The node looks up `job_id` in the template job cache.
3. It splices the cached transaction selection after the coinbase and reconstructs the full block.
4. It submits the block via `block_chain::organize()`.

Transactions never travel over the wire in either direction — the pool holds them, the node re-supplies them from the job.

## Result semantics (Bitcoin `submitblock`)

- Accepted → `result: null`.
- Rejected → `result: "<reason>"` (e.g. `"duplicate block"`, `"high-hash"`), `error: null`.
- Malformed input (missing args, bad hex, undecodable block, unknown/expired `job_id`) → JSON-RPC `-32602` error.

## Unit tests per method (no live chain needed)

To make each mining method testable in CI without spinning up a `block_chain`, the pure logic is split into `rpc/mining.cpp`:

- `render_mining_template()` — the getblocktemplatelight serialization. Test asserts the **exact** JSON (compact bits expanded to the 256-bit target, hashes in display order, every field).
- `assemble_block()` — the submitblocklight reconstruction. Test asserts the reassembly order (coinbase first, then the selection) and the empty-selection case.
- `params_strings()` — positional string params via simdjson, with tests.

The handlers become thin fetch/submit glue around these. Node suite green (81 cases).

## End-to-end verification

Error paths and the reconstruction plumbing verified against a running node:

| input | result |
|---|---|
| `[]` | `-32602 submitblocklight requires [hexdata, job_id]` |
| `["zz","j"]` | `-32602 hexdata is not valid hex` |
| `["00","j"]` | `-32602 hexdata is not a decodable block with a coinbase` |
| genesis block + unknown job | `-32602 job_id not found or expired` (block decoded OK) |
| genesis block + valid job | `result: "duplicate block"` — full decode → job lookup → reconstruct → organize |

Accepting a *fresh valid* block needs real proof-of-work, left to a regtest integration test.

## Also

C-API counterparts (`kth_chain_async_fetch_mining_template`, `kth_chain_async_organize_block`) follow in the generator PR.