### PR TITLE
node: add Stratum V2 message framing

### DIFF
--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -161,6 +161,9 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     # Mining helpers shared by the JSON-RPC server and other template consumers.
     src/mining/job_store.cpp
     src/mining/block_submit.cpp
+
+    # Stratum V2 template provider.
+    src/sv2/framing.cpp
   )
 endif()
 
@@ -212,6 +215,9 @@ set(kth_headers
   # Mining helpers shared by the JSON-RPC server and other template consumers.
   include/kth/node/mining/job_store.hpp
   include/kth/node/mining/block_submit.hpp
+
+  # Stratum V2 template provider.
+  include/kth/node/sv2/framing.hpp
 
   # Optional JSON-RPC server (compiled only when KTH_WITH_RPC is set).
   include/kth/node/rpc/error.hpp
@@ -292,6 +298,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/reservations.cpp
           test/mining_job_store.cpp
           test/mining_block_submit.cpp
+          test/sv2_framing.cpp
           test/settings.cpp
           test/utility.cpp
           test/utility.hpp)

--- a/src/node/include/kth/node/sv2/framing.hpp
+++ b/src/node/include/kth/node/sv2/framing.hpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_SV2_FRAMING_HPP
+#define KTH_NODE_SV2_FRAMING_HPP
+
+#include <cstddef>
+#include <cstdint>
+
+#include <kth/infrastructure/error.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
+
+// Stratum V2 message framing. This is the plaintext frame that the Noise
+// transport later wraps: a 6-byte header followed by the message payload. All
+// integers are little-endian. See sv2-spec 04-Protocol-Overview.
+
+namespace kth::node::sv2 {
+
+// A U24 is the one SV2 fixed-width integer that byte_reader / byte_writer do not
+// already cover; the rest (U8, U16, U32, U64) are their little-endian reads and
+// writes. Used by the frame header (msg_length) and the B0_16M length prefix.
+constexpr uint32_t u24_max = 0xffffffu;
+
+[[nodiscard]]
+expect<void> write_u24(byte_writer& sink, uint32_t value);
+
+[[nodiscard]]
+expect<uint32_t> read_u24(byte_reader& source);
+
+// SV2 message frame header: extension_type (U16), msg_type (U8), msg_length
+// (U24). The high bit of extension_type is the channel_msg flag; the low 15
+// bits are the extension id.
+struct message_header {
+    static constexpr size_t size = 6;
+    static constexpr uint16_t channel_msg_flag = 0x8000u;
+
+    uint16_t extension_type = 0;
+    uint8_t msg_type = 0;
+    uint32_t msg_length = 0;   // U24: must be <= u24_max
+
+    [[nodiscard]]
+    bool channel_msg() const {
+        return (extension_type & channel_msg_flag) != 0;
+    }
+
+    // The extension id with the channel_msg flag cleared.
+    [[nodiscard]]
+    uint16_t extension() const {
+        return extension_type & static_cast<uint16_t>(~channel_msg_flag);
+    }
+
+    [[nodiscard]]
+    size_t serialized_size() const {
+        return size;
+    }
+
+    [[nodiscard]]
+    expect<void> to_data(byte_writer& sink) const;
+
+    [[nodiscard]]
+    static expect<message_header> from_data(byte_reader& source);
+};
+
+} // namespace kth::node::sv2
+
+#endif // KTH_NODE_SV2_FRAMING_HPP

--- a/src/node/src/sv2/framing.cpp
+++ b/src/node/src/sv2/framing.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/sv2/framing.hpp>
+
+namespace kth::node::sv2 {
+
+expect<void> write_u24(byte_writer& sink, uint32_t value) {
+    if (value > u24_max) {
+        return std::unexpected(error::operation_failed);
+    }
+    if (auto r = sink.write_byte(static_cast<uint8_t>(value)); ! r) return r;
+    if (auto r = sink.write_byte(static_cast<uint8_t>(value >> 8)); ! r) return r;
+    return sink.write_byte(static_cast<uint8_t>(value >> 16));
+}
+
+expect<uint32_t> read_u24(byte_reader& source) {
+    auto const b0 = source.read_byte();
+    if ( ! b0) return std::unexpected(b0.error());
+    auto const b1 = source.read_byte();
+    if ( ! b1) return std::unexpected(b1.error());
+    auto const b2 = source.read_byte();
+    if ( ! b2) return std::unexpected(b2.error());
+    return static_cast<uint32_t>(*b0)
+        | (static_cast<uint32_t>(*b1) << 8)
+        | (static_cast<uint32_t>(*b2) << 16);
+}
+
+expect<void> message_header::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_little_endian<uint16_t>(extension_type); ! r) return r;
+    if (auto r = sink.write_byte(msg_type); ! r) return r;
+    return write_u24(sink, msg_length);
+}
+
+expect<message_header> message_header::from_data(byte_reader& source) {
+    auto const extension_type = source.read_little_endian<uint16_t>();
+    if ( ! extension_type) return std::unexpected(extension_type.error());
+    auto const msg_type = source.read_byte();
+    if ( ! msg_type) return std::unexpected(msg_type.error());
+    auto const msg_length = read_u24(source);
+    if ( ! msg_length) return std::unexpected(msg_length.error());
+    return message_header{*extension_type, *msg_type, *msg_length};
+}
+
+} // namespace kth::node::sv2

--- a/src/node/test/sv2_framing.cpp
+++ b/src/node/test/sv2_framing.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <array>
+#include <cstdint>
+
+#include <kth/infrastructure.hpp>
+#include <kth/node/sv2/framing.hpp>
+
+using namespace kth;
+using namespace kth::node::sv2;
+
+// Start Test Suite: sv2 framing tests
+
+TEST_CASE("sv2 message_header serializes to the little-endian wire layout", "[sv2 framing]") {
+    message_header const h{/*extension_type*/ 0x0102u, /*msg_type*/ 0x03u,
+                           /*msg_length*/ 0x040506u};
+
+    auto const bytes = to_data_chunk(h);
+
+    // extension_type (U16 LE), msg_type (U8), msg_length (U24 LE).
+    data_chunk const expected{0x02, 0x01, 0x03, 0x06, 0x05, 0x04};
+    REQUIRE(bytes == expected);
+    REQUIRE(bytes.size() == message_header::size);
+}
+
+TEST_CASE("sv2 message_header round-trips through from_data", "[sv2 framing]") {
+    message_header const h{0x8001u, 0x2au, 0x123456u};
+
+    auto const bytes = to_data_chunk(h);
+    auto const parsed = from_data_chunk<message_header>(bytes);
+
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->extension_type == h.extension_type);
+    REQUIRE(parsed->msg_type == h.msg_type);
+    REQUIRE(parsed->msg_length == h.msg_length);
+}
+
+TEST_CASE("sv2 message_header channel_msg flag and extension id", "[sv2 framing]") {
+    message_header const channel{0x8005u, 0u, 0u};
+    REQUIRE(channel.channel_msg());
+    REQUIRE(channel.extension() == 0x0005u);
+
+    message_header const plain{0x0005u, 0u, 0u};
+    REQUIRE_FALSE(plain.channel_msg());
+    REQUIRE(plain.extension() == 0x0005u);
+}
+
+TEST_CASE("sv2 message_header from_data rejects a short buffer", "[sv2 framing]") {
+    data_chunk const truncated{0x02, 0x01, 0x03, 0x06, 0x05};  // 5 bytes, needs 6
+    auto const parsed = from_data_chunk<message_header>(truncated);
+    REQUIRE_FALSE(parsed.has_value());
+}
+
+TEST_CASE("sv2 u24 round-trips at the boundaries", "[sv2 framing]") {
+    for (uint32_t const value : {uint32_t{0}, uint32_t{1}, uint32_t{0x123456}, u24_max}) {
+        std::array<uint8_t, 3> buf{};
+        byte_writer sink(buf);
+        REQUIRE(write_u24(sink, value).has_value());
+
+        byte_reader source(buf);
+        auto const got = read_u24(source);
+        REQUIRE(got.has_value());
+        REQUIRE(*got == value);
+    }
+}
+
+TEST_CASE("sv2 write_u24 rejects a value above 2^24 - 1", "[sv2 framing]") {
+    std::array<uint8_t, 3> buf{};
+    byte_writer sink(buf);
+    REQUIRE_FALSE(write_u24(sink, u24_max + 1).has_value());
+}
+
+TEST_CASE("sv2 read_u24 is little-endian", "[sv2 framing]") {
+    data_chunk const bytes{0x06, 0x05, 0x04};  // 0x040506
+    byte_reader source(bytes);
+    auto const got = read_u24(source);
+    REQUIRE(got.has_value());
+    REQUIRE(*got == 0x040506u);
+}


### PR DESCRIPTION
## What

First piece of the Stratum V2 template provider: the plaintext message frame the Noise transport will later wrap.

An SV2 frame is a 6-byte header followed by the payload, all little-endian:

- `extension_type` (U16) — high bit is the `channel_msg` flag, low 15 bits are the extension id
- `msg_type` (U8)
- `msg_length` (U24)

## Change

- `kth::node::sv2::message_header` with `channel_msg()` / `extension()` accessors, following the `from_data` / `to_data` convention so it flows through `from_data_chunk` / `to_data_chunk` like the other wire types.
- `read_u24` / `write_u24`: the one SV2 fixed-width integer `byte_reader` / `byte_writer` do not already cover (also used later by the `B0_16M` length prefix). The U16 and U8 fields reuse the existing little-endian reads and writes.
- Lives under `src/node/{include,src}/sv2`, built as node core (no RPC / network dependency).

## Tests

`[sv2 framing]`, 7 cases / 26 assertions: exact wire layout, round-trip, the `channel_msg` flag and extension masking, U24 boundary round-trips, and short-buffer / overflow rejection. Full node suite green (73 cases).
