### PR TITLE
node, blockchain: full validation of post-checkpoint blocks during IBD

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -186,6 +186,7 @@ set(kth_sources_just_legacy
   src/populate/populate_block.cpp
   src/populate/populate_chain_state.cpp
   src/populate/populate_transaction.cpp
+  src/validate/batch_validate.cpp
   src/validate/validate_block.cpp
   src/validate/validate_header.cpp
   src/validate/validate_input.cpp

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -195,6 +195,16 @@ struct KB_API block_chain {
     [[nodiscard]]
     std::pair<size_t, std::vector<utxoz::deferred_deletion_entry>> utxo_process_pending_deletions();
 
+    [[nodiscard]]
+    size_t utxo_deferred_lookups_size() const;
+
+    // Second phase of the find() contract: resolves outpoints whose find()
+    // returned key_not_found (queued, not authoritative) by sweeping older file
+    // versions. Returns {resolved by outpoint, keys that truly don't exist}.
+    [[nodiscard]]
+    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxo_entry>, std::vector<utxoz::raw_outpoint>>
+    utxo_process_pending_lookups();
+
     void utxo_compact();
     void utxo_print_statistics();
     void utxo_print_sizing_report();

--- a/src/blockchain/include/kth/blockchain/validate/batch_validate.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/batch_validate.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_VALIDATE_BATCH_VALIDATE_HPP
+#define KTH_BLOCKCHAIN_VALIDATE_BATCH_VALIDATE_HPP
+
+#include <cstddef>
+#include <vector>
+
+#include <kth/domain.hpp>
+
+#include <kth/domain/config/network.hpp>
+
+#include <kth/blockchain/define.hpp>
+
+namespace kth::blockchain {
+
+class block_chain;
+struct settings;
+
+// Fully validate a contiguous batch of blocks [start_height .. start_height+M-1]
+// that extend a chain whose UTXO-Z set is complete through start_height-1. This
+// is the post-checkpoint (full) validation stage: it verifies scripts, fees,
+// sigchecks and coinbase value against the consensus rules.
+//
+// Design (parallel):
+//   - The UTXO-Z set is a fixed read-only snapshot at start_height-1; reads run
+//     concurrently. A prevout resolves from UTXO-Z OR from an output created by
+//     another block *within the batch* (BCH CTOR: any tx may spend any same-batch
+//     output that is not a same-block/immature coinbase).
+//   - Double-spend: every spent outpoint must be unique across the batch, and a
+//     UTXO-Z prevout must not already be spent.
+//   - Script/signature verification is independent per input once prevouts are
+//     resolved, so it runs in parallel across every input of the whole batch.
+//
+// Flags are computed PER HEIGHT from chain_state (built for the first block and
+// advanced with from_pool_ptr), so each block validates under the forks actually
+// active at its height — not a fixed all-forks set.
+//
+// This stage verifies: input scripts/signatures, in-batch double spends, coinbase
+// maturity, fees (inputs >= outputs) and coinbase value (<= subsidy + fees). It
+// does NOT re-check block-level rules already covered by the fast path or applied
+// elsewhere (merkle root, ABLA block size, per-block sigcheck accounting, tx
+// duplicate / BIP30, coinbase input shape). The batch is NOT applied/persisted
+// here — the caller applies the UTXO delta only after this returns error::success.
+//
+// Returns error::success, or the first consensus error encountered.
+KB_API
+code validate_block_batch(
+    block_chain& chain,
+    settings const& settings,
+    domain::config::network network,
+    std::vector<block_const_ptr> const& blocks,
+    size_t start_height);
+
+} // namespace kth::blockchain
+
+#endif // KTH_BLOCKCHAIN_VALIDATE_BATCH_VALIDATE_HPP

--- a/src/blockchain/include/kth/blockchain/validate/validate_header.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/validate_header.hpp
@@ -99,6 +99,18 @@ struct KB_API validate_header {
                      header_index::index_t parent_idx,
                      header_index const& index) const;
 
+    /// Build a full chain_state for `height` from the header_index (same
+    /// construction accept_full uses). Lets callers obtain per-height consensus
+    /// flags / activations (e.g. post-checkpoint block validation). Advance it
+    /// across contiguous blocks with chain_state::from_pool_ptr.
+    [[nodiscard]]
+    std::expected<domain::chain::chain_state::ptr, code> chain_state_at(
+        domain::chain::header const& header,
+        hash_digest const& hash,
+        size_t height,
+        header_index::index_t parent_idx,
+        header_index const& index) const;
+
     /// Build chain_state::data from header_index for a given height.
     /// This collects the historical bits, versions, and timestamps needed
     /// to construct a chain_state for validation.

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -690,6 +690,15 @@ std::pair<size_t, std::vector<utxoz::deferred_deletion_entry>> block_chain::utxo
     return utxoz_db_.process_pending_deletions();
 }
 
+size_t block_chain::utxo_deferred_lookups_size() const {
+    return utxoz_db_.deferred_lookups_size();
+}
+
+std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxo_entry>, std::vector<utxoz::raw_outpoint>>
+block_chain::utxo_process_pending_lookups() {
+    return utxoz_db_.process_pending_lookups();
+}
+
 void block_chain::utxo_compact() {
     utxoz_db_.compact();
 }

--- a/src/blockchain/src/settings.cpp
+++ b/src/blockchain/src/settings.cpp
@@ -10,6 +10,11 @@
 
 //TODO(fernando): Avoid this dependency
 
+#if defined(KTH_TEST_LOW_CHECKPOINT)
+#include <cstdlib>
+#include <string>
+#endif
+
 namespace kth::blockchain {
 
 settings::settings(domain::config::network net) {
@@ -69,6 +74,18 @@ settings::settings(domain::config::network net) {
     }
 
     checkpoints = domain::config::default_checkpoints(net);
+
+#if defined(KTH_TEST_LOW_CHECKPOINT)
+    // Test-only: cap the checkpoint list at the height given by the
+    // KTH_TEST_MAX_CHECKPOINT environment variable, so full post-checkpoint
+    // validation can be exercised from a low height without a full mainnet sync.
+    // Compiled in only when KTH_TEST_LOW_CHECKPOINT is defined; never in a
+    // production build.
+    if (auto const* cap = std::getenv("KTH_TEST_MAX_CHECKPOINT")) {
+        auto const h = static_cast<size_t>(std::stoull(cap));
+        std::erase_if(checkpoints, [h](auto const& c){ return c.height() > h; });
+    }
+#endif
 
     // Pre-compute sorted list and max height
     checkpoints_sorted = checkpoints;

--- a/src/blockchain/src/validate/batch_validate.cpp
+++ b/src/blockchain/src/validate/batch_validate.cpp
@@ -1,0 +1,343 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/blockchain/validate/batch_validate.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <boost/unordered/unordered_flat_map.hpp>
+#include <boost/unordered/unordered_flat_set.hpp>
+
+#include <kth/blockchain/interface/block_chain.hpp>
+#include <kth/blockchain/settings.hpp>
+#include <kth/blockchain/validate/validate_header.hpp>
+#include <kth/blockchain/validate/validate_input.hpp>
+#include <kth/domain/constants.hpp>
+
+namespace kth::blockchain {
+
+using namespace kth::domain::chain;
+
+namespace {
+
+// Key for the intra-batch created-output and spent-output indexes.
+struct bv_outpoint {
+    hash_digest hash;
+    uint32_t index;
+    bool operator==(bv_outpoint const& o) const {
+        return index == o.index && hash == o.hash;
+    }
+};
+
+struct bv_outpoint_hasher {
+    size_t operator()(bv_outpoint const& k) const noexcept {
+        size_t h;
+        std::memcpy(&h, k.hash.data(), sizeof(h));
+        return h ^ (static_cast<size_t>(k.index) * 0x9e3779b97f4a7c15ull);
+    }
+};
+
+// An output produced by a block inside the batch (not yet in UTXO-Z).
+struct created_output {
+    output const* out;
+    size_t height;     // block height that created it
+    bool coinbase;
+};
+
+// A prevout resolved from UTXO-Z (owns the output by value).
+struct db_prevout {
+    output out;
+    size_t height;
+    bool coinbase;
+};
+
+// One script-verification unit, filled during the serial pass and run in parallel.
+// Flags are the per-height consensus flags for the block the tx belongs to.
+struct verify_task {
+    transaction const* tx;
+    uint32_t input_index;
+    domain::script_flags_t flags;
+    size_t height;   // for diagnostics on failure
+};
+
+} // namespace
+
+code validate_block_batch(
+    block_chain& chain,
+    settings const& settings,
+    domain::config::network network,
+    std::vector<block_const_ptr> const& blocks,
+    size_t start_height) {
+
+    if (blocks.empty()) {
+        return error::success;
+    }
+
+    // Per-height consensus flags: build the chain_state for the first block from
+    // the header_index (same construction header validation uses) and advance it
+    // one block at a time with from_pool_ptr. Using a fixed all-forks flag set
+    // would misvalidate historical blocks (e.g. strict-DER before BIP66).
+    validate_header const header_validator(settings, network);
+    auto const& header_index = chain.headers();
+
+    domain::chain::chain_state::ptr state;
+    std::vector<domain::script_flags_t> block_flags(blocks.size());
+
+    boost::unordered_flat_map<bv_outpoint, created_output, bv_outpoint_hasher> created;
+    boost::unordered_flat_set<bv_outpoint, bv_outpoint_hasher> spent;
+    std::vector<verify_task> tasks;
+
+    boost::unordered_flat_map<bv_outpoint, db_prevout, bv_outpoint_hasher> db_resolved;
+
+    // -----------------------------------------------------------------------
+    // Full intra-batch created-output index. Under BCH CTOR a tx may spend the
+    // output of any other tx in the batch created at its own height or earlier.
+    // -----------------------------------------------------------------------
+    for (size_t i = 0; i < blocks.size(); ++i) {
+        auto const height = start_height + i;
+        for (auto const& tx : blocks[i]->transactions()) {
+            auto const& outs = tx.outputs();
+            auto const txid = tx.hash();
+            bool const cb = tx.is_coinbase();
+            for (uint32_t oi = 0; oi < outs.size(); ++oi) {
+                created.insert({bv_outpoint{txid, oi}, created_output{&outs[oi], height, cb}});
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 1 (serial): per-height consensus flags, double-spend detection, and
+    // EMIT every UTXO-Z lookup. find()/get_utxo is a two-phase contract — its
+    // key_not_found only means "not in the active file, queued as a deferred
+    // lookup", NOT "does not exist". So we do not conclude anything here.
+    // -----------------------------------------------------------------------
+    for (size_t i = 0; i < blocks.size(); ++i) {
+        auto const height = start_height + i;
+        auto const& block = *blocks[i];
+
+        if (i == 0) {
+            auto const parent_idx = header_index.find(block.header().previous_block_hash());
+            if (parent_idx == header_index::null_index) {
+                // Parent header not in the index: cannot build chain_state (the
+                // KTH_ASSERT downstream is a no-op in Release, so guard here).
+                return error::not_found;
+            }
+            auto cs = header_validator.chain_state_at(
+                block.header(), block.hash(), height, parent_idx, header_index);
+            if ( ! cs) {
+                return cs.error();
+            }
+            state = std::move(*cs);
+        } else {
+            state = domain::chain::chain_state::from_pool_ptr(*state, block);
+        }
+        if ( ! state) {
+            return error::operation_failed;
+        }
+        block_flags[i] = state->enabled_flags();
+
+        for (auto const& tx : block.transactions()) {
+            if (tx.is_coinbase()) {
+                continue;
+            }
+            for (auto const& in : tx.inputs()) {
+                auto const& op = in.previous_output();
+                bv_outpoint const key{op.hash(), op.index()};
+
+                // Double spend within the batch (or a prevout claimed twice).
+                if ( ! spent.insert(key).second) {
+                    return error::double_spend;
+                }
+
+                // Resolved intra-batch (created at this height or earlier)?
+                if (auto const it = created.find(key);
+                    it != created.end() && it->second.height <= height) {
+                    continue;
+                }
+
+                // Otherwise it must come from UTXO-Z: emit the lookup. A hit is
+                // recorded now; a miss is queued and resolved after the loop.
+                if (auto const utxo = chain.get_utxo(op, height); utxo) {
+                    db_resolved.insert({key, db_prevout{utxo->output, utxo->height, utxo->coinbase}});
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Second phase of the find() contract: resolve every queued lookup by
+    // sweeping the older UTXO-Z file versions. This MUST run before any deferred
+    // deletion (block_tasks applies deletions only after this returns). Only keys
+    // absent here truly do not exist.
+    // -----------------------------------------------------------------------
+    {
+        auto [found, failed] = chain.utxo_process_pending_lookups();
+        for (auto const& [rk, entry] : found) {
+            bv_outpoint key;
+            std::memcpy(key.hash.data(), rk.data(), key.hash.size());
+            std::memcpy(&key.index, rk.data() + key.hash.size(), sizeof(key.index));
+            db_resolved.insert({key, db_prevout{entry.output(), entry.height(), entry.coinbase()}});
+        }
+        // `failed` = outpoints absent from every UTXO-Z generation (the sweep is
+        // authoritative). Every deferred lookup came from a batch input's prevout,
+        // so a failed key is a genuinely-missing prevout -> invalid block.
+        if ( ! failed.empty()) {
+            auto const& rk = failed.front();
+            hash_digest h;
+            uint32_t idx;
+            std::memcpy(h.data(), rk.data(), h.size());
+            std::memcpy(&idx, rk.data() + h.size(), sizeof(idx));
+            spdlog::error("[batch_validate] prevout not found {}:{} (deferred lookup failed; {} missing total, batch {}-{})",
+                encode_hash(h), idx, failed.size(), start_height, start_height + blocks.size() - 1);
+            return error::missing_previous_output;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2 (serial): now that every prevout is resolved, check coinbase
+    // maturity, fees and coinbase value, and populate each input's prevout cache.
+    // -----------------------------------------------------------------------
+    for (size_t i = 0; i < blocks.size(); ++i) {
+        auto const height = start_height + i;
+        uint64_t block_fees = 0;
+        uint64_t coinbase_value = 0;
+
+        for (auto const& tx : blocks[i]->transactions()) {
+            if (tx.is_coinbase()) {
+                for (auto const& o : tx.outputs()) {
+                    coinbase_value += o.value();
+                }
+                continue;
+            }
+
+            uint64_t in_value = 0;
+            uint64_t out_value = 0;
+            for (auto const& o : tx.outputs()) {
+                out_value += o.value();
+            }
+
+            auto const& inputs = tx.inputs();
+            for (uint32_t ii = 0; ii < inputs.size(); ++ii) {
+                auto const& op = inputs[ii].previous_output();
+                bv_outpoint const key{op.hash(), op.index()};
+
+                output const* out = nullptr;
+                size_t prevout_height = 0;
+                bool prevout_coinbase = false;
+
+                if (auto const it = created.find(key);
+                    it != created.end() && it->second.height <= height) {
+                    out = it->second.out;
+                    prevout_height = it->second.height;
+                    prevout_coinbase = it->second.coinbase;
+                } else if (auto const it2 = db_resolved.find(key); it2 != db_resolved.end()) {
+                    out = &it2->second.out;
+                    prevout_height = it2->second.height;
+                    prevout_coinbase = it2->second.coinbase;
+                } else {
+                    // Absent after the deferred-lookup sweep: the prevout truly does
+                    // not exist -> invalid block.
+                    spdlog::error("[batch_validate] prevout not found {}:{} spent@{} (batch_start={}, utxo_size={}, deferred_lookups_left={})",
+                        encode_hash(op.hash()), op.index(), height, start_height,
+                        chain.utxo_size(), chain.utxo_deferred_lookups_size());
+                    return error::missing_previous_output;
+                }
+
+                if (prevout_coinbase && height < prevout_height + coinbase_maturity) {
+                    return error::coinbase_maturity;
+                }
+
+                op.validation.cache = *out;
+                op.validation.coinbase = prevout_coinbase;
+                op.validation.height = prevout_height;
+                op.validation.spent = false;
+                op.validation.confirmed = true;
+
+                in_value += out->value();
+                tasks.push_back(verify_task{&tx, ii, block_flags[i], height});
+            }
+
+            if (in_value < out_value) {
+                return error::spend_exceeds_value;
+            }
+            block_fees += (in_value - out_value);
+        }
+
+        auto const reward = block::subsidy(height, settings.retarget) + block_fees;
+        if (coinbase_value > reward) {
+            return error::coinbase_value_limit;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2 (parallel): script/signature verification per input. Independent
+    // now that every prevout cache is populated; split across the hardware.
+    // TODO: enforce the per-block dynamic sigchecks limit (ABLA); per-tx limit is
+    // enforced inside verify_script accumulation.
+    // -----------------------------------------------------------------------
+    if (tasks.empty()) {
+        return error::success;
+    }
+
+    unsigned hw = std::thread::hardware_concurrency();
+    size_t const workers = std::max<size_t>(1, std::min<size_t>(hw ? hw : 1, tasks.size()));
+
+    std::atomic<bool> failed{false};
+    std::mutex err_mutex;
+    code first_error = error::success;
+
+    auto run_bucket = [&](size_t bucket) {
+      try {
+        for (size_t t = bucket; t < tasks.size() && ! failed.load(std::memory_order_relaxed); t += workers) {
+            auto const& task = tasks[t];
+            auto const res = validate_input::verify_script(*task.tx, task.input_index, task.flags);
+            if (res.first != error::success) {
+                std::lock_guard<std::mutex> lk(err_mutex);
+                if ( ! failed.exchange(true)) {
+                    first_error = res.first;
+                    // Decisive diagnostic: everything needed to reproduce the failing
+                    // input in a standalone verify_script test.
+                    auto const& in = task.tx->inputs()[task.input_index];
+                    auto const& pv = in.previous_output();
+                    spdlog::error("[batch_validate] script FAIL h={} err={} flags={:#x} tx={} in={} prevout={}:{} value={} prevout_script={} input_script={}",
+                        task.height, res.first.message(),
+                        static_cast<uint64_t>(task.flags),
+                        encode_hash(task.tx->hash()), task.input_index,
+                        encode_hash(pv.hash()), pv.index(),
+                        pv.validation.cache.value(),
+                        encode_base16(to_data_chunk(pv.validation.cache.script(), false)),
+                        encode_base16(to_data_chunk(in.script(), false)));
+                }
+                return;
+            }
+        }
+      } catch (std::exception const& e) {
+        // A worker thread must not let an exception escape (std::terminate).
+        std::lock_guard<std::mutex> lk(err_mutex);
+        if ( ! failed.exchange(true)) {
+            first_error = error::operation_failed;
+            spdlog::error("[batch_validate] script verification threw: {}", e.what());
+        }
+      }
+    };
+
+    std::vector<std::thread> pool;
+    pool.reserve(workers - 1);
+    for (size_t w = 1; w < workers; ++w) {
+        pool.emplace_back(run_bucket, w);
+    }
+    run_bucket(0);
+    for (auto& th : pool) {
+        th.join();
+    }
+
+    return first_error;
+}
+
+} // namespace kth::blockchain

--- a/src/blockchain/src/validate/validate_header.cpp
+++ b/src/blockchain/src/validate/validate_header.cpp
@@ -252,6 +252,38 @@ chain_state::assert_anchor_block_info_t validate_header::get_asert_anchor_block(
 }
 #endif // KTH_CURRENCY_BCH
 
+std::expected<chain_state::ptr, code> validate_header::chain_state_at(
+    header const& header,
+    hash_digest const& hash,
+    size_t height,
+    header_index::index_t parent_idx,
+    header_index const& index) const {
+
+    auto data_result = build_chain_state_data(height, header, hash, parent_idx, index);
+    if ( ! data_result) {
+        return std::unexpected(data_result.error());
+    }
+
+#if defined(KTH_CURRENCY_BCH)
+    auto const anchor = get_asert_anchor_block();
+    return std::make_shared<chain_state>(
+        std::move(*data_result),
+        configured_flags_,
+        checkpoints_,
+        network_,
+        anchor,
+        settings_.asert_half_life,
+        settings_.abla_config,
+        cantor_t(settings_.cantor_activation_time));
+#else
+    return std::make_shared<chain_state>(
+        std::move(*data_result),
+        configured_flags_,
+        checkpoints_,
+        network_);
+#endif
+}
+
 std::expected<chain_state::data, code> validate_header::build_chain_state_data(
     size_t height,
     domain::chain::header const& header,
@@ -352,48 +384,20 @@ code validate_header::accept_full(domain::chain::header const& header,
         return error::store_block_missing_parent;
     }
 
-    // Build chain_state data from header_index
-    auto data_result = build_chain_state_data(height, header, hash, parent_idx, index);
-    if (!data_result) {
-        spdlog::error("[validate_header] accept_full: failed to build chain_state data for height {}", height);
-        return data_result.error();
+    // Build the chain_state for this height. Reuse chain_state_at instead of
+    // duplicating build_chain_state_data + the (BCH-parameter-heavy) construction,
+    // so a new consensus parameter only has to be wired in one place.
+    auto state_result = chain_state_at(header, hash, height, parent_idx, index);
+    if ( ! state_result) {
+        spdlog::error("[validate_header] accept_full: failed to build chain_state for height {}", height);
+        return state_result.error();
     }
-
-    // Create chain_state from the data
-#if defined(KTH_CURRENCY_BCH)
-    auto const anchor = get_asert_anchor_block();
-    chain_state state(
-        std::move(*data_result),
-        configured_flags_,
-        checkpoints_,
-        network_,
-        anchor,
-        settings_.asert_half_life,
-        settings_.abla_config,
-        cantor_t(settings_.cantor_activation_time)
-    );
-#else
-    chain_state state(
-        std::move(*data_result),
-        configured_flags_,
-        checkpoints_,
-        network_
-    );
-#endif
+    chain_state const& state = **state_result;
 
     // Now perform the full header validation using chain_state
     // This is equivalent to header_basis::accept()
 
     // 1. Difficulty check
-    if (height == 32256) {
-        spdlog::warn("[validate_header] DEBUG height 32256: work_required={:#x}, header.bits={:#x}, "
-            "data.timestamp.retarget={}, data.bits.ordered.size={}, "
-            "data.timestamp.ordered.size={}",
-            state.work_required(), header.bits(),
-            data_result->timestamp.retarget,
-            data_result->bits.ordered.size(),
-            data_result->timestamp.ordered.size());
-    }
     if (header.bits() != state.work_required()) {
         spdlog::debug("[validate_header] accept_full: incorrect PoW at height {}: "
             "header bits={:#x}, required={:#x}",

--- a/src/database/include/kth/database/databases/utxoz_database.hpp
+++ b/src/database/include/kth/database/databases/utxoz_database.hpp
@@ -245,6 +245,19 @@ struct KD_API utxoz_database {
     [[nodiscard]]
     std::pair<uint32_t, std::vector<utxoz::deferred_deletion_entry>> process_pending_deletions();
 
+    /// Get the number of pending deferred lookups
+    [[nodiscard]]
+    size_t deferred_lookups_size() const;
+
+    /// Process pending deferred lookups (sweeps cached/older file versions).
+    /// find() is a two-phase contract: its key_not_found only means "not in the
+    /// active file, queued". This resolves the queue. Call once per batch, BEFORE
+    /// process_pending_deletions().
+    /// @return pair of (resolved entries keyed by outpoint, keys that truly don't exist)
+    [[nodiscard]]
+    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxo_entry>, std::vector<utxoz::raw_outpoint>>
+    process_pending_lookups();
+
     /// Compact the database
     void compact();
 

--- a/src/database/include/kth/database/define.hpp
+++ b/src/database/include/kth/database/define.hpp
@@ -37,6 +37,12 @@ namespace kth::database {
 using array_index = uint32_t;
 using file_offset = uint64_t;
 
+/// True if this database library was compiled with UTXO-Z compact storage mode
+/// (KTH_UTXOZ_COMPACT_MODE). Reported for build diagnostics: the option is
+/// declared in more than one CMake list, so a build can end up with the database
+/// and blockchain modules disagreeing — this exposes each module's actual value.
+KD_API bool utxoz_compact_mode();
+
 } // namespace kth::database
 
 #endif

--- a/src/database/src/databases/utxoz_database.cpp
+++ b/src/database/src/databases/utxoz_database.cpp
@@ -16,6 +16,15 @@
 
 namespace kth::database {
 
+bool utxoz_compact_mode() {
+#ifdef KTH_UTXOZ_COMPACT_MODE
+    return true;
+#else
+    return false;
+#endif
+}
+
+
 utxoz_database::~utxoz_database() {
     close();
 }
@@ -134,6 +143,54 @@ std::pair<uint32_t, std::vector<utxoz::deferred_deletion_entry>> utxoz_database:
         return {0, {}};
     }
     return db_->process_pending_deletions();
+}
+
+size_t utxoz_database::deferred_lookups_size() const {
+    if ( ! is_open()) {
+        return 0;
+    }
+    return db_->deferred_lookups_size();
+}
+
+std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxo_entry>, std::vector<utxoz::raw_outpoint>>
+utxoz_database::process_pending_lookups() {
+    boost::unordered_flat_map<utxoz::raw_outpoint, utxo_entry> resolved;
+    std::vector<utxoz::raw_outpoint> failed;
+    if ( ! is_open()) {
+        return {std::move(resolved), std::move(failed)};
+    }
+
+#ifdef KTH_UTXOZ_COMPACT_MODE
+    auto [found, fail] = db_->process_pending_lookups();
+    resolved.reserve(found.size());
+    for (auto const& [key, ref] : found) {
+        uint32_t index;
+        std::memcpy(&index, key.data() + 32, sizeof(index));   // outpoint index (LE)
+        auto entry = resolve_compact_ref(ref, index);
+        if (entry) {
+            resolved.emplace(key, std::move(*entry));
+        } else {
+            failed.push_back(key);   // conversion failure -> treat as missing
+        }
+    }
+    for (auto const& e : fail) {
+        failed.push_back(e.key);
+    }
+#else
+    auto [found, fail] = db_->process_pending_lookups();
+    resolved.reserve(found.size());
+    for (auto const& [key, res] : found) {
+        auto entry = bytes_to_entry(res.data);
+        if (entry) {
+            resolved.emplace(key, std::move(*entry));
+        }
+    }
+    failed.reserve(fail.size());
+    for (auto const& e : fail) {
+        failed.push_back(e.key);
+    }
+#endif
+    return {std::move(resolved), std::move(failed)};
 }
 
 void utxoz_database::compact() {

--- a/src/node/include/kth/node/sync/block_tasks.hpp
+++ b/src/node/include/kth/node/sync/block_tasks.hpp
@@ -139,7 +139,8 @@ extern std::atomic<uint64_t> g_blocks_received_by_validation;
 ::asio::awaitable<void> utxo_build_task(
     blockchain::block_chain& chain,
     std::atomic<uint32_t> const& contiguous_height,
-    uint32_t start_height
+    uint32_t start_height,
+    domain::config::network network
 );
 
 } // namespace kth::node::sync

--- a/src/node/include/kth/node/sync/orchestrator.hpp
+++ b/src/node/include/kth/node/sync/orchestrator.hpp
@@ -38,7 +38,8 @@ namespace kth::node::sync {
 ::asio::awaitable<void> sync_orchestrator(
     blockchain::block_chain& chain,
     blockchain::header_organizer& organizer,
-    kth::node::p2p_node& network
+    kth::node::p2p_node& network,
+    domain::config::network network_type
 );
 
 } // namespace kth::node::sync

--- a/src/node/src/executor/executor.cpp
+++ b/src/node/src/executor/executor.cpp
@@ -528,6 +528,9 @@ void executor::print_version(std::string_view extra) {
     std::println("Knuth Node\n  C++ lib v{}\n  {}\n  Currency: {}\n  Microarchitecture: {}\n  Built for CPU instructions/extensions: {}\n  (Debug Build)",
         kth::version, extra, KTH_CURRENCY_SYMBOL_STR, KTH_MICROARCHITECTURE_STR, march_names());
 #endif
+    // UTXO-Z storage mode (single source of truth).
+    std::println("  UTXO-Z mode: {}",
+        kth::database::utxoz_compact_mode() ? "compact" : "full");
 }
 
 void executor::print_ascii_art() {

--- a/src/node/src/full_node.cpp
+++ b/src/node/src/full_node.cpp
@@ -267,7 +267,7 @@ full_node::~full_node() {
     // run on the network pool's 32 threads instead of the single io_thread.
     co_await ::asio::co_spawn(
         network_.thread_pool().get_executor(),
-        sync::sync_orchestrator(chain_, organizer, network_),
+        sync::sync_orchestrator(chain_, organizer, network_, network_type_),
         ::asio::use_awaitable
     );
 

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <fstream>
@@ -25,12 +26,15 @@
 #include <asio/post.hpp>
 #include <asio/steady_timer.hpp>
 #include <asio/this_coro.hpp>
+#include <asio/co_spawn.hpp>
+#include <asio/thread_pool.hpp>
 #include <asio/use_awaitable.hpp>
 #include <asio/experimental/awaitable_operators.hpp>
 
 #include <kth/infrastructure/utility/task_group.hpp>
 #include <kth/infrastructure/utility/stats.hpp>
 #include <kth/blockchain/utxo_builder.hpp>
+#include <kth/blockchain/validate/batch_validate.hpp>
 #include <kth/network/protocols_coro.hpp>
 
 namespace kth::node::sync {
@@ -1653,16 +1657,29 @@ std::atomic<uint32_t> g_active_download_peers{0};
 ::asio::awaitable<void> utxo_build_task(
     blockchain::block_chain& chain,
     std::atomic<uint32_t> const& contiguous_height,
-    uint32_t start_height
+    uint32_t start_height,
+    domain::config::network network
 ) {
     spdlog::info("[utxo_build] Task started at height {}", start_height);
 
     constexpr uint32_t batch_size = 1000;
     constexpr auto poll_interval = std::chrono::milliseconds(500);
 
-    // Load bloom filter
+    // Load bloom filter. The hardcoded bloom is the FINAL UTXO set as of the real
+    // checkpoint: it prunes outputs spent before then. That is only valid up to the
+    // checkpoint (no validation there); above the checkpoint we need the live UTXO
+    // set to resolve prevouts for full validation, so the bloom is disabled per
+    // batch below.
     auto const bloom = blockchain::load_utxo_bloom();
     auto const* bloom_ptr = bloom.get();
+#if defined(KTH_TEST_LOW_CHECKPOINT)
+    // With a lowered test checkpoint the hardcoded bloom (the final UTXO set at
+    // the real checkpoint) does not match, so disable it entirely and keep every
+    // output. Compiled in only under KTH_TEST_LOW_CHECKPOINT.
+    if (std::getenv("KTH_TEST_MAX_CHECKPOINT") != nullptr) {
+        bloom_ptr = nullptr;
+    }
+#endif
 
     // Resume from saved progress
     uint32_t utxo_built_height = start_height > 0 ? start_height - 1 : 0;
@@ -1683,6 +1700,12 @@ std::atomic<uint32_t> g_active_download_peers{0};
     }
 
     auto executor = co_await ::asio::this_coro::executor;
+
+    // Dedicated worker for block parsing + full validation, so that CPU-heavy work
+    // does not block this coroutine's executor (download supervision, storage).
+    // validate_block_batch fans script verification out to its own threads, so one
+    // pool thread to run the serial phase and orchestrate is enough.
+    ::asio::thread_pool validation_pool(1);
 
     while ( ! chain.stopped()) {
         uint32_t current_contiguous = contiguous_height.load(std::memory_order_acquire);
@@ -1715,6 +1738,52 @@ std::atomic<uint32_t> g_active_download_peers{0};
             continue;
         }
 
+        // Post-checkpoint FULL validation (scripts / signatures / fees / coinbase
+        // value) BEFORE the UTXO delta is applied. Below the highest checkpoint we
+        // keep the fast merkle-only path. Validate ONLY heights strictly above the
+        // checkpoint: below it the bloom may have pruned outputs spent before the
+        // checkpoint, so a pre-checkpoint block can reference a prevout that is
+        // absent from UTXO-Z. On failure we halt: the invalid block is never applied.
+        uint32_t const checkpoint_height =
+            static_cast<uint32_t>(chain.chain_settings().max_checkpoint_height);
+        if (batch_end > checkpoint_height) {
+            uint32_t const validate_start = std::max(batch_start, checkpoint_height + 1);
+            // Parse the above-checkpoint blocks and validate them on the worker
+            // pool, off this coroutine's executor.
+            auto const vc = co_await ::asio::co_spawn(validation_pool.get_executor(),
+                [&]() -> ::asio::awaitable<code> {
+                    std::vector<kth::block_const_ptr> full_blocks;
+                    full_blocks.reserve(raw_result->size());
+                    for (uint32_t i = 0; i < raw_result->size(); ++i) {
+                        uint32_t const h = batch_start + i;
+                        if (h < validate_start) {
+                            continue;   // at/below the checkpoint: merkle-only
+                        }
+                        auto const& raw = (*raw_result)[i];
+                        byte_reader reader(byte_span{raw.data(), raw.size()});
+                        auto blk = domain::message::block::from_data(reader, 0u);
+                        if ( ! blk) {
+                            spdlog::critical("[utxo_build] Failed to parse block for validation at height {}", h);
+                            co_return error::operation_failed;
+                        }
+                        full_blocks.push_back(
+                            std::make_shared<domain::message::block const>(std::move(*blk)));
+                    }
+                    if (full_blocks.empty()) {
+                        co_return error::success;
+                    }
+                    co_return blockchain::validate_block_batch(
+                        chain, chain.chain_settings(), network, full_blocks, validate_start);
+                }, ::asio::use_awaitable);
+
+            if (vc) {
+                spdlog::critical("[utxo_build] POST-CHECKPOINT VALIDATION FAILED at {}-{}: {}",
+                    validate_start, batch_end, vc.message());
+                co_return;
+            }
+            spdlog::info("[utxo_build] Full validation OK for {}-{}", validate_start, batch_end);
+        }
+
         // Parse and process UTXO delta
         blockchain::utxo_raw_delta delta;
         for (uint32_t i = 0; i < raw_result->size(); ++i) {
@@ -1729,11 +1798,14 @@ std::atomic<uint32_t> g_active_download_peers{0};
             }
 
             auto const idx = static_cast<blockchain::header_index::index_t>(h);
+            // Prune with the bloom only up to the checkpoint; above it keep every
+            // output (live UTXO set) so full validation can resolve prevouts.
+            auto const* block_bloom = (h <= checkpoint_height) ? bloom_ptr : nullptr;
             auto block_delta = blockchain::process_compact_block_utxos(
                 *parsed, h, mtp,
                 chain.headers().get_file_number(idx),
                 chain.headers().get_data_pos(idx),
-                bloom_ptr);
+                block_bloom);
             delta.merge(std::move(block_delta));
 
             // Update MTP window from raw block header (timestamp at offset 68)

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -127,7 +127,8 @@ static
 ::asio::awaitable<void> sync_orchestrator(
     blockchain::block_chain& chain,
     blockchain::header_organizer& organizer,
-    kth::node::p2p_node& network
+    kth::node::p2p_node& network,
+    domain::config::network network_type
 ) {
     auto executor = co_await ::asio::this_coro::executor;
 
@@ -627,7 +628,8 @@ static
     all_tasks.spawn("utxo_build_task", utxo_build_task(
         chain,
         *contiguous_height,
-        initial_block_height + 1
+        initial_block_height + 1,
+        network_type
     ));
 
     // Bridge: validated_chunks -> coordinator_events (carries validation errors only)


### PR DESCRIPTION
## Summary

Adds full block validation for blocks **above the highest checkpoint** during the fast IBD. Below the checkpoint the fast merkle-only path is unchanged.

Validated per block: script/signature verification of every input, in-batch double-spend detection, coinbase maturity, fees (inputs ≥ outputs) and coinbase value (≤ subsidy + fees).

## How it works

A parallel batch validator runs as part of the UTXO-Z build, before each batch's delta is applied:

- **Serial phase** — resolves each input's prevout from the intra-batch created outputs or from UTXO-Z, detects in-batch double spends, checks coinbase maturity / fees / coinbase value, and builds **per-height consensus flags** (`chain_state` advanced with `from_pool_ptr`, so historical blocks validate under the rules actually active at their height, not a fixed all-forks set).
- **Parallel phase** — script/signature verification per input, split across the hardware.

Prevout resolution uses the UTXO-Z **two-phase lookup** contract: `find()` only searches the active file generation, so all lookups are emitted first and then `process_pending_lookups()` resolves the ones served from older generations; a key is treated as missing only once that sweep confirms it. This adds `process_pending_lookups()` / `deferred_lookups_size()` to the `utxoz_database` and `block_chain` wrappers.

Wiring: the validator runs when the batch is above `max_checkpoint_height`; on any failure the batch is not applied and the build stops.

## Extras

- `utxoz_compact_mode()` exposed for build diagnostics (node `--version` reports the UTXO-Z storage mode).
- A compile-time `KTH_TEST_LOW_CHECKPOINT` flag (off by default, never compiled into production) caps the checkpoint list at `KTH_TEST_MAX_CHECKPOINT` so this path can be exercised from a low height without a full mainnet sync.

Local build green (node-exe + blockchain tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added efficient batch validation for blockchain synchronization, including consensus, transaction, UTXO, and script checks.
  - Added validation-only support for checking blocks without saving them or changing the current chain state.
  - Added deferred UTXO lookup processing and visibility into unresolved entries.
  - Version information now reports the selected UTXO storage mode (`compact` or `full`).

- **Improvements**
  - Enhanced post-checkpoint synchronization to safely build and verify UTXO data before applying updates.
  - Added chain-state retrieval for specified historical heights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->