### PR TITLE
node: add Stratum V2 variable-length primitives

### DIFF
--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -164,6 +164,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 
     # Stratum V2 template provider.
     src/sv2/framing.cpp
+    src/sv2/primitives.cpp
   )
 endif()
 
@@ -218,6 +219,7 @@ set(kth_headers
 
   # Stratum V2 template provider.
   include/kth/node/sv2/framing.hpp
+  include/kth/node/sv2/primitives.hpp
 
   # Optional JSON-RPC server (compiled only when KTH_WITH_RPC is set).
   include/kth/node/rpc/error.hpp
@@ -299,6 +301,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/mining_job_store.cpp
           test/mining_block_submit.cpp
           test/sv2_framing.cpp
+          test/sv2_primitives.cpp
           test/settings.cpp
           test/utility.cpp
           test/utility.hpp)

--- a/src/node/include/kth/node/sv2/primitives.hpp
+++ b/src/node/include/kth/node/sv2/primitives.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_SV2_PRIMITIVES_HPP
+#define KTH_NODE_SV2_PRIMITIVES_HPP
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include <kth/infrastructure/error.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
+#include <kth/infrastructure/utility/data.hpp>
+
+// Stratum V2 variable-length primitives (sv2-spec 03-Protocol-Overview). Each is
+// a byte payload behind a little-endian length prefix whose width bounds the
+// payload: B0_255 (U8), B0_64K (U16), B0_16M (U24). STR0_255 is a B0_255 carrying
+// UTF-8 text. The fixed-width integers (U8/U16/U32/U64) and U24 are already
+// covered by byte_reader / byte_writer and framing.hpp.
+
+namespace kth::node::sv2 {
+
+constexpr size_t b0_255_max = 0xffu;
+constexpr size_t b0_64k_max = 0xffffu;
+constexpr size_t b0_16m_max = 0xffffffu;
+
+// write_* fail (error::operation_failed) when the payload exceeds the prefix's
+// range. read_* return a view into the reader's buffer, valid for its lifetime.
+[[nodiscard]] expect<void> write_bytes_u8(byte_writer& sink, byte_span value);
+[[nodiscard]] expect<void> write_bytes_u16(byte_writer& sink, byte_span value);
+[[nodiscard]] expect<void> write_bytes_u24(byte_writer& sink, byte_span value);
+
+[[nodiscard]] expect<byte_span> read_bytes_u8(byte_reader& source);
+[[nodiscard]] expect<byte_span> read_bytes_u16(byte_reader& source);
+[[nodiscard]] expect<byte_span> read_bytes_u24(byte_reader& source);
+
+// STR0_255: a U8-length-prefixed UTF-8 string. Unlike byte_reader::read_string,
+// interior and trailing NUL bytes are preserved (SV2 strings are not NUL-padded).
+[[nodiscard]] expect<void> write_string_u8(byte_writer& sink, std::string_view value);
+[[nodiscard]] expect<std::string> read_string_u8(byte_reader& source);
+
+} // namespace kth::node::sv2
+
+#endif // KTH_NODE_SV2_PRIMITIVES_HPP

--- a/src/node/src/sv2/primitives.cpp
+++ b/src/node/src/sv2/primitives.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/sv2/primitives.hpp>
+
+#include <kth/node/sv2/framing.hpp>
+
+namespace kth::node::sv2 {
+
+expect<void> write_bytes_u8(byte_writer& sink, byte_span value) {
+    if (value.size() > b0_255_max) {
+        return std::unexpected(error::operation_failed);
+    }
+    if (auto r = sink.write_byte(static_cast<uint8_t>(value.size())); ! r) return r;
+    return sink.write_bytes(value);
+}
+
+expect<void> write_bytes_u16(byte_writer& sink, byte_span value) {
+    if (value.size() > b0_64k_max) {
+        return std::unexpected(error::operation_failed);
+    }
+    if (auto r = sink.write_little_endian<uint16_t>(static_cast<uint16_t>(value.size())); ! r) return r;
+    return sink.write_bytes(value);
+}
+
+expect<void> write_bytes_u24(byte_writer& sink, byte_span value) {
+    if (value.size() > b0_16m_max) {
+        return std::unexpected(error::operation_failed);
+    }
+    if (auto r = write_u24(sink, static_cast<uint32_t>(value.size())); ! r) return r;
+    return sink.write_bytes(value);
+}
+
+expect<byte_span> read_bytes_u8(byte_reader& source) {
+    auto const size = source.read_byte();
+    if ( ! size) return std::unexpected(size.error());
+    return source.read_bytes(*size);
+}
+
+expect<byte_span> read_bytes_u16(byte_reader& source) {
+    auto const size = source.read_little_endian<uint16_t>();
+    if ( ! size) return std::unexpected(size.error());
+    return source.read_bytes(*size);
+}
+
+expect<byte_span> read_bytes_u24(byte_reader& source) {
+    auto const size = read_u24(source);
+    if ( ! size) return std::unexpected(size.error());
+    return source.read_bytes(*size);
+}
+
+expect<void> write_string_u8(byte_writer& sink, std::string_view value) {
+    return write_bytes_u8(sink, byte_span{
+        reinterpret_cast<uint8_t const*>(value.data()), value.size()});
+}
+
+expect<std::string> read_string_u8(byte_reader& source) {
+    auto const bytes = read_bytes_u8(source);
+    if ( ! bytes) return std::unexpected(bytes.error());
+    return std::string(bytes->begin(), bytes->end());
+}
+
+} // namespace kth::node::sv2

--- a/src/node/test/sv2_primitives.cpp
+++ b/src/node/test/sv2_primitives.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <cstdint>
+#include <string>
+
+#include <kth/infrastructure.hpp>
+#include <kth/node/sv2/primitives.hpp>
+
+using namespace kth;
+using namespace kth::node::sv2;
+
+// Start Test Suite: sv2 primitives tests
+
+TEST_CASE("sv2 B0_255 round-trips a payload behind a U8 length", "[sv2 primitives]") {
+    data_chunk const payload{0xAA, 0xBB, 0xCC};
+
+    data_chunk buf(1 + payload.size());
+    byte_writer sink(buf);
+    REQUIRE(write_bytes_u8(sink, payload).has_value());
+    REQUIRE(buf.front() == 0x03);           // U8 length prefix
+
+    byte_reader source(buf);
+    auto const got = read_bytes_u8(source);
+    REQUIRE(got.has_value());
+    REQUIRE(data_chunk(got->begin(), got->end()) == payload);
+    REQUIRE(source.is_exhausted());
+}
+
+TEST_CASE("sv2 B0_255 handles an empty payload", "[sv2 primitives]") {
+    data_chunk buf(1);
+    byte_writer sink(buf);
+    REQUIRE(write_bytes_u8(sink, byte_span{}).has_value());
+    REQUIRE(buf == data_chunk{0x00});
+
+    byte_reader source(buf);
+    auto const got = read_bytes_u8(source);
+    REQUIRE(got.has_value());
+    REQUIRE(got->empty());
+}
+
+TEST_CASE("sv2 B0_64K uses a two-byte little-endian length", "[sv2 primitives]") {
+    data_chunk const payload(300, 0x7F);    // > 255, needs the U16 prefix
+
+    data_chunk buf(2 + payload.size());
+    byte_writer sink(buf);
+    REQUIRE(write_bytes_u16(sink, payload).has_value());
+    REQUIRE(buf[0] == 0x2C);                 // 300 = 0x012C, little-endian
+    REQUIRE(buf[1] == 0x01);
+
+    byte_reader source(buf);
+    auto const got = read_bytes_u16(source);
+    REQUIRE(got.has_value());
+    REQUIRE(data_chunk(got->begin(), got->end()) == payload);
+}
+
+TEST_CASE("sv2 B0_16M uses a three-byte little-endian length", "[sv2 primitives]") {
+    data_chunk const payload(70000, 0x11);  // > 65535, needs the U24 prefix
+
+    data_chunk buf(3 + payload.size());
+    byte_writer sink(buf);
+    REQUIRE(write_bytes_u24(sink, payload).has_value());
+
+    byte_reader source(buf);
+    auto const got = read_bytes_u24(source);
+    REQUIRE(got.has_value());
+    REQUIRE(got->size() == payload.size());
+}
+
+TEST_CASE("sv2 write_bytes_u8 rejects a payload over 255 bytes", "[sv2 primitives]") {
+    data_chunk const payload(256, 0x00);
+    data_chunk buf(8);
+    byte_writer sink(buf);
+    REQUIRE_FALSE(write_bytes_u8(sink, payload).has_value());
+}
+
+TEST_CASE("sv2 write_bytes_u16 rejects a payload over 65535 bytes", "[sv2 primitives]") {
+    data_chunk const payload(b0_64k_max + 1, 0x00);
+    data_chunk buf(8);
+    byte_writer sink(buf);
+    REQUIRE_FALSE(write_bytes_u16(sink, payload).has_value());
+}
+
+TEST_CASE("sv2 read_bytes_u8 fails when the payload is truncated", "[sv2 primitives]") {
+    data_chunk const bytes{0x03, 0xAA, 0xBB};   // length says 3, only 2 present
+    byte_reader source(bytes);
+    REQUIRE_FALSE(read_bytes_u8(source).has_value());
+}
+
+TEST_CASE("sv2 STR0_255 round-trips and preserves embedded NUL bytes", "[sv2 primitives]") {
+    std::string const text("ab\0cd", 5);   // interior NUL
+
+    data_chunk buf(1 + text.size());
+    byte_writer sink(buf);
+    REQUIRE(write_string_u8(sink, text).has_value());
+
+    byte_reader source(buf);
+    auto const got = read_string_u8(source);
+    REQUIRE(got.has_value());
+    REQUIRE(got->size() == 5);
+    REQUIRE(*got == text);
+}


### PR DESCRIPTION
## What

SV2 messages carry variable-length byte fields behind a little-endian length prefix whose width bounds the payload:

- `B0_255` (U8 prefix)
- `B0_64K` (U16 prefix)
- `B0_16M` (U24 prefix)
- `STR0_255` — a `B0_255` carrying UTF-8 text

## Change

- `read_bytes_u8/u16/u24` and `write_bytes_u8/u16/u24`, plus `read_string_u8` / `write_string_u8`, on top of `byte_reader` / `byte_writer` and the `U24` from framing.hpp (#534).
- `write_*` reject a payload that overflows the prefix; `read_*` return a view into the reader's buffer.
- The string reader preserves interior and trailing NUL bytes, unlike `byte_reader::read_string` (SV2 strings are not NUL-padded).

Together with the already-covered fixed-width integers (U8/U16/U32/U64/U24), this completes the SV2 primitive layer the TDP message structs will build on.

## Tests

`[sv2 primitives]`, 8 cases / 24 assertions: round-trips per width, empty payloads, little-endian prefixes, over-length and truncated-buffer rejection, and NUL preservation in strings. Full node suite green (81 cases).
