### PR TITLE
blockchain: cache the block template in the core

### DIFF
--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -109,10 +109,11 @@ rpc.gbt_cache_size = 10     # recent jobs kept
 rpc.gbt_store_time = 3600   # seconds before a job expires
 ```
 
-> The template is rebuilt on every call (no per-tip cache yet). `tools/rpc_bench.py`
-> load-tests the miner-polling side; a faithful benchmark also simulates
-> transactions and blocks arriving (mempool churn + tip changes), which needs the
-> submit paths added in later phases.
+> The assembled template is cached in the core (`block_chain::fetch_mining_template`,
+> shared by this RPC and the C-API): a new tip rebuilds immediately, while under
+> mempool churn rebuilds are rate-limited to `chain.gbt_template_refresh_seconds`
+> (default 5, bitcoind-style). `tools/rpc_bench.py` load-tests the miner-polling
+> side; a faithful benchmark also simulates transactions and blocks arriving.
 
 ## Mining: getmininginfo
 

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -12,11 +12,15 @@
 #include <filesystem>
 #include <functional>
 #include <expected>
+#include <mutex>
 #include <optional>
 #include <vector>
 
 #include <kth/infrastructure/utility/atomic.hpp>
 
+#include <boost/smart_ptr/atomic_shared_ptr.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
+#include <boost/smart_ptr/shared_ptr.hpp>
 #include <boost/unordered/unordered_flat_map.hpp>
 #include <boost/unordered/unordered_flat_set.hpp>
 
@@ -522,6 +526,32 @@ private:
     mutable transaction_validation_store transaction_validations_;
 
     blockchain::mempool mempool_;
+
+    // Block-template cache: fetch_mining_template() serves this while the tip
+    // and mempool are unchanged (a mempool-only change within the refresh window
+    // is also served). Lives in the core so both the JSON-RPC and C-API frontends
+    // share it.
+    //
+    // Published as an immutable snapshot through an atomic shared_ptr: readers
+    // load() it lock-free and serve a copy, so a GBT request never blocks on
+    // another GBT request. The rebuild is coalesced by template_rebuild_mutex_
+    // (try_lock), so at most one thread rebuilds; a concurrent caller whose
+    // snapshot is stale only for the mempool (same tip) serves that snapshot
+    // instead of blocking, while a tip change waits for the rebuild (a
+    // wrong-parent template would orphan the miner's block). Insertion into the
+    // mempool never touches either of these — it is a separate lock-free
+    // structure.
+    //
+    // boost::atomic_shared_ptr (not std::atomic<std::shared_ptr>): the latter is
+    // unsupported on macOS libc++.
+    struct template_snapshot {
+        blockchain::mining_template value;
+        hash_digest previous;
+        uint64_t generation;
+        uint32_t time;
+    };
+    mutable boost::atomic_shared_ptr<template_snapshot> template_cache_;
+    mutable std::mutex template_rebuild_mutex_;
 
     transaction_organizer transaction_organizer_;
     block_organizer block_organizer_;

--- a/src/blockchain/include/kth/blockchain/pools/mempool.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool.hpp
@@ -5,6 +5,7 @@
 #ifndef KTH_BLOCKCHAIN_POOLS_MEMPOOL_HPP
 #define KTH_BLOCKCHAIN_POOLS_MEMPOOL_HPP
 
+#include <atomic>
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
@@ -119,6 +120,13 @@ struct mempool {
 
     mempool_stats const& stats() const { return stats_; }
 
+    /// A monotonically-increasing counter bumped on every mutation (add or
+    /// remove). Callers cache "has the mempool changed since I last looked?"
+    /// by comparing this — e.g. the block-template cache. Not a cache itself.
+    uint64_t generation() const {
+        return generation_.load(std::memory_order_relaxed);
+    }
+
 private:
     // Erase one tx from pool_ and release its input-outpoint claims in
     // spent_by_. Non-recursive: descendants are untouched.
@@ -137,6 +145,7 @@ private:
     mempool_map<hash_digest, mempool_entry, salted_txid_hasher> pool_;
     mempool_map<outpoint_key, hash_digest, salted_outpoint_hasher> spent_by_;
     mempool_stats stats_;
+    std::atomic<uint64_t> generation_{0};
 };
 
 } // namespace kth::blockchain

--- a/src/blockchain/include/kth/blockchain/settings.hpp
+++ b/src/blockchain/include/kth/blockchain/settings.hpp
@@ -31,6 +31,9 @@ struct KB_API settings {
     uint64_t minimum_output_satoshis = 500;
     uint32_t notify_limit_hours = 24;
     uint32_t reorganization_limit = 256;
+    // Minimum seconds between block-template rebuilds while the mempool churns
+    // (a new tip always rebuilds immediately). Mirrors bitcoind's 5s.
+    uint32_t gbt_template_refresh_seconds = 5;
     infrastructure::config::checkpoint::list checkpoints;
     // Derived fields — populated by settings(network) constructor.
     // If using settings() default and setting checkpoints manually,

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -7,6 +7,7 @@
 #include <kth/database/flat_file_pos.hpp>
 
 #include <algorithm>
+#include <mutex>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -1510,13 +1511,8 @@ block_chain::fetch_mining_template() const {
 
     auto const height = state->height();
 
-    auto selection = build_block_template(mempool_, block_template_context{
-        state->dynamic_max_block_size(),
-        state->dynamic_max_block_sigchecks(),
-        height,
-        state->median_time_past()});
-
     // Previous block hash = the tip, i.e. the block one below the template height.
+    // Together with the mempool generation it forms the cache key.
     hash_digest previous = null_hash;
     if (height > 0) {
         auto const prev = get_block_hash(height - 1);
@@ -1526,18 +1522,76 @@ block_chain::fetch_mining_template() const {
         previous = *prev;
     }
 
+    auto const generation = mempool_.generation();
+    auto const now = static_cast<uint32_t>(zulu_time());
+
+    // A snapshot is usable while the tip is unchanged and the mempool is either
+    // unchanged or its last change is still within the refresh window; a new tip
+    // always forces a rebuild.
+    auto const usable = [&](boost::shared_ptr<template_snapshot> const& s) {
+        return s &&
+               s->previous == previous &&
+               (s->generation == generation ||
+                now - s->time < settings_.gbt_template_refresh_seconds);
+    };
+
+    // Lock-free read: rebuilds are expensive (full mempool scan + fee-rate
+    // ordering), so serve the published snapshot when it is still usable.
+    auto snapshot = template_cache_.load();
+    if (usable(snapshot)) {
+        co_return snapshot->value;
+    }
+
+    // Stale or cold. Coalesce rebuilds: exactly one thread rebuilds. If another
+    // thread already holds the rebuild lock, do not block on it — serve the
+    // previous (bounded-stale) snapshot if we have one. Only a cold start with no
+    // snapshot at all waits for the first build.
+    //
+    // NOTE: there is no co_await between here and co_return; the rebuild is fully
+    // synchronous, so holding this std::mutex across it is safe. Do not introduce
+    // a suspension point inside this section.
+    std::unique_lock<std::mutex> lock(template_rebuild_mutex_, std::try_to_lock);
+    if ( ! lock) {
+        // Another thread is rebuilding. If our stale snapshot is for the SAME tip
+        // (only the mempool moved on), it is still a valid template — serve it
+        // rather than block. Never serve a snapshot from a previous tip: a
+        // wrong-parent template would orphan the miner's block, so wait for the
+        // rebuild in that case (a cold start with no snapshot also waits).
+        if (snapshot && snapshot->previous == previous) {
+            co_return snapshot->value;
+        }
+        lock.lock();
+    }
+
+    // Re-check under the lock: another thread may have published while we waited.
+    snapshot = template_cache_.load();
+    if (usable(snapshot)) {
+        co_return snapshot->value;
+    }
+
+    auto selection = build_block_template(mempool_, block_template_context{
+        state->dynamic_max_block_size(),
+        state->dynamic_max_block_sigchecks(),
+        height,
+        state->median_time_past()});
+
     // 0x20000000: the BIP9 version base. BCH has no active version-bits signaling,
     // and miners routinely override this, so it is only a sensible default.
-    co_return make_mining_template(
+    auto built = make_mining_template(
         0x20000000U,
         previous,
         height,
         state->work_required(),
         state->median_time_past(),
-        static_cast<uint32_t>(zulu_time()),
+        now,
         state->dynamic_max_block_size(),
         state->dynamic_max_block_sigchecks(),
         std::move(selection));
+
+    auto next = boost::make_shared<template_snapshot>(
+        template_snapshot{std::move(built), previous, generation, now});
+    template_cache_.store(next);
+    co_return next->value;
 }
 
 awaitable_expected<blockchain::mining_info>

--- a/src/blockchain/src/pools/mempool.cpp
+++ b/src/blockchain/src/pools/mempool.cpp
@@ -75,6 +75,7 @@ bool mempool::add(mempool_entry entry) {
 
     KTH_STATS_INCREMENT(stats_, add_inserted);
     KTH_STATS_TIME_ADD(stats_, add, add_time_ns);
+    generation_.fetch_add(1, std::memory_order_relaxed);
     return true;
 }
 
@@ -92,6 +93,7 @@ void mempool::remove_entry(hash_digest const& txid) {
         spent_by_.erase(outpoint_key{op.hash(), op.index()});
     }
     pool_.erase(txid);
+    generation_.fetch_add(1, std::memory_order_relaxed);
 }
 
 void mempool::remove_recursive(hash_digest const& txid) {

--- a/src/blockchain/test/mempool_test.cpp
+++ b/src/blockchain/test/mempool_test.cpp
@@ -131,6 +131,25 @@ TEST_CASE("mempool add then query", "[mempool][serial]") {
     CHECK_FALSE(mp.resolve(point{make_hash(999), 0}).has_value());
 }
 
+TEST_CASE("mempool generation bumps on add and remove", "[mempool][serial]") {
+    mempool mp{0x1111u, 0x2222u};
+    auto const g0 = mp.generation();
+
+    auto const tx = make_tx({op(1, 0)}, 1, /*tag*/ 1);
+    REQUIRE(mp.add(entry_for(tx, 1)));
+    auto const g1 = mp.generation();
+    REQUIRE(g1 > g0);
+
+    // A rejected add (duplicate) leaves the counter untouched.
+    REQUIRE_FALSE(mp.add(entry_for(tx, 1)));
+    REQUIRE(mp.generation() == g1);
+
+    // Removing the tx (as part of a block) bumps again.
+    mp.remove_for_block(make_block({tx}));
+    REQUIRE(mp.generation() > g1);
+    REQUIRE(mp.size() == 0u);
+}
+
 TEST_CASE("mempool first-seen rejects conflicting input", "[mempool][serial]") {
     mempool mp{0x1111u, 0x2222u};
 

--- a/src/node/src/parser.cpp
+++ b/src/node/src/parser.cpp
@@ -217,6 +217,7 @@ void add_settings(CLI::App& app, configuration& cfg) {
     app.add_option("--chain.cores",                cfg.chain.cores);
     app.add_option("--chain.priority",             cfg.chain.priority);
     app.add_option("--chain.reorganization_limit", cfg.chain.reorganization_limit);
+    app.add_option("--chain.gbt_template_refresh_seconds", cfg.chain.gbt_template_refresh_seconds);
     add_parse_from_list(app, "--chain.checkpoint", cfg.chain.checkpoints,
         "A hash:height checkpoint.");
     app.add_option("--chain.fix_checkpoints", cfg.chain.fix_checkpoints);


### PR DESCRIPTION
`fetch_mining_template()` rebuilt the full template — a whole mempool scan plus fee-rate ordering — on **every** call, so a mining pool polling `getblocktemplatelight` burned CPU re-deriving the same block.

## What

Cache the assembled template in `block_chain`, keyed on **the tip hash** and a new **mempool generation counter**:

- a new tip → rebuild immediately;
- unchanged tip + unchanged mempool → serve the cache;
- unchanged tip + mempool churn → rebuild rate-limited to `chain.gbt_template_refresh_seconds` (default **5**, matching bitcoind).

## Concurrency: lock-free reads, coalesced rebuilds

The template is published as an **immutable snapshot** through a `boost::atomic_shared_ptr` (`std::atomic<std::shared_ptr>` is unsupported on macOS libc++). Readers `load()` it lock-free and serve a copy, so **a GBT request never blocks on another GBT request**.

The rebuild is coalesced by a `try_lock` mutex — at most one thread rebuilds. A concurrent caller whose snapshot is stale **only for the mempool (same tip)** serves that snapshot instead of blocking; a **tip change** waits for the rebuild, since a wrong-parent template would orphan the miner's block.

**Mempool insertion never touches this path** — `add()` writes a separate lock-free structure and only bumps the generation counter (an atomic), so a GBT request cannot block a new transaction entering the mempool.

## Why in the core (better than bitcoind)

bitcoind caches inside its `getblocktemplate` RPC. KTH caches in `block_chain::fetch_mining_template` instead, so **both frontends benefit** — the JSON-RPC *and* the C-API `kth_chain_sync_mining_template`.

## Change-detection primitive

`mempool::generation()` is a monotonic counter bumped on every add/remove (like bitcoind's `GetTransactionsUpdated()`) — a "has it changed?" signal, not a cache, so the pool stays simple. Unit-tested (bumps on add/remove, not on a rejected duplicate).

## Verification

Rapid `getblocktemplatelight` calls return the identical cached template (same `curtime`) until the tip or mempool changes. Blockchain suite 131 cases, node suite 90 cases, both green (RPC on and off).

Follow-up: a realistic saturation benchmark needs a churning mempool (tx/block inflow) to quantify the win; the cache correctness is validated here.