### PR TITLE
blockchain: accept a coinbase reserve in fetch_mining_template

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -409,8 +409,12 @@ struct KB_API block_chain {
 
     // Full mining template (header fields + coinbase value + tx selection) for
     // getblocktemplate[light]. C-API counterpart: kth_chain_async_fetch_mining_template.
+    // coinbase_reserve_size is the space held back for the caller's coinbase; a
+    // caller with extra coinbase outputs, such as an SV2 CoinbaseOutputDataSize
+    // request, raises it above default_coinbase_reserve_size. The reserve is
+    // part of the template cache key.
     [[nodiscard]] awaitable_expected<blockchain::mining_template>
-    fetch_mining_template() const;
+    fetch_mining_template(uint64_t coinbase_reserve_size) const;
 
     // Mining-relevant chain snapshot (height, difficulty, mempool size, network)
     // for getmininginfo. C-API counterpart: kth_chain_async_fetch_mining_info.
@@ -549,6 +553,7 @@ private:
         hash_digest previous;
         uint64_t generation;
         uint32_t time;
+        uint64_t coinbase_reserve_size;
     };
     mutable boost::atomic_shared_ptr<template_snapshot> template_cache_;
     mutable std::mutex template_rebuild_mutex_;

--- a/src/blockchain/include/kth/blockchain/pools/block_template.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/block_template.hpp
@@ -31,18 +31,20 @@ struct block_template {
 // Everything the builder needs about the block being assembled, taken from the
 // chain state of the tip's next block. Kept as plain scalars so the builder is a
 // pure function of (mempool, context), independent of chain_state.
+// Space and sigchecks held back for the coinbase the caller prepends, matching
+// BCHN's BlockAssembler. getblocktemplate uses these; a caller with a larger
+// coinbase (extra outputs, e.g. an SV2 CoinbaseOutputDataSize request) raises
+// the size reserve so the selection leaves room for it.
+constexpr uint64_t default_coinbase_reserve_size = 1000;
+constexpr uint64_t default_coinbase_reserve_sigchecks = 100;
+
 struct block_template_context {
     uint64_t max_block_size;        // consensus block size limit
     uint64_t max_block_sigchecks;   // consensus block sigchecks limit
     size_t height;                  // template height (tip + 1)
     uint32_t median_time_past;      // tip's MTP (BIP113 finality time)
-
-    // Space and sigchecks held back for the coinbase the caller prepends. The
-    // defaults match BCHN's BlockAssembler; a caller that needs a larger
-    // coinbase (extra outputs, e.g. an SV2 CoinbaseOutputDataSize request)
-    // raises the size reserve so the selection leaves room for it.
-    uint64_t coinbase_reserve_size = 1000;
-    uint64_t coinbase_reserve_sigchecks = 100;
+    uint64_t coinbase_reserve_size = default_coinbase_reserve_size;
+    uint64_t coinbase_reserve_sigchecks = default_coinbase_reserve_sigchecks;
 };
 
 // Assemble a block template from the mempool, mirroring BCHN's BlockAssembler

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1499,7 +1499,7 @@ block_chain::fetch_template() const {
 }
 
 awaitable_expected<blockchain::mining_template>
-block_chain::fetch_mining_template() const {
+block_chain::fetch_mining_template(uint64_t coinbase_reserve_size) const {
     if (stopped()) {
         co_return std::unexpected(error::service_stopped);
     }
@@ -1531,6 +1531,7 @@ block_chain::fetch_mining_template() const {
     auto const usable = [&](boost::shared_ptr<template_snapshot> const& s) {
         return s &&
                s->previous == previous &&
+               s->coinbase_reserve_size == coinbase_reserve_size &&
                (s->generation == generation ||
                 now - s->time < settings_.gbt_template_refresh_seconds);
     };
@@ -1573,7 +1574,8 @@ block_chain::fetch_mining_template() const {
         state->dynamic_max_block_size(),
         state->dynamic_max_block_sigchecks(),
         height,
-        state->median_time_past()});
+        state->median_time_past(),
+        coinbase_reserve_size});
 
     // 0x20000000: the BIP9 version base. BCH has no active version-bits signaling,
     // and miners routinely override this, so it is only a sensible default.
@@ -1589,7 +1591,7 @@ block_chain::fetch_mining_template() const {
         std::move(selection));
 
     auto next = boost::make_shared<template_snapshot>(
-        template_snapshot{std::move(built), previous, generation, now});
+        template_snapshot{std::move(built), previous, generation, now, coinbase_reserve_size});
     template_cache_.store(next);
     co_return next->value;
 }

--- a/src/c-api/include/kth/capi/chain/chain_async.h
+++ b/src/c-api/include/kth/capi/chain/chain_async.h
@@ -24,7 +24,7 @@ void kth_chain_async_last_height(kth_chain_t chain, void* ctx, kth_last_height_f
 // completes. The handler must release the list with
 // kth_domain_chain_transaction_list_destruct.
 KTH_EXPORT
-void kth_chain_async_mining_template(kth_chain_t chain, void* ctx, kth_mining_template_fetch_handler_t handler);
+void kth_chain_async_mining_template(kth_chain_t chain, uint64_t coinbase_reserve_size, void* ctx, kth_mining_template_fetch_handler_t handler);
 
 // kth_chain_async_block_height is generated (see chain_query.h).
 

--- a/src/c-api/include/kth/capi/chain/chain_sync.h
+++ b/src/c-api/include/kth/capi/chain/chain_sync.h
@@ -99,7 +99,7 @@ int kth_chain_sync_organize_block(kth_chain_t chain, kth_block_mut_t block);
  *   `kth_domain_chain_transaction_list_destruct`.
  */
 KTH_EXPORT KTH_OWNED
-kth_error_code_t kth_chain_sync_mining_template(kth_chain_t chain, kth_mining_template_t* out, kth_transaction_list_mut_t* out_txs);
+kth_error_code_t kth_chain_sync_mining_template(kth_chain_t chain, uint64_t coinbase_reserve_size, kth_mining_template_t* out, kth_transaction_list_mut_t* out_txs);
 
 KTH_EXPORT
 int kth_chain_sync_organize_transaction(kth_chain_t chain, kth_transaction_mut_t transaction);

--- a/src/c-api/src/chain/chain_async.cpp
+++ b/src/c-api/src/chain/chain_async.cpp
@@ -63,10 +63,10 @@ void kth_chain_async_last_height(kth_chain_t chain, void* ctx, kth_last_height_f
 
 // kth_chain_async_mining_info is generated (chain_mining.cpp).
 
-void kth_chain_async_mining_template(kth_chain_t chain, void* ctx, kth_mining_template_fetch_handler_t handler) {
+void kth_chain_async_mining_template(kth_chain_t chain, uint64_t coinbase_reserve_size, void* ctx, kth_mining_template_fetch_handler_t handler) {
     auto& bc = safe_chain(chain);
-    ::asio::co_spawn(bc.executor(), [&bc, chain, ctx, handler]() -> ::asio::awaitable<void> {
-        auto result = co_await bc.fetch_mining_template();
+    ::asio::co_spawn(bc.executor(), [&bc, chain, coinbase_reserve_size, ctx, handler]() -> ::asio::awaitable<void> {
+        auto result = co_await bc.fetch_mining_template(coinbase_reserve_size);
         if (result) {
             kth_mining_template_t tmpl;
             kth_transaction_list_mut_t txs = nullptr;

--- a/src/c-api/src/chain/chain_sync.cpp
+++ b/src/c-api/src/chain/chain_sync.cpp
@@ -332,9 +332,9 @@ int kth_chain_sync_organize_transaction(kth_chain_t chain, kth_transaction_mut_t
     return kth::to_c_err(ec);
 }
 
-kth_error_code_t kth_chain_sync_mining_template(kth_chain_t chain, kth_mining_template_t* out, kth_transaction_list_mut_t* out_txs) {
+kth_error_code_t kth_chain_sync_mining_template(kth_chain_t chain, uint64_t coinbase_reserve_size, kth_mining_template_t* out, kth_transaction_list_mut_t* out_txs) {
     auto& bc = safe_chain(chain);
-    auto result = sync_wait(bc, bc.fetch_mining_template());
+    auto result = sync_wait(bc, bc.fetch_mining_template(coinbase_reserve_size));
     if ( ! result) {
         return kth::to_c_err(result.error());
     }

--- a/src/c-api/test/chain/chain_mining_compile_check.c
+++ b/src/c-api/test/chain/chain_mining_compile_check.c
@@ -34,9 +34,9 @@ static void mining_readers_sig_check(kth_chain_t chain) {
     // getblocktemplatelight — both flavors (header POD + owned tx list).
     kth_mining_template_t tmpl;
     kth_transaction_list_mut_t txs;
-    kth_error_code_t rc2 = kth_chain_sync_mining_template(chain, &tmpl, &txs);
+    kth_error_code_t rc2 = kth_chain_sync_mining_template(chain, 1000, &tmpl, &txs);
     (void)rc2; (void)tmpl; (void)txs;
-    kth_chain_async_mining_template(chain, NULL, &on_mining_template);
+    kth_chain_async_mining_template(chain, 1000, NULL, &on_mining_template);
 }
 
 int main(void) {

--- a/src/node/src/rpc/methods.cpp
+++ b/src/node/src/rpc/methods.cpp
@@ -47,7 +47,8 @@ get_block_count(method_context& ctx, request const& /*req*/) {
 // C-API counterpart: kth_chain_async_fetch_mining_template (see docs/json-rpc.md).
 ::asio::awaitable<std::expected<std::string, rpc_error>>
 get_block_template_light(method_context& ctx, request const& /*req*/) {
-    auto const tmpl = co_await ctx.chain.fetch_mining_template();
+    auto const tmpl = co_await ctx.chain.fetch_mining_template(
+        blockchain::default_coinbase_reserve_size);
     if ( ! tmpl) {
         co_return std::unexpected(from_code(tmpl.error()));
     }


### PR DESCRIPTION
## What

Follow-up to #530. That PR made the coinbase reserve a parameter of `build_block_template`; this one exposes it on `fetch_mining_template` so a caller can request the extra coinbase space per template.

## Change

- `fetch_mining_template(uint64_t coinbase_reserve_size)`. The parameter is **required, not defaulted**: a default would let the C-API keep compiling against the old zero-argument signature and silently fall behind the C++ API. The previous `1000` / `100` are centralized as `default_coinbase_reserve_size` / `default_coinbase_reserve_sigchecks`, and the size is passed explicitly from the getblocktemplatelight path.
- The reserve joins the template cache key (`template_snapshot` + the `usable()` check), so a snapshot built for one reserve is never served to a request for a different one.
- The C-API `mining_template` wrappers (sync + async) carry the new parameter.

## C-API note

The chain-interface readers are not covered by the C-API generator yet (kth-tools#3), so `kth_chain_sync_mining_template` / `kth_chain_async_mining_template` are updated by hand here. Once the generator gains a chain-interface spec, these become generated like the rest.

The builder-level behavior (a larger reserve shrinks the selection) is covered by the tests added in #530. Full build green (blockchain + c-api).
