### PR TITLE
node: add the fixed-shape Stratum V2 TDP messages

### DIFF
--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -165,6 +165,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     # Stratum V2 template provider.
     src/sv2/framing.cpp
     src/sv2/primitives.cpp
+    src/sv2/messages.cpp
   )
 endif()
 
@@ -220,6 +221,7 @@ set(kth_headers
   # Stratum V2 template provider.
   include/kth/node/sv2/framing.hpp
   include/kth/node/sv2/primitives.hpp
+  include/kth/node/sv2/messages.hpp
 
   # Optional JSON-RPC server (compiled only when KTH_WITH_RPC is set).
   include/kth/node/rpc/error.hpp
@@ -302,6 +304,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/mining_block_submit.cpp
           test/sv2_framing.cpp
           test/sv2_primitives.cpp
+          test/sv2_messages.cpp
           test/settings.cpp
           test/utility.cpp
           test/utility.hpp)

--- a/src/node/include/kth/node/sv2/messages.hpp
+++ b/src/node/include/kth/node/sv2/messages.hpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_SV2_MESSAGES_HPP
+#define KTH_NODE_SV2_MESSAGES_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include <kth/infrastructure/error.hpp>
+#include <kth/infrastructure/hash_define.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
+#include <kth/infrastructure/utility/data.hpp>
+
+// Stratum V2 Template Distribution Protocol messages (sv2-spec 07). For all of
+// them extension_type is 0 and the channel_msg flag is unset; message_type is
+// the value carried in the frame header. Each follows the from_data / to_data
+// convention so it flows through from_data_chunk / to_data_chunk. This header
+// covers the messages with no sequence fields; NewTemplate and
+// RequestTransactionData.Success (which carry SEQ fields) are added separately.
+
+namespace kth::node::sv2 {
+
+// CoinbaseOutputConstraints (0x70, Client -> Server): the downstream declares
+// how much extra room its coinbase output and sigops need.
+struct coinbase_output_constraints {
+    static constexpr uint8_t message_type = 0x70;
+
+    uint32_t coinbase_output_max_additional_size = 0;
+    uint16_t coinbase_output_max_additional_sigops = 0;
+
+    [[nodiscard]] size_t serialized_size() const { return 4 + 2; }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<coinbase_output_constraints> from_data(byte_reader& source);
+};
+
+// SetNewPrevHash (0x72, Server -> Client): the tip moved; work must build on
+// prev_hash with the given target.
+struct set_new_prev_hash {
+    static constexpr uint8_t message_type = 0x72;
+
+    uint64_t template_id = 0;
+    hash_digest prev_hash{};
+    uint32_t header_timestamp = 0;
+    uint32_t n_bits = 0;
+    hash_digest target{};
+
+    [[nodiscard]] size_t serialized_size() const { return 8 + hash_size + 4 + 4 + hash_size; }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<set_new_prev_hash> from_data(byte_reader& source);
+};
+
+// RequestTransactionData (0x73, Client -> Server): ask for a template's full
+// transaction list.
+struct request_transaction_data {
+    static constexpr uint8_t message_type = 0x73;
+
+    uint64_t template_id = 0;
+
+    [[nodiscard]] size_t serialized_size() const { return 8; }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<request_transaction_data> from_data(byte_reader& source);
+};
+
+// RequestTransactionData.Error (0x75, Server -> Client).
+struct request_transaction_data_error {
+    static constexpr uint8_t message_type = 0x75;
+
+    uint64_t template_id = 0;
+    std::string error_code;   // STR0_255
+
+    [[nodiscard]] size_t serialized_size() const { return 8 + 1 + error_code.size(); }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<request_transaction_data_error> from_data(byte_reader& source);
+};
+
+// SubmitSolution (0x76, Client -> Server): the miner submits the solved header
+// fields and the full coinbase transaction.
+struct submit_solution {
+    static constexpr uint8_t message_type = 0x76;
+
+    uint64_t template_id = 0;
+    uint32_t version = 0;
+    uint32_t header_timestamp = 0;
+    uint32_t header_nonce = 0;
+    data_chunk coinbase_tx;   // B0_64K
+
+    [[nodiscard]] size_t serialized_size() const { return 8 + 4 + 4 + 4 + 2 + coinbase_tx.size(); }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<submit_solution> from_data(byte_reader& source);
+};
+
+} // namespace kth::node::sv2
+
+#endif // KTH_NODE_SV2_MESSAGES_HPP

--- a/src/node/src/sv2/messages.cpp
+++ b/src/node/src/sv2/messages.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/sv2/messages.hpp>
+
+#include <utility>
+
+#include <kth/node/sv2/primitives.hpp>
+
+namespace kth::node::sv2 {
+
+// --- CoinbaseOutputConstraints (0x70) ---------------------------------------
+
+expect<void> coinbase_output_constraints::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_little_endian<uint32_t>(coinbase_output_max_additional_size); ! r) return r;
+    return sink.write_little_endian<uint16_t>(coinbase_output_max_additional_sigops);
+}
+
+expect<coinbase_output_constraints> coinbase_output_constraints::from_data(byte_reader& source) {
+    auto const size = source.read_little_endian<uint32_t>();
+    if ( ! size) return std::unexpected(size.error());
+    auto const sigops = source.read_little_endian<uint16_t>();
+    if ( ! sigops) return std::unexpected(sigops.error());
+    return coinbase_output_constraints{*size, *sigops};
+}
+
+// --- SetNewPrevHash (0x72) --------------------------------------------------
+
+expect<void> set_new_prev_hash::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_little_endian<uint64_t>(template_id); ! r) return r;
+    if (auto r = sink.write_bytes(byte_span{prev_hash}); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(header_timestamp); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(n_bits); ! r) return r;
+    return sink.write_bytes(byte_span{target});
+}
+
+expect<set_new_prev_hash> set_new_prev_hash::from_data(byte_reader& source) {
+    auto const template_id = source.read_little_endian<uint64_t>();
+    if ( ! template_id) return std::unexpected(template_id.error());
+    auto const prev_hash = source.read_array<hash_size>();
+    if ( ! prev_hash) return std::unexpected(prev_hash.error());
+    auto const header_timestamp = source.read_little_endian<uint32_t>();
+    if ( ! header_timestamp) return std::unexpected(header_timestamp.error());
+    auto const n_bits = source.read_little_endian<uint32_t>();
+    if ( ! n_bits) return std::unexpected(n_bits.error());
+    auto const target = source.read_array<hash_size>();
+    if ( ! target) return std::unexpected(target.error());
+    return set_new_prev_hash{*template_id, *prev_hash, *header_timestamp, *n_bits, *target};
+}
+
+// --- RequestTransactionData (0x73) ------------------------------------------
+
+expect<void> request_transaction_data::to_data(byte_writer& sink) const {
+    return sink.write_little_endian<uint64_t>(template_id);
+}
+
+expect<request_transaction_data> request_transaction_data::from_data(byte_reader& source) {
+    auto const template_id = source.read_little_endian<uint64_t>();
+    if ( ! template_id) return std::unexpected(template_id.error());
+    return request_transaction_data{*template_id};
+}
+
+// --- RequestTransactionData.Error (0x75) ------------------------------------
+
+expect<void> request_transaction_data_error::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_little_endian<uint64_t>(template_id); ! r) return r;
+    return write_string_u8(sink, error_code);
+}
+
+expect<request_transaction_data_error> request_transaction_data_error::from_data(byte_reader& source) {
+    auto const template_id = source.read_little_endian<uint64_t>();
+    if ( ! template_id) return std::unexpected(template_id.error());
+    auto error_code = read_string_u8(source);
+    if ( ! error_code) return std::unexpected(error_code.error());
+    return request_transaction_data_error{*template_id, std::move(*error_code)};
+}
+
+// --- SubmitSolution (0x76) --------------------------------------------------
+
+expect<void> submit_solution::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_little_endian<uint64_t>(template_id); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(version); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(header_timestamp); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(header_nonce); ! r) return r;
+    return write_bytes_u16(sink, byte_span{coinbase_tx});
+}
+
+expect<submit_solution> submit_solution::from_data(byte_reader& source) {
+    auto const template_id = source.read_little_endian<uint64_t>();
+    if ( ! template_id) return std::unexpected(template_id.error());
+    auto const version = source.read_little_endian<uint32_t>();
+    if ( ! version) return std::unexpected(version.error());
+    auto const header_timestamp = source.read_little_endian<uint32_t>();
+    if ( ! header_timestamp) return std::unexpected(header_timestamp.error());
+    auto const header_nonce = source.read_little_endian<uint32_t>();
+    if ( ! header_nonce) return std::unexpected(header_nonce.error());
+    auto const coinbase_tx = read_bytes_u16(source);
+    if ( ! coinbase_tx) return std::unexpected(coinbase_tx.error());
+    return submit_solution{*template_id, *version, *header_timestamp, *header_nonce,
+        data_chunk(coinbase_tx->begin(), coinbase_tx->end())};
+}
+
+} // namespace kth::node::sv2

--- a/src/node/test/sv2_messages.cpp
+++ b/src/node/test/sv2_messages.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <cstdint>
+#include <string>
+
+#include <kth/infrastructure.hpp>
+#include <kth/node/sv2/messages.hpp>
+
+using namespace kth;
+using namespace kth::node::sv2;
+
+namespace {
+
+// A 32-byte value with distinct, position-dependent bytes.
+hash_digest seq_hash(uint8_t start) {
+    hash_digest h{};
+    for (size_t i = 0; i < h.size(); ++i) {
+        h[i] = static_cast<uint8_t>(start + i);
+    }
+    return h;
+}
+
+} // namespace
+
+// Start Test Suite: sv2 messages tests
+
+TEST_CASE("sv2 CoinbaseOutputConstraints round-trips and matches the wire layout", "[sv2 messages]") {
+    coinbase_output_constraints const msg{/*size*/ 0x01020304u, /*sigops*/ 0x0506u};
+
+    auto const bytes = to_data_chunk(msg);
+    REQUIRE(bytes == data_chunk{0x04, 0x03, 0x02, 0x01, 0x06, 0x05});  // U32 LE, U16 LE
+
+    auto const parsed = from_data_chunk<coinbase_output_constraints>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->coinbase_output_max_additional_size == msg.coinbase_output_max_additional_size);
+    REQUIRE(parsed->coinbase_output_max_additional_sigops == msg.coinbase_output_max_additional_sigops);
+    REQUIRE(coinbase_output_constraints::message_type == 0x70);
+}
+
+TEST_CASE("sv2 SetNewPrevHash round-trips", "[sv2 messages]") {
+    set_new_prev_hash const msg{
+        /*template_id*/ 0x1122334455667788ull,
+        /*prev_hash*/ seq_hash(0x01),
+        /*header_timestamp*/ 0xAABBCCDDu,
+        /*n_bits*/ 0x1d00ffffu,
+        /*target*/ seq_hash(0x80)};
+
+    auto const bytes = to_data_chunk(msg);
+    REQUIRE(bytes.size() == msg.serialized_size());
+    REQUIRE(bytes.size() == 80u);
+
+    auto const parsed = from_data_chunk<set_new_prev_hash>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->template_id == msg.template_id);
+    REQUIRE(parsed->prev_hash == msg.prev_hash);
+    REQUIRE(parsed->header_timestamp == msg.header_timestamp);
+    REQUIRE(parsed->n_bits == msg.n_bits);
+    REQUIRE(parsed->target == msg.target);
+    REQUIRE(set_new_prev_hash::message_type == 0x72);
+}
+
+TEST_CASE("sv2 RequestTransactionData round-trips", "[sv2 messages]") {
+    request_transaction_data const msg{0xdeadbeefcafef00dull};
+
+    auto const bytes = to_data_chunk(msg);
+    REQUIRE(bytes.size() == 8u);
+
+    auto const parsed = from_data_chunk<request_transaction_data>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->template_id == msg.template_id);
+    REQUIRE(request_transaction_data::message_type == 0x73);
+}
+
+TEST_CASE("sv2 RequestTransactionData.Error round-trips its id and reason", "[sv2 messages]") {
+    request_transaction_data_error const msg{42u, "template not found"};
+
+    auto const bytes = to_data_chunk(msg);
+    auto const parsed = from_data_chunk<request_transaction_data_error>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->template_id == msg.template_id);
+    REQUIRE(parsed->error_code == msg.error_code);
+    REQUIRE(request_transaction_data_error::message_type == 0x75);
+}
+
+TEST_CASE("sv2 SubmitSolution round-trips its header fields and coinbase", "[sv2 messages]") {
+    submit_solution const msg{
+        /*template_id*/ 7u,
+        /*version*/ 0x20000000u,
+        /*header_timestamp*/ 1234u,
+        /*header_nonce*/ 0x89abcdefu,
+        /*coinbase_tx*/ data_chunk{0x01, 0x02, 0x03, 0x04, 0x05}};
+
+    auto const bytes = to_data_chunk(msg);
+    auto const parsed = from_data_chunk<submit_solution>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->template_id == msg.template_id);
+    REQUIRE(parsed->version == msg.version);
+    REQUIRE(parsed->header_timestamp == msg.header_timestamp);
+    REQUIRE(parsed->header_nonce == msg.header_nonce);
+    REQUIRE(parsed->coinbase_tx == msg.coinbase_tx);
+    REQUIRE(submit_solution::message_type == 0x76);
+}
+
+TEST_CASE("sv2 message from_data rejects a truncated buffer", "[sv2 messages]") {
+    data_chunk const short_buffer{0x04, 0x03, 0x02};  // needs 6 for the constraints
+    auto const parsed = from_data_chunk<coinbase_output_constraints>(short_buffer);
+    REQUIRE_FALSE(parsed.has_value());
+}


### PR DESCRIPTION
## What

The Stratum V2 Template Distribution Protocol messages that carry no sequence fields, built on the framing (#534) and primitives (#535):

| Message | msg_type | Fields |
|---|---|---|
| CoinbaseOutputConstraints | 0x70 | U32, U16 |
| SetNewPrevHash | 0x72 | U64, U256, U32, U32, U256 |
| RequestTransactionData | 0x73 | U64 |
| RequestTransactionData.Error | 0x75 | U64, STR0_255 |
| SubmitSolution | 0x76 | U64, U32, U32, U32, B0_64K |

## Change

Each message is a struct exposing its `message_type` and a `from_data` / `to_data` pair, so it serializes through `from_data_chunk` / `to_data_chunk` like the other wire types. Field types and order follow sv2-spec 07 (U256 for `prev_hash` / `target`, STR0_255 for the error reason, B0_64K for the submitted coinbase).

`NewTemplate` (0x71) and `RequestTransactionData.Success` (0x74) carry SEQ fields and are added separately once the SEQ helpers land.

## Tests

`[sv2 messages]`, 6 cases / 30 assertions: per-message round-trips, the CoinbaseOutputConstraints wire layout, the `message_type` constants, and truncated-buffer rejection. Full node suite green (87 cases).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Stratum V2 distribution protocol messages, including transaction requests, solution submissions, previous-block updates, and coinbase constraints.
  * Added reliable serialization and deserialization for these messages, including validation of incomplete or invalid data.

* **Tests**
  * Added coverage for message encoding, decoding, field preservation, message types, and truncated input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->