### PR TITLE
c-api: generate the block-height reader (sync + async)

### DIFF
--- a/src/c-api/CMakeLists.txt
+++ b/src/c-api/CMakeLists.txt
@@ -258,6 +258,7 @@ set(kth_sources
         src/chain/chain_sync.cpp
         src/chain/chain_mempool.cpp
         src/chain/chain_mining.cpp
+        src/chain/chain_query.cpp
 
         src/domain/message/compact_block.cpp
         src/domain/message/double_spend_proof.cpp
@@ -643,6 +644,9 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 
     add_executable(kth_chain_mining_compile_check test/chain/chain_mining_compile_check.c)
     target_link_libraries(kth_chain_mining_compile_check PRIVATE ${PROJECT_NAME})
+
+    add_executable(kth_chain_query_compile_check test/chain/chain_query_compile_check.c)
+    target_link_libraries(kth_chain_query_compile_check PRIVATE ${PROJECT_NAME})
 
     # README C snippet — runtime smoke. Same flow as the README but
     # adapted for CI: regtest network, fresh temp data dir, 16 MiB DB

--- a/src/c-api/include/kth/capi/chain/chain_async.h
+++ b/src/c-api/include/kth/capi/chain/chain_async.h
@@ -26,8 +26,7 @@ void kth_chain_async_last_height(kth_chain_t chain, void* ctx, kth_last_height_f
 KTH_EXPORT
 void kth_chain_async_mining_template(kth_chain_t chain, void* ctx, kth_mining_template_fetch_handler_t handler);
 
-KTH_EXPORT
-void kth_chain_async_block_height(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_block_height_fetch_handler_t handler);
+// kth_chain_async_block_height is generated (see chain_query.h).
 
 // Block Header ---------------------------------------------------------------------
 KTH_EXPORT

--- a/src/c-api/include/kth/capi/chain/chain_query.h
+++ b/src/c-api/include/kth/capi/chain/chain_query.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_CHAIN_QUERY_H_
+#define KTH_CAPI_CHAIN_CHAIN_QUERY_H_
+
+#include <stdint.h>
+
+#include <kth/capi/primitives.h>
+#include <kth/capi/visibility.h>
+#include <kth/capi/callbacks.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Operations
+
+/** @param hash Borrowed input; must be non-null. Read during the call; ownership of `hash` stays with the caller. */
+KTH_EXPORT
+kth_error_code_t kth_chain_sync_block_height(kth_chain_t self, kth_hash_t const* hash, kth_size_t* out);
+
+/** @warning `hash` MUST point to a buffer of at least 32 bytes. Passing a shorter buffer is undefined behavior. Prefer the safe variant (without the `_unsafe` suffix) when your language can pass a pointer to `kth_hash_t`. */
+KTH_EXPORT
+kth_error_code_t kth_chain_sync_block_height_unsafe(kth_chain_t self, uint8_t const* hash, kth_size_t* out);
+
+/** @param hash Borrowed input; must be non-null. Read during the call; ownership of `hash` stays with the caller. */
+KTH_EXPORT
+void kth_chain_async_block_height(kth_chain_t self, void* ctx, kth_hash_t const* hash, kth_block_height_fetch_handler_t handler);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // KTH_CAPI_CHAIN_CHAIN_QUERY_H_

--- a/src/c-api/include/kth/capi/chain/chain_sync.h
+++ b/src/c-api/include/kth/capi/chain/chain_sync.h
@@ -18,8 +18,7 @@ extern "C" {
 KTH_EXPORT
 kth_error_code_t kth_chain_sync_last_height(kth_chain_t chain, kth_size_t* out_height);
 
-KTH_EXPORT
-kth_error_code_t kth_chain_sync_block_height(kth_chain_t chain, kth_hash_t hash, kth_size_t* out_height);
+// kth_chain_sync_block_height is generated (see chain_query.h).
 
 
 // Block Header ---------------------------------------------------------------------

--- a/src/c-api/src/chain/chain_async.cpp
+++ b/src/c-api/src/chain/chain_async.cpp
@@ -78,18 +78,7 @@ void kth_chain_async_mining_template(kth_chain_t chain, void* ctx, kth_mining_te
     }, ::asio::detached);
 }
 
-void kth_chain_async_block_height(kth_chain_t chain, void* ctx, kth_hash_t hash, kth_block_height_fetch_handler_t handler) {
-    auto hash_cpp = kth::to_array(hash.hash);
-    auto& bc = safe_chain(chain);
-    ::asio::co_spawn(bc.executor(), [&bc, hash_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
-        auto result = co_await bc.fetch_block_height(hash_cpp);
-        if (result) {
-            handler(chain, ctx, kth::to_c_err(std::error_code{}), *result);
-        } else {
-            handler(chain, ctx, kth::to_c_err(result.error()), 0);
-        }
-    }, ::asio::detached);
-}
+// kth_chain_async_block_height is generated (chain_query.cpp).
 
 void kth_chain_async_block_header_by_height(kth_chain_t chain, void* ctx, kth_size_t height, kth_block_header_fetch_handler_t handler) {
     auto& bc = safe_chain(chain);

--- a/src/c-api/src/chain/chain_query.cpp
+++ b/src/c-api/src/chain/chain_query.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/capi/chain/chain_query.h>
+
+#include <kth/capi/conversions.hpp>
+#include <kth/capi/helpers.hpp>
+#include <kth/capi/detail/sync_wait.hpp>
+#include <system_error>
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <kth/blockchain/interface/block_chain.hpp>
+
+// File-local alias so `kth::cpp_ref<T>(...)` and friends don't
+// spell out the full qualified C++ name at every call site.
+namespace {
+using cpp_t = kth::blockchain::block_chain;
+} // namespace
+
+// ---------------------------------------------------------------------------
+extern "C" {
+
+// Operations
+
+kth_error_code_t kth_chain_sync_block_height(kth_chain_t self, kth_hash_t const* hash, kth_size_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(hash != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    auto const hash_cpp = kth::hash_to_cpp(hash->hash);
+    auto const result = kth::capi::sync_wait(kth::cpp_ref<cpp_t>(self), kth::cpp_ref<cpp_t>(self).fetch_block_height(hash_cpp));
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = static_cast<kth_size_t>(*result);
+    return kth_ec_success;
+}
+
+kth_error_code_t kth_chain_sync_block_height_unsafe(kth_chain_t self, uint8_t const* hash, kth_size_t* out) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(hash != nullptr);
+    KTH_PRECONDITION(out != nullptr);
+    auto const hash_cpp = kth::hash_to_cpp(hash);
+    auto const result = kth::capi::sync_wait(kth::cpp_ref<cpp_t>(self), kth::cpp_ref<cpp_t>(self).fetch_block_height(hash_cpp));
+    if ( ! result) return kth::to_c_err(result.error());
+    *out = static_cast<kth_size_t>(*result);
+    return kth_ec_success;
+}
+
+void kth_chain_async_block_height(kth_chain_t self, void* ctx, kth_hash_t const* hash, kth_block_height_fetch_handler_t handler) {
+    KTH_PRECONDITION(self != nullptr);
+    KTH_PRECONDITION(hash != nullptr);
+    auto const arg0 = kth::hash_to_cpp(hash->hash);
+    auto& bc = kth::cpp_ref<cpp_t>(self);
+    ::asio::co_spawn(bc.executor(), [&bc, self, ctx, handler, arg0]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_block_height(arg0);
+        if (result) {
+            handler(self, ctx, kth::to_c_err(std::error_code{}), static_cast<kth_size_t>(*result));
+        } else {
+            handler(self, ctx, kth::to_c_err(result.error()), kth_size_t{});
+        }
+    }, ::asio::detached);
+}
+
+} // extern "C"

--- a/src/c-api/src/chain/chain_sync.cpp
+++ b/src/c-api/src/chain/chain_sync.cpp
@@ -70,17 +70,7 @@ kth_error_code_t kth_chain_sync_last_height(kth_chain_t chain, kth_size_t* out_h
     return kth::to_c_err(result.error());
 }
 
-kth_error_code_t kth_chain_sync_block_height(kth_chain_t chain, kth_hash_t hash, kth_size_t* out_height) {
-    auto& bc = safe_chain(chain);
-    auto hash_cpp = kth::to_array(hash.hash);
-    auto result = sync_wait(bc, bc.fetch_block_height(hash_cpp));
-    if (result) {
-        *out_height = *result;
-        return kth::to_c_err(std::error_code{});
-    }
-    *out_height = 0;
-    return kth::to_c_err(result.error());
-}
+// kth_chain_sync_block_height is generated (chain_query.cpp).
 
 kth_error_code_t kth_chain_sync_block_header_by_height(kth_chain_t chain, kth_size_t height, kth_header_mut_t* out_header, kth_size_t* out_height) {
     auto& bc = safe_chain(chain);

--- a/src/c-api/test/chain/chain_query_compile_check.c
+++ b/src/c-api/test/chain/chain_query_compile_check.c
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Compile + link check for the generated chain query readers
+// (kth_chain_sync/async_block_height). They need a running node to execute, so
+// like the rest of the chain interface they are not unit-tested at runtime; this
+// file fails the build if any public signature drifts.
+
+#include <kth/capi.h>
+#include <kth/capi/chain/chain_query.h>
+#include <kth/capi/chain/chain_async.h>
+
+static void on_block_height(kth_chain_t chain, void* ctx, kth_error_code_t ec,
+                            kth_size_t height) {
+    (void)chain; (void)ctx; (void)ec; (void)height;
+}
+
+static void query_readers_sig_check(kth_chain_t chain, kth_hash_t const* hash) {
+    // Synchronous (blocking) flavor.
+    kth_size_t height = 0;
+    kth_error_code_t rc = kth_chain_sync_block_height(chain, hash, &height);
+    (void)rc; (void)height;
+
+    // Asynchronous (callback) flavor.
+    kth_chain_async_block_height(chain, NULL, hash, &on_block_height);
+}
+
+int main(void) {
+    // Referenced but never called: forces linkage of every symbol above
+    // without needing a live chain handle.
+    void (*ref)(kth_chain_t, kth_hash_t const*) = &query_readers_sig_check;
+    (void)ref;
+    return 0;
+}


### PR DESCRIPTION
Absorbs `fetch_block_height` into the generator, exercising the async generator's new **input + expected<scalar>** path end-to-end.

## What

`kth_chain_sync_block_height` and `kth_chain_async_block_height` are now generated (new `chain_query.{h,cpp}`) instead of hand-written in `chain_sync.cpp` / `chain_async.cpp`.

```c
kth_error_code_t kth_chain_sync_block_height(kth_chain_t self, kth_hash_t const* hash, kth_size_t* out);
void kth_chain_async_block_height(kth_chain_t self, void* ctx, kth_hash_t const* hash,
                                  kth_block_height_fetch_handler_t handler);
```

The async body converts the input hash to its C++ value **before** `co_spawn` and captures it by copy — so the detached coroutine never dereferences caller memory that may already be freed (the bug the previous nullary-only async generator sidestepped by having no inputs).

## ABI note

The hash input now follows the generator convention — a `kth_hash_t const*` (plus a `_unsafe` raw-pointer sync variant) rather than the previous by-value `kth_hash_t`. This matches every other hash-input chain function; the by-value hand-written version was the odd one out.

## Tests

`chain_query_compile_check.c` covers both signatures; runtime behavior needs a live node (covered at the C++ level).

Next: the remaining hand-written async readers (owned-handle, pair, tuple, and `code` shapes) fold in incrementally.