### PR TITLE
node: move the mining job store out of the rpc layer

### DIFF
--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -157,6 +157,9 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     src/sync/header_tasks.cpp
     src/sync/block_tasks.cpp
     src/sync/orchestrator.cpp
+
+    # Mining helpers shared by the JSON-RPC server and other template consumers.
+    src/mining/job_store.cpp
   )
 endif()
 
@@ -167,7 +170,6 @@ if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     ${kth_sources_just_legacy}
     src/rpc/json.cpp
     src/rpc/dispatch.cpp
-    src/rpc/job_store.cpp
     src/rpc/mining.cpp
     src/rpc/query.cpp
     src/rpc/methods.cpp
@@ -206,11 +208,13 @@ set(kth_headers
   include/kth/node/full_node.hpp
   include/kth/node/parser.hpp
 
+  # Mining helpers shared by the JSON-RPC server and other template consumers.
+  include/kth/node/mining/job_store.hpp
+
   # Optional JSON-RPC server (compiled only when KTH_WITH_RPC is set).
   include/kth/node/rpc/error.hpp
   include/kth/node/rpc/json.hpp
   include/kth/node/rpc/dispatch.hpp
-  include/kth/node/rpc/job_store.hpp
   include/kth/node/rpc/mining.hpp
   include/kth/node/rpc/query.hpp
   include/kth/node/rpc/server.hpp
@@ -284,6 +288,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/performance.cpp
           test/reservation.cpp
           test/reservations.cpp
+          test/mining_job_store.cpp
           test/settings.cpp
           test/utility.cpp
           test/utility.hpp)
@@ -291,7 +296,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   # JSON-RPC unit tests build only when the server is compiled in.
   if(KTH_WITH_RPC AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     target_sources(kth_node_test PRIVATE
-      test/rpc_json.cpp test/rpc_job_store.cpp test/rpc_mining.cpp test/rpc_query.cpp)
+      test/rpc_json.cpp test/rpc_mining.cpp test/rpc_query.cpp)
   endif()
 
   target_include_directories(kth_node_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>)

--- a/src/node/include/kth/node/mining/job_store.hpp
+++ b/src/node/include/kth/node/mining/job_store.hpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef KTH_NODE_RPC_JOB_STORE_HPP
-#define KTH_NODE_RPC_JOB_STORE_HPP
+#ifndef KTH_NODE_MINING_JOB_STORE_HPP
+#define KTH_NODE_MINING_JOB_STORE_HPP
 
 #include <cstdint>
 #include <deque>
@@ -16,13 +16,14 @@
 
 #include <kth/blockchain/pools/block_template.hpp>
 
-namespace kth::node::rpc {
+namespace kth::node::mining {
 
-// Stores the transaction selection behind each getblocktemplatelight job so a
-// later submitblocklight can reconstruct the full block from the miner's solved
-// header + coinbase alone (transactions never travel over the wire). Bounded by
-// count (gbtcachesize) with insertion-order eviction and a TTL (gbtstoretime).
-// Thread-safe: RPC handlers run on the shared asio executor.
+// Stores the transaction selection behind a mining job so a later submission can
+// reconstruct the full block from the miner's solved header + coinbase alone
+// (transactions never travel over the wire). Used by getblocktemplatelight /
+// submitblocklight, and shareable by any other template consumer. Bounded by
+// count with insertion-order eviction and a TTL. Thread-safe: callers run on
+// the shared asio executor.
 struct job_store {
     job_store(std::size_t max_jobs, std::uint32_t ttl_seconds);
 
@@ -30,8 +31,7 @@ struct job_store {
     // the same selection yields the same id (idempotent).
     std::string add(std::vector<transaction_const_ptr> txs);
 
-    // The transactions for `job_id`, or nullopt if unknown or expired. Used by
-    // submitblocklight (F1b).
+    // The transactions for `job_id`, or nullopt if unknown or expired.
     std::optional<std::vector<transaction_const_ptr>> get(std::string const& job_id) const;
 
 private:
@@ -49,6 +49,6 @@ private:
     std::uint32_t ttl_seconds_;
 };
 
-} // namespace kth::node::rpc
+} // namespace kth::node::mining
 
-#endif // KTH_NODE_RPC_JOB_STORE_HPP
+#endif // KTH_NODE_MINING_JOB_STORE_HPP

--- a/src/node/include/kth/node/rpc/dispatch.hpp
+++ b/src/node/include/kth/node/rpc/dispatch.hpp
@@ -20,15 +20,17 @@ namespace kth::blockchain {
 class block_chain;
 } // namespace kth::blockchain
 
-namespace kth::node::rpc {
-
+namespace kth::node::mining {
 struct job_store;
+} // namespace kth::node::mining
+
+namespace kth::node::rpc {
 
 // Shared state a handler may reach: the chain and the getblocktemplatelight job
 // cache. Passed by reference; owned by the server for the connection's lifetime.
 struct method_context {
     blockchain::block_chain& chain;
-    job_store& jobs;
+    mining::job_store& jobs;
 };
 
 // A method handler serializes the JSON-RPC "result" fragment for `req`, or

--- a/src/node/include/kth/node/rpc/server.hpp
+++ b/src/node/include/kth/node/rpc/server.hpp
@@ -13,7 +13,7 @@
 #include <asio/ip/tcp.hpp>
 
 #include <kth/node/rpc/dispatch.hpp>
-#include <kth/node/rpc/job_store.hpp>
+#include <kth/node/mining/job_store.hpp>
 #include <kth/node/settings.hpp>
 
 namespace kth::blockchain {
@@ -40,7 +40,7 @@ private:
     rpc_settings const& settings_;
     blockchain::block_chain& chain_;
     dispatcher dispatcher_;
-    job_store jobs_;
+    mining::job_store jobs_;
     // Plaintext "user:password" (or "__cookie__:token") the Authorization header
     // must decode to.
     std::string expected_credentials_;

--- a/src/node/src/mining/job_store.cpp
+++ b/src/node/src/mining/job_store.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <kth/node/rpc/job_store.hpp>
+#include <kth/node/mining/job_store.hpp>
 
 #include <utility>
 
@@ -11,7 +11,7 @@
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/timer.hpp>
 
-namespace kth::node::rpc {
+namespace kth::node::mining {
 
 job_store::job_store(std::size_t max_jobs, std::uint32_t ttl_seconds)
     : max_jobs_(max_jobs == 0 ? 1 : max_jobs)
@@ -72,4 +72,4 @@ void job_store::evict_locked() {
     }
 }
 
-} // namespace kth::node::rpc
+} // namespace kth::node::mining

--- a/src/node/src/rpc/methods.cpp
+++ b/src/node/src/rpc/methods.cpp
@@ -19,7 +19,7 @@
 
 #include <kth/node/rpc/dispatch.hpp>
 #include <kth/node/rpc/error.hpp>
-#include <kth/node/rpc/job_store.hpp>
+#include <kth/node/mining/job_store.hpp>
 #include <kth/node/rpc/json.hpp>
 #include <kth/node/rpc/mining.hpp>
 #include <kth/node/rpc/query.hpp>

--- a/src/node/test/mining_job_store.cpp
+++ b/src/node/test/mining_job_store.cpp
@@ -8,10 +8,10 @@
 #include <vector>
 
 #include <kth/domain.hpp>
-#include <kth/node/rpc/job_store.hpp>
+#include <kth/node/mining/job_store.hpp>
 
 using namespace kth;
-using namespace kth::node::rpc;
+using namespace kth::node::mining;
 
 namespace {
 
@@ -31,9 +31,9 @@ std::vector<transaction_const_ptr> txs(std::initializer_list<uint32_t> locktimes
 
 } // namespace
 
-// Start Test Suite: rpc job_store tests
+// Start Test Suite: mining job_store tests
 
-TEST_CASE("job_store add then get roundtrips", "[rpc job_store]") {
+TEST_CASE("job_store add then get roundtrips", "[mining job_store]") {
     job_store store(10, 3600);
     auto const id = store.add(txs({1, 2}));
     auto const got = store.get(id);
@@ -41,24 +41,24 @@ TEST_CASE("job_store add then get roundtrips", "[rpc job_store]") {
     REQUIRE(got->size() == 2u);
 }
 
-TEST_CASE("job_store add is idempotent for equal selections", "[rpc job_store]") {
+TEST_CASE("job_store add is idempotent for equal selections", "[mining job_store]") {
     job_store store(10, 3600);
     auto const a = store.add(txs({7, 8, 9}));
     auto const b = store.add(txs({7, 8, 9}));
     REQUIRE(a == b);
 }
 
-TEST_CASE("job_store distinct selections get distinct ids", "[rpc job_store]") {
+TEST_CASE("job_store distinct selections get distinct ids", "[mining job_store]") {
     job_store store(10, 3600);
     REQUIRE(store.add(txs({1})) != store.add(txs({2})));
 }
 
-TEST_CASE("job_store returns nullopt for unknown id", "[rpc job_store]") {
+TEST_CASE("job_store returns nullopt for unknown id", "[mining job_store]") {
     job_store store(10, 3600);
     REQUIRE_FALSE(store.get("deadbeef").has_value());
 }
 
-TEST_CASE("job_store evicts the oldest past the count bound", "[rpc job_store]") {
+TEST_CASE("job_store evicts the oldest past the count bound", "[mining job_store]") {
     job_store store(/*max_jobs*/ 2, /*ttl*/ 3600);
     auto const first = store.add(txs({1}));
     store.add(txs({2}));


### PR DESCRIPTION
## What

`job_store` keeps the transaction selection behind a getblocktemplatelight job so `submitblocklight` can rebuild the full block from the miner's solved header and coinbase alone. It lived in `kth::node::rpc` and was compiled only under `KTH_WITH_RPC`, but it is a plain mining helper with no RPC dependency, and the upcoming SV2 template provider needs the same id-to-selection store.

## Change

- Move it to `kth::node::mining` (`src/node/{include,src}/mining/job_store.hpp` / `.cpp`), built as part of the node core regardless of the RPC option.
- The RPC `method_context` and `server` now reference `mining::job_store`. Pure move, no behavior change.
- The unit test moves with it (`mining_job_store.cpp`, `[mining job_store]`) and out of the RPC-gated test block, so it now runs in the default build (previously it only built with `KTH_WITH_RPC`).

## Tests

`[mining job_store]` passes (5 cases). Full node suite green (64 cases).
