### PR TITLE
node: add the sequence-bearing Stratum V2 TDP messages

### DIFF
--- a/src/node/include/kth/node/sv2/messages.hpp
+++ b/src/node/include/kth/node/sv2/messages.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include <kth/infrastructure/error.hpp>
 #include <kth/infrastructure/hash_define.hpp>
@@ -91,6 +92,56 @@ struct submit_solution {
     [[nodiscard]] size_t serialized_size() const { return 8 + 4 + 4 + 4 + 2 + coinbase_tx.size(); }
     [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
     [[nodiscard]] static expect<submit_solution> from_data(byte_reader& source);
+};
+
+// NewTemplate (0x71, Server -> Client): a new block template. The client builds
+// the coinbase around coinbase_prefix / coinbase_tx_outputs and pairs it with
+// merkle_path to compute the block's merkle root.
+struct new_template {
+    static constexpr uint8_t message_type = 0x71;
+
+    uint64_t template_id = 0;
+    bool future_template = false;              // BOOL
+    uint32_t version = 0;
+    uint32_t coinbase_tx_version = 0;
+    data_chunk coinbase_prefix;                // B0_255
+    uint32_t coinbase_tx_input_sequence = 0;
+    uint64_t coinbase_tx_value_remaining = 0;
+    uint32_t coinbase_tx_outputs_count = 0;
+    data_chunk coinbase_tx_outputs;            // B0_64K
+    uint32_t coinbase_tx_locktime = 0;
+    std::vector<hash_digest> merkle_path;      // SEQ0_255[U256]
+
+    [[nodiscard]] size_t serialized_size() const {
+        return 8 + 1 + 4 + 4
+            + (1 + coinbase_prefix.size())
+            + 4 + 8 + 4
+            + (2 + coinbase_tx_outputs.size())
+            + 4
+            + (1 + merkle_path.size() * hash_size);
+    }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<new_template> from_data(byte_reader& source);
+};
+
+// RequestTransactionData.Success (0x74, Server -> Client): the full transaction
+// list behind a template, plus any excess (segwit-style) data.
+struct request_transaction_data_success {
+    static constexpr uint8_t message_type = 0x74;
+
+    uint64_t template_id = 0;
+    data_chunk excess_data;                    // B0_64K
+    std::vector<data_chunk> transaction_list;  // SEQ0_64K[B0_16M]
+
+    [[nodiscard]] size_t serialized_size() const {
+        size_t size = 8 + (2 + excess_data.size()) + 2;
+        for (auto const& tx : transaction_list) {
+            size += 3 + tx.size();
+        }
+        return size;
+    }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<request_transaction_data_success> from_data(byte_reader& source);
 };
 
 } // namespace kth::node::sv2

--- a/src/node/include/kth/node/sv2/primitives.hpp
+++ b/src/node/include/kth/node/sv2/primitives.hpp
@@ -8,8 +8,10 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <kth/infrastructure/error.hpp>
+#include <kth/infrastructure/hash_define.hpp>
 #include <kth/infrastructure/utility/byte_reader.hpp>
 #include <kth/infrastructure/utility/byte_writer.hpp>
 #include <kth/infrastructure/utility/data.hpp>
@@ -40,6 +42,17 @@ constexpr size_t b0_16m_max = 0xffffffu;
 // interior and trailing NUL bytes are preserved (SV2 strings are not NUL-padded).
 [[nodiscard]] expect<void> write_string_u8(byte_writer& sink, std::string_view value);
 [[nodiscard]] expect<std::string> read_string_u8(byte_reader& source);
+
+// Sequences: a little-endian count followed by that many elements. write_* fail
+// when the element count overflows the count prefix.
+//
+// SEQ0_255[U256]: a U8 count of 32-byte values (e.g. a merkle path).
+[[nodiscard]] expect<void> write_hash_seq_u8(byte_writer& sink, std::vector<hash_digest> const& items);
+[[nodiscard]] expect<std::vector<hash_digest>> read_hash_seq_u8(byte_reader& source);
+
+// SEQ0_64K[B0_16M]: a U16 count of B0_16M byte blobs (e.g. a transaction list).
+[[nodiscard]] expect<void> write_bytes_seq_u16(byte_writer& sink, std::vector<data_chunk> const& items);
+[[nodiscard]] expect<std::vector<data_chunk>> read_bytes_seq_u16(byte_reader& source);
 
 } // namespace kth::node::sv2
 

--- a/src/node/src/sv2/messages.cpp
+++ b/src/node/src/sv2/messages.cpp
@@ -101,4 +101,72 @@ expect<submit_solution> submit_solution::from_data(byte_reader& source) {
         data_chunk(coinbase_tx->begin(), coinbase_tx->end())};
 }
 
+// --- NewTemplate (0x71) -----------------------------------------------------
+
+expect<void> new_template::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_little_endian<uint64_t>(template_id); ! r) return r;
+    if (auto r = sink.write_byte(future_template ? 1 : 0); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(version); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(coinbase_tx_version); ! r) return r;
+    if (auto r = write_bytes_u8(sink, byte_span{coinbase_prefix}); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(coinbase_tx_input_sequence); ! r) return r;
+    if (auto r = sink.write_little_endian<uint64_t>(coinbase_tx_value_remaining); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(coinbase_tx_outputs_count); ! r) return r;
+    if (auto r = write_bytes_u16(sink, byte_span{coinbase_tx_outputs}); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(coinbase_tx_locktime); ! r) return r;
+    return write_hash_seq_u8(sink, merkle_path);
+}
+
+expect<new_template> new_template::from_data(byte_reader& source) {
+    auto const template_id = source.read_little_endian<uint64_t>();
+    if ( ! template_id) return std::unexpected(template_id.error());
+    auto const future_template = source.read_byte();
+    if ( ! future_template) return std::unexpected(future_template.error());
+    auto const version = source.read_little_endian<uint32_t>();
+    if ( ! version) return std::unexpected(version.error());
+    auto const coinbase_tx_version = source.read_little_endian<uint32_t>();
+    if ( ! coinbase_tx_version) return std::unexpected(coinbase_tx_version.error());
+    auto const coinbase_prefix = read_bytes_u8(source);
+    if ( ! coinbase_prefix) return std::unexpected(coinbase_prefix.error());
+    auto const coinbase_tx_input_sequence = source.read_little_endian<uint32_t>();
+    if ( ! coinbase_tx_input_sequence) return std::unexpected(coinbase_tx_input_sequence.error());
+    auto const coinbase_tx_value_remaining = source.read_little_endian<uint64_t>();
+    if ( ! coinbase_tx_value_remaining) return std::unexpected(coinbase_tx_value_remaining.error());
+    auto const coinbase_tx_outputs_count = source.read_little_endian<uint32_t>();
+    if ( ! coinbase_tx_outputs_count) return std::unexpected(coinbase_tx_outputs_count.error());
+    auto const coinbase_tx_outputs = read_bytes_u16(source);
+    if ( ! coinbase_tx_outputs) return std::unexpected(coinbase_tx_outputs.error());
+    auto const coinbase_tx_locktime = source.read_little_endian<uint32_t>();
+    if ( ! coinbase_tx_locktime) return std::unexpected(coinbase_tx_locktime.error());
+    auto merkle_path = read_hash_seq_u8(source);
+    if ( ! merkle_path) return std::unexpected(merkle_path.error());
+    return new_template{
+        *template_id, *future_template != 0, *version, *coinbase_tx_version,
+        data_chunk(coinbase_prefix->begin(), coinbase_prefix->end()),
+        *coinbase_tx_input_sequence, *coinbase_tx_value_remaining, *coinbase_tx_outputs_count,
+        data_chunk(coinbase_tx_outputs->begin(), coinbase_tx_outputs->end()),
+        *coinbase_tx_locktime, std::move(*merkle_path)};
+}
+
+// --- RequestTransactionData.Success (0x74) ----------------------------------
+
+expect<void> request_transaction_data_success::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_little_endian<uint64_t>(template_id); ! r) return r;
+    if (auto r = write_bytes_u16(sink, byte_span{excess_data}); ! r) return r;
+    return write_bytes_seq_u16(sink, transaction_list);
+}
+
+expect<request_transaction_data_success> request_transaction_data_success::from_data(byte_reader& source) {
+    auto const template_id = source.read_little_endian<uint64_t>();
+    if ( ! template_id) return std::unexpected(template_id.error());
+    auto const excess_data = read_bytes_u16(source);
+    if ( ! excess_data) return std::unexpected(excess_data.error());
+    auto transaction_list = read_bytes_seq_u16(source);
+    if ( ! transaction_list) return std::unexpected(transaction_list.error());
+    return request_transaction_data_success{
+        *template_id,
+        data_chunk(excess_data->begin(), excess_data->end()),
+        std::move(*transaction_list)};
+}
+
 } // namespace kth::node::sv2

--- a/src/node/src/sv2/primitives.cpp
+++ b/src/node/src/sv2/primitives.cpp
@@ -61,4 +61,52 @@ expect<std::string> read_string_u8(byte_reader& source) {
     return std::string(bytes->begin(), bytes->end());
 }
 
+expect<void> write_hash_seq_u8(byte_writer& sink, std::vector<hash_digest> const& items) {
+    if (items.size() > b0_255_max) {
+        return std::unexpected(error::operation_failed);
+    }
+    if (auto r = sink.write_byte(static_cast<uint8_t>(items.size())); ! r) return r;
+    for (auto const& hash : items) {
+        if (auto r = sink.write_bytes(byte_span{hash}); ! r) return r;
+    }
+    return {};
+}
+
+expect<std::vector<hash_digest>> read_hash_seq_u8(byte_reader& source) {
+    auto const count = source.read_byte();
+    if ( ! count) return std::unexpected(count.error());
+    std::vector<hash_digest> items;
+    items.reserve(*count);
+    for (uint8_t i = 0; i < *count; ++i) {
+        auto const hash = source.read_array<hash_size>();
+        if ( ! hash) return std::unexpected(hash.error());
+        items.push_back(*hash);
+    }
+    return items;
+}
+
+expect<void> write_bytes_seq_u16(byte_writer& sink, std::vector<data_chunk> const& items) {
+    if (items.size() > b0_64k_max) {
+        return std::unexpected(error::operation_failed);
+    }
+    if (auto r = sink.write_little_endian<uint16_t>(static_cast<uint16_t>(items.size())); ! r) return r;
+    for (auto const& item : items) {
+        if (auto r = write_bytes_u24(sink, byte_span{item}); ! r) return r;
+    }
+    return {};
+}
+
+expect<std::vector<data_chunk>> read_bytes_seq_u16(byte_reader& source) {
+    auto const count = source.read_little_endian<uint16_t>();
+    if ( ! count) return std::unexpected(count.error());
+    std::vector<data_chunk> items;
+    items.reserve(*count);
+    for (uint16_t i = 0; i < *count; ++i) {
+        auto const bytes = read_bytes_u24(source);
+        if ( ! bytes) return std::unexpected(bytes.error());
+        items.emplace_back(bytes->begin(), bytes->end());
+    }
+    return items;
+}
+
 } // namespace kth::node::sv2

--- a/src/node/test/sv2_messages.cpp
+++ b/src/node/test/sv2_messages.cpp
@@ -110,3 +110,53 @@ TEST_CASE("sv2 message from_data rejects a truncated buffer", "[sv2 messages]") 
     auto const parsed = from_data_chunk<coinbase_output_constraints>(short_buffer);
     REQUIRE_FALSE(parsed.has_value());
 }
+
+TEST_CASE("sv2 NewTemplate round-trips all its fields", "[sv2 messages]") {
+    new_template const msg{
+        /*template_id*/ 0x0102030405060708ull,
+        /*future_template*/ true,
+        /*version*/ 0x20000000u,
+        /*coinbase_tx_version*/ 2u,
+        /*coinbase_prefix*/ data_chunk{0x03, 0x51, 0x52, 0x53},
+        /*coinbase_tx_input_sequence*/ 0xffffffffu,
+        /*coinbase_tx_value_remaining*/ 5000000000ull,
+        /*coinbase_tx_outputs_count*/ 1u,
+        /*coinbase_tx_outputs*/ data_chunk{0xAA, 0xBB, 0xCC, 0xDD},
+        /*coinbase_tx_locktime*/ 0u,
+        /*merkle_path*/ std::vector<hash_digest>{seq_hash(0x10), seq_hash(0x20)}};
+
+    auto const bytes = to_data_chunk(msg);
+    REQUIRE(bytes.size() == msg.serialized_size());
+
+    auto const parsed = from_data_chunk<new_template>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->template_id == msg.template_id);
+    REQUIRE(parsed->future_template == msg.future_template);
+    REQUIRE(parsed->version == msg.version);
+    REQUIRE(parsed->coinbase_tx_version == msg.coinbase_tx_version);
+    REQUIRE(parsed->coinbase_prefix == msg.coinbase_prefix);
+    REQUIRE(parsed->coinbase_tx_input_sequence == msg.coinbase_tx_input_sequence);
+    REQUIRE(parsed->coinbase_tx_value_remaining == msg.coinbase_tx_value_remaining);
+    REQUIRE(parsed->coinbase_tx_outputs_count == msg.coinbase_tx_outputs_count);
+    REQUIRE(parsed->coinbase_tx_outputs == msg.coinbase_tx_outputs);
+    REQUIRE(parsed->coinbase_tx_locktime == msg.coinbase_tx_locktime);
+    REQUIRE(parsed->merkle_path == msg.merkle_path);
+    REQUIRE(new_template::message_type == 0x71);
+}
+
+TEST_CASE("sv2 RequestTransactionData.Success round-trips its excess data and tx list", "[sv2 messages]") {
+    request_transaction_data_success const msg{
+        /*template_id*/ 99u,
+        /*excess_data*/ data_chunk{0x01, 0x02, 0x03},
+        /*transaction_list*/ std::vector<data_chunk>{{0xDE, 0xAD}, {}, {0xBE, 0xEF, 0x00, 0x11}}};
+
+    auto const bytes = to_data_chunk(msg);
+    REQUIRE(bytes.size() == msg.serialized_size());
+
+    auto const parsed = from_data_chunk<request_transaction_data_success>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->template_id == msg.template_id);
+    REQUIRE(parsed->excess_data == msg.excess_data);
+    REQUIRE(parsed->transaction_list == msg.transaction_list);
+    REQUIRE(request_transaction_data_success::message_type == 0x74);
+}

--- a/src/node/test/sv2_primitives.cpp
+++ b/src/node/test/sv2_primitives.cpp
@@ -13,6 +13,19 @@
 using namespace kth;
 using namespace kth::node::sv2;
 
+namespace {
+
+// A 32-byte value with distinct, position-dependent bytes.
+hash_digest seq_hash(uint8_t start) {
+    hash_digest h{};
+    for (size_t i = 0; i < h.size(); ++i) {
+        h[i] = static_cast<uint8_t>(start + i);
+    }
+    return h;
+}
+
+} // namespace
+
 // Start Test Suite: sv2 primitives tests
 
 TEST_CASE("sv2 B0_255 round-trips a payload behind a U8 length", "[sv2 primitives]") {
@@ -102,4 +115,50 @@ TEST_CASE("sv2 STR0_255 round-trips and preserves embedded NUL bytes", "[sv2 pri
     REQUIRE(got.has_value());
     REQUIRE(got->size() == 5);
     REQUIRE(*got == text);
+}
+
+TEST_CASE("sv2 SEQ0_255[U256] round-trips behind a U8 count", "[sv2 primitives]") {
+    std::vector<hash_digest> const items{seq_hash(1), seq_hash(0x40), seq_hash(0x80)};
+
+    data_chunk buf(1 + items.size() * 32);
+    byte_writer sink(buf);
+    REQUIRE(write_hash_seq_u8(sink, items).has_value());
+    REQUIRE(buf.front() == 0x03);          // U8 count
+
+    byte_reader source(buf);
+    auto const got = read_hash_seq_u8(source);
+    REQUIRE(got.has_value());
+    REQUIRE(*got == items);
+    REQUIRE(source.is_exhausted());
+}
+
+TEST_CASE("sv2 SEQ0_255[U256] handles an empty sequence", "[sv2 primitives]") {
+    data_chunk buf(1);
+    byte_writer sink(buf);
+    REQUIRE(write_hash_seq_u8(sink, {}).has_value());
+    REQUIRE(buf == data_chunk{0x00});
+
+    byte_reader source(buf);
+    auto const got = read_hash_seq_u8(source);
+    REQUIRE(got.has_value());
+    REQUIRE(got->empty());
+}
+
+TEST_CASE("sv2 SEQ0_64K[B0_16M] round-trips variable-size elements behind a U16 count", "[sv2 primitives]") {
+    std::vector<data_chunk> const items{{0x01, 0x02}, {}, {0xAA, 0xBB, 0xCC}};
+
+    size_t size = 2;                       // U16 count
+    for (auto const& item : items) size += 3 + item.size();  // U24 prefix each
+
+    data_chunk buf(size);
+    byte_writer sink(buf);
+    REQUIRE(write_bytes_seq_u16(sink, items).has_value());
+    REQUIRE(buf[0] == 0x03);               // count, little-endian
+    REQUIRE(buf[1] == 0x00);
+
+    byte_reader source(buf);
+    auto const got = read_bytes_seq_u16(source);
+    REQUIRE(got.has_value());
+    REQUIRE(*got == items);
+    REQUIRE(source.is_exhausted());
 }


### PR DESCRIPTION
## What

Completes the SV2 Template Distribution Protocol message layer with the two messages that carry SEQ fields, plus the sequence primitives they need.

**Sequence primitives**
- `SEQ0_255[U256]`: a U8 count of 32-byte values (`write_hash_seq_u8` / `read_hash_seq_u8`).
- `SEQ0_64K[B0_16M]`: a U16 count of B0_16M byte blobs (`write_bytes_seq_u16` / `read_bytes_seq_u16`).

**Messages**
| Message | msg_type | Notable fields |
|---|---|---|
| NewTemplate | 0x71 | coinbase prefix (B0_255), serialized outputs (B0_64K), merkle path (SEQ0_255[U256]) |
| RequestTransactionData.Success | 0x74 | excess data (B0_64K), transaction list (SEQ0_64K[B0_16M]) |

Both follow the `from_data` / `to_data` convention. Field types and order follow sv2-spec 07 (note `coinbase_tx_outputs` is `B0_64K`, not `B0_16M`).

With this, all seven TDP messages are implemented (#537 covered the fixed-shape ones).

## Tests

`[sv2 primitives]` and `[sv2 messages]`: sequence round-trips (empty and variable-size elements, little-endian counts), full-message round-trips, and the `message_type` constants. `serialized_size` is exercised by `to_data_chunk`, which now aborts on a size mismatch (#538), so the round-trips also pin it. Full node suite green (92 cases).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SV2 `NewTemplate` and `RequestTransactionData.Success` messages.
  * Added encoding and decoding for hash sequences and variable-length transaction data lists.
  * Added validation for sequence size limits during serialization.

* **Tests**
  * Added coverage for message round trips, empty sequences, multiple transactions, and variable-sized data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->