### PR TITLE
chore: review all source modules in coderabbit, not just infrastructure

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,35 +1,29 @@
 reviews:
   path_filters:
-    # === Incremental review strategy ===
-    # Start with infrastructure only. After review, expand to next module.
-    # Order: infrastructure -> domain -> database -> network -> blockchain -> node
-
-    # Include only infrastructure
+    # Review the Knuth source modules and their tests.
     - "src/infrastructure/**"
+    - "src/domain/**"
+    - "src/database/**"
+    - "src/network/**"
+    - "src/blockchain/**"
+    - "src/node/**"
+    - "src/node-exe/**"
+    - "src/c-api/**"
 
-    # Exclude everything else
-    - "!src/domain/**"
-    - "!src/database/**"
-    - "!src/network/**"
-    - "!src/blockchain/**"
-    - "!src/node/**"
-    - "!src/node-exe/**"
-    - "!src/c-api/**"
+    # Vendored / third-party code we do not review.
     - "!src/consensus/**"
     - "!src/secp256k1/**"
 
-    # Always exclude
+    # Non-source and generated files.
     - "!data/**"
     - "!**/*.dat"
     - "!**/*.png"
     - "!**/*.pdf"
     - "!scripts/**"
-    - "!**/CMakeLists.txt"
     - "!**/conanfile.py"
     - "!conan.lock"
     - "!.gitignore"
     - "!.github/**"
-    - "!**/test/**"
     - "!**/tools/**"
     - "!**/*.ipp"
     - "!**/*.S.in"


### PR DESCRIPTION
## Why

CodeRabbit was skipping every recent PR with "review was skipped due to path filters". The config was an incremental **infrastructure-only** allowlist: the single include was `src/infrastructure/**`, and everything else (domain, database, network, blockchain, node, node-exe, c-api, all tests, all `CMakeLists.txt`) was excluded and matched no include.

## Change

That first incremental pass is done, so graduate to reviewing all first-party source and its tests:

- **Include** the source modules: infrastructure, domain, database, network, blockchain, node, node-exe, c-api.
- Keep **vendored / third-party** code out: `src/consensus/**` (bch-rules synced from BCHN) and `src/secp256k1/**`.
- Keep non-source / generated files out: data, binaries, scripts, conan files, `.github`, generated `*.ipp` / `*.S.in`, docs.
- Tests and `CMakeLists.txt` are **no longer excluded** (the SV2 PRs' round-trip tests are the main deliverable, and reviewing the build lists catches source-list mistakes). If that turns out too noisy, re-adding `!**/test/**` or `!**/CMakeLists.txt` is a one-line change.

Takes effect once merged to the default branch.
