### PR TITLE
node: add getmininginfo JSON-RPC method

### DIFF
--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -68,6 +68,7 @@ counterpart.
 |---|---|---|
 | `getblockcount` | `kth_chain_sync_last_height` | `fetch_last_height().block` |
 | `getblocktemplatelight` | `kth_chain_async_fetch_mining_template` _(pending)_ | `fetch_mining_template()` |
+| `getmininginfo` | `kth_chain_async_fetch_mining_info` _(pending)_ | `fetch_mining_info()` |
 | `submitblocklight` | `kth_chain_async_organize_block` _(pending)_ | `organize(block)` |
 
 _More methods land per phase: mining (`submitblock`, `getmininginfo`), mempool
@@ -96,6 +97,13 @@ rpc.gbt_store_time = 3600   # seconds before a job expires
 > load-tests the miner-polling side; a faithful benchmark also simulates
 > transactions and blocks arriving (mempool churn + tip changes), which needs the
 > submit paths added in later phases.
+
+## Mining: getmininginfo
+
+Returns a small mining snapshot: `blocks` (tip height), `difficulty` (of the next
+required work, matching the template's `bits`), `pooledtx` (mempool size), `chain`
+(network name), and `warnings`. `networkhashps` is not reported yet — it needs a
+historical hashrate estimate and is a follow-up.
 
 ## Mining: submitblocklight
 

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -408,6 +408,11 @@ struct KB_API block_chain {
     [[nodiscard]] awaitable_expected<blockchain::mining_template>
     fetch_mining_template() const;
 
+    // Mining-relevant chain snapshot (height, difficulty, mempool size, network)
+    // for getmininginfo. C-API counterpart: kth_chain_async_fetch_mining_info.
+    [[nodiscard]] awaitable_expected<blockchain::mining_info>
+    fetch_mining_info() const;
+
     [[nodiscard]] awaitable_expected<inventory_ptr>
     fetch_mempool(size_t count_limit, uint64_t minimum_fee) const;
 

--- a/src/blockchain/include/kth/blockchain/pools/block_template.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/block_template.hpp
@@ -73,6 +73,20 @@ mining_template make_mining_template(
     uint32_t bits, uint32_t median_time_past, uint32_t now,
     uint64_t size_limit, uint64_t sigchecks_limit, block_template selection);
 
+// A snapshot of mining-relevant chain state, for the getmininginfo RPC and its
+// C-API counterpart.
+struct mining_info {
+    size_t blocks;                      // current block height (tip)
+    double difficulty;                  // difficulty of the next required work
+    size_t pooled_tx;                   // transactions in the mempool
+    domain::config::network chain;      // network the node is on
+};
+
+// The Bitcoin difficulty a compact nBits target represents (target 1 == 1.0).
+// Pure, so it is unit-tested directly.
+KB_API
+double difficulty_from_bits(uint32_t bits);
+
 } // namespace kth::blockchain
 
 #endif

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1540,6 +1540,29 @@ block_chain::fetch_mining_template() const {
         std::move(selection));
 }
 
+awaitable_expected<blockchain::mining_info>
+block_chain::fetch_mining_info() const {
+    if (stopped()) {
+        co_return std::unexpected(error::service_stopped);
+    }
+
+    auto const state = chain_state();
+    if ( ! state) {
+        co_return std::unexpected(error::not_found);
+    }
+
+    auto const heights = co_await fetch_last_height();
+    if ( ! heights) {
+        co_return std::unexpected(heights.error());
+    }
+
+    co_return blockchain::mining_info{
+        heights->block,
+        difficulty_from_bits(state->work_required()),
+        mempool_.size(),
+        state->network()};
+}
+
 awaitable_expected<inventory_ptr>
 block_chain::fetch_mempool(size_t count_limit, uint64_t /*minimum_fee*/) const {
     if (stopped()) {

--- a/src/blockchain/src/pools/block_template.cpp
+++ b/src/blockchain/src/pools/block_template.cpp
@@ -216,4 +216,26 @@ mining_template make_mining_template(
         std::move(selection)};
 }
 
+double difficulty_from_bits(uint32_t bits) {
+    auto const mantissa = bits & 0x00ffffffu;
+    if (mantissa == 0) {
+        return 0.0;
+    }
+
+    // Standard Bitcoin difficulty: the ratio of the difficulty-1 target
+    // (0x1d00ffff) to this target, scaled by the exponent difference.
+    int shift = static_cast<int>((bits >> 24) & 0xffu);
+    double difficulty = static_cast<double>(0x0000ffff) /
+        static_cast<double>(mantissa);
+    while (shift < 29) {
+        difficulty *= 256.0;
+        ++shift;
+    }
+    while (shift > 29) {
+        difficulty /= 256.0;
+        --shift;
+    }
+    return difficulty;
+}
+
 } // namespace kth::blockchain

--- a/src/blockchain/test/block_template_test.cpp
+++ b/src/blockchain/test/block_template_test.cpp
@@ -8,6 +8,8 @@
 
 #include <test_helpers.hpp>
 
+#include <catch2/catch_approx.hpp>
+
 #include <kth/blockchain/pools/block_template.hpp>
 #include <kth/blockchain/pools/mempool.hpp>
 #include <kth/domain.hpp>
@@ -298,4 +300,23 @@ TEST_CASE("make_mining_template passes the header fields through", "[block_templ
     REQUIRE(t.bits == 0x1d00ffffu);
     REQUIRE(t.size_limit == 32000000u);
     REQUIRE(t.sigchecks_limit == 226950u);
+}
+
+// ---------------------------------------------------------------------------
+// difficulty_from_bits: the compact nBits -> Bitcoin difficulty conversion.
+
+TEST_CASE("difficulty_from_bits is 1.0 at the difficulty-1 target", "[block_template]") {
+    using kth::blockchain::difficulty_from_bits;
+    REQUIRE(difficulty_from_bits(0x1d00ffffu) == Catch::Approx(1.0));
+}
+
+TEST_CASE("difficulty_from_bits scales with the exponent", "[block_template]") {
+    using kth::blockchain::difficulty_from_bits;
+    // One lower exponent byte is a 256x harder target.
+    REQUIRE(difficulty_from_bits(0x1c00ffffu) == Catch::Approx(256.0));
+}
+
+TEST_CASE("difficulty_from_bits is zero for a zero mantissa", "[block_template]") {
+    using kth::blockchain::difficulty_from_bits;
+    REQUIRE(difficulty_from_bits(0x1d000000u) == Catch::Approx(0.0));
 }

--- a/src/node/include/kth/node/rpc/mining.hpp
+++ b/src/node/include/kth/node/rpc/mining.hpp
@@ -33,6 +33,9 @@ domain::message::block assemble_block(
     domain::chain::transaction const& coinbase,
     std::vector<transaction_const_ptr> const& job_txs);
 
+// Serialize a mining_info as the getmininginfo "result" object.
+std::string render_mining_info(blockchain::mining_info const& info);
+
 } // namespace kth::node::rpc
 
 #endif // KTH_NODE_RPC_MINING_HPP

--- a/src/node/src/rpc/methods.cpp
+++ b/src/node/src/rpc/methods.cpp
@@ -52,6 +52,17 @@ get_block_template_light(method_context& ctx, request const& /*req*/) {
     co_return render_mining_template(*tmpl, job_id);
 }
 
+// getmininginfo -> height, difficulty, mempool size, and network.
+// C-API counterpart: kth_chain_async_fetch_mining_info (see docs/json-rpc.md).
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_mining_info(method_context& ctx, request const& /*req*/) {
+    auto const info = co_await ctx.chain.fetch_mining_info();
+    if ( ! info) {
+        co_return std::unexpected(from_code(info.error()));
+    }
+    co_return render_mining_info(*info);
+}
+
 // submitblocklight -> reconstruct the full block from the miner's solved header +
 // coinbase and the cached job selection, then submit it to the chain. Returns
 // (Bitcoin submitblock semantics) null on accept, or a reject-reason string.
@@ -106,6 +117,7 @@ submit_block_light(method_context& ctx, request const& req) {
 void register_builtin_methods(dispatcher& d) {
     d.add("getblockcount", get_block_count);
     d.add("getblocktemplatelight", get_block_template_light);
+    d.add("getmininginfo", get_mining_info);
     d.add("submitblocklight", submit_block_light);
 }
 

--- a/src/node/src/rpc/mining.cpp
+++ b/src/node/src/rpc/mining.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include <kth/domain/chain/compact.hpp>
+#include <kth/domain/config/network.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 
 #include <kth/node/rpc/json.hpp>
@@ -77,6 +78,18 @@ domain::message::block assemble_block(
         txs.push_back(*tx); // slice message::transaction -> chain::transaction
     }
     return domain::message::block(header, std::move(txs));
+}
+
+std::string render_mining_info(blockchain::mining_info const& info) {
+    writer w;
+    w.begin_object();
+    w.field("blocks", static_cast<std::uint64_t>(info.blocks));
+    w.field("difficulty", info.difficulty);
+    w.field("pooledtx", static_cast<std::uint64_t>(info.pooled_tx));
+    w.field("chain", domain::config::name(info.chain));
+    w.field("warnings", "");
+    w.end_object();
+    return w.str();
 }
 
 } // namespace kth::node::rpc

--- a/src/node/test/rpc_mining.cpp
+++ b/src/node/test/rpc_mining.cpp
@@ -67,3 +67,14 @@ TEST_CASE("assemble_block with an empty selection is coinbase-only", "[rpc minin
     REQUIRE(block.transactions().size() == 1u);
     REQUIRE(block.transactions()[0].hash() == coinbase.hash());
 }
+
+TEST_CASE("render_mining_info serializes the getmininginfo fields", "[rpc mining]") {
+    blockchain::mining_info info{
+        /*blocks*/ 42u,
+        /*difficulty*/ 1.0,
+        /*pooled_tx*/ 3u,
+        /*chain*/ domain::config::network::mainnet};
+
+    REQUIRE(render_mining_info(info) ==
+        R"({"blocks":42,"difficulty":1.0,"pooledtx":3,"chain":"Mainnet","warnings":""})");
+}


### PR DESCRIPTION
Completes the mining trio (getblocktemplatelight #517, submitblocklight #518).

## What

`getmininginfo` returns a small mining snapshot:

```json
{"blocks": 0, "difficulty": 1.0, "pooledtx": 0, "chain": "Mainnet", "warnings": ""}
```

- `blocks` — tip height
- `difficulty` — of the next required work (matches the template's `bits`)
- `pooledtx` — mempool size
- `chain` — network name
- `warnings` — reserved (empty)

## Core (blockchain)

`block_chain::fetch_mining_info()` returns a `mining_info` from `fetch_last_height` + `chain_state` + the mempool. The nBits→difficulty conversion is factored into a pure `difficulty_from_bits()`.

## Tests (per method, no live chain)

- `difficulty_from_bits()` — target 1 → `1.0`, one lower exponent byte → `256.0`, zero mantissa → `0.0`.
- `render_mining_info()` — exact getmininginfo JSON.

Verified end-to-end against a running node (values above are the genesis snapshot). Blockchain suite 130 cases, node suite 82 cases.

## Deferred

- `networkhashps` — needs a historical hashrate estimate; follow-up.
- C-API counterpart (`kth_chain_async_fetch_mining_info`) lands in the generator PR.