### PR TITLE
domain: activate BIP16 (P2SH) by height, matching BCHN

### DIFF
--- a/src/domain/include/kth/domain/constants/bch.hpp
+++ b/src/domain/include/kth/domain/constants/bch.hpp
@@ -70,6 +70,12 @@ constexpr size_t chipnet_bip65_freeze = 3;
 constexpr size_t chipnet_bip66_freeze = 4;
 constexpr size_t chipnet_bip34_freeze = 2;
 
+// P2SH (BIP16) activation heights for the BCH test networks, matching BCHN
+// (consensus.BIP16Height = 1 on testnet4/scalenet/chipnet).
+constexpr size_t testnet4_bip16_activation_height = 1;
+constexpr size_t scalenet_bip16_activation_height = 1;
+constexpr size_t chipnet_bip16_activation_height = 1;
+
 static
 const infrastructure::config::checkpoint testnet4_bip34_active_checkpoint {
     "00000000b0c65b1e03baace7d5c093db0d6aac224df01484985ffd5e86a1a20c"_hash, 2};

--- a/src/domain/include/kth/domain/constants/bch_btc.hpp
+++ b/src/domain/include/kth/domain/constants/bch_btc.hpp
@@ -46,6 +46,15 @@ constexpr size_t regtest_bip65_freeze = 1351;
 constexpr size_t regtest_bip66_freeze = 1251;
 constexpr size_t regtest_bip34_freeze = 0;
 
+// P2SH (BIP16) activation by height, matching BCHN (consensus.BIP16Height).
+// BCHN activates P2SH at a fixed height (mainnet 173805 = the 2012-04-01 flag
+// day), NOT by the block timestamp. The date-based path below enforces P2SH
+// ~7000 blocks early (from mainnet 166832) and then needs a per-block exception;
+// height-based activation matches BCHN exactly and needs no exception.
+constexpr size_t mainnet_bip16_activation_height = 173805;
+constexpr size_t testnet_bip16_activation_height = 514;
+constexpr size_t regtest_bip16_activation_height = 0;
+
 // Block 514 is the first testnet block after date-based activation.
 // Block 166832 is the first mainnet block after date-based activation.
 constexpr uint32_t bip16_activation_time = 0x4f3af580;

--- a/src/domain/src/chain/chain_state.cpp
+++ b/src/domain/src/chain/chain_state.cpp
@@ -290,6 +290,26 @@ bool bip65(size_t height, bool frozen, domain::config::network network) {
                             );
 }
 
+#if ! defined(KTH_CURRENCY_LTC)
+// P2SH (BIP16) activates by height, matching BCHN (consensus.BIP16Height):
+// block N enforces P2SH iff N >= BIP16 height. Unlike the date-based path this
+// needs no per-block exception (the historical invalid-p2sh block precedes the
+// height on every network).
+inline
+bool bip16(size_t height, domain::config::network network) {
+    return network_relation(network, std::greater_equal<>{}, height
+                            , mainnet_bip16_activation_height
+                            , testnet_bip16_activation_height
+                            , regtest_bip16_activation_height
+#if defined(KTH_CURRENCY_BCH)
+                            , testnet4_bip16_activation_height
+                            , scalenet_bip16_activation_height
+                            , chipnet_bip16_activation_height
+#endif
+                            );
+}
+#endif // ! KTH_CURRENCY_LTC
+
 inline
 uint32_t timestamp_high(chain_state::data const& values) {
     return values.timestamp.ordered.back();
@@ -443,12 +463,21 @@ chain_state::activations chain_state::activation(data const& values, script_flag
     // bip90 is activated based on configuration alone (network upgrade).
     result.flags |= (script_flags::bip90_rule & flags);
 
+#if defined(KTH_CURRENCY_LTC)
     // bip16 is activated with a one-time test on mainnet/testnet (~55% rule).
     // There was one invalid p2sh tx mined after that time (code shipped late).
     if (values.timestamp.self >= bip16_activation_time &&
         ! is_bip16_exception({values.hash, height}, network)) {
         result.flags |= (script_flags::bip16_rule & flags);
     }
+#else
+    // bip16 (P2SH) is activated by height, matching BCHN (consensus.BIP16Height).
+    // The date-based path (LTC branch) enforces P2SH ~7000 blocks early and needs
+    // a per-block exception; height-based activation matches BCHN and needs none.
+    if (bip16(height, network)) {
+        result.flags |= (script_flags::bip16_rule & flags);
+    }
+#endif
 
     // bip30 is active for all but two mainnet blocks that violate the rule.
     // These two blocks each have a coinbase transaction that exctly duplicates

--- a/src/domain/test/chain/chain_state.cpp
+++ b/src/domain/test/chain/chain_state.cpp
@@ -46,6 +46,13 @@ chain::chain_state::data make_data_with_mtp(uint32_t mtp_anchor, int32_t offset 
     return values;
 }
 
+// Helper: minimal data at a given height (MTP irrelevant for height-gated rules).
+chain::chain_state::data make_data_at_height(size_t height) {
+    auto values = make_data_with_mtp(1500000000u);
+    values.height = height;
+    return values;
+}
+
 } // namespace
 
 // Start Test Suite: chain_state tests
@@ -110,3 +117,24 @@ TEST_CASE("chain_state activation leaves Cantor bits off while MTP is below the 
 
     REQUIRE_FALSE(chain::script::is_enabled(result.flags, script_flags::bch_2027_may));
 }
+
+#if defined(KTH_CURRENCY_BCH)
+// P2SH (BIP16) must activate by height, matching BCHN (consensus.BIP16Height,
+// mainnet 173805), not by block timestamp. The date-based path enforced P2SH
+// ~7000 blocks early (from ~166832), which wrongly rejected pre-enforcement
+// P2SH-format spends (e.g. block 170060). Block 173804 has no P2SH; 173805 does.
+TEST_CASE("chain_state activation gates BIP16 (P2SH) by height, matching BCHN", "[chain_state]") {
+    using namespace kth::domain::machine;
+    auto const mask = static_cast<domain::script_flags_t>(script_flags::bip16_rule);
+
+    auto const below = chain_state_test_access::activation(
+        make_data_at_height(173804), mask, domain::config::network::mainnet,
+        bch_cantor_activation_time);
+    REQUIRE_FALSE(chain::script::is_enabled(below.flags, script_flags::bip16_rule));
+
+    auto const at = chain_state_test_access::activation(
+        make_data_at_height(173805), mask, domain::config::network::mainnet,
+        bch_cantor_activation_time);
+    REQUIRE(chain::script::is_enabled(at.flags, script_flags::bip16_rule));
+}
+#endif // KTH_CURRENCY_BCH


### PR DESCRIPTION
## Problem

KTH activates P2SH (BIP16) by **block timestamp** (`values.timestamp.self >= bip16_activation_time`, mainnet 2012-02-15 ≈ block 166832). BCHN activates it by **height** — `consensus.BIP16Height` (mainnet **173805**, the 2012-04-01 flag day), enforced as `(pindex->nHeight + 1) >= BIP16Height`.

The date-based path turns P2SH on ~7000 blocks early and then needs a per-block exception. For blocks in the `166832..173804` window it enforces P2SH where BCHN does not, and **rejects pre-enforcement P2SH-format spends that BCHN accepts** — e.g. mainnet block **170060**, whose input simply reveals its redeem script (a 1-of-1 bare multisig) with **no signature**: valid only while P2SH is not yet enforced, invalid once it is (the redeem script runs and `OP_CHECKMULTISIG` fails on an empty stack).

This is latent in production — checkpoints skip script validation below the highest checkpoint, and above it P2SH is active in both models — but it breaks validation from genesis / below a lowered checkpoint.

## Fix

Gate BIP16 by height per network, matching BCHN's `BIP16Height`:

| network | height |
|---|---|
| mainnet | 173805 |
| testnet | 514 |
| testnet4 / scalenet / chipnet | 1 |
| regtest | 0 |

This mirrors how BIP34/66/65 are already frozen by height (their freeze heights already equal BCHN's), and needs **no exception** — the historical invalid-p2sh block precedes the activation height on every network. LTC keeps its date-based activation.

## Test

Adds a `chain_state` activation boundary test: mainnet block **173804** has no P2SH, **173805** has it.

Full `[chain_state]` suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected P2SH (BIP16) activation behavior across supported Bitcoin Cash networks.
  - Activation now follows the appropriate network-specific block heights.
  - Preserved existing Litecoin activation behavior.
  - Added coverage for the mainnet activation boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->