### PR TITLE
blockchain: make the block-template coinbase reserve configurable

### DIFF
--- a/src/blockchain/include/kth/blockchain/pools/block_template.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/block_template.hpp
@@ -36,6 +36,13 @@ struct block_template_context {
     uint64_t max_block_sigchecks;   // consensus block sigchecks limit
     size_t height;                  // template height (tip + 1)
     uint32_t median_time_past;      // tip's MTP (BIP113 finality time)
+
+    // Space and sigchecks held back for the coinbase the caller prepends. The
+    // defaults match BCHN's BlockAssembler; a caller that needs a larger
+    // coinbase (extra outputs, e.g. an SV2 CoinbaseOutputDataSize request)
+    // raises the size reserve so the selection leaves room for it.
+    uint64_t coinbase_reserve_size = 1000;
+    uint64_t coinbase_reserve_sigchecks = 100;
 };
 
 // Assemble a block template from the mempool, mirroring BCHN's BlockAssembler

--- a/src/blockchain/src/pools/block_template.cpp
+++ b/src/blockchain/src/pools/block_template.cpp
@@ -30,10 +30,6 @@ struct digest_hasher {
     }
 };
 
-// Coinbase reserve, matching BCHN BlockAssembler::resetBlock (miner.cpp).
-constexpr uint64_t coinbase_size_reserve = 1000;
-constexpr uint64_t coinbase_sigchecks_reserve = 100;
-
 // Give up adding once the block is nearly full and a run of candidates in a row
 // have all failed the size/sigchecks test (BCHN's MAX_CONSECUTIVE_FAILURES).
 constexpr int max_consecutive_failures = 1000;
@@ -115,6 +111,8 @@ block_template build_block_template(mempool const& pool, block_template_context 
     auto const max_sigchecks = ctx.max_block_sigchecks;
     auto const height = ctx.height;
     auto const mtp = ctx.median_time_past;
+    auto const coinbase_size_reserve = ctx.coinbase_reserve_size;
+    auto const coinbase_sigchecks_reserve = ctx.coinbase_reserve_sigchecks;
 
     std::vector<uint32_t> missing(n);   // in-mempool parents not yet added
     for (uint32_t i = 0; i < n; ++i) {

--- a/src/blockchain/test/block_template_test.cpp
+++ b/src/blockchain/test/block_template_test.cpp
@@ -169,6 +169,48 @@ TEST_CASE("block_template: size limit selects highest fee-rate first", "[block_t
     REQUIRE(present.count(lo->hash()) == 0u);
 }
 
+TEST_CASE("block_template: a larger coinbase size reserve shrinks the selection", "[block_template]") {
+    mempool pool(0x1111u, 0x2222u);
+
+    auto hi  = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto mid = as_ptr(make_tx({op(2, 0)}, 1, 2));
+    auto lo  = as_ptr(make_tx({op(3, 0)}, 1, 3));
+    REQUIRE(pool.add(make_entry(hi,  300u, 100u, 1u)));
+    REQUIRE(pool.add(make_entry(mid, 200u, 100u, 1u)));
+    REQUIRE(pool.add(make_entry(lo,  100u, 100u, 1u)));
+
+    // The same 1250-byte block that fits two 100-byte txs under the default
+    // 1000-byte reserve leaves room for only one once the reserve grows to 1100.
+    auto ctx = unlimited_ctx();
+    ctx.max_block_size = 1000u + 250u;
+    ctx.coinbase_reserve_size = 1100u;
+
+    auto const tpl = build_block_template(pool, ctx);
+
+    REQUIRE(tpl.txs.size() == 1u);
+    REQUIRE(tpl.total_fees == 300u);   // only the top fee-rate tx.
+}
+
+TEST_CASE("block_template: a larger coinbase sigchecks reserve caps selection", "[block_template]") {
+    mempool pool(0x1111u, 0x2222u);
+
+    auto a = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto b = as_ptr(make_tx({op(2, 0)}, 1, 2));
+    REQUIRE(pool.add(make_entry(a, 300u, 100u, /*sigchecks*/ 40u)));
+    REQUIRE(pool.add(make_entry(b, 200u, 100u, /*sigchecks*/ 40u)));
+
+    // 200 sigchecks fits both under the default 100 reserve; a 130 reserve
+    // leaves room for one.
+    auto ctx = unlimited_ctx();
+    ctx.max_block_sigchecks = 200u;
+    ctx.coinbase_reserve_sigchecks = 130u;
+
+    auto const tpl = build_block_template(pool, ctx);
+
+    REQUIRE(tpl.txs.size() == 1u);
+    REQUIRE(tpl.total_sigchecks == 40u);
+}
+
 TEST_CASE("block_template: sigchecks limit caps selection", "[block_template]") {
     mempool pool(0x1111u, 0x2222u);
 


### PR DESCRIPTION
## What

`build_block_template` reserved a fixed 1000 bytes and 100 sigchecks for the coinbase the caller prepends, as two file-local constants. That works for `getblocktemplatelight` (small coinbase), but a caller that needs a bigger coinbase has no way to make the selection leave room for it.

## Change

Move the two reserves into `block_template_context` as `coinbase_reserve_size` and `coinbase_reserve_sigchecks`, defaulting to the previous `1000` / `100`. The builder reads them from the context. Existing callers are unchanged (the defaults preserve current behavior).

This is the hook a caller with extra coinbase outputs needs: for example an SV2 Template Distribution request carrying a `CoinbaseOutputDataSize` raises the size reserve, and the selection is assembled around the larger coinbase.

## Tests

Two new cases in `block_template_test`: a larger size reserve, and a larger sigchecks reserve, each drop one tx from a selection that otherwise fits two. Full `[block_template]` suite passes (14 cases).
