### PR TITLE
node: extract block reassembly and submit from submitblocklight

### DIFF
--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -160,6 +160,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 
     # Mining helpers shared by the JSON-RPC server and other template consumers.
     src/mining/job_store.cpp
+    src/mining/block_submit.cpp
   )
 endif()
 
@@ -210,6 +211,7 @@ set(kth_headers
 
   # Mining helpers shared by the JSON-RPC server and other template consumers.
   include/kth/node/mining/job_store.hpp
+  include/kth/node/mining/block_submit.hpp
 
   # Optional JSON-RPC server (compiled only when KTH_WITH_RPC is set).
   include/kth/node/rpc/error.hpp
@@ -289,6 +291,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/reservation.cpp
           test/reservations.cpp
           test/mining_job_store.cpp
+          test/mining_block_submit.cpp
           test/settings.cpp
           test/utility.cpp
           test/utility.hpp)

--- a/src/node/include/kth/node/mining/block_submit.hpp
+++ b/src/node/include/kth/node/mining/block_submit.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_MINING_BLOCK_SUBMIT_HPP
+#define KTH_NODE_MINING_BLOCK_SUBMIT_HPP
+
+#include <vector>
+
+#include <asio/awaitable.hpp>
+
+#include <kth/domain.hpp>
+#include <kth/infrastructure/error.hpp>
+
+namespace kth::blockchain {
+class block_chain;
+} // namespace kth::blockchain
+
+namespace kth::node::mining {
+
+// Reassemble the full block a light submission refers to: the miner's coinbase
+// first, then the job's cached selection (CTOR order preserved).
+domain::message::block assemble_block(
+    domain::chain::header const& header,
+    domain::chain::transaction const& coinbase,
+    std::vector<transaction_const_ptr> const& job_txs);
+
+// Reassemble via assemble_block and submit the block to the chain. Returns the
+// organize result (success == accepted, otherwise the reject reason). Shared by
+// the getblocktemplatelight submit path and the SV2 template provider.
+::asio::awaitable<code> submit_block_light(
+    blockchain::block_chain& chain,
+    domain::chain::header const& header,
+    domain::chain::transaction const& coinbase,
+    std::vector<transaction_const_ptr> const& job_txs);
+
+} // namespace kth::node::mining
+
+#endif // KTH_NODE_MINING_BLOCK_SUBMIT_HPP

--- a/src/node/include/kth/node/rpc/mining.hpp
+++ b/src/node/include/kth/node/rpc/mining.hpp
@@ -7,16 +7,13 @@
 
 #include <string>
 #include <string_view>
-#include <vector>
 
 #include <kth/blockchain/pools/block_template.hpp>
-#include <kth/domain/chain/header.hpp>
-#include <kth/domain/chain/transaction.hpp>
-#include <kth/domain/message/block.hpp>
 
-// The pure (chain-free) logic behind the mining RPCs, split out so it can be
+// The pure (chain-free) rendering behind the mining RPCs, split out so it can be
 // unit-tested without a live block_chain: the handlers are just fetch/submit
-// glue around these.
+// glue around these. Block reassembly and submission live in
+// kth/node/mining/block_submit.hpp.
 
 namespace kth::node::rpc {
 
@@ -25,13 +22,6 @@ namespace kth::node::rpc {
 // tagged with `job_id`.
 std::string render_mining_template(
     blockchain::mining_template const& tmpl, std::string_view job_id);
-
-// Reassemble the full block a submitblocklight refers to: the miner's coinbase
-// first, then the job's cached selection (CTOR order preserved).
-domain::message::block assemble_block(
-    domain::chain::header const& header,
-    domain::chain::transaction const& coinbase,
-    std::vector<transaction_const_ptr> const& job_txs);
 
 // Serialize a mining_info as the getmininginfo "result" object.
 std::string render_mining_info(blockchain::mining_info const& info);

--- a/src/node/src/mining/block_submit.cpp
+++ b/src/node/src/mining/block_submit.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/mining/block_submit.hpp>
+
+#include <memory>
+#include <utility>
+
+#include <kth/blockchain/interface/block_chain.hpp>
+
+namespace kth::node::mining {
+
+domain::message::block assemble_block(
+    domain::chain::header const& header,
+    domain::chain::transaction const& coinbase,
+    std::vector<transaction_const_ptr> const& job_txs) {
+
+    domain::chain::transaction::list txs;
+    txs.reserve(1 + job_txs.size());
+    txs.push_back(coinbase);
+    for (auto const& tx : job_txs) {
+        txs.push_back(*tx); // slice message::transaction -> chain::transaction
+    }
+    return domain::message::block(header, std::move(txs));
+}
+
+::asio::awaitable<code> submit_block_light(
+    blockchain::block_chain& chain,
+    domain::chain::header const& header,
+    domain::chain::transaction const& coinbase,
+    std::vector<transaction_const_ptr> const& job_txs) {
+
+    auto const block = std::make_shared<domain::message::block>(
+        assemble_block(header, coinbase, job_txs));
+    co_return co_await chain.organize(block);
+}
+
+} // namespace kth::node::mining

--- a/src/node/src/rpc/methods.cpp
+++ b/src/node/src/rpc/methods.cpp
@@ -19,6 +19,7 @@
 
 #include <kth/node/rpc/dispatch.hpp>
 #include <kth/node/rpc/error.hpp>
+#include <kth/node/mining/block_submit.hpp>
 #include <kth/node/mining/job_store.hpp>
 #include <kth/node/rpc/json.hpp>
 #include <kth/node/rpc/mining.hpp>
@@ -100,13 +101,12 @@ submit_block_light(method_context& ctx, request const& req) {
             "job_id not found or expired"));
     }
 
-    // Reassemble: coinbase (from the miner) followed by the cached selection.
-    auto const block = std::make_shared<domain::message::block>(assemble_block(
+    // Reassemble (coinbase followed by the cached selection) and submit.
+    auto const ec = co_await mining::submit_block_light(
+        ctx.chain,
         header_and_coinbase->header(),
         header_and_coinbase->transactions().front(),
-        *job));
-
-    auto const ec = co_await ctx.chain.organize(block);
+        *job);
 
     writer w;
     if (ec) {

--- a/src/node/src/rpc/mining.cpp
+++ b/src/node/src/rpc/mining.cpp
@@ -66,20 +66,6 @@ std::string render_mining_template(
     return w.str();
 }
 
-domain::message::block assemble_block(
-    domain::chain::header const& header,
-    domain::chain::transaction const& coinbase,
-    std::vector<transaction_const_ptr> const& job_txs) {
-
-    domain::chain::transaction::list txs;
-    txs.reserve(1 + job_txs.size());
-    txs.push_back(coinbase);
-    for (auto const& tx : job_txs) {
-        txs.push_back(*tx); // slice message::transaction -> chain::transaction
-    }
-    return domain::message::block(header, std::move(txs));
-}
-
 std::string render_mining_info(blockchain::mining_info const& info) {
     writer w;
     w.begin_object();

--- a/src/node/test/mining_block_submit.cpp
+++ b/src/node/test/mining_block_submit.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <memory>
+#include <vector>
+
+#include <kth/domain.hpp>
+#include <kth/node/mining/block_submit.hpp>
+
+using namespace kth;
+using namespace kth::node::mining;
+
+namespace {
+
+transaction_const_ptr make_tx(uint32_t locktime) {
+    return std::make_shared<domain::message::transaction>(
+        domain::chain::transaction{1u, locktime, {}, {}});
+}
+
+} // namespace
+
+// Start Test Suite: mining block_submit tests
+
+TEST_CASE("assemble_block puts the coinbase first then the job selection", "[mining block_submit]") {
+    domain::chain::transaction coinbase{1u, 0u, {}, {}};
+    std::vector<transaction_const_ptr> job{make_tx(11), make_tx(22)};
+
+    auto const block = assemble_block(domain::chain::header{}, coinbase, job);
+
+    REQUIRE(block.transactions().size() == 3u);
+    REQUIRE(block.transactions()[0].hash() == coinbase.hash());
+    REQUIRE(block.transactions()[1].hash() == job[0]->hash());
+    REQUIRE(block.transactions()[2].hash() == job[1]->hash());
+}
+
+TEST_CASE("assemble_block with an empty selection is coinbase-only", "[mining block_submit]") {
+    domain::chain::transaction coinbase{1u, 7u, {}, {}};
+    auto const block = assemble_block(domain::chain::header{}, coinbase, {});
+    REQUIRE(block.transactions().size() == 1u);
+    REQUIRE(block.transactions()[0].hash() == coinbase.hash());
+}

--- a/src/node/test/rpc_mining.cpp
+++ b/src/node/test/rpc_mining.cpp
@@ -4,23 +4,11 @@
 
 #include <test_helpers.hpp>
 
-#include <memory>
-#include <vector>
-
 #include <kth/domain.hpp>
 #include <kth/node/rpc/mining.hpp>
 
 using namespace kth;
 using namespace kth::node::rpc;
-
-namespace {
-
-transaction_const_ptr make_tx(uint32_t locktime) {
-    return std::make_shared<domain::message::transaction>(
-        domain::chain::transaction{1u, locktime, {}, {}});
-}
-
-} // namespace
 
 // Start Test Suite: rpc mining tests
 
@@ -47,25 +35,6 @@ TEST_CASE("render_mining_template serializes the GBT-light fields", "[rpc mining
         R"("noncerange":"00000000ffffffff",)"
         R"("mutable":["time","transactions","prevblock"],)"
         R"("job_id":"testjob"})");
-}
-
-TEST_CASE("assemble_block puts the coinbase first then the job selection", "[rpc mining]") {
-    domain::chain::transaction coinbase{1u, 0u, {}, {}};
-    std::vector<transaction_const_ptr> job{make_tx(11), make_tx(22)};
-
-    auto const block = assemble_block(domain::chain::header{}, coinbase, job);
-
-    REQUIRE(block.transactions().size() == 3u);
-    REQUIRE(block.transactions()[0].hash() == coinbase.hash());
-    REQUIRE(block.transactions()[1].hash() == job[0]->hash());
-    REQUIRE(block.transactions()[2].hash() == job[1]->hash());
-}
-
-TEST_CASE("assemble_block with an empty selection is coinbase-only", "[rpc mining]") {
-    domain::chain::transaction coinbase{1u, 7u, {}, {}};
-    auto const block = assemble_block(domain::chain::header{}, coinbase, {});
-    REQUIRE(block.transactions().size() == 1u);
-    REQUIRE(block.transactions()[0].hash() == coinbase.hash());
 }
 
 TEST_CASE("render_mining_info serializes the getmininginfo fields", "[rpc mining]") {


### PR DESCRIPTION
## What

`submitblocklight` rebuilt the full block (the miner's coinbase followed by the job's cached selection) and submitted it through the chain, all inside the RPC handler. The SV2 template provider does the same on a `SubmitSolution`, so this pulls the reassembly and submission out of the RPC layer.

## Change

- Move `assemble_block` into `kth::node::mining` and add `submit_block_light` alongside it: it reassembles via `assemble_block` and `organize`s the block, returning the organize result (success == accepted).
- The `submitblocklight` handler now parses its request and calls `mining::submit_block_light`; the reassembly and submission are no longer RPC-specific.
- Both build as node core, independent of `KTH_WITH_RPC`.

## Tests

`assemble_block`'s unit tests move with it (`mining_block_submit.cpp`, `[mining block_submit]`) and out of the RPC-gated test block, so they run in the default build. `rpc_mining.cpp` keeps the `render_*` tests. Core build green; node suite 66 cases. RPC translation units syntax-checked with `KTH_WITH_RPC`.
