### PR TITLE
c-api: expose the mining info reader (sync + async) on the chain interface

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -257,6 +257,7 @@ set(kth_sources
         src/chain/chain_other.cpp
         src/chain/chain_sync.cpp
         src/chain/chain_mempool.cpp
+        src/chain/chain_mining.cpp
 
         src/domain/message/compact_block.cpp
         src/domain/message/double_spend_proof.cpp
@@ -639,6 +640,9 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     # Chain-interface mempool readers — compile + link signature check.
     add_executable(kth_chain_mempool_compile_check test/chain/chain_mempool_compile_check.c)
     target_link_libraries(kth_chain_mempool_compile_check PRIVATE ${PROJECT_NAME})
+
+    add_executable(kth_chain_mining_compile_check test/chain/chain_mining_compile_check.c)
+    target_link_libraries(kth_chain_mining_compile_check PRIVATE ${PROJECT_NAME})
 
     # README C snippet — runtime smoke. Same flow as the README but
     # adapted for CI: regtest network, fresh temp data dir, 16 MiB DB

--- a/src/c-api/include/kth/capi/callbacks.h
+++ b/src/c-api/include/kth/capi/callbacks.h
@@ -11,6 +11,7 @@
 
 #include <kth/capi/error.h>
 #include <kth/capi/handles.h>
+#include <kth/capi/chain/mining_info.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,6 +55,7 @@ typedef void (*kth_compact_block_fetch_handler_t)(kth_chain_t, void*, kth_error_
 // Owned: `history` (`kth_history_compact_list_mut_t`) — caller must release with `kth_domain_chain_history_compact_list_destruct`.
 typedef void (*kth_history_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_history_compact_list_mut_t history);
 typedef void (*kth_last_height_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_size_t);
+typedef void (*kth_mining_info_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_mining_info_t);
 
 // Owned: `block` (`kth_merkle_block_mut_t`) — caller must release with `kth_domain_message_merkle_block_destruct`.
 typedef void (*kth_merkle_block_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_merkle_block_mut_t block, kth_size_t);

--- a/src/c-api/include/kth/capi/chain/chain_async.h
+++ b/src/c-api/include/kth/capi/chain/chain_async.h
@@ -17,6 +17,11 @@ extern "C" {
 KTH_EXPORT
 void kth_chain_async_last_height(kth_chain_t chain, void* ctx, kth_last_height_fetch_handler_t handler);
 
+// Async counterpart of kth_chain_sync_mining_info: the handler receives the
+// mining_info snapshot (by value) once fetch_mining_info() completes.
+KTH_EXPORT
+void kth_chain_async_mining_info(kth_chain_t chain, void* ctx, kth_mining_info_fetch_handler_t handler);
+
 KTH_EXPORT
 void kth_chain_async_block_height(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_block_height_fetch_handler_t handler);
 

--- a/src/c-api/include/kth/capi/chain/chain_mining.h
+++ b/src/c-api/include/kth/capi/chain/chain_mining.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_CHAIN_MINING_H_
+#define KTH_CAPI_CHAIN_CHAIN_MINING_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/chain/mining_info.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Getters
+
+KTH_EXPORT
+kth_error_code_t kth_chain_sync_mining_info(kth_chain_t self, kth_mining_info_t* out);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_CHAIN_CHAIN_MINING_H_

--- a/src/c-api/include/kth/capi/chain/mining_info.h
+++ b/src/c-api/include/kth/capi/chain/mining_info.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_MINING_INFO_H_
+#define KTH_CAPI_CHAIN_MINING_INFO_H_
+
+#include <stdint.h>
+
+typedef struct kth_mining_info {
+    size_t blocks;
+    double difficulty;
+    size_t pooled_tx;
+    uint32_t chain;
+} kth_mining_info_t;
+
+#endif // KTH_CAPI_CHAIN_MINING_INFO_H_

--- a/src/c-api/include/kth/capi/detail/sync_wait.hpp
+++ b/src/c-api/include/kth/capi/detail/sync_wait.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_DETAIL_SYNC_WAIT_HPP_
+#define KTH_CAPI_DETAIL_SYNC_WAIT_HPP_
+
+#include <utility>
+
+#include <asio/co_spawn.hpp>
+#include <asio/use_future.hpp>
+
+namespace kth::capi {
+
+// Drive an awaitable to completion synchronously on the chain's executor and
+// return the awaited value (typically std::expected<T, code> for fetch_*
+// methods, or code for organize()). This is how the synchronous C-API wraps the
+// node's asio::awaitable interface. Templated on the chain type so this header
+// stays free of the heavy block_chain include.
+template <typename Chain, typename Awaitable>
+auto sync_wait(Chain& chain, Awaitable awaitable) {
+    auto future = ::asio::co_spawn(
+        chain.executor(), std::move(awaitable), ::asio::use_future);
+    return future.get();
+}
+
+} // namespace kth::capi
+
+#endif // KTH_CAPI_DETAIL_SYNC_WAIT_HPP_

--- a/src/c-api/src/chain/chain_async.cpp
+++ b/src/c-api/src/chain/chain_async.cpp
@@ -59,6 +59,19 @@ void kth_chain_async_last_height(kth_chain_t chain, void* ctx, kth_last_height_f
     }, ::asio::detached);
 }
 
+void kth_chain_async_mining_info(kth_chain_t chain, void* ctx, kth_mining_info_fetch_handler_t handler) {
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_mining_info();
+        if (result) {
+            handler(chain, ctx, kth::to_c_err(std::error_code{}),
+                kth::to_c_struct<kth_mining_info_t>(*result));
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), kth_mining_info_t{});
+        }
+    }, ::asio::detached);
+}
+
 void kth_chain_async_block_height(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_block_height_fetch_handler_t handler) {
     auto hash_cpp = kth::to_array(hash.hash);
     auto& bc = safe_chain(chain);

--- a/src/c-api/src/chain/chain_mining.cpp
+++ b/src/c-api/src/chain/chain_mining.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/chain/chain_mining.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/capi/detail/sync_wait.hpp>
+#include <kth/blockchain/interface/block_chain.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::blockchain::block_chain;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Getters
+
+kth_error_code_t kth_chain_sync_mining_info(kth_chain_t self, kth_mining_info_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    auto const result = kth::capi::sync_wait(kth::cpp_ref<cpp_t>(self), kth::cpp_ref<cpp_t>(self).fetch_mining_info());
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = kth::to_c_struct<kth_mining_info_t>(*result);
+    return kth_ec_success;
+}
+
+} // extern "C"

--- a/src/c-api/test/chain/chain_mining_compile_check.c
+++ b/src/c-api/test/chain/chain_mining_compile_check.c
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Compile + link check for the generated mining readers on the chain interface
+// (kth_chain_fetch_mining_*). These need a running node to execute, so like the
+// rest of the chain interface they are not unit-tested at runtime; this file
+// fails the build if any public signature drifts. The behavioral coverage lives
+// at the C++ level (fetch_mining_info / difficulty_from_bits tests).
+
+#include <kth/capi.h>
+#include <kth/capi/chain/chain_mining.h>
+#include <kth/capi/chain/chain_async.h>
+
+static void on_mining_info(kth_chain_t chain, void* ctx, kth_error_code_t ec,
+                           kth_mining_info_t info) {
+    (void)chain; (void)ctx; (void)ec; (void)info;
+}
+
+static void mining_readers_sig_check(kth_chain_t chain) {
+    // Synchronous (blocking) flavor.
+    kth_mining_info_t info;
+    kth_error_code_t rc = kth_chain_sync_mining_info(chain, &info);
+    (void)rc; (void)info;
+
+    // Asynchronous (callback) flavor.
+    kth_chain_async_mining_info(chain, NULL, &on_mining_info);
+}
+
+int main(void) {
+    // Referenced but never called: forces linkage of every symbol above
+    // without needing a live chain handle.
+    void (*ref)(kth_chain_t) = &mining_readers_sig_check;
+    (void)ref;
+    return 0;
+}

--- a/src/node/test/p2p_node.cpp
+++ b/src/node/test/p2p_node.cpp
@@ -242,7 +242,7 @@ TEST_CASE("p2p_node connect to invalid host fails", "[p2p_node][integration]") {
     ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
         start_result = co_await node.start();
         if (start_result == error::success) {
-            connect_result = co_await node.connect("invalid.host.that.does.not.exist.local", 18333);
+            connect_result = co_await node.connect("invalid.host.that.does.not.exist.invalid", 18333);
         }
         done = true;
     }, ::asio::detached);


### PR DESCRIPTION
Adds the C-API counterpart of the `getmininginfo` JSON-RPC method (#519), keeping RPC↔C-API parity — in **both flavors** the async chain interface warrants.

## What

```c
// Blocking: drives the awaitable to completion (kth::capi::sync_wait).
kth_error_code_t kth_chain_sync_mining_info(kth_chain_t chain, kth_mining_info_t* out);

// Non-blocking: returns immediately, invokes the handler on completion.
void kth_chain_async_mining_info(kth_chain_t chain, void* ctx,
                                 kth_mining_info_fetch_handler_t handler);

typedef struct kth_mining_info {
    size_t   blocks;      // tip height
    double   difficulty;  // of the next required work
    size_t   pooled_tx;   // mempool size
    uint32_t chain;       // network (values match kth_network_t)
} kth_mining_info_t;
```

## Two flavors

The chain interface is asynchronous (`asio::awaitable`). Following the existing convention (`kth_chain_sync_last_height` / `kth_chain_async_last_height`):

- **sync** wraps the awaitable in `kth::capi::sync_wait` and blocks until done.
- **async** `co_spawn`s it detached and invokes the callback `handler(chain, ctx, error, info)` on completion — the same shape as the other async chain readers, and the basis for future push-style notifications.

The POD conversion is a `static_assert`-guarded memcpy (layout-checked at compile time).

## Tests

A compile + link check (`chain_mining_compile_check.c`) exercises both signatures and fails the build on drift; runtime behavior needs a live node, so it stays covered at the C++ level (`fetch_mining_info` / `difficulty_from_bits`).

Follow-ups: the C-API for `fetch_mining_template` (header POD + tx list) and `organize` (submitblock); and teaching the generator to emit the async-callback flavor (today it's hand-written, like the ~15 existing async readers).