### PR TITLE
node: add blockchain query JSON-RPC methods

### DIFF
--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -67,6 +67,12 @@ counterpart.
 | JSON-RPC method | C-API function | C++ (`block_chain`) |
 |---|---|---|
 | `getblockcount` | `kth_chain_sync_last_height` | `fetch_last_height().block` |
+| `getbestblockhash` | `kth_chain_sync_block_hash` | `get_last_heights()` + `get_block_hash()` |
+| `getblockhash` | `kth_chain_sync_block_hash` | `get_block_hash(height)` |
+| `getdifficulty` | `kth_chain_sync_mining_info` | `fetch_mining_info().difficulty` |
+| `getblockchaininfo` | `kth_chain_sync_mining_info` + `kth_chain_sync_block_hash` | `fetch_mining_info()` + `get_last_heights()` |
+| `getrawtransaction` | `kth_chain_sync_transaction` | `fetch_transaction(hash)` |
+| `getblock` | `kth_chain_sync_block_by_hash` | `fetch_block(hash)` |
 | `getblocktemplatelight` | `kth_chain_sync_mining_template` / `kth_chain_async_mining_template` | `fetch_mining_template()` |
 | `getmininginfo` | `kth_chain_sync_mining_info` / `kth_chain_async_mining_info` | `fetch_mining_info()` |
 | `submitblocklight` | `kth_chain_sync_organize_block` / `kth_chain_async_organize_block` | `organize(block)` |

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -169,6 +169,7 @@ if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     src/rpc/dispatch.cpp
     src/rpc/job_store.cpp
     src/rpc/mining.cpp
+    src/rpc/query.cpp
     src/rpc/methods.cpp
     src/rpc/server.cpp
   )
@@ -211,6 +212,7 @@ set(kth_headers
   include/kth/node/rpc/dispatch.hpp
   include/kth/node/rpc/job_store.hpp
   include/kth/node/rpc/mining.hpp
+  include/kth/node/rpc/query.hpp
   include/kth/node/rpc/server.hpp
 
   # CSP-based sync system
@@ -289,7 +291,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   # JSON-RPC unit tests build only when the server is compiled in.
   if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     target_sources(kth_node_test PRIVATE
-      test/rpc_json.cpp test/rpc_job_store.cpp test/rpc_mining.cpp)
+      test/rpc_json.cpp test/rpc_job_store.cpp test/rpc_mining.cpp test/rpc_query.cpp)
   endif()
 
   target_include_directories(kth_node_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)

--- a/src/node/include/kth/node/rpc/json.hpp
+++ b/src/node/include/kth/node/rpc/json.hpp
@@ -35,6 +35,11 @@ std::expected<request, rpc_error> parse_request(std::string_view body);
 // handlers validate arity and emptiness themselves.
 std::vector<std::string> params_strings(std::string_view params_json);
 
+// The positional param at `index` as an unsigned integer. Accepts a JSON number
+// (e.g. getblockhash's `[0]`) or a numeric string (`["0"]`); nullopt when absent
+// or not a non-negative integer.
+std::optional<std::uint64_t> params_uint(std::string_view params_json, std::size_t index);
+
 // Build the response envelopes. `result_raw` / `id_raw` are already-serialized
 // JSON fragments and are emitted verbatim.
 std::string build_success(std::string_view id_raw, std::string_view result_raw);

--- a/src/node/include/kth/node/rpc/query.hpp
+++ b/src/node/include/kth/node/rpc/query.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_RPC_QUERY_HPP
+#define KTH_NODE_RPC_QUERY_HPP
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+#include <kth/domain/chain/block.hpp>
+#include <kth/domain/chain/transaction.hpp>
+
+// The pure (chain-free) serialization behind the blockchain query RPCs, split
+// out so it can be unit-tested without a live block_chain.
+
+namespace kth::node::rpc {
+
+// Wire-serialize a transaction / block to a lowercase hex string
+// (getrawtransaction / getblock).
+std::string transaction_to_hex(domain::chain::transaction const& tx);
+std::string block_to_hex(domain::chain::block const& block);
+
+// Serialize the getblockchaininfo result object.
+std::string render_blockchain_info(
+    std::string_view chain, std::size_t blocks, std::size_t headers,
+    std::string_view best_block_hash, double difficulty);
+
+} // namespace kth::node::rpc
+
+#endif // KTH_NODE_RPC_QUERY_HPP

--- a/src/node/src/rpc/json.cpp
+++ b/src/node/src/rpc/json.cpp
@@ -4,6 +4,8 @@
 
 #include <kth/node/rpc/json.hpp>
 
+#include <charconv>
+#include <cstdint>
 #include <string>
 #include <string_view>
 
@@ -88,6 +90,51 @@ std::vector<std::string> params_strings(std::string_view params_json) {
         }
     }
     return out;
+}
+
+std::optional<std::uint64_t> params_uint(std::string_view params_json, std::size_t index) {
+    if (params_json.empty()) {
+        return std::nullopt;
+    }
+
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string padded(params_json);
+
+    simdjson::ondemand::document doc;
+    if (parser.iterate(padded).get(doc) != simdjson::SUCCESS) {
+        return std::nullopt;
+    }
+
+    simdjson::ondemand::array arr;
+    if (doc.get_array().get(arr) != simdjson::SUCCESS) {
+        return std::nullopt;
+    }
+
+    std::size_t i = 0;
+    for (auto element : arr) {
+        if (i != index) {
+            ++i;
+            continue;
+        }
+        simdjson::ondemand::value value;
+        std::string_view raw;
+        if (element.get(value) != simdjson::SUCCESS ||
+            value.raw_json().get(raw) != simdjson::SUCCESS) {
+            return std::nullopt;
+        }
+        // Accept a bare number ("0") or a quoted numeric string ("\"0\"").
+        std::string_view text = raw;
+        if (text.size() >= 2 && text.front() == '"' && text.back() == '"') {
+            text = text.substr(1, text.size() - 2);
+        }
+        std::uint64_t out = 0;
+        auto const [ptr, ec] = std::from_chars(text.data(), text.data() + text.size(), out);
+        if (ec == std::errc{} && ptr == text.data() + text.size()) {
+            return out;
+        }
+        return std::nullopt;
+    }
+    return std::nullopt;
 }
 
 std::string build_success(std::string_view id_raw, std::string_view result_raw) {

--- a/src/node/src/rpc/methods.cpp
+++ b/src/node/src/rpc/methods.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <cstddef>
 #include <cstdint>
 #include <expected>
 #include <memory>
@@ -10,6 +11,7 @@
 #include <asio/awaitable.hpp>
 
 #include <kth/blockchain/interface/block_chain.hpp>
+#include <kth/domain/config/network.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -19,6 +21,7 @@
 #include <kth/node/rpc/job_store.hpp>
 #include <kth/node/rpc/json.hpp>
 #include <kth/node/rpc/mining.hpp>
+#include <kth/node/rpc/query.hpp>
 
 namespace kth::node::rpc {
 
@@ -112,10 +115,138 @@ submit_block_light(method_context& ctx, request const& req) {
     co_return w.str();
 }
 
+// ---- blockchain query methods --------------------------------------------
+
+// getbestblockhash -> the tip block hash.
+// C-API counterpart: kth_chain_sync_block_hash (see docs/json-rpc.md).
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_best_block_hash(method_context& ctx, request const& /*req*/) {
+    auto const heights = ctx.chain.get_last_heights();
+    if ( ! heights) {
+        co_return std::unexpected(make_error(error_code::internal_error,
+            "chain height unavailable"));
+    }
+    auto const hash = ctx.chain.get_block_hash(heights->block);
+    if ( ! hash) {
+        co_return std::unexpected(make_error(error_code::internal_error,
+            "best block hash unavailable"));
+    }
+    writer w;
+    w.value(encode_hash(*hash));
+    co_return w.str();
+}
+
+// getblockhash <height> -> the block hash at that height.
+// C-API counterpart: kth_chain_sync_block_hash.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_block_hash(method_context& ctx, request const& req) {
+    auto const height = params_uint(req.params, 0);
+    if ( ! height) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "getblockhash requires [height] (a non-negative integer)"));
+    }
+    auto const hash = ctx.chain.get_block_hash(static_cast<std::size_t>(*height));
+    if ( ! hash) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "block height out of range"));
+    }
+    writer w;
+    w.value(encode_hash(*hash));
+    co_return w.str();
+}
+
+// getdifficulty -> the difficulty of the next required work.
+// C-API counterpart: kth_chain_sync_mining_info.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_difficulty(method_context& ctx, request const& /*req*/) {
+    auto const info = co_await ctx.chain.fetch_mining_info();
+    if ( ! info) {
+        co_return std::unexpected(from_code(info.error()));
+    }
+    writer w;
+    w.value(info->difficulty);
+    co_return w.str();
+}
+
+// getblockchaininfo -> chain, height, headers, best block hash, difficulty.
+// C-API counterpart: kth_chain_sync_mining_info (+ sync_block_hash).
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_blockchain_info(method_context& ctx, request const& /*req*/) {
+    auto const info = co_await ctx.chain.fetch_mining_info();
+    if ( ! info) {
+        co_return std::unexpected(from_code(info.error()));
+    }
+    auto const heights = ctx.chain.get_last_heights();
+    if ( ! heights) {
+        co_return std::unexpected(make_error(error_code::internal_error,
+            "chain height unavailable"));
+    }
+    auto const best = ctx.chain.get_block_hash(info->blocks);
+    if ( ! best) {
+        co_return std::unexpected(make_error(error_code::internal_error,
+            "best block hash unavailable"));
+    }
+    co_return render_blockchain_info(
+        domain::config::name(info->chain), info->blocks, heights->header,
+        encode_hash(*best), info->difficulty);
+}
+
+// getrawtransaction <txid> -> the wire-serialized transaction as hex.
+// C-API counterpart: kth_chain_sync_transaction.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_raw_transaction(method_context& ctx, request const& req) {
+    auto const args = params_strings(req.params);
+    if (args.empty() || args[0].empty()) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "getrawtransaction requires [txid]"));
+    }
+    auto const hash = decode_hash(args[0]);
+    if ( ! hash) {
+        co_return std::unexpected(make_error(error_code::invalid_params, "invalid txid"));
+    }
+    auto const result = co_await ctx.chain.fetch_transaction(*hash, /*require_confirmed*/ false);
+    if ( ! result) {
+        co_return std::unexpected(from_code(result.error()));
+    }
+    auto const& tx = std::get<0>(*result);
+    writer w;
+    w.value(transaction_to_hex(*tx));
+    co_return w.str();
+}
+
+// getblock <blockhash> -> the wire-serialized block as hex.
+// C-API counterpart: kth_chain_sync_block_by_hash.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_block(method_context& ctx, request const& req) {
+    auto const args = params_strings(req.params);
+    if (args.empty() || args[0].empty()) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "getblock requires [blockhash]"));
+    }
+    auto const hash = decode_hash(args[0]);
+    if ( ! hash) {
+        co_return std::unexpected(make_error(error_code::invalid_params, "invalid block hash"));
+    }
+    auto const result = co_await ctx.chain.fetch_block(*hash);
+    if ( ! result) {
+        co_return std::unexpected(from_code(result.error()));
+    }
+    auto const& block = std::get<0>(*result);
+    writer w;
+    w.value(block_to_hex(*block));
+    co_return w.str();
+}
+
 } // namespace
 
 void register_builtin_methods(dispatcher& d) {
     d.add("getblockcount", get_block_count);
+    d.add("getbestblockhash", get_best_block_hash);
+    d.add("getblockhash", get_block_hash);
+    d.add("getdifficulty", get_difficulty);
+    d.add("getblockchaininfo", get_blockchain_info);
+    d.add("getrawtransaction", get_raw_transaction);
+    d.add("getblock", get_block);
     d.add("getblocktemplatelight", get_block_template_light);
     d.add("getmininginfo", get_mining_info);
     d.add("submitblocklight", submit_block_light);

--- a/src/node/src/rpc/query.cpp
+++ b/src/node/src/rpc/query.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/rpc/query.hpp>
+
+#include <cstdint>
+#include <span>
+
+#include <kth/infrastructure/formats/base_16.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
+#include <kth/infrastructure/utility/data.hpp>
+
+#include <kth/node/rpc/json.hpp>
+
+namespace kth::node::rpc {
+
+std::string transaction_to_hex(domain::chain::transaction const& tx) {
+    auto const size = tx.serialized_size(/*wire*/ true);
+    data_chunk buffer(size);
+    byte_writer writer(std::span<uint8_t>{buffer.data(), size});
+    tx.to_data(writer, /*wire*/ true);
+    return encode_base16(buffer);
+}
+
+std::string block_to_hex(domain::chain::block const& block) {
+    auto const size = block.serialized_size();
+    data_chunk buffer(size);
+    byte_writer writer(std::span<uint8_t>{buffer.data(), size});
+    block.to_data(writer);
+    return encode_base16(buffer);
+}
+
+std::string render_blockchain_info(
+    std::string_view chain, std::size_t blocks, std::size_t headers,
+    std::string_view best_block_hash, double difficulty) {
+
+    writer w;
+    w.begin_object();
+    w.field("chain", chain);
+    w.field("blocks", static_cast<std::uint64_t>(blocks));
+    w.field("headers", static_cast<std::uint64_t>(headers));
+    w.field("bestblockhash", best_block_hash);
+    w.field("difficulty", difficulty);
+    w.end_object();
+    return w.str();
+}
+
+} // namespace kth::node::rpc

--- a/src/node/test/rpc_json.cpp
+++ b/src/node/test/rpc_json.cpp
@@ -100,3 +100,18 @@ TEST_CASE("params_strings tolerates empty and non-array params", "[rpc json]") {
     REQUIRE(params_strings("[]").empty());
     REQUIRE(params_strings("{}").empty());
 }
+
+TEST_CASE("params_uint reads a JSON number or numeric string", "[rpc json]") {
+    REQUIRE(params_uint("[0]", 0) == 0u);
+    REQUIRE(params_uint("[42]", 0) == 42u);
+    REQUIRE(params_uint(R"(["7"])", 0) == 7u);
+    REQUIRE(params_uint("[1,2,3]", 2) == 3u);
+}
+
+TEST_CASE("params_uint rejects missing or non-integer params", "[rpc json]") {
+    REQUIRE_FALSE(params_uint("[]", 0).has_value());
+    REQUIRE_FALSE(params_uint("[0]", 1).has_value());     // out of range
+    REQUIRE_FALSE(params_uint(R"(["x"])", 0).has_value());
+    REQUIRE_FALSE(params_uint("[1.5]", 0).has_value());
+    REQUIRE_FALSE(params_uint("", 0).has_value());
+}

--- a/src/node/test/rpc_query.cpp
+++ b/src/node/test/rpc_query.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <kth/domain.hpp>
+#include <kth/infrastructure/formats/base_16.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/node/rpc/query.hpp>
+
+using namespace kth;
+using namespace kth::node::rpc;
+
+// Start Test Suite: rpc query tests
+
+TEST_CASE("render_blockchain_info serializes the getblockchaininfo fields", "[rpc query]") {
+    REQUIRE(render_blockchain_info(
+                "Mainnet", /*blocks*/ 10u, /*headers*/ 12u,
+                "00ff", /*difficulty*/ 1.0) ==
+        R"({"chain":"Mainnet","blocks":10,"headers":12,"bestblockhash":"00ff","difficulty":1.0})");
+}
+
+TEST_CASE("transaction_to_hex round-trips through the wire format", "[rpc query]") {
+    domain::chain::transaction tx{1u, 7u, {}, {}};
+
+    auto const hex = transaction_to_hex(tx);
+    REQUIRE(hex.size() == tx.serialized_size(true) * 2u);
+
+    auto const bytes = decode_base16(hex);
+    REQUIRE(bytes.has_value());
+    byte_reader reader(*bytes);
+    auto const decoded = domain::chain::transaction::from_data(reader);
+    REQUIRE(decoded.has_value());
+    REQUIRE(decoded->hash() == tx.hash());
+}


### PR DESCRIPTION
Adds six read-only blockchain query RPCs — the common explorer/wallet lookups — each backed by an existing chain reader and an existing C-API counterpart.

## Methods

| Method | Result |
|---|---|
| `getbestblockhash` | tip block hash |
| `getblockhash <height>` | block hash at height |
| `getdifficulty` | difficulty of the next required work |
| `getblockchaininfo` | `{chain, blocks, headers, bestblockhash, difficulty}` |
| `getrawtransaction <txid>` | wire-serialized transaction hex |
| `getblock <blockhash>` | wire-serialized block hex |

## Structure

The pure serialization — `transaction_to_hex`, `block_to_hex`, and the `getblockchaininfo` object — lives in `rpc/query.cpp`, so it is unit-tested without a live chain (round-trip through the wire format + exact JSON). The handlers are thin fetch/serialize glue over `get_last_heights`, `get_block_hash`, `fetch_mining_info`, `fetch_transaction`, and `fetch_block`.

A new `params_uint()` helper accepts `getblockhash`'s height as either a JSON number (`[0]`) or a numeric string (`["0"]`).

## C-API parity

Every method maps to an existing C-API function (`kth_chain_sync_block_hash`, `kth_chain_sync_mining_info`, `kth_chain_sync_transaction`, `kth_chain_sync_block_by_hash`) — the equivalence table in `docs/json-rpc.md` is updated.

## Verification

End-to-end via `curl` (hashes, difficulty, chain info, error paths); node suite green (86 cases).