### PR TITLE
consensus: add StackItem abstraction and hwaccel::IsAllZeros to the interpreter

### DIFF
--- a/src/consensus/CMakeLists.txt
+++ b/src/consensus/CMakeLists.txt
@@ -168,6 +168,7 @@ if (${CURRENCY} STREQUAL "BCH")
     src/bch-rules/script/bigint.cpp
     src/bch-rules/script/bitfield.cpp
     src/bch-rules/script/bitfield.h
+    src/bch-rules/script/container_types.h
     src/bch-rules/script/interpreter.cpp
     src/bch-rules/script/interpreter.h
     src/bch-rules/script/script.cpp
@@ -188,6 +189,8 @@ if (${CURRENCY} STREQUAL "BCH")
 
 
     src/bch-rules/util/bitmanip.cpp
+    src/bch-rules/util/hwaccel.cpp
+    src/bch-rules/util/hwaccel.h
     src/bch-rules/util/strencodings.cpp
     src/bch-rules/util/strencodings.h
     src/bch-rules/util/string.cpp

--- a/src/consensus/src/bch-rules/script/container_types.h
+++ b/src/consensus/src/bch-rules/script/container_types.h
@@ -1,14 +1,80 @@
-// Copyright (c) 2025 The Bitcoin developers
+// Copyright (c) 2025-present The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <span>
+#include <utility>
 #include <vector>
 
-using valtype = std::vector<uint8_t>; ///< used by the script interpreter as the stack element type
-using StackT = std::vector<valtype>; ///< used by the script interpreter as the stack type
+//! The stack element type is a simple vector of uint8_t
+using StackVec = std::vector<uint8_t>;
+
+//! Provides an abstraction on top of a simple byte vector to memoize (cache) known properties of a stack item.
+//!
+//! Currently we memoize the following:
+//!   - Whether this stack element is known to evaluate to: boolean true, boolean false, or not yet known
+//!
+//! Future VM optimizations may cache additional information here (such as script number value, etc).
+class StackItem {
+    StackVec vch;
+    std::optional<bool> cachedBool;
+
+public:
+    StackItem() noexcept = default;
+    // Converting constructors
+    StackItem(const StackVec &vchIn, std::optional<bool> cachedBoolIn = std::nullopt)
+        : vch(vchIn), cachedBool(cachedBoolIn) {}
+    StackItem(StackVec &&vchIn, std::optional<bool> cachedBoolIn = std::nullopt) noexcept
+        : vch(std::move(vchIn)), cachedBool(cachedBoolIn) {}
+    // Copy and move
+    StackItem(const StackItem &) = default;
+    StackItem(StackItem &&o) noexcept { *this = std::move(o); }
+
+    StackItem &operator=(const StackItem &) = default;
+    StackItem &operator=(StackItem &&o) noexcept {
+        vch = std::move(o.vch);
+        cachedBool = std::move(o.cachedBool);
+        // explicitly clear and invalidate any caches `o` may have, to preserve class invariants, since `o` has mutated
+        o.resetCaches();
+        return *this;
+    }
+
+    // Preferred getter when modification is not necessary; caches do not get invalidated
+    const StackVec & vec() const { return vch; }
+
+    // Returning the mutable data resets any item-specific caches, since caller may modify the returned value.
+    StackVec & mutableVec() {
+        resetCaches();
+        return vch;
+    }
+
+    // Convenience
+    size_t size() const { return vec().size(); }
+    bool empty() const { return vec().empty(); }
+    StackVec::const_reference at(size_t i) const { return vec().at(i); }
+    StackVec::const_reference operator[](size_t i) const { return vec()[i]; }
+    friend inline void swap(StackItem &a, StackItem &b) {
+        StackItem tmp(std::move(a));
+        a = std::move(b);
+        b = std::move(tmp);
+    }
+
+    // Cache ops
+    std::optional<bool> getCachedBool() const { return cachedBool; }
+    void setCachedBool(std::optional<bool> b) { cachedBool = b; }
+    void resetCachedBool() { setCachedBool(std::nullopt); }
+    // Resets all cached values
+    void resetCaches() { resetCachedBool(); }
+
+    // Equality -- note that equality only compares the vectors and not any cached metadata
+    bool operator==(const StackItem &o) const noexcept { return vch == o.vch; }
+    bool operator!=(const StackItem &o) const noexcept { return vch != o.vch; }
+};
+
+using StackT = std::vector<StackItem>; ///< used by the script interpreter as the stack type
 
 using ByteView = std::span<const uint8_t>; ///< read-only view into a vector or other array type

--- a/src/consensus/src/bch-rules/script/interpreter.cpp
+++ b/src/consensus/src/bch-rules/script/interpreter.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
-// Copyright (c) 2017-2025 The Bitcoin developers
+// Copyright (c) 2017-present The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,6 +18,7 @@
 #include <tinyformat.h>
 #include <uint256.h>
 #include <util/bitmanip.h>
+#include <util/hwaccel.h>
 
 #include <limits>
 #include <list>
@@ -27,17 +28,38 @@
 
 // namespace Interpreter { //Note(Knuth): Workaround for name collision
 
-bool CastToBool(const valtype &vch) {
-    for (size_t i = 0; i < vch.size(); i++) {
-        if (vch[i] != 0) {
-            // Can be negative zero
-            if (i == vch.size() - 1 && vch[i] == 0x80) {
-                return false;
-            }
+bool CastToBool(StackItem &item) {
+    if (auto opt = item.getCachedBool()) {
+        // Has a memoized result of CastToBool, just return that
+        return *opt;
+    }
+    // Has no memoized result, calculate and memoize
+    auto Calculate = [](const StackVec &vch) {
+        // Note: 'false' can be all zero bytes or "negative zero", which is, byte-wise, 0 or more 0x0's followed by a 0x80
+        // byte, e.g.: {0x0, 0x0, ..., 0x0, 0x80}
+
+        const size_t sz = vch.size();
+        if (sz == 0) {
+            // Empty vector is false
+            return false;
+        } else if (const auto last = vch.back(); last != 0x00u && last != 0x80u) {
+            // If the last byte is not zero and is not negative 0, then this byte blob must be truthy (fast path)
             return true;
         }
-    }
-    return false;
+        // At this point we know that the vector is: (1) not empty and (2) the last byte is either 0x00 or it's 0x80
+
+        if (sz == 1) {
+            // Since the only byte is one of: 0x00 or 0x80 ("negative 0"), we know it's false
+            return false;
+        }
+
+        // At this point we know that: sz > 1, and last byte is either 0x00 or 0x80, proceed with scanning all bytes except
+        // the last one. If all remaining bytes are zero, it's false, otherwise it's true.
+        return not hwaccel::IsAllZeros(std::span{vch}.first(sz - 1));
+    };
+    const bool ret = Calculate(item.vec());
+    item.setCachedBool(ret); // memoize
+    return ret;
 }
 
 /**
@@ -46,7 +68,7 @@ bool CastToBool(const valtype &vch) {
  */
 #define stacktop(i) (stack.at(stack.size() + (i)))
 #define altstacktop(i) (altstack.at(altstack.size() + (i)))
-static inline void popstack(std::vector<valtype> &stack) {
+static inline void popstack(StackT &stack) {
     if (stack.empty()) {
         throw std::runtime_error("popstack(): stack empty");
     }
@@ -138,8 +160,6 @@ static bool IsOpcodeDisabled(opcodetype opcode, uint32_t flags) {
         case OP_RSHIFTBIN:
             // Disabled before May 2026
             return (flags & SCRIPT_ENABLE_MAY2026) == 0;
-        case OP_MUL:
-            return (flags & SCRIPT_64_BIT_INTEGERS) == 0;
         default:
             break;
     }
@@ -340,45 +360,36 @@ public:
 };
 
 template<bool UsesBigInt>
-bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, uint32_t flags,
+bool EvalScriptImpl(StackT &stack, const CScript &initialScript, uint32_t flags,
                     const BaseSignatureChecker &checker, ScriptExecutionMetrics &metrics, ScriptError *serror) {
     // UsesBigInt template arg must match flags
     assert(UsesBigInt == bool(flags & SCRIPT_ENABLE_MAY2025));
     using ScriptNumType = std::conditional_t<UsesBigInt, FastBigNum, CScriptNum>;
 
     static auto const bnZero = ScriptNumType::fromIntUnchecked(0);
-    static const valtype vchFalse(0);
-    static const valtype vchTrue(1, 1);
+    static const StackItem itemFalse(StackVec(0), false);
+    static const StackItem itemTrue(StackVec(1, 1), true);
 
     if (initialScript.size() > MAX_SCRIPT_SIZE) {
         return set_error(serror, ScriptError::SCRIPT_SIZE);
     }
 
     // Function table (OP_DEFINE/OP_INVOKE support)
-    using FunctionTable = std::map<valtype, const valtype>;
+    using FunctionTable = std::map<StackVec, const StackVec>;
     FunctionTable functionTable;
 
-    std::vector<valtype> altstack;
+    StackT altstack;
     set_error(serror, ScriptError::UNKNOWN);
     int nOpCount = 0; /* Only used iff chipVmLimitsEnabled == false */
     bool const fRequireMinimal = (flags & SCRIPT_VERIFY_MINIMALDATA) != 0;
-    bool const nativeIntrospection = (flags & SCRIPT_NATIVE_INTROSPECTION) != 0;
-    bool const integers64Bit = (flags & SCRIPT_64_BIT_INTEGERS) != 0;
     bool const nativeTokens = (flags & SCRIPT_ENABLE_TOKENS) != 0;
     const ScriptExecutionContext * const context = checker.GetContext();
 
-    size_t const maxIntegerSizeLegacy =
-        integers64Bit ? CScriptNum::MAXIMUM_ELEMENT_SIZE_64_BIT
-                      : CScriptNum::MAXIMUM_ELEMENT_SIZE_32_BIT;
-
+    size_t const maxIntegerSizeLegacy = CScriptNum::MAXIMUM_ELEMENT_SIZE_64_BIT;
     size_t const maxIntegerSize = UsesBigInt ? ScriptBigInt::MAXIMUM_ELEMENT_SIZE_BIG_INT : maxIntegerSizeLegacy;
 
-    ScriptError const invalidNumberRangeErrorLegacy =
-        integers64Bit ? ScriptError::INVALID_NUMBER_RANGE_64_BIT
-                      : ScriptError::INVALID_NUMBER_RANGE;
-
     ScriptError const invalidNumberRangeError = UsesBigInt ? ScriptError::INVALID_NUMBER_RANGE_BIG_INT
-                                                           : invalidNumberRangeErrorLegacy;
+                                                           : ScriptError::INVALID_NUMBER_RANGE_64_BIT;
 
     bool const chipVmLimitsEnabled = (flags & SCRIPT_ENABLE_MAY2025) != 0;
     size_t const maxScriptElementSize = chipVmLimitsEnabled ? may2025::MAX_SCRIPT_ELEMENT_SIZE
@@ -410,7 +421,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                 // Read instruction
                 //
                 opcodetype opcode;
-                valtype vchPushValue;
+                StackVec vchPushValue;
                 if (!GetScriptOp(pc, pend, opcode, &vchPushValue)) {
                     return set_error(serror, ScriptError::BAD_OPCODE);
                 }
@@ -440,7 +451,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                         !CheckMinimalPush(vchPushValue, opcode)) {
                         return set_error(serror, ScriptError::MINIMALDATA);
                     }
-                    stack.push_back(std::move(vchPushValue));
+                    stack.emplace_back(std::move(vchPushValue));
                     metrics.TallyPushOp(stack.back().size());
                 } else if (fExec || (OP_IF <= opcode && opcode <= OP_ENDIF)) {
                     switch (opcode) {
@@ -466,7 +477,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                         case OP_16: {
                             // ( -- value)
                             auto const bn = CScriptNum::fromIntUnchecked(int(opcode) - int(OP_1 - 1));
-                            stack.push_back(bn.getvch());
+                            stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                             metrics.TallyPushOp(stack.back().size());
                             // The result of these opcodes should always be the
                             // minimal way to push the data they push, so no need
@@ -501,7 +512,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             // up to 5-byte bignums, which are good until 2**39-1,
                             // well beyond the 2**32-1 limit of the nLockTime field
                             // itself.
-                            const CScriptNum nLockTime(stacktop(-1), fRequireMinimal, 5);
+                            const CScriptNum nLockTime(stacktop(-1).vec(), fRequireMinimal, 5);
 
                             // In the rare event that the argument may be < 0 due to
                             // some arithmetic being done first, you can always use
@@ -532,7 +543,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             // nSequence, like nLockTime, is a 32-bit unsigned
                             // integer field. See the comment in CHECKLOCKTIMEVERIFY
                             // regarding 5-byte numeric operands.
-                            const CScriptNum nSequence(stacktop(-1), fRequireMinimal, 5);
+                            const CScriptNum nSequence(stacktop(-1).vec(), fRequireMinimal, 5);
 
                             // In the rare event that the argument may be < 0 due to
                             // some arithmetic being done first, you can always use
@@ -601,7 +612,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             }
 
                             const auto & [it, inserted] =
-                                functionTable.try_emplace(std::move(funcId), std::move(funcCode));
+                                functionTable.try_emplace(std::move(funcId.mutableVec()),
+                                                          std::move(funcCode.mutableVec()));
 
                             if ( ! inserted) {
                                 // overwriting existing functions is disallowed
@@ -630,7 +642,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(serror, ScriptError::INVALID_FUNCTION_IDENTIFIER);
                             }
 
-                            const auto it = functionTable.find(funcId);
+                            const auto it = functionTable.find(funcId.vec());
                             if (it == functionTable.end()) {
                                 return set_error(serror, ScriptError::INVOKED_UNDEFINED_FUNCTION);
                             }
@@ -655,18 +667,18 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                         serror,
                                         ScriptError::UNBALANCED_CONDITIONAL);
                                 }
-                                const valtype &vch = stacktop(-1);
+                                StackItem &item = stacktop(-1);
                                 if (flags & SCRIPT_VERIFY_MINIMALIF) {
-                                    if (vch.size() > 1) {
+                                    if (item.size() > 1) {
                                         return set_error(serror,
                                                          ScriptError::MINIMALIF);
                                     }
-                                    if (vch.size() == 1 && vch[0] != 1) {
+                                    if (item.size() == 1 && item[0] != 1) {
                                         return set_error(serror,
                                                          ScriptError::MINIMALIF);
                                     }
                                 }
-                                fValue = CastToBool(vch);
+                                fValue = CastToBool(item);
                                 if (opcode == OP_NOTIF) {
                                     fValue = !fValue;
                                 }
@@ -782,11 +794,11 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(
                                     serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype vch1 = stacktop(-2);
-                            valtype vch2 = stacktop(-1);
-                            stack.push_back(std::move(vch1));
+                            StackItem item1 = stacktop(-2);
+                            StackItem item2 = stacktop(-1);
+                            stack.push_back(std::move(item1));
                             metrics.TallyPushOp(stack.back().size());
-                            stack.push_back(std::move(vch2));
+                            stack.push_back(std::move(item2));
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -796,14 +808,14 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(
                                     serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype vch1 = stacktop(-3);
-                            valtype vch2 = stacktop(-2);
-                            valtype vch3 = stacktop(-1);
-                            stack.push_back(std::move(vch1));
+                            StackItem item1 = stacktop(-3);
+                            StackItem item2 = stacktop(-2);
+                            StackItem item3 = stacktop(-1);
+                            stack.push_back(std::move(item1));
                             metrics.TallyPushOp(stack.back().size());
-                            stack.push_back(std::move(vch2));
+                            stack.push_back(std::move(item2));
                             metrics.TallyPushOp(stack.back().size());
-                            stack.push_back(std::move(vch3));
+                            stack.push_back(std::move(item3));
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -813,11 +825,11 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(
                                     serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype vch1 = stacktop(-4);
-                            valtype vch2 = stacktop(-3);
-                            stack.push_back(std::move(vch1));
+                            StackItem item1 = stacktop(-4);
+                            StackItem item2 = stacktop(-3);
+                            stack.push_back(std::move(item1));
                             metrics.TallyPushOp(stack.back().size());
-                            stack.push_back(std::move(vch2));
+                            stack.push_back(std::move(item2));
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -827,12 +839,12 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(
                                     serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype vch1 = stacktop(-6);
-                            valtype vch2 = stacktop(-5);
+                            StackItem item1 = std::move(stacktop(-6));
+                            StackItem item2 = std::move(stacktop(-5));
                             stack.erase(stack.end() - 6, stack.end() - 4);
-                            stack.push_back(std::move(vch1));
+                            stack.push_back(std::move(item1));
                             metrics.TallyPushOp(stack.back().size());
-                            stack.push_back(std::move(vch2));
+                            stack.push_back(std::move(item2));
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -853,9 +865,10 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(
                                     serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype vch = stacktop(-1);
-                            if (CastToBool(vch)) {
-                                stack.push_back(std::move(vch));
+                            StackItem &item = stacktop(-1);
+                            if (CastToBool(item)) {
+                                StackItem copy = item;
+                                stack.push_back(std::move(copy)); // Note: `item` reference may be invalidated here
                                 metrics.TallyPushOp(stack.back().size());
                             }
                         } break;
@@ -863,7 +876,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                         case OP_DEPTH: {
                             // -- stacksize
                             auto const bn = CScriptNum::fromIntUnchecked(stack.size());
-                            stack.push_back(bn.getvch());
+                            stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -881,8 +894,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(
                                     serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype vch = stacktop(-1);
-                            stack.push_back(std::move(vch));
+                            StackItem copy = stacktop(-1);
+                            stack.push_back(std::move(copy));
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -901,8 +914,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(
                                     serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype vch = stacktop(-2);
-                            stack.push_back(std::move(vch));
+                            StackItem copy = stacktop(-2);
+                            stack.push_back(std::move(copy));
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -913,24 +926,24 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 2) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            int64_t const n = CScriptNum(stacktop(-1), fRequireMinimal, maxIntegerSizeLegacy).getint64();
+                            int64_t const n = CScriptNum(stacktop(-1).vec(), fRequireMinimal, maxIntegerSizeLegacy).getint64();
                             popstack(stack);
                             if (n < 0 || uint64_t(n) >= stack.size()) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
 
-                            valtype vch;
+                            StackItem item;
                             if (auto it = stack.end() - n - 1; opcode == OP_ROLL) {
                                 // We use std::move to avoid excess copying in the OP_ROLL case.
-                                vch = std::move(*it);
+                                item = std::move(*it);
                                 stack.erase(it); // `it` is invalidated here
                                 metrics.TallyOp(n); // erasing in the middle is linear with `n`
                             } else {
                                 // The OP_PICK case must do a copy, but at least we save on not having to erase in the
                                 // middle and thus we don't have to slide everything over by 1 (hence extraCost = 0).
-                                vch = *it;
+                                item = *it;
                             }
-                            stack.push_back(std::move(vch)); // move-construct to save on copying
+                            stack.push_back(std::move(item)); // move-construct to save on copying
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -960,9 +973,9 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 2) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype vch = stacktop(-1);
-                            metrics.TallyPushOp(vch.size());
-                            stack.insert(stack.end() - 2, std::move(vch));
+                            StackItem item = stacktop(-1);
+                            metrics.TallyPushOp(item.size());
+                            stack.insert(stack.end() - 2, std::move(item));
                         } break;
 
                         case OP_SIZE: {
@@ -971,7 +984,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
                             auto const bn = CScriptNum::fromIntUnchecked(stacktop(-1).size());
-                            stack.push_back(bn.getvch());
+                            stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -985,8 +998,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 2) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype &vch1 = stacktop(-2);
-                            valtype &vch2 = stacktop(-1);
+                            StackVec &vch1 = stacktop(-2).mutableVec();
+                            const StackVec &vch2 = stacktop(-1).vec();
 
                             // Inputs must be the same size
                             if (vch1.size() != vch2.size()) {
@@ -1027,7 +1040,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 1) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype &data = stacktop(-1);
+                            StackVec &data = stacktop(-1).mutableVec();
                             // Ensure result would respect size limits; this branch is only reachable from tests.
                             if (data.size() > maxScriptElementSize) {
                                 return set_error(serror, ScriptError::PUSH_SIZE);
@@ -1047,7 +1060,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                                 }
 
-                                const bool fEqual = stacktop(-2) == stacktop(-1);
+                                const bool fEqual = stacktop(-2).vec() == stacktop(-1).vec();
                                 // OP_NOTEQUAL is disabled because it would be too
                                 // easy to say something like n != 1 and have some
                                 // wiseguy pass in 1 with extra zero bytes after it
@@ -1056,7 +1069,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 //    fEqual = !fEqual;
                                 popstack(stack);
                                 popstack(stack);
-                                stack.push_back(fEqual ? vchTrue : vchFalse);
+                                stack.push_back(fEqual ? itemTrue : itemFalse);
                                 metrics.TallyPushOp(stack.back().size());
                                 if (opcode == OP_EQUALVERIFY) {
                                     if (fEqual) {
@@ -1081,7 +1094,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 1) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            ScriptNumType bn(stacktop(-1), fRequireMinimal, maxIntegerSize);
+                            ScriptNumType bn(stacktop(-1).vec(), fRequireMinimal, maxIntegerSize);
                             uint32_t pushCostFactor = 2u; // all except OP_NOT and OP_0NOTEQUAL will be costed 2x
 
                             switch (opcode) {
@@ -1125,7 +1138,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (UsesBigInt && vch.size() > maxScriptElementSize) {
                                 return set_error(serror, invalidNumberRangeError);
                             }
-                            stack.push_back(std::move(vch));
+                            stack.emplace_back(std::move(vch), /* cache known bool value: */ bn.getint64() != 0);
                             metrics.TallyPushOp(stack.back().size() * pushCostFactor);
                         } break;
 
@@ -1149,8 +1162,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 2) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            const valtype &vch1 = stacktop(-2);
-                            const valtype &vch2 = stacktop(-1);
+                            const StackVec &vch1 = stacktop(-2).vec();
+                            const StackVec &vch2 = stacktop(-1).vec();
                             ScriptNumType bn1(vch1, fRequireMinimal, maxIntegerSize);
                             ScriptNumType const bn2(vch2, fRequireMinimal, maxIntegerSize);
                             auto bn = ScriptNumType::fromIntUnchecked(0);
@@ -1262,7 +1275,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 if (UsesBigInt && vch.size() > maxScriptElementSize) {
                                     return set_error(serror, invalidNumberRangeError);
                                 }
-                                stack.push_back(std::move(vch));
+                                stack.emplace_back(std::move(vch), /* cache known bool value: */ bn.getint64() != 0);
                             }
                             metrics.TallyPushOp(stack.back().size() * pushCostFactor);
 
@@ -1295,7 +1308,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 static_assert(std::in_range<int32_t>(ScriptBigInt::MAX_BITS),
                                               "Assumption is a 32-bit int can hold more than the bit size of a script number");
                                 // Note: This call clamps i32bits to the range: [INT_MIN, INT_MAX].
-                                int32_t const i32bits = ScriptNumType(stacktop(-1), fRequireMinimal, maxIntegerSize).getint32();
+                                int32_t const i32bits = ScriptNumType(stacktop(-1).vec(), fRequireMinimal, maxIntegerSize).getint32();
 
                                 // Disallow negative bit counts
                                 if (i32bits < 0) {
@@ -1309,10 +1322,10 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 if (nbits == 0) {
                                     // If nbits == 0 the number already on the stack can remain, saving cycles, however we
                                     // must still validate it; we never accept an invalid number as a numeric argument.
-                                    ScriptBigInt::throwIfInvalidScriptNumEncoding(stacktop(-1), fRequireMinimal, maxIntegerSize);
+                                    ScriptBigInt::throwIfInvalidScriptNumEncoding(stacktop(-1).vec(), fRequireMinimal, maxIntegerSize);
                                 } else {
                                     // nbits > 0, we must do actual work
-                                    ScriptNumType num(stacktop(-1), fRequireMinimal, maxIntegerSize);
+                                    ScriptNumType num(stacktop(-1).vec(), fRequireMinimal, maxIntegerSize);
                                     popstack(stack); // consume numeric argument
 
                                     bool valid{};
@@ -1329,13 +1342,13 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                         return set_error(serror, invalidNumberRangeError);
                                     }
 
-                                    valtype vch = num.getvch();
+                                    StackVec vch = num.getvch();
                                     // Ensure result respects size limits; this check is redundant with the above code
                                     // block, but is here for belt-and-suspenders.
                                     if (vch.size() > maxScriptElementSize) {
                                         return set_error(serror, ScriptError::PUSH_SIZE);
                                     }
-                                    stack.push_back(std::move(vch));
+                                    stack.emplace_back(std::move(vch), /* cache known bool value: */ num.getint64() != 0);
                                 }
 
                                 metrics.TallyPushOp(stack.back().size());
@@ -1347,15 +1360,15 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 3) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            ScriptNumType const bn1(stacktop(-3), fRequireMinimal, maxIntegerSize);
-                            ScriptNumType const bn2(stacktop(-2), fRequireMinimal, maxIntegerSize);
-                            ScriptNumType const bn3(stacktop(-1), fRequireMinimal, maxIntegerSize);
+                            ScriptNumType const bn1(stacktop(-3).vec(), fRequireMinimal, maxIntegerSize);
+                            ScriptNumType const bn2(stacktop(-2).vec(), fRequireMinimal, maxIntegerSize);
+                            ScriptNumType const bn3(stacktop(-1).vec(), fRequireMinimal, maxIntegerSize);
 
                             bool fValue = (bn2 <= bn1 && bn1 < bn3);
                             popstack(stack);
                             popstack(stack);
                             popstack(stack);
-                            stack.push_back(fValue ? vchTrue : vchFalse);
+                            stack.push_back(fValue ? itemTrue : itemFalse);
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -1371,12 +1384,12 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 1) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            const valtype &vch = stacktop(-1);
-                            valtype vchHash((opcode == OP_RIPEMD160 ||
-                                             opcode == OP_SHA1 ||
-                                             opcode == OP_HASH160)
-                                                ? 20
-                                                : 32);
+                            const StackVec &vch = stacktop(-1).vec();
+                            StackVec vchHash((opcode == OP_RIPEMD160 ||
+                                              opcode == OP_SHA1 ||
+                                              opcode == OP_HASH160)
+                                                 ? 20
+                                                 : 32);
                             bool isTwoRoundHashOp = false;
                             if (opcode == OP_RIPEMD160) {
                                 CRIPEMD160()
@@ -1399,7 +1412,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             }
                             metrics.TallyHashOp(vch.size(), isTwoRoundHashOp);
                             popstack(stack);
-                            stack.push_back(std::move(vchHash));
+                            stack.emplace_back(std::move(vchHash));
                             metrics.TallyPushOp(stack.back().size());
                         } break;
 
@@ -1414,8 +1427,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 2) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype const &vchSig = stacktop(-2);
-                            valtype const &vchPubKey = stacktop(-1);
+                            StackVec const &vchSig = stacktop(-2).vec();
+                            StackVec const &vchPubKey = stacktop(-1).vec();
 
                             if (!CheckTransactionSignatureEncoding(vchSig, flags,
                                                                    serror) ||
@@ -1447,7 +1460,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
 
                             popstack(stack);
                             popstack(stack);
-                            stack.push_back(fSuccess ? vchTrue : vchFalse);
+                            stack.push_back(fSuccess ? itemTrue : itemFalse);
                             metrics.TallyPushOp(stack.back().size());
                             if (opcode == OP_CHECKSIGVERIFY) {
                                 if (fSuccess) {
@@ -1465,9 +1478,9 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
 
-                            valtype const &vchSig = stacktop(-3);
-                            valtype const &vchMessage = stacktop(-2);
-                            valtype const &vchPubKey = stacktop(-1);
+                            StackVec const &vchSig = stacktop(-3).vec();
+                            StackVec const &vchMessage = stacktop(-2).vec();
+                            StackVec const &vchPubKey = stacktop(-1).vec();
 
                             if (!CheckDataSignatureEncoding(vchSig, flags,
                                                             serror) ||
@@ -1494,7 +1507,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             popstack(stack);
                             popstack(stack);
                             popstack(stack);
-                            stack.push_back(fSuccess ? vchTrue : vchFalse);
+                            stack.push_back(fSuccess ? itemTrue : itemFalse);
                             metrics.TallyPushOp(stack.back().size());
                             if (opcode == OP_CHECKDATASIGVERIFY) {
                                 if (fSuccess) {
@@ -1513,7 +1526,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < idxKeyCount) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            int64_t const nKeysCount = CScriptNum(stacktop(-idxKeyCount), fRequireMinimal, maxIntegerSizeLegacy).getint64();
+                            int64_t const nKeysCount = CScriptNum(stacktop(-idxKeyCount).vec(), fRequireMinimal, maxIntegerSizeLegacy).getint64();
                             if (nKeysCount < 0 || nKeysCount > MAX_PUBKEYS_PER_MULTISIG) {
                                 return set_error(serror, ScriptError::PUBKEY_COUNT);
                             }
@@ -1534,7 +1547,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < idxSigCount) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            int64_t const nSigsCount = CScriptNum(stacktop(-idxSigCount), fRequireMinimal, maxIntegerSizeLegacy).getint64();
+                            int64_t const nSigsCount = CScriptNum(stacktop(-idxSigCount).vec(), fRequireMinimal, maxIntegerSizeLegacy).getint64();
                             if (nSigsCount < 0 || nSigsCount > nKeysCount) {
                                 return set_error(serror, ScriptError::SIG_COUNT);
                             }
@@ -1563,7 +1576,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
 
                                 // Dummy element is to be interpreted as a bitfield
                                 // that represent which pubkeys should be checked.
-                                valtype const &vchDummy = stacktop(-idxDummy);
+                                StackVec const &vchDummy = stacktop(-idxDummy).vec();
                                 if ( ! DecodeBitfield(vchDummy, nKeysCount, checkBits, serror)) {
                                     // serror is set
                                     return false;
@@ -1602,8 +1615,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     }
 
                                     // Check the signature.
-                                    valtype const &vchSig = stacktop(-idxBottomSig + iSig);
-                                    valtype const &vchPubKey = stacktop(-idxBottomKey + iKey);
+                                    StackVec const &vchSig = stacktop(-idxBottomSig + iSig).vec();
+                                    StackVec const &vchPubKey = stacktop(-idxBottomKey + iKey).vec();
 
                                     // Note that only pubkeys associated with a
                                     // signature are checked for validity.
@@ -1646,27 +1659,21 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
 
                                 // Remove signature for pre-fork scripts
                                 for (int k = 0; k < nSigsCount; k++) {
-                                    valtype const &vchSig = stacktop(-idxTopSig - k);
+                                    StackVec const &vchSig = stacktop(-idxTopSig - k).vec();
                                     cleanedUp = CleanupScriptCode(std::move(cleanedUp), vchSig, flags);
                                 }
 
                                 int nSigsRemaining = nSigsCount;
                                 int nKeysRemaining = nKeysCount;
                                 while (fSuccess && nSigsRemaining > 0) {
-                                    valtype const &vchSig = stacktop(
-                                        -idxTopSig - (nSigsCount - nSigsRemaining));
-                                    valtype const &vchPubKey = stacktop(
-                                        -idxTopKey - (nKeysCount - nKeysRemaining));
+                                    StackVec const &vchSig = stacktop(-idxTopSig - (nSigsCount - nSigsRemaining)).vec();
+                                    StackVec const &vchPubKey = stacktop(-idxTopKey - (nKeysCount - nKeysRemaining)).vec();
 
-                                    // Note how this makes the exact order of
-                                    // pubkey/signature evaluation distinguishable
-                                    // by CHECKMULTISIG NOT if the STRICTENC flag is
-                                    // set. See the script_(in)valid tests for
-                                    // details.
-                                    if (!CheckTransactionECDSASignatureEncoding(
-                                            vchSig, flags, serror) ||
-                                        !CheckPubKeyEncoding(vchPubKey, flags,
-                                                             serror)) {
+                                    // Note how this makes the exact order of pubkey/signature evaluation
+                                    // distinguishable by CHECKMULTISIG NOT if the STRICTENC flag is set. See the
+                                    // script_(in)valid tests for details.
+                                    if (!CheckTransactionECDSASignatureEncoding(vchSig, flags, serror) ||
+                                        !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
                                         // serror is set
                                         return false;
                                     }
@@ -1684,10 +1691,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     }
                                     nKeysRemaining--;
 
-                                    // If there are more signatures left than keys
-                                    // left, then too many signatures have failed.
-                                    // Exit early, without checking any further
-                                    // signatures.
+                                    // If there are more signatures left than keys left, then too many signatures have
+                                    // failed. Exit early, without checking any further signatures.
                                     if (nSigsRemaining > nKeysRemaining) {
                                         fSuccess = false;
                                     }
@@ -1701,18 +1706,14 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     }
                                 }
 
-                                // If the operation failed, we may require that all
-                                // signatures must be empty vector
-                                if (!fSuccess && (flags & SCRIPT_VERIFY_NULLFAIL) &&
-                                    !areAllSignaturesNull) {
+                                // If the operation failed, we may require that all signatures must be empty vector
+                                if (!fSuccess && (flags & SCRIPT_VERIFY_NULLFAIL) && !areAllSignaturesNull) {
                                     return set_error(serror, ScriptError::SIG_NULLFAIL);
                                 }
 
                                 if (!areAllSignaturesNull) {
-                                    // This is not identical to the number of actual
-                                    // ECDSA verifies, but, it is an upper bound
-                                    // that can be easily determined without doing
-                                    // CPU-intensive checks.
+                                    // This is not identical to the number of actual ECDSA verifies, but, it is an upper
+                                    // bound that can be easily determined without doing CPU-intensive checks.
                                     metrics.TallySigChecks(nKeysCount);
                                 }
                             }
@@ -1722,7 +1723,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 popstack(stack);
                             }
 
-                            stack.push_back(fSuccess ? vchTrue : vchFalse);
+                            stack.push_back(fSuccess ? itemTrue : itemFalse);
                             metrics.TallyPushOp(stack.back().size());
                             if (opcode == OP_CHECKMULTISIGVERIFY) {
                                 if (fSuccess) {
@@ -1741,8 +1742,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 2) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            valtype &vch1 = stacktop(-2);
-                            const valtype &vch2 = stacktop(-1);
+                            StackVec &vch1 = stacktop(-2).mutableVec();
+                            const StackVec &vch2 = stacktop(-1).vec();
                             if (vch1.size() + vch2.size() > maxScriptElementSize) {
                                 return set_error(serror, ScriptError::PUSH_SIZE);
                             }
@@ -1757,22 +1758,22 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
 
-                            const valtype &data = stacktop(-2);
+                            const StackVec &data = stacktop(-2).vec();
 
                             // Make sure the split point is appropriate.
-                            int64_t const position = CScriptNum(stacktop(-1), fRequireMinimal, maxIntegerSizeLegacy).getint64();
+                            int64_t const position = CScriptNum(stacktop(-1).vec(), fRequireMinimal, maxIntegerSizeLegacy).getint64();
                             if (position < 0 || uint64_t(position) > data.size()) {
                                 return set_error(serror, ScriptError::INVALID_SPLIT_RANGE);
                             }
 
                             // Prepare the results in their own buffer as `data` will be invalidated.
-                            valtype n1(data.begin(), data.begin() + position);
-                            valtype n2(data.begin() + position, data.end());
+                            StackVec n1(data.begin(), data.begin() + position);
+                            StackVec n2(data.begin() + position, data.end());
 
                             // Replace existing stack values by the new values.
                             const size_t totalSize = n1.size() + n2.size();
-                            stacktop(-2) = std::move(n1);
-                            stacktop(-1) = std::move(n2);
+                            stacktop(-2) = StackItem(std::move(n1));
+                            stacktop(-1) = StackItem(std::move(n2));
                             metrics.TallyPushOp(totalSize);
                         } break;
 
@@ -1782,7 +1783,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
 
-                            valtype &data = stacktop(-1);
+                            StackVec &data = stacktop(-1).mutableVec();
                             std::reverse(data.begin(), data.end());
                             metrics.TallyPushOp(data.size());
                         } break;
@@ -1796,13 +1797,13 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
 
-                            uint64_t const size = CScriptNum(stacktop(-1), fRequireMinimal, maxIntegerSizeLegacy).getint64();
+                            uint64_t const size = CScriptNum(stacktop(-1).vec(), fRequireMinimal, maxIntegerSizeLegacy).getint64();
                             if (size > maxScriptElementSize) {
                                 return set_error(serror, ScriptError::PUSH_SIZE);
                             }
 
                             popstack(stack);
-                            valtype &rawnum = stacktop(-1);
+                            StackVec &rawnum = stacktop(-1).mutableVec();
 
                             // Try to see if we can fit that number in the number of byte requested.
                             ScriptNumType::MinimallyEncode(rawnum);
@@ -1838,7 +1839,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
 
-                            valtype &n = stacktop(-1);
+                            StackVec &n = stacktop(-1).mutableVec();
                             ScriptNumType::MinimallyEncode(n);
                             metrics.TallyPushOp(n.size());
 
@@ -1869,13 +1870,13 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             // So, in order to handle this, and as an optimization, we just saturate `nbits` to INT_MAX here
                             // even if the number of bits requested is > 2^31 - 1. Since the input data can never exceed 80k
                             // bits (let alone INT_MAX bits), this is ok and produces consensus-correct behavior.
-                            int32_t const nbits = ScriptNumType(stacktop(-1), fRequireMinimal, maxIntegerSize).getint32();
+                            int32_t const nbits = ScriptNumType(stacktop(-1).vec(), fRequireMinimal, maxIntegerSize).getint32();
 
                             // Negative bit counts are not allowed
                             if (nbits < 0) {
                                 return set_error(serror, ScriptError::INVALID_BIT_SHIFT);
                             }
-                            valtype data = std::move(stacktop(-2));
+                            StackVec data = std::move(stacktop(-2).mutableVec());
 
                             popstack(stack);
                             popstack(stack);
@@ -1889,7 +1890,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 // This branch can never be taken outside of tests.
                                 return set_error(serror, ScriptError::PUSH_SIZE);
                             }
-                            stack.push_back(std::move(data));
+                            stack.emplace_back(std::move(data));
 
                             metrics.TallyPushOp(stack.back().size());
                         } break;
@@ -1905,9 +1906,6 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                         case OP_TXINPUTCOUNT:
                         case OP_TXOUTPUTCOUNT:
                         case OP_TXLOCKTIME: {
-                            if ( ! nativeIntrospection) {
-                                return set_error(serror, ScriptError::BAD_OPCODE);
-                            }
                             if ( ! context) {
                                 return set_error(serror, ScriptError::CONTEXT_NOT_PRESENT);
                             }
@@ -1916,7 +1914,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                 //  Operations
                                 case OP_INPUTINDEX: {
                                     auto const bn = CScriptNum::fromInt(context->inputIndex()).value();
-                                    stack.push_back(bn.getvch());
+                                    stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                 } break;
                                 case OP_ACTIVEBYTECODE: {
                                     // Subset of script starting at the most recent code separator (if any)
@@ -1924,23 +1922,23 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     if (static_cast<size_t>(pend - pbegincodehash) > maxScriptElementSize) {
                                         return set_error(serror, ScriptError::PUSH_SIZE);
                                     }
-                                    stack.emplace_back(pbegincodehash, pend);
+                                    stack.emplace_back(StackVec(pbegincodehash, pend));
                                 } break;
                                 case OP_TXVERSION: {
                                     auto const bn = CScriptNum::fromInt(context->tx().nVersion()).value();
-                                    stack.push_back(bn.getvch());
+                                    stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                 } break;
                                 case OP_TXINPUTCOUNT: {
                                     auto const bn = CScriptNum::fromInt(context->tx().vin().size()).value();
-                                    stack.push_back(bn.getvch());
+                                    stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                 } break;
                                 case OP_TXOUTPUTCOUNT: {
                                     auto const bn = CScriptNum::fromInt(context->tx().vout().size()).value();
-                                    stack.push_back(bn.getvch());
+                                    stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                 } break;
                                 case OP_TXLOCKTIME: {
                                     auto const bn = CScriptNum::fromInt(context->tx().nLockTime()).value();
-                                    stack.push_back(bn.getvch());
+                                    stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                 } break;
                                 default: {
                                     assert(!"invalid opcode");
@@ -1971,10 +1969,6 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                         case OP_INPUTSEQUENCENUMBER:
                         case OP_OUTPUTVALUE:
                         case OP_OUTPUTBYTECODE: {
-
-                            if ( ! nativeIntrospection) {
-                                return set_error(serror, ScriptError::BAD_OPCODE);
-                            }
                             if ( ! context) {
                                 return set_error(serror, ScriptError::CONTEXT_NOT_PRESENT);
                             }
@@ -1983,7 +1977,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                             if (stack.size() < 1) {
                                 return set_error(serror, ScriptError::INVALID_STACK_OPERATION);
                             }
-                            auto const index = CScriptNum(stacktop(-1), fRequireMinimal, maxIntegerSizeLegacy).getint64();
+                            auto const index = CScriptNum(stacktop(-1).vec(), fRequireMinimal, maxIntegerSizeLegacy).getint64();
                             popstack(stack); // consume element
 
                             auto is_valid_input_index = [&] {
@@ -2025,7 +2019,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                         return set_error(serror, ScriptError::LIMITED_CONTEXT_NO_SIBLING_INFO);
                                     }
                                     auto const bn = CScriptNum::fromInt(context->coinAmount(index) / SATOSHI).value();
-                                    stack.push_back(bn.getvch());
+                                    stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                 } break;
 
                                 case OP_UTXOBYTECODE: {
@@ -2041,7 +2035,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     if (utxoScript.size() > maxScriptElementSize) {
                                         return set_error(serror, ScriptError::PUSH_SIZE);
                                     }
-                                    stack.push_back(std::move(utxoScript));
+                                    stack.emplace_back(std::move(utxoScript));
                                 } break;
 
                                 case OP_OUTPOINTTXHASH: {
@@ -2051,7 +2045,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     auto const& input = context->tx().vin()[index];
                                     auto const& txid = input.prevout.GetTxId();
                                     static_assert(TxId::size() <= std::min(MAX_SCRIPT_ELEMENT_SIZE_LEGACY, may2025::MAX_SCRIPT_ELEMENT_SIZE));
-                                    stack.emplace_back(txid.begin(), txid.end());
+                                    stack.emplace_back(StackVec(txid.begin(), txid.end()));
                                 } break;
 
                                 case OP_OUTPOINTINDEX: {
@@ -2060,7 +2054,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     }
                                     auto const& input = context->tx().vin()[index];
                                     auto const bn = CScriptNum::fromInt(input.prevout.GetN()).value();
-                                    stack.push_back(bn.getvch());
+                                    stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                 } break;
 
                                 case OP_INPUTBYTECODE: {
@@ -2071,7 +2065,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     if (inputScript.size() > maxScriptElementSize) {
                                         return set_error(serror, ScriptError::PUSH_SIZE);
                                     }
-                                    stack.emplace_back(inputScript.begin(), inputScript.end());
+                                    stack.emplace_back(StackVec(inputScript.begin(), inputScript.end()));
                                 } break;
 
                                 case OP_INPUTSEQUENCENUMBER: {
@@ -2080,7 +2074,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     }
                                     auto const& input = context->tx().vin()[index];
                                     auto const bn = CScriptNum::fromInt(input.nSequence).value();
-                                    stack.push_back(bn.getvch());
+                                    stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                 } break;
 
                                 case OP_OUTPUTVALUE: {
@@ -2089,7 +2083,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     }
                                     auto const& output = context->tx().vout()[index];
                                     auto const bn = CScriptNum::fromInt(output.nValue / SATOSHI).value();
-                                    stack.push_back(bn.getvch());
+                                    stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                 } break;
 
                                 case OP_OUTPUTBYTECODE: {
@@ -2100,7 +2094,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     if (outputScript.size() > maxScriptElementSize) {
                                         return set_error(serror, ScriptError::PUSH_SIZE);
                                     }
-                                    stack.push_back(std::move(outputScript));
+                                    stack.emplace_back(std::move(outputScript));
                                 } break;
 
                                 // Token introspection
@@ -2115,11 +2109,12 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     }
                                     if (const auto &pdata = context->coinTokenData(index); !pdata) {
                                         // no token data, push CScriptNum 0 (empty vec)
-                                        stack.push_back(CScriptNum::fromIntUnchecked(0).getvch());
+                                        stack.emplace_back(CScriptNum::fromIntUnchecked(0).getvch(),
+                                                           /* cache known bool value: */ false);
                                     } else {
                                         // has token data, push token id (32 bytes) + *maybe* 0x1 or 0x2 (1 byte)
                                         const auto &tokId = pdata->GetId();
-                                        valtype vch;
+                                        StackVec vch;
                                         // only push the capability if it's one of: 0x1 (mutable) or 0x2 (minting)
                                         const bool pushCapByte = pdata->IsMintingNFT() || pdata->IsMutableNFT();
                                         vch.reserve(tokId.size() + pushCapByte);
@@ -2129,7 +2124,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                             // This branch cannot be taken in the current code, but is left in defensively.
                                             return set_error(serror, ScriptError::PUSH_SIZE);
                                         }
-                                        stack.push_back(std::move(vch));
+                                        stack.emplace_back(std::move(vch));
                                     }
                                 } break;
 
@@ -2144,7 +2139,8 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     }
                                     if (const auto &pdata = context->coinTokenData(index); !pdata || !pdata->HasNFT()) {
                                         // no token data, or has token data but is not an NFT, push CScriptNum 0 (empty vec)
-                                        stack.push_back(CScriptNum::fromIntUnchecked(0).getvch());
+                                        stack.emplace_back(CScriptNum::fromIntUnchecked(0).getvch(),
+                                                           /* cache known bool value: */ false);
                                     } else {
                                         // Has token data, push commitment bytes, if they are <= MAX_SCRIPT_ELEMENT_SIZE_*
                                         const auto &commitment = pdata->GetCommitment();
@@ -2153,7 +2149,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                             return set_error(serror, ScriptError::PUSH_SIZE);
                                         }
                                         // Push the bytes verbatim to the stack
-                                        stack.emplace_back(commitment.begin(), commitment.end());
+                                        stack.emplace_back(StackVec(commitment.begin(), commitment.end()));
                                     }
                                 } break;
 
@@ -2168,12 +2164,13 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     }
                                     if (const auto &pdata = context->coinTokenData(index); !pdata) {
                                         // no token data, push VM number 0 (empty vector)
-                                        stack.push_back(CScriptNum::fromIntUnchecked(0).getvch());
+                                        stack.emplace_back(CScriptNum::fromIntUnchecked(0).getvch(),
+                                                           /* cache known bool value: */ false);
                                     } else {
                                         // push the amount as a CScriptNum amount. Note it can be zero for NFT-only
                                         // tokens, in which case an empty vector {} will be pushed.
                                         auto const bn = CScriptNum::fromInt(pdata->GetAmount().getint64()).value();
-                                        stack.push_back(bn.getvch());
+                                        stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                     }
                                 } break;
 
@@ -2184,11 +2181,12 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     auto const& output = context->tx().vout()[index];
                                     if (const auto &pdata = output.tokenDataPtr; !pdata) {
                                         // no token data, push CScriptNum 0 (empty vec)
-                                        stack.push_back(CScriptNum::fromIntUnchecked(0).getvch());
+                                        stack.emplace_back(CScriptNum::fromIntUnchecked(0).getvch(),
+                                                           /* cache known bool value: */ false);
                                     } else {
                                         // has token data, push token id (32 bytes) + *maybe* 0x1 or 0x2 (1 byte)
                                         const auto &tokId = pdata->GetId();
-                                        valtype vch;
+                                        StackVec vch;
                                         // only push the capability if it's one of: 0x1 (mutable) or 0x2 (minting)
                                         const bool pushCapByte = pdata->IsMintingNFT() || pdata->IsMutableNFT();
                                         vch.reserve(tokId.size() + pushCapByte);
@@ -2198,7 +2196,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                             // This branch cannot be taken in the current code, but is left in defensively.
                                             return set_error(serror, ScriptError::PUSH_SIZE);
                                         }
-                                        stack.push_back(std::move(vch));
+                                        stack.emplace_back(std::move(vch));
                                     }
                                 } break;
 
@@ -2209,7 +2207,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     auto const& output = context->tx().vout()[index];
                                     if (const auto &pdata = output.tokenDataPtr; !pdata || !pdata->HasNFT()) {
                                         // no token data, or has token data but is not an NFT, push CScriptNum 0 (empty vec)
-                                        stack.push_back(CScriptNum::fromIntUnchecked(0).getvch());
+                                        stack.emplace_back(CScriptNum::fromIntUnchecked(0).getvch(), false);
                                     } else {
                                         // Has token data, push commitment bytes, if they are <= MAX_SCRIPT_ELEMENT_SIZE_*
                                         const auto &commitment = pdata->GetCommitment();
@@ -2218,7 +2216,7 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                             return set_error(serror, ScriptError::PUSH_SIZE);
                                         }
                                         // Push the bytes verbatim to the stack
-                                        stack.emplace_back(commitment.begin(), commitment.end());
+                                        stack.emplace_back(StackVec(commitment.begin(), commitment.end()));
                                     }
                                 } break;
 
@@ -2229,12 +2227,13 @@ bool EvalScriptImpl(std::vector<valtype> &stack, const CScript &initialScript, u
                                     auto const& output = context->tx().vout()[index];
                                     if (const auto &pdata = output.tokenDataPtr; !pdata) {
                                         // no token data, push VM number 0 (empty vector)
-                                        stack.push_back(CScriptNum::fromIntUnchecked(0).getvch());
+                                        stack.emplace_back(CScriptNum::fromIntUnchecked(0).getvch(),
+                                                           /* cache known bool value: */ false);
                                     } else {
                                         // push the amount as a CScriptNum amount. Note it can be zero for NFT-only
                                         // tokens, in which case an empty vector {} will be pushed.
                                         auto const bn = CScriptNum::fromInt(pdata->GetAmount().getint64()).value();
-                                        stack.push_back(bn.getvch());
+                                        stack.emplace_back(bn.getvch(), /* cache known bool value: */ bn.getint64() != 0);
                                     }
                                 } break;
 
@@ -2385,8 +2384,7 @@ public:
     /** Serialize an output of txTo */
     template <typename S>
     void SerializeOutput(S &s, unsigned int nOutput) const {
-        if (sigHashType.getBaseType() == BaseSigHashType::SINGLE &&
-            nOutput != nIn) {
+        if (sigHashType.getBaseType() == BaseSigHashType::SINGLE && nOutput != nIn) {
             // Do not lock-in the txout payee at other indices as txin
             ::Serialize(s, CTxOut());
         } else {
@@ -2413,7 +2411,7 @@ public:
                        ? nIn + 1
                        : txTo.vout().size());
         ::WriteCompactSize(s, nOutputs);
-        for (unsigned int nOutput = 0; nOutput < nOutputs; nOutput++) {
+        for (unsigned int nOutput = 0; nOutput < nOutputs; ++nOutput) {
             SerializeOutput(s, nOutput);
         }
         // Serialize nLockTime
@@ -2697,7 +2695,7 @@ bool TransactionSignatureChecker::CheckSequence(const CScriptNum &nSequence) con
     return true;
 }
 
-bool EvalScript(std::vector<valtype> &stack, const CScript &script, uint32_t flags,
+bool EvalScript(StackT &stack, const CScript &script, uint32_t flags,
                 const BaseSignatureChecker &checker, ScriptExecutionMetrics &metrics, ScriptError *serror) {
     if (flags & SCRIPT_ENABLE_MAY2025) {
         return EvalScriptImpl<true>(stack, script, flags, checker, metrics, serror);
@@ -2727,7 +2725,7 @@ bool VerifyScript(const CScript &scriptSig, const CScript &scriptPubKey, uint32_
         metrics.SetScriptLimits(flags, scriptSig.size());
     }
 
-    std::vector<valtype> stack, stackCopy;
+    StackT stack, stackCopy;
     if ( ! EvalScript(stack, scriptSig, flags, checker, metrics, serror)) {
         // serror is set
         return false;
@@ -2761,7 +2759,7 @@ bool VerifyScript(const CScript &scriptSig, const CScript &scriptPubKey, uint32_
         // EvalScript above would return false.
         assert(!stack.empty());
 
-        const CScript pubKey2(stack.back().begin(), stack.back().end());
+        const CScript pubKey2(stack.back().vec().begin(), stack.back().vec().end());
         popstack(stack);
 
         // Bail out early if SCRIPT_DISALLOW_SEGWIT_RECOVERY is not set, the

--- a/src/consensus/src/bch-rules/script/interpreter.h
+++ b/src/consensus/src/bch-rules/script/interpreter.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
-// Copyright (c) 2017-2025 The Bitcoin developers
+// Copyright (c) 2017-present The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -145,5 +145,6 @@ struct FindAndDeleteResult {
 [[nodiscard]]
 FindAndDeleteResult FindAndDelete(const ByteView &script, const CScript &b);
 
-/** Used internally by interpreter.cpp but also exported here for use by tests. */
-bool CastToBool(const StackT::value_type &vch);
+/** Used internally by interpreter.cpp but also exported here for use by tests.
+    Note that this function may modify its argument to set the memoized result. */
+bool CastToBool(StackItem &stackItem);

--- a/src/consensus/src/bch-rules/uint256.h
+++ b/src/consensus/src/bch-rules/uint256.h
@@ -1,14 +1,17 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
-// Copyright (c) 2021-2022 The Bitcoin developers
+// Copyright (c) 2021-present The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #pragma once
 
+#include <util/hwaccel.h>
+
 #include <cassert>
 #include <cstdint>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 /** Template base class for fixed-sized opaque blobs. */
@@ -33,12 +36,16 @@ public:
     explicit base_blob(const std::vector<uint8_t> &vch) noexcept;
 
     constexpr bool IsNull() const noexcept {
-        unsigned i = 0;
-        do {
-            if (m_data[i] != 0)
-                return false;
-        } while (++i < WIDTH);
-        return true;
+        if (std::is_constant_evaluated()) {
+            unsigned i = 0;
+            do {
+                if (m_data[i] != 0)
+                    return false;
+            } while (++i < WIDTH);
+            return true;
+        } else {
+            return hwaccel::IsAllZeros({m_data, WIDTH});
+        }
     }
 
     constexpr void SetNull() noexcept { *this = base_blob{}; }

--- a/src/consensus/src/bch-rules/util/hwaccel.cpp
+++ b/src/consensus/src/bch-rules/util/hwaccel.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) 2026-present The Bitcoin Cash Node developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <util/hwaccel.h>
+
+#include <cstring>
+
+#if defined(__x86_64__) && (defined(__clang__) || defined(__GNUC__)) && __has_include(<immintrin.h>)
+#  define USE_X86_SIMD 1
+#  include <immintrin.h>
+#elif defined(__aarch64__) && __has_include(<arm_neon.h>)
+#  define USE_ARM64_SIMD 1
+#  include <arm_neon.h>
+#endif
+
+namespace hwaccel {
+
+namespace detail {
+    //! All-zero check for any n. Bulk of the range is done in 128-byte (or 64-byte) blocks (8 uint128s or 8 uint64s)
+    //! with a key feature being that we do only one branch per block; the sub-blockSize remainder is folded via
+    //! possibly overlapping wordSize loads.
+    bool IsAllZerosPortable(const std::span<const std::byte> &bytes) noexcept {
+#if HAVE_INT128
+        using WordType = unsigned __int128;
+#else
+        using WordType = uint64_t;
+#endif
+        static constexpr size_t wordSize = sizeof(WordType);
+        auto ReadWord = [](const std::byte *p) noexcept {
+            WordType w;
+            std::memcpy(&w, p, wordSize);
+            return w;
+        };
+
+        const std::byte *p = bytes.data();
+        const size_t n = bytes.size();
+
+        if (n < wordSize) {
+            std::byte acc{0};
+            for (size_t i = 0; i < n; ++i) { acc |= p[i]; }
+            return acc == std::byte{0};
+        }
+        const std::byte *end = p + n;
+        if (n <= 2u * wordSize) {
+            // Two possibly-overlapping loads cover [0, n) exactly.
+            return (ReadWord(p) | ReadWord(end - wordSize)) == 0;
+        }
+        constexpr size_t blockSize = 8u * wordSize;
+        while (static_cast<size_t>(end - p) >= blockSize) {
+            const WordType a = ReadWord(p) | ReadWord(p + wordSize);
+            const WordType b = ReadWord(p + 2u*wordSize) | ReadWord(p + 3u*wordSize);
+            const WordType c = ReadWord(p + 4u*wordSize) | ReadWord(p + 5u*wordSize);
+            const WordType d = ReadWord(p + 6u*wordSize) | ReadWord(p + 7u*wordSize);
+            if ((a | b) | (c | d)) { return false; }
+            p += blockSize;
+        }
+        WordType acc = 0;
+        while (static_cast<size_t>(end - p) >= wordSize) { acc |= ReadWord(p); p += wordSize; }
+        if (p < end) { acc |= ReadWord(end - wordSize); } // overlapping load; safe since at this point n >= wordSize
+        return acc == 0;
+    }
+} // namespace detail
+
+namespace {
+#if USE_X86_SIMD
+    // x86-64 kernels, selected once at runtime by CPU capability. They are only
+    // invoked with n >= 128 but remain correct for any n. All three were fuzzed
+    // against the reference byte loop for equivalence (sizes 0..10000, all
+    // alignments, negative-zero patterns).
+
+    // Unaligned vector loads expressed as memcpy: folds to (v)movups, and unlike
+    // casting the byte pointer for _mm_loadu_si128 it does not trip -Wcast-align.
+    inline __m128i Read128(const std::byte *p) noexcept {
+        __m128i v;
+        std::memcpy(&v, p, sizeof(v));
+        return v;
+    }
+
+    __attribute__((target("avx2")))
+    inline __m256i Read256(const std::byte *p) noexcept {
+        __m256i v;
+        std::memcpy(&v, p, sizeof(v));
+        return v;
+    }
+
+    [[maybe_unused]]
+    bool IsAllZerosSSE2(const std::span<const std::byte> &bytes) noexcept {
+        const size_t n = bytes.size();
+        if (n < 128u) return detail::IsAllZerosPortable(bytes);
+        const std::byte *p = bytes.data();
+        const std::byte *end = p + n;
+        const __m128i zero = _mm_setzero_si128();
+        while (end - p >= 128) {
+            const __m128i a = _mm_or_si128(Read128(p), Read128(p + 16));
+            const __m128i b = _mm_or_si128(Read128(p + 32), Read128(p + 48));
+            const __m128i c = _mm_or_si128(Read128(p + 64), Read128(p + 80));
+            const __m128i d = _mm_or_si128(Read128(p + 96), Read128(p + 112));
+            const __m128i acc = _mm_or_si128(_mm_or_si128(a, b), _mm_or_si128(c, d));
+            if (_mm_movemask_epi8(_mm_cmpeq_epi8(acc, zero)) != 0xFFFF) return false;
+            p += 128;
+        }
+        __m128i acc = _mm_setzero_si128();
+        while (end - p >= 16) { acc = _mm_or_si128(acc, Read128(p)); p += 16; }
+        if (p < end) acc = _mm_or_si128(acc, Read128(end - 16)); // overlapping load; safe: n >= 128
+        return _mm_movemask_epi8(_mm_cmpeq_epi8(acc, zero)) == 0xFFFF;
+    }
+
+    [[maybe_unused]]
+    __attribute__((target("avx2")))
+    bool IsAllZerosAVX2(const std::span<const std::byte> &bytes) noexcept {
+        const size_t n = bytes.size();
+        if (n < 128u) return detail::IsAllZerosPortable(bytes);
+        const std::byte *p = bytes.data();
+        const std::byte *end = p + n;
+        while (end - p >= 256) {
+            const __m256i a = _mm256_or_si256(Read256(p), Read256(p + 32));
+            const __m256i b = _mm256_or_si256(Read256(p + 64), Read256(p + 96));
+            const __m256i c = _mm256_or_si256(Read256(p + 128), Read256(p + 160));
+            const __m256i d = _mm256_or_si256(Read256(p + 192), Read256(p + 224));
+            const __m256i acc = _mm256_or_si256(_mm256_or_si256(a, b), _mm256_or_si256(c, d));
+            if (!_mm256_testz_si256(acc, acc)) return false;
+            p += 256;
+        }
+        __m256i acc = _mm256_setzero_si256();
+        while (end - p >= 32) { acc = _mm256_or_si256(acc, Read256(p)); p += 32; }
+        if (p < end) acc = _mm256_or_si256(acc, Read256(end - 32)); // overlapping load; safe: n >= 128
+        return _mm256_testz_si256(acc, acc);
+    }
+
+    [[maybe_unused]]
+    __attribute__((target("avx512f")))
+    bool IsAllZerosAVX512(const std::span<const std::byte> &bytes) noexcept {
+        const size_t n = bytes.size();
+        if (n < 512u) return IsAllZerosAVX2(bytes);
+        const std::byte *p = bytes.data();
+        const std::byte *end = p + n;
+        // Check the first (possibly misaligned) 64 bytes, then round p up to a
+        // 64-byte boundary so no load in the bulk loop splits a cache line.
+        const __m512i head = _mm512_loadu_si512(p);
+        if (_mm512_test_epi64_mask(head, head)) return false;
+        p += 64u - (uintptr_t(p) & 63u);
+        while (end - p >= 512) {
+            const __m512i a = _mm512_or_si512(_mm512_load_si512(p), _mm512_load_si512(p + 64));
+            const __m512i b = _mm512_or_si512(_mm512_load_si512(p + 128), _mm512_load_si512(p + 192));
+            const __m512i c = _mm512_or_si512(_mm512_load_si512(p + 256), _mm512_load_si512(p + 320));
+            const __m512i d = _mm512_or_si512(_mm512_load_si512(p + 384), _mm512_load_si512(p + 448));
+            const __m512i acc = _mm512_or_si512(_mm512_or_si512(a, b), _mm512_or_si512(c, d));
+            if (_mm512_test_epi64_mask(acc, acc)) return false;
+            p += 512;
+        }
+        __m512i acc = _mm512_setzero_si512();
+        while (end - p >= 64) { acc = _mm512_or_si512(acc, _mm512_load_si512(p)); p += 64; }
+        if (p < end) acc = _mm512_or_si512(acc, _mm512_loadu_si512(end - 64)); // safe: n >= 512
+        return _mm512_test_epi64_mask(acc, acc) == 0;
+    }
+#endif // USE_X86_SIMD
+#if USE_ARM64_SIMD
+    // Horizontal max (single umaxv)
+    static inline bool neon_nonzero_maxv(uint8x16_t v) noexcept {
+        return vmaxvq_u32(vreinterpretq_u32_u8(v)) != 0;
+    }
+    /// Returns true if all bytes are zero. Features 8x unrolled accumulated OR (128 bytes per iteration).
+    bool IsAllZerosARM64(const std::span<const std::byte> &bytes) noexcept {
+        const size_t n = bytes.size();
+        if (n < 16u) return detail::IsAllZerosPortable(bytes); /* below code requires n >= 16 */
+        const uint8_t *p = reinterpret_cast<const uint8_t *>(bytes.data());
+        const uint8_t *end = p + n;
+        while (end - p >= 128) {
+            const uint8x16_t a = vorrq_u8(vld1q_u8(p), vld1q_u8(p + 16));
+            const uint8x16_t b = vorrq_u8(vld1q_u8(p + 32), vld1q_u8(p + 48));
+            const uint8x16_t c = vorrq_u8(vld1q_u8(p + 64), vld1q_u8(p + 80));
+            const uint8x16_t d = vorrq_u8(vld1q_u8(p + 96), vld1q_u8(p + 112));
+            const uint8x16_t acc = vorrq_u8(vorrq_u8(a, b), vorrq_u8(c, d));
+            if (neon_nonzero_maxv(acc)) return false;
+            p += 128;
+        }
+        uint8x16_t acc = vdupq_n_u8(0);
+        while (end - p >= 16) { acc = vorrq_u8(acc, vld1q_u8(p)); p += 16; }
+        if (p < end) acc = vorrq_u8(acc, vld1q_u8(end - 16)); // overlap; safe: n >= 16
+        return !neon_nonzero_maxv(acc);
+    }
+#endif
+} // namespace
+
+bool IsAllZeros(std::span<const std::byte> bytes) noexcept {
+#if USE_X86_SIMD
+    if (bytes.size() >= 128u) {
+#  if HAVE_X86_BUILTIN_CPU_SUPPORTS
+        static const auto hwspecific = [] {
+            if (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx2")) return &IsAllZerosAVX512;
+            if (__builtin_cpu_supports("avx2")) return &IsAllZerosAVX2;
+            if (__builtin_cpu_supports("sse2")) return &IsAllZerosSSE2;
+            return &detail::IsAllZerosPortable;
+        }();
+        return hwspecific(bytes);
+#  else
+        // Cross-compiling on Linux for macOS x86-64 leads to this compile-time branch (such as on gitian builds).
+        // This is because clang-18 that we use to cross-compile when using gitian expects the runtime libs to provide
+        // the symbol: __cpu_model, but the macOS SDK does not have this symbol (perhaps it's inlined on apple-clang?).
+        //
+        // We can remove this branch for darwin x86-64 when we go beyond clang-18 for the cross compiler on gitian.
+        return detail::IsAllZerosPortable(bytes);
+#  endif /* HAVE_X86_BUILTIN_CPU_SUPPORTS */
+    }
+#elif USE_ARM64_SIMD
+    if (bytes.size() >= 128u) {
+        return IsAllZerosARM64(bytes);
+    }
+#endif
+    return detail::IsAllZerosPortable(bytes);
+}
+
+} // namespace hwaccel

--- a/src/consensus/src/bch-rules/util/hwaccel.h
+++ b/src/consensus/src/bch-rules/util/hwaccel.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2026-present The Bitcoin Cash Node developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+// Utility functions that may be hardware-accelerated via SIMD instructions (SSE2, AVX2, etc).
+// All functions below fall back to portable versions if the machine we are on is unknown or has no SIMD instructions.
+namespace hwaccel {
+
+//! Returns true if the specified byte blob is empty or if it contains nothing but zeroes. False otherwise.
+bool IsAllZeros(std::span<const std::byte> bytes) noexcept;
+
+//! Convenience version of above for uint8_t
+inline bool IsAllZeros(std::span<const uint8_t> bytes) noexcept { return IsAllZeros(std::as_bytes(bytes)); }
+
+namespace detail {
+//! Internal portable version of the above -- always uses plain portable C++ and no SIMD or other platform-specific
+//! optimizations. Used by tests & benchmarks.
+bool IsAllZerosPortable(const std::span<const std::byte> &bytes) noexcept;
+} // namespace detail
+
+} // namespace hwaccel

--- a/src/consensus/src/consensus/consensus.cpp
+++ b/src/consensus/src/consensus/consensus.cpp
@@ -339,7 +339,22 @@ verify_result_type eval_script_with_metrics(
     ScriptExecutionMetrics metrics;
     ScriptError error;
 
-    EvalScript(stack, script, script_flags, standalone_sig_checker, metrics, &error);
+    // Note(kth): the interpreter stack element type is now the StackItem wrapper
+    // (StackT = std::vector<StackItem>). Convert the public byte-vector stack to StackT for
+    // evaluation, then copy the resulting items back out.
+    StackT stack_items;
+    stack_items.reserve(stack.size());
+    for (auto & elem : stack) {
+        stack_items.emplace_back(std::move(elem));
+    }
+
+    EvalScript(stack_items, script, script_flags, standalone_sig_checker, metrics, &error);
+
+    stack.clear();
+    stack.reserve(stack_items.size());
+    for (auto const& item : stack_items) {
+        stack.push_back(item.vec());
+    }
 
     metrics_out.sig_checks = metrics.GetSigChecks();
     metrics_out.op_cost = metrics.GetBaseOpCost();


### PR DESCRIPTION
## What

Update the `src/consensus` script interpreter (the bch-rules mirror) with the
`StackItem` stack-element abstraction and the `hwaccel::IsAllZeros` helper.

## Changes

- `container_types.h`: a `StackItem` wrapper that memoizes the per-item
  `CastToBool` result; the interpreter stack type becomes
  `StackT = std::vector<StackItem>`.
- `util/hwaccel.{h,cpp}`: a branchless / SIMD all-zeros scan with runtime CPU
  dispatch (SSE2 / AVX2 / AVX-512 / NEON) and a portable fallback, used in
  `CastToBool` and `base_blob::IsNull`.
- consensus glue (`eval_script_with_metrics`) adapted to the new stack type.

## Tests

Builds and links with `consensus=True`. Broader consensus-side test coverage is
tracked separately (the consensus test target is currently disabled; running the
shared VM test vectors against this path is a follow-up).
