### PR TITLE
infrastructure: fix integer-overflow bounds checks in byte_reader (remote DoS)

### DIFF
--- a/src/domain/src/chain/light_block.cpp
+++ b/src/domain/src/chain/light_block.cpp
@@ -4,6 +4,7 @@
 
 #include <kth/domain/chain/light_block.hpp>
 
+#include <kth/domain/constants/functions.hpp>
 #include <kth/infrastructure/math/hash.hpp>
 
 // Bitcoin Core optimized SHA256D64 for merkle tree computation
@@ -23,10 +24,13 @@ expect<uint32_t> skip_transaction(byte_reader& reader) {
         return std::unexpected(ec.error());
     }
 
-    // Input count (varint)
+    // Input count (varint).
     auto input_count = reader.read_size_little_endian();
     if (!input_count) {
         return std::unexpected(input_count.error());
+    }
+    if (*input_count > static_absolute_max_block_size()) {
+        return std::unexpected(error::invalid_size);
     }
 
     // Skip all inputs
@@ -42,8 +46,12 @@ expect<uint32_t> skip_transaction(byte_reader& reader) {
             return std::unexpected(script_len.error());
         }
 
-        // Script + sequence (4 bytes)
-        if (auto ec = reader.skip(*script_len + 4); !ec) {
+        // Script and sequence skipped separately so script_len is never added
+        // to another value (the sum could overflow past the bounds check).
+        if (auto ec = reader.skip(*script_len); !ec) {
+            return std::unexpected(ec.error());
+        }
+        if (auto ec = reader.skip(4); !ec) {
             return std::unexpected(ec.error());
         }
     }
@@ -52,6 +60,9 @@ expect<uint32_t> skip_transaction(byte_reader& reader) {
     auto output_count = reader.read_size_little_endian();
     if (!output_count) {
         return std::unexpected(output_count.error());
+    }
+    if (*output_count > static_absolute_max_block_size()) {
+        return std::unexpected(error::invalid_size);
     }
 
     // Skip all outputs
@@ -95,10 +106,13 @@ expect<light_block> light_block::from_data(byte_reader& reader, bool wire) {
         return std::unexpected(hdr.error());
     }
 
-    // 2. Read transaction count (varint)
+    // 2. Read transaction count (varint). Cap before reserve() below.
     auto tx_count = reader.read_size_little_endian();
     if (!tx_count) {
         return std::unexpected(tx_count.error());
+    }
+    if (*tx_count > static_absolute_max_block_size()) {
+        return std::unexpected(error::invalid_size);
     }
 
     // 3. For each transaction: record start offset and skip

--- a/src/domain/test/chain/light_block.cpp
+++ b/src/domain/test/chain/light_block.cpp
@@ -2,9 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 #include <test_helpers.hpp>
 
 #include <kth/domain/chain/light_block.hpp>
+#include <kth/domain/message/heading.hpp>
+#include <kth/domain/message/block.hpp>
+#include <kth/domain/multi_crypto_support.hpp>
+#include <kth/infrastructure/math/checksum.hpp>
 
 using namespace kth;
 using namespace kd;
@@ -136,4 +144,96 @@ TEST_CASE("light_block tx_length returns correct lengths", "[chain light_block]"
 
     // Block = header (80) + tx_count varint (1) + transactions
     REQUIRE(total_tx_bytes == raw_block.size() - 80 - 1);
+}
+
+// Builds the 139-byte malicious `block` payload from the report: input_count
+// = 2^64-1 and script_len = 0xFFFFFFFFFFFFFFCF, so `*script_len + 4` == 2^64-45
+// rewinds the cursor by the 45 bytes consumed per iteration -> pre-fix, an
+// infinite loop with a static cursor.
+static data_chunk make_malicious_block_payload() {
+    data_chunk payload;
+    payload.insert(payload.end(), 80, 0x00);   // block header
+    payload.push_back(0x01);                    // tx_count = 1
+    payload.insert(payload.end(), 4, 0x00);     // tx version
+    payload.push_back(0xFF);                    // input_count varint prefix
+    payload.insert(payload.end(), 8, 0xFF);     // input_count = 2^64 - 1
+    payload.insert(payload.end(), 36, 0x00);    // prevout hash(32) + index(4)
+    payload.push_back(0xFF);                    // script_len varint prefix
+    payload.push_back(0xCF);                    // script_len = 0xFFFFFFFFFFFFFFCF
+    payload.insert(payload.end(), 7, 0xFF);
+    return payload;
+}
+
+// ---------------------------------------------------------------------------
+// Regression: reproduces the remote reception path for an inbound `block`
+// message and checks the malicious payload is rejected (not hung) once it
+// reaches the parser. Gate labels map to the node source at kth @ 22a7d59b.
+// The parse runs on a watchdog thread so a re-regression cannot hang CI.
+// ---------------------------------------------------------------------------
+TEST_CASE("light_block inbound block message is rejected without hanging", "[chain light_block]") {
+    using namespace std::chrono_literals;
+
+    auto const payload = make_malicious_block_payload();
+    REQUIRE(payload.size() == 139);
+
+    uint32_t const magic = netmagic::bch_mainnet;
+
+    // A well-formed frame carrying a malicious payload; the checksum is bogus
+    // to show it is not what gates the payload (validate_checksum defaults off).
+    uint32_t const bogus_checksum = 0xDEADBEEF;
+    message::heading const head(magic, message::block::command,
+                                static_cast<uint32_t>(payload.size()), bogus_checksum);
+
+    data_chunk frame = head.to_data();
+    REQUIRE(frame.size() == message::heading::maximum_size());
+    frame.insert(frame.end(), payload.begin(), payload.end());
+    REQUIRE(frame.size() == 163);
+
+    // Gate: heading parse (peer_session.cpp:625).
+    byte_reader head_reader(frame);
+    auto const parsed_head = message::heading::from_data(head_reader, 0);
+    REQUIRE(parsed_head.has_value());
+
+    // Gate: magic (peer_session.cpp:635).
+    REQUIRE(parsed_head->magic() == magic);
+
+    // Gate: payload_size <= maximum_payload_ (peer_session.cpp:640).
+    size_t const max_payload =
+        message::heading::maximum_payload_size(0, magic, /*is_chipnet*/ false);
+    REQUIRE(parsed_head->payload_size() <= max_payload);
+
+    // Gate: checksum is ignored by default; the bogus value does not match.
+    uint32_t const real_checksum = bitcoin_checksum(byte_span{payload});
+    REQUIRE(parsed_head->checksum() != real_checksum);
+
+    // Gate: command routes to the block channel (p2p_node.cpp:825).
+    REQUIRE(parsed_head->command() == message::block::command);
+
+    data_chunk const wire_payload(frame.begin() + message::heading::maximum_size(),
+                                  frame.end());
+    REQUIRE(wire_payload == payload);
+
+    // The exact node parse (protocols_coro.cpp:863-868), under a watchdog.
+    std::atomic<bool> finished{false};
+    std::atomic<bool> rejected{false};
+    std::thread worker([&]() {
+        byte_reader reader(wire_payload);
+        auto const r = chain::light_block::from_data(reader, true);
+        rejected.store( ! r.has_value(), std::memory_order_relaxed);
+        finished.store(true, std::memory_order_release);
+    });
+
+    for (int i = 0; i < 30 && !finished.load(std::memory_order_acquire); ++i) {
+        std::this_thread::sleep_for(100ms);
+    }
+
+    bool const hung = !finished.load(std::memory_order_acquire);
+    if (hung) {
+        worker.detach();
+    } else {
+        worker.join();
+    }
+
+    REQUIRE( ! hung);
+    REQUIRE(rejected.load(std::memory_order_relaxed));
 }

--- a/src/infrastructure/include/kth/infrastructure/utility/byte_reader.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/byte_reader.hpp
@@ -45,7 +45,8 @@ struct byte_reader {
 
     [[nodiscard]] constexpr
     expect<void> skip(size_t count) {
-        if (position_ + count > buffer_.size()) {
+        // `position_ + count` would wrap modulo 2^64 and let a huge count pass.
+        if (count > remaining_size()) {
             return std::unexpected(error::skip_past_end_of_buffer);
         }
         position_ += count;
@@ -89,7 +90,7 @@ struct byte_reader {
 
     [[nodiscard]] constexpr
     expect<byte_span> read_bytes(size_t size) {
-        if (position_ + size > buffer_.size()) {
+        if (size > remaining_size()) {
             return std::unexpected(error::read_past_end_of_buffer);
         }
         auto const start = position_;
@@ -101,7 +102,7 @@ struct byte_reader {
     // Size to read is determined by dest.size().
     [[nodiscard]]
     expect<void> read_bytes_to(std::span<uint8_t> dest) {
-        if (position_ + dest.size() > buffer_.size()) {
+        if (dest.size() > remaining_size()) {
             return std::unexpected(error::read_past_end_of_buffer);
         }
         std::memcpy(dest.data(), buffer_.data() + position_, dest.size());
@@ -113,7 +114,7 @@ struct byte_reader {
     template <size_t N>
     [[nodiscard]]
     expect<std::array<uint8_t, N>> read_array() {
-        if (position_ + N > buffer_.size()) {
+        if (N > remaining_size()) {
             return std::unexpected(error::read_past_end_of_buffer);
         }
         std::array<uint8_t, N> result;
@@ -137,7 +138,7 @@ struct byte_reader {
     template <std::integral I>
     [[nodiscard]]
     expect<I> read_little_endian() {
-        if (position_ + sizeof(I) > buffer_.size()) {
+        if (sizeof(I) > remaining_size()) {
             return std::unexpected(error::read_past_end_of_buffer);
         }
         I value = 0;
@@ -149,7 +150,7 @@ struct byte_reader {
     template <std::integral I>
     [[nodiscard]] constexpr
     expect<I> read_big_endian() {
-        if (position_ + sizeof(I) > buffer_.size()) {
+        if (sizeof(I) > remaining_size()) {
             return std::unexpected(error::read_past_end_of_buffer);
         }
         I value = 0;
@@ -162,7 +163,7 @@ struct byte_reader {
     template <trivially_copyable T>
     [[nodiscard]]
     expect<T> read_packed() {
-        if (position_ + sizeof(T) > buffer_.size()) {
+        if (sizeof(T) > remaining_size()) {
             return std::unexpected(error::read_past_end_of_buffer);
         }
         T value;
@@ -205,7 +206,7 @@ struct byte_reader {
     // Removes trailing zeros, required for bitcoin string comparisons.
     [[nodiscard]]
     expect<std::string> read_string(size_t size) {
-        if (position_ + size > buffer_.size()) {
+        if (size > remaining_size()) {
             return std::unexpected(error::read_past_end_of_buffer);
         }
 

--- a/src/infrastructure/test/utility/byte_reader.cpp
+++ b/src/infrastructure/test/utility/byte_reader.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <limits>
+
 #include <test_helpers.hpp>
 
 #include <kth/infrastructure.hpp>
@@ -407,6 +409,47 @@ TEST_CASE("byte_reader - read_array fails when not enough bytes", "[byte_reader 
     auto result = reader.read_array<5>();
     REQUIRE( ! result.has_value());
     REQUIRE(result.error() == error::read_past_end_of_buffer);
+}
+
+// ---------------------------------------------------------------------------
+// Regression: integer-overflow / wrap-around in the bounds checks (0xaudron
+// report). Before the fix, `position_ + count > buffer_.size()` wrapped modulo
+// 2^64, so a huge count passed the guard and moved the cursor backwards. The
+// fix compares against remaining_size(). These tests pin the fixed behavior.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("byte_reader - skip rejects wrapping count and does not move cursor", "[overflow-poc]") {
+    data_chunk const buffer(100, 0x00);
+    byte_reader reader(buffer);
+
+    // Advance to a known position.
+    REQUIRE(reader.skip(50).has_value());
+    REQUIRE(reader.position() == 50);
+
+    // count = 2^64 - 10.  Pre-fix, 50 + count wrapped to 40 and passed the
+    // guard; post-fix it is correctly rejected (10 remaining bytes < count).
+    size_t const wrapping_count = std::numeric_limits<size_t>::max() - 9;
+    auto const result = reader.skip(wrapping_count);
+
+    REQUIRE( ! result.has_value());
+    REQUIRE(result.error() == error::skip_past_end_of_buffer);
+    REQUIRE(reader.position() == 50);   // cursor untouched
+}
+
+TEST_CASE("byte_reader - read_bytes rejects wrapping size", "[overflow-poc]") {
+    data_chunk const buffer(100, 0x00);
+    byte_reader reader(buffer);
+
+    REQUIRE(reader.skip(50).has_value());
+
+    // size = 2^64 - 10.  Pre-fix this returned a bogus ~2^64-byte span; post-fix
+    // it is rejected and the cursor stays put.
+    size_t const wrapping_size = std::numeric_limits<size_t>::max() - 9;
+    auto const result = reader.read_bytes(wrapping_size);
+
+    REQUIRE( ! result.has_value());
+    REQUIRE(result.error() == error::read_past_end_of_buffer);
+    REQUIRE(reader.position() == 50);
 }
 
 // End Test Suite

--- a/src/network/test/peer_session.cpp
+++ b/src/network/test/peer_session.cpp
@@ -2449,3 +2449,96 @@ TEST_CASE("peer_session OLD pattern without check_interval is slow",
         INFO("Channel close worked correctly this time - took " << stop_ms << "ms");
     }
 }
+
+// =============================================================================
+// Regression (0xaudron report): an inbound `block` message carrying an
+// overflowing script_len must be rejected by the real node download path
+// without hanging the worker thread. Drives the actual
+// `request_blocks_batch<sync_mode::fast>` (as a block_download_task does,
+// block_tasks.cpp:225) over a real loopback socket, with the io_context on a
+// dedicated thread so a re-regression is observed as a hang rather than
+// hanging the test itself. build_message() supplies a valid checksum, so
+// checksum validation is not what gates the payload.
+// =============================================================================
+
+// The 139-byte malicious `block` payload from the report (script_len wraps).
+static data_chunk make_malicious_block_payload_net() {
+    data_chunk p;
+    p.insert(p.end(), 80, 0x00);   // block header
+    p.push_back(0x01);             // tx_count = 1
+    p.insert(p.end(), 4, 0x00);    // tx version
+    p.push_back(0xFF);             // input_count varint prefix
+    p.insert(p.end(), 8, 0xFF);    // input_count = 2^64 - 1
+    p.insert(p.end(), 36, 0x00);   // prevout (32) + index (4)
+    p.push_back(0xFF);             // script_len varint prefix
+    p.push_back(0xCF);             // script_len = 0xFFFFFFFFFFFFFFCF
+    p.insert(p.end(), 7, 0xFF);
+    return p;
+}
+
+TEST_CASE("peer_session inbound block is rejected by request_blocks_batch without hanging",
+          "[integration]") {
+    ::asio::io_context ctx;
+    auto settings = make_test_settings();
+    auto [client, server] = make_connected_sockets(ctx);
+
+    auto session = std::make_shared<peer_session>(std::move(server), settings);
+
+    std::atomic<bool> batch_returned{false};
+    std::atomic<bool> batch_errored{false};
+    std::atomic<bool> block_routed{false};
+
+    // (1) Real peer read loop: socket -> messages().
+    ::asio::co_spawn(ctx, session->run(), ::asio::detached);
+
+    // (2) Router replicating p2p_node.cpp:825-830: forward `block` command
+    //     from messages() to the block_responses() channel.
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        for (;;) {
+            auto [ec, raw] = co_await session->messages().async_receive(
+                ::asio::as_tuple(::asio::use_awaitable));
+            if (ec) co_return;
+            if (raw.heading.command() == domain::message::block::command) {
+                block_routed.store(true, std::memory_order_release);
+                co_await session->block_responses().async_send(
+                    std::error_code{}, raw, ::asio::use_awaitable);
+            }
+        }
+    }, ::asio::detached);
+
+    // (3) The real node download function. The requested (height,hash) is a
+    //     dummy; the malicious block is rejected during the parse regardless.
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        std::vector<std::pair<uint32_t, hash_digest>> want{{1u, hash_digest{}}};
+        auto r = co_await request_blocks_batch<sync_mode::fast>(*session, want, 60s);
+        batch_errored.store( ! r.has_value(), std::memory_order_relaxed);
+        batch_returned.store(true, std::memory_order_release);
+    }, ::asio::detached);
+
+    std::thread worker([&]{ ctx.run(); });
+
+    auto const frame = build_message("block", make_malicious_block_payload_net(),
+                                     settings.identifier);
+    REQUIRE(frame.size() == 163);
+    std::error_code write_ec;
+    ::asio::write(client, ::asio::buffer(frame), write_ec);
+    REQUIRE(!write_ec);
+
+    auto const deadline = std::chrono::steady_clock::now() + 4s;
+    while (!batch_returned.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(50ms);
+    }
+
+    bool const hung = !batch_returned.load(std::memory_order_acquire);
+    if (hung) {
+        worker.detach();
+    } else {
+        ctx.stop();
+        worker.join();
+    }
+
+    REQUIRE(block_routed.load());
+    REQUIRE( ! hung);
+    REQUIRE(batch_errored.load(std::memory_order_relaxed));
+}


### PR DESCRIPTION
## What

`byte_reader`'s bounds checks computed `position_ + count > buffer_.size()`. Both operands are `size_t`, so the sum wraps modulo 2^64: a `count` near `SIZE_MAX` passes the guard and the following `position_ += count` wraps the same way, moving the cursor backwards instead of failing.

`light_block::from_data` drives `skip()` with wire-controlled varints. With `input_count = 2^64-1` and `script_len = 0xFFFFFFFFFFFFFFCF`, `*script_len + 4` rewinds the cursor by exactly the 45 bytes each loop iteration consumes, so the input loop spins forever over a static cursor. `light_block` is the parser used for block download during IBD/catch-up (`request_blocks_batch` in fast mode), reachable from any connected peer (inbound included), and the parse runs before the block hash is checked. A single unauthenticated 163-byte `block` message permanently consumes a network worker thread. The same wrapping pattern in `read_string`/`read_bytes` is an out-of-bounds read reachable earlier, at the handshake (`version.user_agent`).

## Fix

- All eight `byte_reader` guards now compare the requested length against `remaining_size()` instead of computing `position_ + length`. The invariant `position_ <= buffer_.size()` keeps `remaining_size()` underflow-free, so the addition (and the wrap) is gone. Covers `skip`, `read_bytes`, `read_bytes_to`, `read_array`, `read_little_endian`, `read_big_endian`, `read_packed`, `read_string`.
- `light_block::from_data` hardened: the script and its 4-byte sequence are skipped separately so `script_len` is never summed into another value, and the tx/input/output counts are rejected above `static_absolute_max_block_size()` (the same cap `read_collection<>` applies), bounding both the `reserve()` and the loops.

## Tests

- Unit regression that the wrapping lengths are rejected by `skip`/`read_bytes`.
- A `light_block` test that the malicious block is refused without hanging.
- An end-to-end `[integration]` test that drives the real `request_blocks_batch` over a loopback socket and asserts the worker thread returns promptly instead of hanging (0.05s vs a permanent hang before the fix).

Full suites pass: infrastructure (456 cases), domain (3820 cases), network (86 cases).

## Refs

Reported privately by 0xaudron. CWE-190, CWE-835. CVSS:3.1 AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (7.5, High).

