### PR TITLE
consensus: map verify_flags_minimal_if to SCRIPT_VERIFY_MINIMALIF

### DIFF
--- a/src/consensus/src/consensus/conversions.cpp
+++ b/src/consensus/src/consensus/conversions.cpp
@@ -38,6 +38,10 @@ unsigned int verify_flags_to_script_flags(unsigned int flags) {
         script_flags |= SCRIPT_VERIFY_MINIMALDATA;
     }
 
+    if ((flags & verify_flags_minimal_if) != 0) {
+        script_flags |= SCRIPT_VERIFY_MINIMALIF;
+    }
+
     if ((flags & verify_flags_discourage_upgradable_nops) != 0) {
         script_flags |= SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS;
     }


### PR DESCRIPTION
## What

`verify_flags_to_script_flags()` did not map `verify_flags_minimal_if`, so a
caller passing that flag had it silently dropped and `SCRIPT_VERIFY_MINIMALIF`
was never enforced by the consensus library.

## Fix

Add the missing `verify_flags_minimal_if -> SCRIPT_VERIFY_MINIMALIF` mapping.
