### PR TITLE
node: add mempool, block-header and sendrawtransaction JSON-RPC methods

### DIFF
--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -73,6 +73,13 @@ counterpart.
 | `getblockchaininfo` | `kth_chain_sync_mining_info` + `kth_chain_sync_block_hash` | `fetch_mining_info()` + `get_last_heights()` |
 | `getrawtransaction` | `kth_chain_sync_transaction` | `fetch_transaction(hash)` |
 | `getblock` | `kth_chain_sync_block_by_hash` | `fetch_block(hash)` |
+| `getblockheader` | `kth_chain_sync_block_header_by_hash` | `fetch_block_header(hash)` |
+| `sendrawtransaction` | `kth_chain_sync_organize_transaction` | `organize(tx)` |
+| `getrawmempool` | `kth_chain_get_mempool_txids` | `get_mempool_txids()` |
+| `getmempoolinfo` | `kth_chain_get_mempool_info` | `get_mempool_info()` |
+| `getmempoolentry` | `kth_chain_get_mempool_entry` | `get_mempool_entry()` (+ depends/spentby) |
+| `getmempoolancestors` | `kth_chain_get_mempool_ancestors` | `get_mempool_ancestors()` |
+| `getmempooldescendants` | `kth_chain_get_mempool_descendants` | `get_mempool_descendants()` |
 | `getblocktemplatelight` | `kth_chain_sync_mining_template` / `kth_chain_async_mining_template` | `fetch_mining_template()` |
 | `getmininginfo` | `kth_chain_sync_mining_info` / `kth_chain_async_mining_info` | `fetch_mining_info()` |
 | `submitblocklight` | `kth_chain_sync_organize_block` / `kth_chain_async_organize_block` | `organize(block)` |

--- a/src/node/include/kth/node/rpc/query.hpp
+++ b/src/node/include/kth/node/rpc/query.hpp
@@ -10,10 +10,17 @@
 #include <string_view>
 
 #include <kth/domain/chain/block.hpp>
+#include <kth/domain/chain/header.hpp>
 #include <kth/domain/chain/transaction.hpp>
+#include <kth/infrastructure/hash_define.hpp>
 
 // The pure (chain-free) serialization behind the blockchain query RPCs, split
 // out so it can be unit-tested without a live block_chain.
+
+namespace kth::blockchain {
+struct mempool_totals;
+struct mempool_entry_info;
+} // namespace kth::blockchain
 
 namespace kth::node::rpc {
 
@@ -26,6 +33,19 @@ std::string block_to_hex(domain::chain::block const& block);
 std::string render_blockchain_info(
     std::string_view chain, std::size_t blocks, std::size_t headers,
     std::string_view best_block_hash, double difficulty);
+
+// A JSON array of display-order hashes (getrawmempool, getmempoolancestors,
+// getmempooldescendants).
+std::string render_hash_list(hash_list const& hashes);
+
+// getmempoolinfo / getmempoolentry result objects.
+std::string render_mempool_info(blockchain::mempool_totals const& totals);
+std::string render_mempool_entry(blockchain::mempool_entry_info const& entry,
+                                 hash_list const& depends, hash_list const& spentby);
+
+// getblockheader (verbose) result object.
+std::string render_block_header(domain::chain::header const& header,
+                                std::size_t height, hash_digest const& hash);
 
 } // namespace kth::node::rpc
 

--- a/src/node/src/rpc/methods.cpp
+++ b/src/node/src/rpc/methods.cpp
@@ -12,6 +12,7 @@
 
 #include <kth/blockchain/interface/block_chain.hpp>
 #include <kth/domain/config/network.hpp>
+#include <kth/domain/message/transaction.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -237,16 +238,147 @@ get_block(method_context& ctx, request const& req) {
     co_return w.str();
 }
 
+// getblockheader <blockhash> -> the header fields (verbose).
+// C-API counterpart: kth_chain_sync_block_header_by_hash.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_block_header(method_context& ctx, request const& req) {
+    auto const args = params_strings(req.params);
+    if (args.empty() || args[0].empty()) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "getblockheader requires [blockhash]"));
+    }
+    auto const hash = decode_hash(args[0]);
+    if ( ! hash) {
+        co_return std::unexpected(make_error(error_code::invalid_params, "invalid block hash"));
+    }
+    auto const result = co_await ctx.chain.fetch_block_header(*hash);
+    if ( ! result) {
+        co_return std::unexpected(from_code(result.error()));
+    }
+    auto const& [header, height] = *result;
+    co_return render_block_header(*header, height, *hash);
+}
+
+// sendrawtransaction <hexstring> -> the accepted txid, or a reject error.
+// C-API counterpart: kth_chain_sync_organize_transaction.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+send_raw_transaction(method_context& ctx, request const& req) {
+    auto const args = params_strings(req.params);
+    if (args.empty() || args[0].empty()) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "sendrawtransaction requires [hexstring]"));
+    }
+    auto const raw = decode_base16(args[0]);
+    if ( ! raw) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "hexstring is not valid hex"));
+    }
+    byte_reader reader(*raw);
+    auto tx = domain::chain::transaction::from_data(reader, /*wire*/ true);
+    if ( ! tx) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "transaction decode failed"));
+    }
+
+    auto const txid = encode_hash(tx->hash());
+    auto const pooled = std::make_shared<domain::message::transaction>(std::move(*tx));
+    auto const ec = co_await ctx.chain.organize(pooled);
+    if (ec) {
+        co_return std::unexpected(make_error(error_code::misc_error, ec.message()));
+    }
+
+    writer w;
+    w.value(txid);
+    co_return w.str();
+}
+
+// ---- mempool query methods -----------------------------------------------
+
+// getrawmempool -> the txids currently in the mempool.
+// C-API counterpart: kth_chain_get_mempool_txids.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_raw_mempool(method_context& ctx, request const& /*req*/) {
+    co_return render_hash_list(ctx.chain.get_mempool_txids());
+}
+
+// getmempoolinfo -> mempool size, byte total, and fee total.
+// C-API counterpart: kth_chain_get_mempool_info.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_mempool_info(method_context& ctx, request const& /*req*/) {
+    co_return render_mempool_info(ctx.chain.get_mempool_info());
+}
+
+// getmempoolentry <txid> -> the entry's fee/size/time plus depends/spentby.
+// C-API counterpart: kth_chain_get_mempool_entry.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_mempool_entry(method_context& ctx, request const& req) {
+    auto const args = params_strings(req.params);
+    if (args.empty() || args[0].empty()) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "getmempoolentry requires [txid]"));
+    }
+    auto const hash = decode_hash(args[0]);
+    if ( ! hash) {
+        co_return std::unexpected(make_error(error_code::invalid_params, "invalid txid"));
+    }
+    auto const entry = ctx.chain.get_mempool_entry(*hash);
+    if ( ! entry) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "transaction not in mempool"));
+    }
+    co_return render_mempool_entry(*entry,
+        ctx.chain.get_mempool_depends(*hash), ctx.chain.get_mempool_spentby(*hash));
+}
+
+// getmempoolancestors <txid> -> in-mempool ancestor txids.
+// C-API counterpart: kth_chain_get_mempool_ancestors.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_mempool_ancestors(method_context& ctx, request const& req) {
+    auto const args = params_strings(req.params);
+    if (args.empty() || args[0].empty()) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "getmempoolancestors requires [txid]"));
+    }
+    auto const hash = decode_hash(args[0]);
+    if ( ! hash) {
+        co_return std::unexpected(make_error(error_code::invalid_params, "invalid txid"));
+    }
+    co_return render_hash_list(ctx.chain.get_mempool_ancestors(*hash));
+}
+
+// getmempooldescendants <txid> -> in-mempool descendant txids.
+// C-API counterpart: kth_chain_get_mempool_descendants.
+::asio::awaitable<std::expected<std::string, rpc_error>>
+get_mempool_descendants(method_context& ctx, request const& req) {
+    auto const args = params_strings(req.params);
+    if (args.empty() || args[0].empty()) {
+        co_return std::unexpected(make_error(error_code::invalid_params,
+            "getmempooldescendants requires [txid]"));
+    }
+    auto const hash = decode_hash(args[0]);
+    if ( ! hash) {
+        co_return std::unexpected(make_error(error_code::invalid_params, "invalid txid"));
+    }
+    co_return render_hash_list(ctx.chain.get_mempool_descendants(*hash));
+}
+
 } // namespace
 
 void register_builtin_methods(dispatcher& d) {
     d.add("getblockcount", get_block_count);
     d.add("getbestblockhash", get_best_block_hash);
     d.add("getblockhash", get_block_hash);
+    d.add("getblockheader", get_block_header);
     d.add("getdifficulty", get_difficulty);
     d.add("getblockchaininfo", get_blockchain_info);
     d.add("getrawtransaction", get_raw_transaction);
     d.add("getblock", get_block);
+    d.add("sendrawtransaction", send_raw_transaction);
+    d.add("getrawmempool", get_raw_mempool);
+    d.add("getmempoolinfo", get_mempool_info);
+    d.add("getmempoolentry", get_mempool_entry);
+    d.add("getmempoolancestors", get_mempool_ancestors);
+    d.add("getmempooldescendants", get_mempool_descendants);
     d.add("getblocktemplatelight", get_block_template_light);
     d.add("getmininginfo", get_mining_info);
     d.add("submitblocklight", submit_block_light);

--- a/src/node/src/rpc/query.cpp
+++ b/src/node/src/rpc/query.cpp
@@ -5,8 +5,11 @@
 #include <kth/node/rpc/query.hpp>
 
 #include <cstdint>
+#include <iomanip>
 #include <span>
+#include <sstream>
 
+#include <kth/blockchain/interface/block_chain.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -42,6 +45,72 @@ std::string render_blockchain_info(
     w.field("headers", static_cast<std::uint64_t>(headers));
     w.field("bestblockhash", best_block_hash);
     w.field("difficulty", difficulty);
+    w.end_object();
+    return w.str();
+}
+
+namespace {
+
+// Compact nBits as an 8-char hex string (the getblockheader bits format).
+std::string bits_to_hex(std::uint32_t bits) {
+    std::ostringstream os;
+    os << std::hex << std::setfill('0') << std::setw(8) << bits;
+    return os.str();
+}
+
+void write_hash_array(writer& w, hash_list const& hashes) {
+    w.begin_array();
+    for (auto const& h : hashes) {
+        w.value(encode_hash(h));
+    }
+    w.end_array();
+}
+
+} // namespace
+
+std::string render_hash_list(hash_list const& hashes) {
+    writer w;
+    write_hash_array(w, hashes);
+    return w.str();
+}
+
+std::string render_mempool_info(blockchain::mempool_totals const& totals) {
+    writer w;
+    w.begin_object();
+    w.field("size", static_cast<std::uint64_t>(totals.size));
+    w.field("bytes", static_cast<std::uint64_t>(totals.bytes));
+    w.field("total_fee", static_cast<std::uint64_t>(totals.total_fee));
+    w.end_object();
+    return w.str();
+}
+
+std::string render_mempool_entry(blockchain::mempool_entry_info const& entry,
+                                 hash_list const& depends, hash_list const& spentby) {
+    writer w;
+    w.begin_object();
+    w.field("fee", static_cast<std::uint64_t>(entry.fee));
+    w.field("size", static_cast<std::uint64_t>(entry.size));
+    w.field("time", static_cast<std::uint64_t>(entry.time));
+    w.key("depends");
+    write_hash_array(w, depends);
+    w.key("spentby");
+    write_hash_array(w, spentby);
+    w.end_object();
+    return w.str();
+}
+
+std::string render_block_header(domain::chain::header const& header,
+                                std::size_t height, hash_digest const& hash) {
+    writer w;
+    w.begin_object();
+    w.field("hash", encode_hash(hash));
+    w.field("height", static_cast<std::uint64_t>(height));
+    w.field("version", static_cast<std::int64_t>(header.version()));
+    w.field("previousblockhash", encode_hash(header.previous_block_hash()));
+    w.field("merkleroot", encode_hash(header.merkle()));
+    w.field("time", static_cast<std::int64_t>(header.timestamp()));
+    w.field("bits", bits_to_hex(header.bits()));
+    w.field("nonce", static_cast<std::int64_t>(header.nonce()));
     w.end_object();
     return w.str();
 }

--- a/src/node/test/rpc_query.cpp
+++ b/src/node/test/rpc_query.cpp
@@ -4,6 +4,7 @@
 
 #include <test_helpers.hpp>
 
+#include <kth/blockchain/interface/block_chain.hpp>
 #include <kth/domain.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
@@ -11,6 +12,11 @@
 
 using namespace kth;
 using namespace kth::node::rpc;
+
+namespace {
+// encode_hash(null_hash) — 64 zero hex chars.
+constexpr auto zeros = "0000000000000000000000000000000000000000000000000000000000000000";
+} // namespace
 
 // Start Test Suite: rpc query tests
 
@@ -33,4 +39,32 @@ TEST_CASE("transaction_to_hex round-trips through the wire format", "[rpc query]
     auto const decoded = domain::chain::transaction::from_data(reader);
     REQUIRE(decoded.has_value());
     REQUIRE(decoded->hash() == tx.hash());
+}
+
+TEST_CASE("render_hash_list serializes a JSON array of display hashes", "[rpc query]") {
+    REQUIRE(render_hash_list({}) == "[]");
+    REQUIRE(render_hash_list({null_hash, null_hash}) ==
+        std::string("[\"") + zeros + "\",\"" + zeros + "\"]");
+}
+
+TEST_CASE("render_mempool_info serializes the getmempoolinfo fields", "[rpc query]") {
+    blockchain::mempool_totals totals{/*size*/ 5u, /*bytes*/ 100u, /*total_fee*/ 200u};
+    REQUIRE(render_mempool_info(totals) ==
+        R"({"size":5,"bytes":100,"total_fee":200})");
+}
+
+TEST_CASE("render_mempool_entry serializes fields plus depends/spentby", "[rpc query]") {
+    blockchain::mempool_entry_info entry{/*fee*/ 1000u, /*size*/ 250u, /*time*/ 42u};
+    REQUIRE(render_mempool_entry(entry, {null_hash}, {}) ==
+        std::string(R"({"fee":1000,"size":250,"time":42,"depends":[")") + zeros +
+        R"("],"spentby":[]})");
+}
+
+TEST_CASE("render_block_header serializes the verbose header fields", "[rpc query]") {
+    domain::chain::header h{/*version*/ 2u, null_hash, null_hash,
+                           /*timestamp*/ 1000u, /*bits*/ 0x1d00ffffu, /*nonce*/ 42u};
+    REQUIRE(render_block_header(h, /*height*/ 5u, null_hash) ==
+        std::string(R"({"hash":")") + zeros + R"(","height":5,"version":2,)" +
+        R"("previousblockhash":")" + zeros + R"(","merkleroot":")" + zeros + R"(",)" +
+        R"("time":1000,"bits":"1d00ffff","nonce":42})");
 }


### PR DESCRIPTION
Rounds out the query surface with the mempool readers, `getblockheader`, and `sendrawtransaction` — all in one PR. Each is backed by an existing chain reader/organizer with an existing C-API counterpart.

## Methods

| Method | Result |
|---|---|
| `getrawmempool` | mempool txids |
| `getmempoolinfo` | `{size, bytes, total_fee}` |
| `getmempoolentry <txid>` | `{fee, size, time, depends, spentby}` |
| `getmempoolancestors <txid>` | in-mempool ancestor txids |
| `getmempooldescendants <txid>` | in-mempool descendant txids |
| `getblockheader <hash>` | verbose header object |
| `sendrawtransaction <hex>` | decode + `organize(tx)`, returns the txid |

## Notes

- The mempool readers are synchronous (`get_mempool_*`); the C++ mempool graph logic already has its own tests.
- `getblockheader` renders the header **fields** (version, previousblockhash, merkleroot, time, bits, nonce) — no wire serialization needed. Verified against genesis (correct merkleroot / nonce / time).
- `sendrawtransaction` decodes the hex, deserializes the transaction, organizes it, and returns its txid on accept or a reject error.

The pure rendering (hash arrays, mempool info/entry, verbose header) lives in `rpc/query.cpp` and is unit-tested without a live chain.

## Verification

End-to-end via `curl` (empty-mempool reads, genesis header, error paths); node suite green (90 cases). C-API equivalences documented.