### PR TITLE
c-api: generate the async mining-info flavor

### DIFF
--- a/src/c-api/include/kth/capi/chain/chain_async.h
+++ b/src/c-api/include/kth/capi/chain/chain_async.h
@@ -17,10 +17,7 @@ extern "C" {
 KTH_EXPORT
 void kth_chain_async_last_height(kth_chain_t chain, void* ctx, kth_last_height_fetch_handler_t handler);
 
-// Async counterpart of kth_chain_sync_mining_info: the handler receives the
-// mining_info snapshot (by value) once fetch_mining_info() completes.
-KTH_EXPORT
-void kth_chain_async_mining_info(kth_chain_t chain, void* ctx, kth_mining_info_fetch_handler_t handler);
+// kth_chain_async_mining_info is generated (see chain_mining.h).
 
 // Async counterpart of kth_chain_sync_mining_template: the handler receives the
 // header POD and the owned transaction selection once fetch_mining_template()

--- a/src/c-api/include/kth/capi/chain/chain_mining.h
+++ b/src/c-api/include/kth/capi/chain/chain_mining.h
@@ -10,6 +10,7 @@
 #include <kth/capi/primitives.h>
 #include <kth/capi/visibility.h>
 #include <kth/capi/chain/mining_info.h>
+#include <kth/capi/callbacks.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,6 +20,9 @@ extern "C" {
 
 KTH_EXPORT
 kth_error_code_t kth_chain_sync_mining_info(kth_chain_t self, kth_mining_info_t* out);
+
+KTH_EXPORT
+void kth_chain_async_mining_info(kth_chain_t self, void* ctx, kth_mining_info_fetch_handler_t handler);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/c-api/src/chain/chain_async.cpp
+++ b/src/c-api/src/chain/chain_async.cpp
@@ -61,18 +61,7 @@ void kth_chain_async_last_height(kth_chain_t chain, void* ctx, kth_last_height_f
     }, ::asio::detached);
 }
 
-void kth_chain_async_mining_info(kth_chain_t chain, void* ctx, kth_mining_info_fetch_handler_t handler) {
-    auto& bc = safe_chain(chain);
-    ::asio::co_spawn(bc.executor(), [&bc, chain, ctx, handler]() -> ::asio::awaitable<void> {
-        auto result = co_await bc.fetch_mining_info();
-        if (result) {
-            handler(chain, ctx, kth::to_c_err(std::error_code{}),
-                kth::to_c_struct<kth_mining_info_t>(*result));
-        } else {
-            handler(chain, ctx, kth::to_c_err(result.error()), kth_mining_info_t{});
-        }
-    }, ::asio::detached);
-}
+// kth_chain_async_mining_info is generated (chain_mining.cpp).
 
 void kth_chain_async_mining_template(kth_chain_t chain, void* ctx, kth_mining_template_fetch_handler_t handler) {
     auto& bc = safe_chain(chain);

--- a/src/c-api/src/chain/chain_mining.cpp
+++ b/src/c-api/src/chain/chain_mining.cpp
@@ -7,6 +7,9 @@
 #include <kth/capi/conversions.hpp>
 #include <kth/capi/helpers.hpp>
 #include <kth/capi/detail/sync_wait.hpp>
+#include <system_error>
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
 #include <kth/blockchain/interface/block_chain.hpp>
 
 // File-local alias so `kth::cpp_ref<T>(...)` and friends don't
@@ -27,6 +30,19 @@ kth_error_code_t kth_chain_sync_mining_info(kth_chain_t self, kth_mining_info_t*
     if ( ! result) return kth::to_c_err(result.error());
     *out = kth::to_c_struct<kth_mining_info_t>(*result);
     return kth_ec_success;
+}
+
+void kth_chain_async_mining_info(kth_chain_t self, void* ctx, kth_mining_info_fetch_handler_t handler) {
+    KTH_PRECONDITION(self != nullptr);
+    auto& bc = kth::cpp_ref<cpp_t>(self);
+    ::asio::co_spawn(bc.executor(), [&bc, self, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_mining_info();
+        if (result) {
+            handler(self, ctx, kth::to_c_err(std::error_code{}), kth::to_c_struct<kth_mining_info_t>(*result));
+        } else {
+            handler(self, ctx, kth::to_c_err(result.error()), kth_mining_info_t{});
+        }
+    }, ::asio::detached);
 }
 
 } // extern "C"


### PR DESCRIPTION
`kth_chain_async_mining_info` now comes from the generator (`chain_mining.h`/`.cpp`) rather than being hand-written in `chain_async.cpp`, so a chain reader's blocking and callback wrappers share one source.

## What changed

The generator learned to emit the **async callback companion** of an async C++ method: for a nullary `expected<c_struct>` reader (e.g. `fetch_mining_info`) it produces

```c
void kth_chain_async_mining_info(kth_chain_t self, void* ctx,
                                 kth_mining_info_fetch_handler_t handler);
```

whose body `co_spawn`s the awaitable detached and delivers the result to the handler — matching the hand-written version byte-for-byte in behavior. The hand-written copy is removed from `chain_async.{h,cpp}`.

This is the first step of folding the ~15 hand-written async chain readers into the generator; input-taking and other return shapes still fall back to `chain_async.cpp` and will be absorbed incrementally.

## Tests

The compile + link check covers the signature; runtime behavior needs a live node (covered at the C++ level).