### PR TITLE
node: add the Stratum V2 connection-setup messages

### DIFF
--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -166,6 +166,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     src/sv2/framing.cpp
     src/sv2/primitives.cpp
     src/sv2/messages.cpp
+    src/sv2/connection.cpp
   )
 endif()
 
@@ -222,6 +223,7 @@ set(kth_headers
   include/kth/node/sv2/framing.hpp
   include/kth/node/sv2/primitives.hpp
   include/kth/node/sv2/messages.hpp
+  include/kth/node/sv2/connection.hpp
 
   # Optional JSON-RPC server (compiled only when KTH_WITH_RPC is set).
   include/kth/node/rpc/error.hpp
@@ -305,6 +307,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/sv2_framing.cpp
           test/sv2_primitives.cpp
           test/sv2_messages.cpp
+          test/sv2_connection.cpp
           test/settings.cpp
           test/utility.cpp
           test/utility.hpp)

--- a/src/node/include/kth/node/sv2/connection.hpp
+++ b/src/node/include/kth/node/sv2/connection.hpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_SV2_CONNECTION_HPP
+#define KTH_NODE_SV2_CONNECTION_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include <kth/infrastructure/error.hpp>
+#include <kth/infrastructure/utility/byte_reader.hpp>
+#include <kth/infrastructure/utility/byte_writer.hpp>
+
+// Stratum V2 common connection-setup messages (sv2-spec 03). Every SV2
+// sub-protocol opens with these before its own messages; the Template
+// Distribution provider negotiates one with protocol == template_distribution.
+// channel_msg is unset and extension_type is 0 for all three.
+
+namespace kth::node::sv2 {
+
+// SetupConnection (0x00, Client -> Server): open a connection for one
+// sub-protocol and negotiate the version range and feature flags.
+struct setup_connection {
+    static constexpr uint8_t message_type = 0x00;
+
+    // protocol field values.
+    static constexpr uint8_t protocol_mining = 0;
+    static constexpr uint8_t protocol_job_declaration = 1;
+    static constexpr uint8_t protocol_template_distribution = 2;
+
+    uint8_t protocol = 0;
+    uint16_t min_version = 0;
+    uint16_t max_version = 0;
+    uint32_t flags = 0;
+    std::string endpoint_host;      // STR0_255
+    uint16_t endpoint_port = 0;
+    std::string vendor;             // STR0_255
+    std::string hardware_version;   // STR0_255
+    std::string firmware;           // STR0_255
+    std::string device_id;          // STR0_255
+
+    [[nodiscard]] size_t serialized_size() const {
+        return 1 + 2 + 2 + 4
+            + (1 + endpoint_host.size())
+            + 2
+            + (1 + vendor.size())
+            + (1 + hardware_version.size())
+            + (1 + firmware.size())
+            + (1 + device_id.size());
+    }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<setup_connection> from_data(byte_reader& source);
+};
+
+// SetupConnection.Success (0x01, Server -> Client): the negotiated version and
+// the flags the server accepted.
+struct setup_connection_success {
+    static constexpr uint8_t message_type = 0x01;
+
+    uint16_t used_version = 0;
+    uint32_t flags = 0;
+
+    [[nodiscard]] size_t serialized_size() const { return 2 + 4; }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<setup_connection_success> from_data(byte_reader& source);
+};
+
+// SetupConnection.Error (0x02, Server -> Client): version negotiation or a
+// required feature failed.
+struct setup_connection_error {
+    static constexpr uint8_t message_type = 0x02;
+
+    uint32_t flags = 0;
+    std::string error_code;         // STR0_255
+
+    [[nodiscard]] size_t serialized_size() const { return 4 + 1 + error_code.size(); }
+    [[nodiscard]] expect<void> to_data(byte_writer& sink) const;
+    [[nodiscard]] static expect<setup_connection_error> from_data(byte_reader& source);
+};
+
+} // namespace kth::node::sv2
+
+#endif // KTH_NODE_SV2_CONNECTION_HPP

--- a/src/node/src/sv2/connection.cpp
+++ b/src/node/src/sv2/connection.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/sv2/connection.hpp>
+
+#include <utility>
+
+#include <kth/node/sv2/primitives.hpp>
+
+namespace kth::node::sv2 {
+
+// --- SetupConnection (0x00) -------------------------------------------------
+
+expect<void> setup_connection::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_byte(protocol); ! r) return r;
+    if (auto r = sink.write_little_endian<uint16_t>(min_version); ! r) return r;
+    if (auto r = sink.write_little_endian<uint16_t>(max_version); ! r) return r;
+    if (auto r = sink.write_little_endian<uint32_t>(flags); ! r) return r;
+    if (auto r = write_string_u8(sink, endpoint_host); ! r) return r;
+    if (auto r = sink.write_little_endian<uint16_t>(endpoint_port); ! r) return r;
+    if (auto r = write_string_u8(sink, vendor); ! r) return r;
+    if (auto r = write_string_u8(sink, hardware_version); ! r) return r;
+    if (auto r = write_string_u8(sink, firmware); ! r) return r;
+    return write_string_u8(sink, device_id);
+}
+
+expect<setup_connection> setup_connection::from_data(byte_reader& source) {
+    auto const protocol = source.read_byte();
+    if ( ! protocol) return std::unexpected(protocol.error());
+    auto const min_version = source.read_little_endian<uint16_t>();
+    if ( ! min_version) return std::unexpected(min_version.error());
+    auto const max_version = source.read_little_endian<uint16_t>();
+    if ( ! max_version) return std::unexpected(max_version.error());
+    auto const flags = source.read_little_endian<uint32_t>();
+    if ( ! flags) return std::unexpected(flags.error());
+    auto endpoint_host = read_string_u8(source);
+    if ( ! endpoint_host) return std::unexpected(endpoint_host.error());
+    auto const endpoint_port = source.read_little_endian<uint16_t>();
+    if ( ! endpoint_port) return std::unexpected(endpoint_port.error());
+    auto vendor = read_string_u8(source);
+    if ( ! vendor) return std::unexpected(vendor.error());
+    auto hardware_version = read_string_u8(source);
+    if ( ! hardware_version) return std::unexpected(hardware_version.error());
+    auto firmware = read_string_u8(source);
+    if ( ! firmware) return std::unexpected(firmware.error());
+    auto device_id = read_string_u8(source);
+    if ( ! device_id) return std::unexpected(device_id.error());
+    return setup_connection{
+        *protocol, *min_version, *max_version, *flags,
+        std::move(*endpoint_host), *endpoint_port,
+        std::move(*vendor), std::move(*hardware_version),
+        std::move(*firmware), std::move(*device_id)};
+}
+
+// --- SetupConnection.Success (0x01) -----------------------------------------
+
+expect<void> setup_connection_success::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_little_endian<uint16_t>(used_version); ! r) return r;
+    return sink.write_little_endian<uint32_t>(flags);
+}
+
+expect<setup_connection_success> setup_connection_success::from_data(byte_reader& source) {
+    auto const used_version = source.read_little_endian<uint16_t>();
+    if ( ! used_version) return std::unexpected(used_version.error());
+    auto const flags = source.read_little_endian<uint32_t>();
+    if ( ! flags) return std::unexpected(flags.error());
+    return setup_connection_success{*used_version, *flags};
+}
+
+// --- SetupConnection.Error (0x02) -------------------------------------------
+
+expect<void> setup_connection_error::to_data(byte_writer& sink) const {
+    if (auto r = sink.write_little_endian<uint32_t>(flags); ! r) return r;
+    return write_string_u8(sink, error_code);
+}
+
+expect<setup_connection_error> setup_connection_error::from_data(byte_reader& source) {
+    auto const flags = source.read_little_endian<uint32_t>();
+    if ( ! flags) return std::unexpected(flags.error());
+    auto error_code = read_string_u8(source);
+    if ( ! error_code) return std::unexpected(error_code.error());
+    return setup_connection_error{*flags, std::move(*error_code)};
+}
+
+} // namespace kth::node::sv2

--- a/src/node/test/sv2_connection.cpp
+++ b/src/node/test/sv2_connection.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <cstdint>
+#include <string>
+
+#include <kth/infrastructure.hpp>
+#include <kth/node/sv2/connection.hpp>
+
+using namespace kth;
+using namespace kth::node::sv2;
+
+// Start Test Suite: sv2 connection tests
+
+TEST_CASE("sv2 SetupConnection round-trips all its fields", "[sv2 connection]") {
+    setup_connection const msg{
+        /*protocol*/ setup_connection::protocol_template_distribution,
+        /*min_version*/ 2u,
+        /*max_version*/ 2u,
+        /*flags*/ 0x00000001u,
+        /*endpoint_host*/ "0.0.0.0",
+        /*endpoint_port*/ 3336u,
+        /*vendor*/ "knuth",
+        /*hardware_version*/ "",
+        /*firmware*/ "kth-1.3",
+        /*device_id*/ "tp-01"};
+
+    auto const bytes = to_data_chunk(msg);
+    REQUIRE(bytes.size() == msg.serialized_size());
+
+    auto const parsed = from_data_chunk<setup_connection>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->protocol == msg.protocol);
+    REQUIRE(parsed->min_version == msg.min_version);
+    REQUIRE(parsed->max_version == msg.max_version);
+    REQUIRE(parsed->flags == msg.flags);
+    REQUIRE(parsed->endpoint_host == msg.endpoint_host);
+    REQUIRE(parsed->endpoint_port == msg.endpoint_port);
+    REQUIRE(parsed->vendor == msg.vendor);
+    REQUIRE(parsed->hardware_version == msg.hardware_version);
+    REQUIRE(parsed->firmware == msg.firmware);
+    REQUIRE(parsed->device_id == msg.device_id);
+    REQUIRE(setup_connection::message_type == 0x00);
+    REQUIRE(setup_connection::protocol_template_distribution == 2);
+}
+
+TEST_CASE("sv2 SetupConnection.Success round-trips and matches the wire layout", "[sv2 connection]") {
+    setup_connection_success const msg{/*used_version*/ 0x0002u, /*flags*/ 0x0a0b0c0du};
+
+    auto const bytes = to_data_chunk(msg);
+    REQUIRE(bytes == data_chunk{0x02, 0x00, 0x0d, 0x0c, 0x0b, 0x0a});  // U16 LE, U32 LE
+
+    auto const parsed = from_data_chunk<setup_connection_success>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->used_version == msg.used_version);
+    REQUIRE(parsed->flags == msg.flags);
+    REQUIRE(setup_connection_success::message_type == 0x01);
+}
+
+TEST_CASE("sv2 SetupConnection.Error round-trips its flags and reason", "[sv2 connection]") {
+    setup_connection_error const msg{/*flags*/ 0x00000002u, "protocol-version-mismatch"};
+
+    auto const bytes = to_data_chunk(msg);
+    auto const parsed = from_data_chunk<setup_connection_error>(bytes);
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->flags == msg.flags);
+    REQUIRE(parsed->error_code == msg.error_code);
+    REQUIRE(setup_connection_error::message_type == 0x02);
+}
+
+TEST_CASE("sv2 SetupConnection.Success from_data rejects a short buffer", "[sv2 connection]") {
+    data_chunk const short_buffer{0x02, 0x00, 0x0d};  // needs 6
+    REQUIRE_FALSE(from_data_chunk<setup_connection_success>(short_buffer).has_value());
+}


### PR DESCRIPTION
## What

Every SV2 sub-protocol opens with a common connection handshake before its own messages, so the Template Distribution provider negotiates one first. This adds the three common messages (sv2-spec 03):

| Message | msg_type | Fields |
|---|---|---|
| SetupConnection | 0x00 | protocol (U8), min/max_version (U16), flags (U32), endpoint_host (STR0_255), endpoint_port (U16), vendor / hardware_version / firmware / device_id (STR0_255) |
| SetupConnection.Success | 0x01 | used_version (U16), flags (U32) |
| SetupConnection.Error | 0x02 | flags (U32), error_code (STR0_255) |

`SetupConnection` also carries the `protocol` enum (mining / job_declaration / template_distribution).

## Change

Same `from_data` / `to_data` convention and primitives as the TDP messages. They live in their own header (`sv2/connection.hpp`) since they are protocol-common, not TDP-specific.

## Tests

`[sv2 connection]`, 4 cases / 24 assertions: full round-trips, the Success wire layout, the `message_type` / protocol constants, and short-buffer rejection. Full node suite green (96 cases).
