### PR TITLE
database, blockchain: fix full-mode UTXO-Z value serialization

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -299,6 +299,7 @@ if (ENABLE_TEST)
         test/mempool_test.cpp
         test/mempool_persistence_test.cpp
         test/block_template_test.cpp
+        test/utxoz_roundtrip.cpp
     )
 
     # Disabled until ported to v1.0 APIs:

--- a/src/blockchain/include/kth/blockchain/utxo_builder.hpp
+++ b/src/blockchain/include/kth/blockchain/utxo_builder.hpp
@@ -82,9 +82,9 @@ KB_API expect<utxo_compact_block> parse_utxo_block(byte_span raw_block);
 // =============================================================================
 // Pre-serialized UTXO value for zero-copy insertion into UTXO-Z.
 // =============================================================================
-// Format: height(4) + mtp(4) + coinbase(1) + raw_output_bytes
-// Fixed prefix is 9 bytes. Raw output starts at offset 9 to end of buffer.
-// No size field needed — output size = total_size - 9.
+// Format: raw_output_bytes (wire) + height(4) + mtp(4) + coinbase(1) — matches utxo_entry
+// Raw output starts at offset 0; the 9-byte fixed metadata follows it.
+// No size field needed — the wire output is self-delimiting.
 // =============================================================================
 
 struct utxo_raw_value {

--- a/src/blockchain/src/utxo_builder.cpp
+++ b/src/blockchain/src/utxo_builder.cpp
@@ -145,7 +145,7 @@ expect<utxo_compact_block> parse_utxo_block(byte_span raw_block) {
 // =============================================================================
 // utxo_raw_value serialization
 // =============================================================================
-// Format: height(4) + mtp(4) + coinbase(1) + raw_output_bytes
+// Format: raw_output_bytes (wire) + height(4) + mtp(4) + coinbase(1)
 // =============================================================================
 
 namespace {
@@ -159,9 +159,18 @@ std::vector<uint8_t> serialize_utxo_raw_value(
     uint32_t median_time_past,
     bool coinbase
 ) {
-    size_t const total = utxo_raw_prefix_size + raw_output.size();
+    // Layout MUST match utxo_entry::from_data (the database read path via
+    // bytes_to_entry, i.e. get_utxo/find): the wire output first (self-delimiting),
+    // then the fixed metadata. Writing the metadata first made from_data misparse
+    // the value as an output and fail with "not found" for every full-mode UTXO
+    // lookup.
+    size_t const total = raw_output.size() + utxo_raw_prefix_size;
     std::vector<uint8_t> result(total);
     auto* p = result.data();
+
+    // raw output bytes (value + varint + script)
+    std::memcpy(p, raw_output.data(), raw_output.size());
+    p += raw_output.size();
 
     // height (4 bytes LE)
     std::memcpy(p, &height, 4);
@@ -172,10 +181,7 @@ std::vector<uint8_t> serialize_utxo_raw_value(
     p += 4;
 
     // coinbase (1 byte)
-    *p++ = coinbase ? uint8_t{1} : uint8_t{0};
-
-    // raw output bytes (value + varint + script)
-    std::memcpy(p, raw_output.data(), raw_output.size());
+    *p = coinbase ? uint8_t{1} : uint8_t{0};
 
     return result;
 }

--- a/src/blockchain/test/utxoz_roundtrip.cpp
+++ b/src/blockchain/test/utxoz_roundtrip.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <filesystem>
+#include <span>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+#include <test_helpers.hpp>
+
+#include <kth/blockchain.hpp>
+#include <kth/database.hpp>
+
+using namespace kth;
+using namespace kth::blockchain;
+using namespace kth::database;
+using namespace kd::chain;
+
+namespace {
+
+std::filesystem::path fresh_utxoz_dir() {
+    // Unique per-run path so concurrent test binaries don't clobber each other's db.
+    auto const p = std::filesystem::temp_directory_path() /
+        ("kth_utxoz_roundtrip_test_" + std::to_string(getpid()));
+    std::error_code ec;
+    std::filesystem::remove_all(p, ec);
+    REQUIRE( ! ec);
+    REQUIRE(std::filesystem::create_directories(p, ec));
+    REQUIRE( ! ec);
+    return p;
+}
+
+} // namespace
+
+// Regression test for the full-mode UTXO write/read format mismatch.
+//
+// utxo_build stores UTXO values via process_compact_block_utxos ->
+// apply_delta_raw, and get_utxo (validation / mempool prevout resolution) reads
+// them back via utxoz_database::find -> utxo_entry::from_data. The two must agree
+// on the byte layout of the value. Two mismatches (present since UTXO-Z was
+// introduced) made EVERY full-mode UTXO lookup return the key but fail to decode:
+//   1. field order: the writer put the fixed metadata before the output, while the
+//      reader expects the output first;
+//   2. output form: the writer stores the block's WIRE output bytes, while the
+//      reader deserialized the output in non-wire form.
+// Both are invisible until something reads UTXO-Z (IBD is merkle-only and never
+// calls get_utxo), so it stayed latent.
+#ifndef KTH_UTXOZ_COMPACT_MODE
+TEST_CASE("utxoz full-mode value round-trips write path -> find", "[utxoz][regression]") {
+    utxoz_database db;
+    REQUIRE(db.open(fresh_utxoz_dir(), true));
+
+    // The output that will become a UTXO (value + a trivial script).
+    output out;
+    out.set_value(1234500);
+    out.set_script(script{data_chunk{0x51}, false});   // OP_TRUE
+
+    // Raw output bytes exactly as parse_utxo_block captures them from a block:
+    // the WIRE serialization, which is what utxo_build stores.
+    data_chunk raw(out.serialized_size(true));
+    byte_writer writer(raw);
+    REQUIRE(out.to_data(writer, true).has_value());
+
+    hash_digest txid{};
+    txid[0] = 0xAB;
+    txid[31] = 0xCD;
+    uint32_t const index = 0;
+
+    // Build the compact block exactly as parse_utxo_block would for one output.
+    utxo_compact_block block;
+    utxo_compact_block::output_entry oe{
+        utxoz::make_outpoint(std::span<uint8_t const, 32>(txid.data(), 32), index),
+        std::span<uint8_t const>(raw.data(), raw.size()),
+        /*coinbase*/ false,
+        /*tx_start*/ 0u
+    };
+    block.outputs.push_back(oe);
+
+    // Write path (blockchain): serialize + insert.
+    auto delta = process_compact_block_utxos(
+        block, /*height*/ 100u, /*mtp*/ 111u, /*file*/ 0, /*data_pos*/ 0u, nullptr);
+    REQUIRE(db.apply_delta_raw(delta.inserts, delta.deletes) == result_code::success);
+
+    // Read path (database), the same one get_utxo uses. Look the prevout up at a
+    // later height than it was created (as validation does at the spending block).
+    auto const found = db.find(point{txid, index}, 200000);
+    REQUIRE(found.has_value());                        // both mismatches make this fail
+    CHECK(found->output().value() == 1234500u);
+    CHECK(found->height() == 100u);
+    CHECK(found->median_time_past() == 111u);
+    CHECK(found->coinbase() == false);
+}
+#endif // KTH_UTXOZ_COMPACT_MODE

--- a/src/database/include/kth/database/databases/utxo_entry.hpp
+++ b/src/database/include/kth/database/databases/utxo_entry.hpp
@@ -31,7 +31,7 @@ struct KD_API utxo_entry {
 
     [[nodiscard]]
     expect<void> to_data(byte_writer& writer) const {
-        if (auto r = output_.to_data(writer, false); ! r) return r;
+        if (auto r = output_.to_data(writer, true); ! r) return r;
         return to_data_fixed(writer, height_, median_time_past_, coinbase_);
     }
 
@@ -51,7 +51,7 @@ struct KD_API utxo_entry {
     [[nodiscard]]
     static
     expect<void> to_data_with_fixed(byte_writer& writer, domain::chain::output const& output, data_chunk const& fixed) {
-        if (auto r = output.to_data(writer, false); ! r) return r;
+        if (auto r = output.to_data(writer, true); ! r) return r;
         return writer.write_bytes(fixed);
     }
 

--- a/src/database/src/databases/utxo_entry.cpp
+++ b/src/database/src/databases/utxo_entry.cpp
@@ -55,7 +55,7 @@ size_t utxo_entry::serialized_size_fixed() {
 }
 
 size_t utxo_entry::serialized_size() const {
-    return output_.serialized_size(false) + serialized_size_fixed();
+    return output_.serialized_size(true) + serialized_size_fixed();
 }
 
 // Serialization.
@@ -73,7 +73,7 @@ data_chunk utxo_entry::to_data_fixed(uint32_t height, uint32_t median_time_past,
 
 // static
 data_chunk utxo_entry::to_data_with_fixed(domain::chain::output const& output, data_chunk const& fixed) {
-    auto const size = output.serialized_size(false) + fixed.size();
+    auto const size = output.serialized_size(true) + fixed.size();
     data_chunk data(size);
     byte_writer writer(data);
     auto const r = to_data_with_fixed(writer, output, fixed);
@@ -87,7 +87,7 @@ data_chunk utxo_entry::to_data_with_fixed(domain::chain::output const& output, d
 
 // static
 expect<utxo_entry> utxo_entry::from_data(byte_reader& reader) {
-    auto output = domain::chain::output::from_data(reader, false);
+    auto output = domain::chain::output::from_data(reader, true);
     if ( ! output) {
         return std::unexpected(output.error());
     }


### PR DESCRIPTION
## Problem

In full mode, the UTXO-Z value is written and read in two incompatible byte layouts, so every `get_utxo` / `find` that locates a key then **fails to decode its value** and returns "not found".

This is latent during IBD (which is merkle-only and never calls `get_utxo`), but it breaks everything that reads the confirmed UTXO set:
- full script validation of a block against the UTXO set, and
- mempool prevout resolution against confirmed outputs.

The mismatch has been present since UTXO-Z was introduced.

## Root cause

Two independent mismatches between the write path (`serialize_utxo_raw_value`, blockchain) and the read path (`utxo_entry::from_data` / `to_data`, database):

1. **Field order.** The writer put the fixed metadata (`height`, `mtp`, `coinbase`) *before* the output; `utxo_entry::from_data` reads the **output first**.
2. **Output form.** `utxo_build` stores the block's **wire** output bytes (zero-copy span from the block); `utxo_entry` (de)serialized the output in **non-wire** form. The non-wire form prepends a mutable `spender_height`, which has no place in the persisted UTXO set.

Either one alone makes the decode fail — `find` returns the key but the value can't be parsed.

## Fix

- Reorder `serialize_utxo_raw_value` to **output-first**, matching the canonical `utxo_entry` layout: `raw_output (wire) + height(4) + mtp(4) + coinbase(1)`.
- Serialize/deserialize the output in `utxo_entry` in **wire** form, matching the bytes `utxo_build` stores.

Write and read paths now agree.

## Test

Adds `test/utxoz_roundtrip.cpp`: builds a compact-block output exactly as the write path does, inserts it via `apply_delta_raw`, then reads it back with `utxoz_database::find` (the same path `get_utxo` uses). The round-trip fails on **either** mismatch and passes with the fix. Guarded by `#ifndef KTH_UTXOZ_COMPACT_MODE` (full mode only).

Full blockchain suite green (1037 assertions, 132 cases).