### PR TITLE
infrastructure: make to_data_chunk fail loud on a serialization error

### DIFF
--- a/src/infrastructure/include/kth/infrastructure/utility/byte_writer.hpp
+++ b/src/infrastructure/include/kth/infrastructure/utility/byte_writer.hpp
@@ -15,6 +15,7 @@
 #include <kth/infrastructure/constants.hpp>
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/math/hash.hpp>
+#include <kth/infrastructure/utility/assert.hpp>
 #include <kth/infrastructure/utility/data.hpp>
 #include <kth/infrastructure/utility/endian.hpp>
 
@@ -226,7 +227,11 @@ data_chunk to_data_chunk(T const& obj, Args... args) {
     data_chunk buf(obj.serialized_size(args...));
     byte_writer writer(buf);
     auto const r = obj.to_data(writer, args...);
-    KTH_ASSERT(r.has_value());
+    // A failed write means the buffer was mis-sized (serialized_size disagrees
+    // with to_data) or a field is out of range; either way the returned buffer
+    // would be malformed. Abort loudly in Release rather than emit it, since
+    // this data goes on the wire / to disk. KTH_ASSERT alone is a Release no-op.
+    KTH_CONTRACT(r.has_value());
     return buf;
 }
 


### PR DESCRIPTION
## What

`to_data_chunk` sizes a buffer to `serialized_size()`, writes `to_data()` into it, and guarded the result with `KTH_ASSERT` — a **no-op in Release**. So a `to_data` failure (a `serialized_size` that disagrees with `to_data`, or a field outside its wire range) was swallowed in Release, and a malformed buffer was returned and then sent on the wire or written to disk.

## Change

Use `KTH_CONTRACT` instead of `KTH_ASSERT`. It stays live in Release and aborts on a failed serialization, which is exactly what that macro is documented for ("contract checks whose violation would corrupt observable output ... instead of silently letting a broken hash / signature / block reach the network"). It is already used on serialization write paths in `script.cpp`, `transaction.cpp`, `output.cpp`, etc.

Correct code never trips it: `serialized_size` is meant to match `to_data`, and fields are meant to be within range. A trip means a real bug, and aborting beats emitting corruption.

## Context

Surfaced by a CodeRabbit review on #537: an oversized variable-length field (e.g. an over-255-byte `STR0_255`) is correctly rejected by the primitive writers at runtime, but `to_data_chunk` discarded that error in Release. This fixes it at the root for every `Serializable` type.

## Tests

All suites pass unchanged (infrastructure, domain, blockchain, network, node), so no current serialization path relied on the swallowed error.
