### PR TITLE
network: fix regtest network identifier (regtest was running as mainnet)

### DIFF
--- a/src/network/src/settings.cpp
+++ b/src/network/src/settings.cpp
@@ -138,7 +138,7 @@ settings::settings(domain::config::network context)
         }
 
         case domain::config::network::regtest: {
-            identifier = 3669344250;        //TODO(fernando): use appropiate constant
+            identifier = netmagic::bch_regtest;
             inbound_port = 18444;
 
             // Regtest is private network only, so there is no seeding.


### PR DESCRIPTION
## Bug

`-n regtest` silently ran the node **as mainnet**.

`network::settings(regtest)` hardcoded `identifier = 3669344250` (`0xdab5bffa` — the BTC / block-file *disk* magic) with a `//TODO: use appropriate constant`. But `get_network()` derives the running network by matching that identifier against `netmagic::bch_regtest` (`0xfabfb5da`). The two never matched, so the lookup fell through to `default: mainnet`.

Result: `get_genesis_block()` and the chain settings came out **mainnet** — mainnet genesis `000000000019d668…`, `bits = 0x1d00ffff`, retargeting **on** — so a fresh regtest chain was effectively impossible to mine.

## Fix

```cpp
identifier = netmagic::bch_regtest;
```

which is exactly the "appropriate constant" the TODO asked for.

## Verified

After the fix the node boots regtest correctly:

- genesis `06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f`
- `bits = 0x207fffff`, retargeting off (trivial PoW, as regtest should be)

Confirmed end to end by launching `kth -n regtest` and reading `getblocktemplatelight` / the header-index tip.