### PR TITLE
c-api: expose the mining template reader (sync + async) on the chain interface

### DIFF
--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -67,9 +67,12 @@ counterpart.
 | JSON-RPC method | C-API function | C++ (`block_chain`) |
 |---|---|---|
 | `getblockcount` | `kth_chain_sync_last_height` | `fetch_last_height().block` |
-| `getblocktemplatelight` | `kth_chain_async_fetch_mining_template` _(pending)_ | `fetch_mining_template()` |
-| `getmininginfo` | `kth_chain_async_fetch_mining_info` _(pending)_ | `fetch_mining_info()` |
-| `submitblocklight` | `kth_chain_async_organize_block` _(pending)_ | `organize(block)` |
+| `getblocktemplatelight` | `kth_chain_sync_mining_template` / `kth_chain_async_mining_template` | `fetch_mining_template()` |
+| `getmininginfo` | `kth_chain_sync_mining_info` / `kth_chain_async_mining_info` | `fetch_mining_info()` |
+| `submitblocklight` | `kth_chain_sync_organize_block` / `kth_chain_async_organize_block` | `organize(block)` |
+
+Each async chain reader is exposed in both a blocking (`kth_chain_sync_*`) and a
+callback (`kth_chain_async_*`) flavor.
 
 _More methods land per phase: mining (`submitblock`, `getmininginfo`), mempool
 (`getrawmempool`, `getmempoolentry`, ...), and blockchain/raw-tx (`getblock`,

--- a/src/c-api/include/kth/capi/callbacks.h
+++ b/src/c-api/include/kth/capi/callbacks.h
@@ -12,6 +12,7 @@
 #include <kth/capi/error.h>
 #include <kth/capi/handles.h>
 #include <kth/capi/chain/mining_info.h>
+#include <kth/capi/chain/mining_template.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,6 +57,9 @@ typedef void (*kth_compact_block_fetch_handler_t)(kth_chain_t, void*, kth_error_
 typedef void (*kth_history_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_history_compact_list_mut_t history);
 typedef void (*kth_last_height_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_size_t);
 typedef void (*kth_mining_info_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_mining_info_t);
+// The owned kth_transaction_list_mut_t is the template's tx selection; the caller
+// must release it with kth_domain_chain_transaction_list_destruct.
+typedef void (*kth_mining_template_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_mining_template_t, kth_transaction_list_mut_t);
 
 // Owned: `block` (`kth_merkle_block_mut_t`) — caller must release with `kth_domain_message_merkle_block_destruct`.
 typedef void (*kth_merkle_block_fetch_handler_t)(kth_chain_t, void*, kth_error_code_t, kth_merkle_block_mut_t block, kth_size_t);

--- a/src/c-api/include/kth/capi/chain/chain_async.h
+++ b/src/c-api/include/kth/capi/chain/chain_async.h
@@ -22,6 +22,13 @@ void kth_chain_async_last_height(kth_chain_t chain, void* ctx, kth_last_height_f
 KTH_EXPORT
 void kth_chain_async_mining_info(kth_chain_t chain, void* ctx, kth_mining_info_fetch_handler_t handler);
 
+// Async counterpart of kth_chain_sync_mining_template: the handler receives the
+// header POD and the owned transaction selection once fetch_mining_template()
+// completes. The handler must release the list with
+// kth_domain_chain_transaction_list_destruct.
+KTH_EXPORT
+void kth_chain_async_mining_template(kth_chain_t chain, void* ctx, kth_mining_template_fetch_handler_t handler);
+
 KTH_EXPORT
 void kth_chain_async_block_height(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_block_height_fetch_handler_t handler);
 

--- a/src/c-api/include/kth/capi/chain/chain_sync.h
+++ b/src/c-api/include/kth/capi/chain/chain_sync.h
@@ -9,6 +9,7 @@
 
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
+#include <kth/capi/chain/mining_template.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -91,6 +92,15 @@ kth_transaction_list_mut_t kth_chain_sync_mempool_transactions_from_wallets(kth_
 //-------------------------------------------------------------------------
 KTH_EXPORT
 int kth_chain_sync_organize_block(kth_chain_t chain, kth_block_mut_t block);
+
+/**
+ * Fetch the mining template. On success fills `out` with the header fields and
+ * hands back the transaction selection as an owned `*out_txs`.
+ * @return Owned `*out_txs` on success. Caller must release it with
+ *   `kth_domain_chain_transaction_list_destruct`.
+ */
+KTH_EXPORT KTH_OWNED
+kth_error_code_t kth_chain_sync_mining_template(kth_chain_t chain, kth_mining_template_t* out, kth_transaction_list_mut_t* out_txs);
 
 KTH_EXPORT
 int kth_chain_sync_organize_transaction(kth_chain_t chain, kth_transaction_mut_t transaction);

--- a/src/c-api/include/kth/capi/chain/mining_template.h
+++ b/src/c-api/include/kth/capi/chain/mining_template.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_MINING_TEMPLATE_H_
+#define KTH_CAPI_CHAIN_MINING_TEMPLATE_H_
+
+#include <stdint.h>
+
+#include <kth/capi/handles.h>
+
+// The header fields of a mining template. The transaction selection is returned
+// separately as an owned kth_transaction_list_mut_t, since it is variable-length
+// (this struct stays a fixed POD).
+typedef struct kth_mining_template {
+    uint32_t version;
+    kth_hash_t previous_block_hash;
+    size_t height;
+    uint32_t bits;
+    uint32_t min_time;
+    uint32_t current_time;
+    uint64_t coinbase_value;
+    uint64_t size_limit;
+    uint64_t sigchecks_limit;
+} kth_mining_template_t;
+
+#endif // KTH_CAPI_CHAIN_MINING_TEMPLATE_H_

--- a/src/c-api/include/kth/capi/detail/mining_template.hpp
+++ b/src/c-api/include/kth/capi/detail/mining_template.hpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_DETAIL_MINING_TEMPLATE_HPP_
+#define KTH_CAPI_DETAIL_MINING_TEMPLATE_HPP_
+
+#include <cstring>
+#include <utility>
+#include <vector>
+
+#include <kth/blockchain/pools/block_template.hpp>
+#include <kth/domain/chain/transaction.hpp>
+
+#include <kth/capi/chain/mining_template.h>
+#include <kth/capi/handles.h>
+#include <kth/capi/helpers.hpp>
+
+namespace kth::capi {
+
+// Fill the C header POD from a C++ mining_template and hand the caller an owned
+// transaction list built from the selection. Shared by the sync and async
+// wrappers. mining_template is not trivially copyable (it owns the selection
+// vector), so the header fields are copied one by one rather than memcpy'd.
+inline void fill_mining_template(
+    kth_mining_template_t& out,
+    kth_transaction_list_mut_t& out_txs,
+    kth::blockchain::mining_template const& tmpl) {
+
+    out.version = tmpl.version;
+    std::memcpy(out.previous_block_hash.hash,
+        tmpl.previous_block_hash.data(), tmpl.previous_block_hash.size());
+    out.height = tmpl.height;
+    out.bits = tmpl.bits;
+    out.min_time = tmpl.min_time;
+    out.current_time = tmpl.current_time;
+    out.coinbase_value = tmpl.coinbase_value;
+    out.size_limit = tmpl.size_limit;
+    out.sigchecks_limit = tmpl.sigchecks_limit;
+
+    std::vector<kth::domain::chain::transaction> txs;
+    txs.reserve(tmpl.selection.txs.size());
+    for (auto const& tx : tmpl.selection.txs) {
+        txs.push_back(*tx); // slice message::transaction -> chain::transaction
+    }
+    out_txs = kth::leak(std::move(txs));
+}
+
+} // namespace kth::capi
+
+#endif // KTH_CAPI_DETAIL_MINING_TEMPLATE_HPP_

--- a/src/c-api/src/chain/chain_async.cpp
+++ b/src/c-api/src/chain/chain_async.cpp
@@ -13,6 +13,8 @@
 #include <kth/domain/chain/transaction.hpp>
 #include <kth/blockchain/interface/block_chain.hpp>
 
+#include <kth/capi/detail/mining_template.hpp>
+
 #include <kth/capi/domain/chain/block_list.h>
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
@@ -68,6 +70,21 @@ void kth_chain_async_mining_info(kth_chain_t chain, void* ctx, kth_mining_info_f
                 kth::to_c_struct<kth_mining_info_t>(*result));
         } else {
             handler(chain, ctx, kth::to_c_err(result.error()), kth_mining_info_t{});
+        }
+    }, ::asio::detached);
+}
+
+void kth_chain_async_mining_template(kth_chain_t chain, void* ctx, kth_mining_template_fetch_handler_t handler) {
+    auto& bc = safe_chain(chain);
+    ::asio::co_spawn(bc.executor(), [&bc, chain, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_mining_template();
+        if (result) {
+            kth_mining_template_t tmpl;
+            kth_transaction_list_mut_t txs = nullptr;
+            kth::capi::fill_mining_template(tmpl, txs, *result);
+            handler(chain, ctx, kth::to_c_err(std::error_code{}), tmpl, txs);
+        } else {
+            handler(chain, ctx, kth::to_c_err(result.error()), kth_mining_template_t{}, nullptr);
         }
     }, ::asio::detached);
 }

--- a/src/c-api/src/chain/chain_sync.cpp
+++ b/src/c-api/src/chain/chain_sync.cpp
@@ -14,6 +14,8 @@
 #include <kth/domain/chain/transaction.hpp>
 #include <kth/blockchain/interface/block_chain.hpp>
 
+#include <kth/capi/detail/mining_template.hpp>
+
 #include <kth/capi/domain/chain/block_list.h>
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
@@ -338,6 +340,16 @@ int kth_chain_sync_organize_transaction(kth_chain_t chain, kth_transaction_mut_t
     auto& bc = safe_chain(chain);
     auto ec = sync_wait(bc, bc.organize(tx_shared(transaction)));
     return kth::to_c_err(ec);
+}
+
+kth_error_code_t kth_chain_sync_mining_template(kth_chain_t chain, kth_mining_template_t* out, kth_transaction_list_mut_t* out_txs) {
+    auto& bc = safe_chain(chain);
+    auto result = sync_wait(bc, bc.fetch_mining_template());
+    if ( ! result) {
+        return kth::to_c_err(result.error());
+    }
+    kth::capi::fill_mining_template(*out, *out_txs, *result);
+    return kth::to_c_err(std::error_code{});
 }
 
 //-------------------------------------------------------------------------

--- a/src/c-api/test/chain/chain_mining_compile_check.c
+++ b/src/c-api/test/chain/chain_mining_compile_check.c
@@ -10,6 +10,7 @@
 
 #include <kth/capi.h>
 #include <kth/capi/chain/chain_mining.h>
+#include <kth/capi/chain/chain_sync.h>
 #include <kth/capi/chain/chain_async.h>
 
 static void on_mining_info(kth_chain_t chain, void* ctx, kth_error_code_t ec,
@@ -17,14 +18,25 @@ static void on_mining_info(kth_chain_t chain, void* ctx, kth_error_code_t ec,
     (void)chain; (void)ctx; (void)ec; (void)info;
 }
 
+static void on_mining_template(kth_chain_t chain, void* ctx, kth_error_code_t ec,
+                               kth_mining_template_t tmpl,
+                               kth_transaction_list_mut_t txs) {
+    (void)chain; (void)ctx; (void)ec; (void)tmpl; (void)txs;
+}
+
 static void mining_readers_sig_check(kth_chain_t chain) {
-    // Synchronous (blocking) flavor.
+    // getmininginfo — both flavors.
     kth_mining_info_t info;
     kth_error_code_t rc = kth_chain_sync_mining_info(chain, &info);
     (void)rc; (void)info;
-
-    // Asynchronous (callback) flavor.
     kth_chain_async_mining_info(chain, NULL, &on_mining_info);
+
+    // getblocktemplatelight — both flavors (header POD + owned tx list).
+    kth_mining_template_t tmpl;
+    kth_transaction_list_mut_t txs;
+    kth_error_code_t rc2 = kth_chain_sync_mining_template(chain, &tmpl, &txs);
+    (void)rc2; (void)tmpl; (void)txs;
+    kth_chain_async_mining_template(chain, NULL, &on_mining_template);
 }
 
 int main(void) {


### PR DESCRIPTION
Adds the C-API counterpart of `getblocktemplatelight`'s backing (`fetch_mining_template`), completing the mining C-API parity.

## What

```c
// Blocking
kth_error_code_t kth_chain_sync_mining_template(
    kth_chain_t chain, kth_mining_template_t* out, kth_transaction_list_mut_t* out_txs);

// Non-blocking
void kth_chain_async_mining_template(
    kth_chain_t chain, void* ctx, kth_mining_template_fetch_handler_t handler);

typedef struct kth_mining_template {
    uint32_t   version;
    kth_hash_t previous_block_hash;
    size_t     height;
    uint32_t   bits;
    uint32_t   min_time;
    uint32_t   current_time;
    uint64_t   coinbase_value;
    uint64_t   size_limit;
    uint64_t   sigchecks_limit;
} kth_mining_template_t;
```

## Header POD + owned tx list

The C++ `mining_template` owns the transaction selection (a vector), so it is **not** trivially copyable — no whole-struct memcpy. Following the design chosen for this: the fixed header fields go into `kth_mining_template_t`, and the selection is handed back as an **owned** `kth_transaction_list_mut_t` (release with `kth_domain_chain_transaction_list_destruct`). A small shared helper does the field copy + list leak for both flavors.

## Parity complete

| JSON-RPC | C-API (sync / async) |
|---|---|
| getmininginfo | `kth_chain_sync_mining_info` / `kth_chain_async_mining_info` |
| submitblocklight | `kth_chain_sync_organize_block` / `kth_chain_async_organize_block` |
| getblocktemplatelight | `kth_chain_sync_mining_template` / `kth_chain_async_mining_template` |
| getblockcount | `kth_chain_sync_last_height` |

## Tests

The compile + link check exercises both new signatures; runtime behavior needs a live node, so it stays covered at the C++ level.