### PR TITLE
node, blockchain: align UTXO-build batches to the checkpoint boundary

### DIFF
--- a/src/blockchain/include/kth/blockchain/utxo_builder.hpp
+++ b/src/blockchain/include/kth/blockchain/utxo_builder.hpp
@@ -289,6 +289,18 @@ KB_API bool save_utxo_bloom(
 [[nodiscard]]
 KB_API std::shared_ptr<database::utxo_bloom_filter const> load_utxo_bloom();
 
+/// Whether this build embeds a UTXO bloom filter (KTH_HAS_EMBEDDED_BLOOM).
+/// Build-info: with an embedded bloom, IBD skips inserting outputs known to be
+/// spent before the checkpoint; without it, IBD runs unoptimized. Single source
+/// of truth for the node's --version / startup banner.
+[[nodiscard]]
+KB_API bool embedded_bloom_available();
+
+/// The checkpoint height baked into the embedded bloom filter, if any.
+/// @return the height, or 0 when this build has no embedded bloom.
+[[nodiscard]]
+KB_API uint32_t embedded_bloom_checkpoint_height();
+
 } // namespace kth::blockchain
 
 #endif // KTH_BLOCKCHAIN_UTXO_BUILDER_HPP

--- a/src/blockchain/src/utxo_builder.cpp
+++ b/src/blockchain/src/utxo_builder.cpp
@@ -709,6 +709,44 @@ std::shared_ptr<database::utxo_bloom_filter const> load_utxo_bloom() {
 #endif
 }
 
+bool embedded_bloom_available() {
+#ifdef KTH_HAS_EMBEDDED_BLOOM
+    return true;
+#else
+    return false;
+#endif
+}
+
+uint32_t embedded_bloom_checkpoint_height() {
+#ifndef KTH_HAS_EMBEDDED_BLOOM
+    return 0;
+#else
+    auto const data_size = static_cast<size_t>(kth_utxo_bloom_data_end - kth_utxo_bloom_data);
+    if (data_size < bloom_header_size) {
+        return 0;
+    }
+    auto const* p = kth_utxo_bloom_data;
+
+    std::array<char, 4> magic{};
+    std::memcpy(magic.data(), p, 4);
+    p += 4;
+    if (magic != bloom_magic) {
+        return 0;
+    }
+
+    uint32_t version = 0;
+    std::memcpy(&version, p, sizeof(version));
+    p += sizeof(version);
+    if (version != bloom_version) {
+        return 0;
+    }
+
+    uint32_t stored_height = 0;
+    std::memcpy(&stored_height, p, sizeof(stored_height));
+    return stored_height;
+#endif
+}
+
 ::asio::awaitable<database::result_code> build_utxo_set(
     block_chain& chain,
     ::asio::thread_pool& pool,

--- a/src/node/src/executor/executor.cpp
+++ b/src/node/src/executor/executor.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/core/null_deleter.hpp>
 
+#include <kth/blockchain/utxo_builder.hpp>
 #include <kth/domain/multi_crypto_support.hpp>
 #include <kth/node.hpp>
 #include <kth/node/parser.hpp>
@@ -531,6 +532,13 @@ void executor::print_version(std::string_view extra) {
     // UTXO-Z storage mode (single source of truth).
     std::println("  UTXO-Z mode: {}",
         kth::database::utxoz_compact_mode() ? "compact" : "full");
+    // Embedded UTXO bloom filter (single source of truth).
+    if (kth::blockchain::embedded_bloom_available()) {
+        std::println("  UTXO bloom: embedded (checkpoint height {})",
+            kth::blockchain::embedded_bloom_checkpoint_height());
+    } else {
+        std::println("  UTXO bloom: none");
+    }
 }
 
 void executor::print_ascii_art() {

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1665,21 +1665,27 @@ std::atomic<uint32_t> g_active_download_peers{0};
     constexpr uint32_t batch_size = 1000;
     constexpr auto poll_interval = std::chrono::milliseconds(500);
 
-    // Load bloom filter. The hardcoded bloom is the FINAL UTXO set as of the real
-    // checkpoint: it prunes outputs spent before then. That is only valid up to the
-    // checkpoint (no validation there); above the checkpoint we need the live UTXO
-    // set to resolve prevouts for full validation, so the bloom is disabled per
-    // batch below.
+    // Highest checkpoint height: at/below it IBD is merkle-only (fast), strictly
+    // above it every block runs FULL validation. Constant for the whole run.
+    uint32_t const checkpoint_height =
+        static_cast<uint32_t>(chain.chain_settings().max_checkpoint_height);
+
+    // Load bloom filter. The embedded bloom is the FINAL UTXO set as of the height
+    // it was built for: it prunes outputs spent before then. Use it only when that
+    // height matches the active checkpoint — otherwise skip-insert would drop
+    // outputs still unspent at this checkpoint (a lowered test checkpoint, or any
+    // build whose embedded bloom targets a different height). It is valid only up to
+    // the checkpoint; above it we need the live UTXO set to resolve prevouts for
+    // full validation, so the bloom is disabled per batch below.
     auto const bloom = blockchain::load_utxo_bloom();
     auto const* bloom_ptr = bloom.get();
-#if defined(KTH_TEST_LOW_CHECKPOINT)
-    // With a lowered test checkpoint the hardcoded bloom (the final UTXO set at
-    // the real checkpoint) does not match, so disable it entirely and keep every
-    // output. Compiled in only under KTH_TEST_LOW_CHECKPOINT.
-    if (std::getenv("KTH_TEST_MAX_CHECKPOINT") != nullptr) {
+    if (bloom_ptr != nullptr &&
+        blockchain::embedded_bloom_checkpoint_height() != checkpoint_height) {
+        spdlog::info(
+            "[utxo_build] Embedded bloom checkpoint {} != active checkpoint {}; disabling bloom",
+            blockchain::embedded_bloom_checkpoint_height(), checkpoint_height);
         bloom_ptr = nullptr;
     }
-#endif
 
     // Resume from saved progress
     uint32_t utxo_built_height = start_height > 0 ? start_height - 1 : 0;
@@ -1727,6 +1733,18 @@ std::atomic<uint32_t> g_active_download_peers{0};
         uint32_t batch_start = utxo_built_height + 1;
         uint32_t batch_end = batch_start + batch_size - 1;
 
+        // Never let a batch straddle the checkpoint. Cap it at the checkpoint so
+        // the below-checkpoint remainder is built (merkle-only) as its own batch
+        // and the UTXO delta of those blocks is applied first. The next batch then
+        // starts strictly above the checkpoint and is validated in full against a
+        // UTXO-Z that already contains every below-checkpoint output. A straddling
+        // batch would instead validate above-checkpoint blocks whose prevouts were
+        // created by below-checkpoint blocks in the SAME batch — outputs whose delta
+        // is applied only after validation — yielding spurious "prevout not found".
+        if (batch_start <= checkpoint_height && checkpoint_height < batch_end) {
+            batch_end = checkpoint_height;
+        }
+
         // Read raw blocks from flat files
         auto raw_result = chain.fetch_blocks_raw(batch_start, batch_end);
         if ( ! raw_result) {
@@ -1739,26 +1757,22 @@ std::atomic<uint32_t> g_active_download_peers{0};
         }
 
         // Post-checkpoint FULL validation (scripts / signatures / fees / coinbase
-        // value) BEFORE the UTXO delta is applied. Below the highest checkpoint we
-        // keep the fast merkle-only path. Validate ONLY heights strictly above the
-        // checkpoint: below it the bloom may have pruned outputs spent before the
-        // checkpoint, so a pre-checkpoint block can reference a prevout that is
-        // absent from UTXO-Z. On failure we halt: the invalid block is never applied.
-        uint32_t const checkpoint_height =
-            static_cast<uint32_t>(chain.chain_settings().max_checkpoint_height);
-        if (batch_end > checkpoint_height) {
-            uint32_t const validate_start = std::max(batch_start, checkpoint_height + 1);
-            // Parse the above-checkpoint blocks and validate them on the worker
-            // pool, off this coroutine's executor.
+        // value) BEFORE the UTXO delta is applied. At/below the highest checkpoint
+        // we keep the fast merkle-only path; strictly above it the whole batch runs
+        // full validation. Because a batch never straddles the checkpoint (capped
+        // above), a batch that starts above the checkpoint is entirely above it, so
+        // every block in it is validated against a UTXO-Z that already holds every
+        // below-checkpoint output. On failure we halt: the invalid block is never
+        // applied.
+        if (batch_start > checkpoint_height) {
+            // Parse the blocks and validate them on the worker pool, off this
+            // coroutine's executor.
             auto const vc = co_await ::asio::co_spawn(validation_pool.get_executor(),
                 [&]() -> ::asio::awaitable<code> {
                     std::vector<kth::block_const_ptr> full_blocks;
                     full_blocks.reserve(raw_result->size());
                     for (uint32_t i = 0; i < raw_result->size(); ++i) {
                         uint32_t const h = batch_start + i;
-                        if (h < validate_start) {
-                            continue;   // at/below the checkpoint: merkle-only
-                        }
                         auto const& raw = (*raw_result)[i];
                         byte_reader reader(byte_span{raw.data(), raw.size()});
                         auto blk = domain::message::block::from_data(reader, 0u);
@@ -1773,15 +1787,15 @@ std::atomic<uint32_t> g_active_download_peers{0};
                         co_return error::success;
                     }
                     co_return blockchain::validate_block_batch(
-                        chain, chain.chain_settings(), network, full_blocks, validate_start);
+                        chain, chain.chain_settings(), network, full_blocks, batch_start);
                 }, ::asio::use_awaitable);
 
             if (vc) {
                 spdlog::critical("[utxo_build] POST-CHECKPOINT VALIDATION FAILED at {}-{}: {}",
-                    validate_start, batch_end, vc.message());
+                    batch_start, batch_end, vc.message());
                 co_return;
             }
-            spdlog::info("[utxo_build] Full validation OK for {}-{}", validate_start, batch_end);
+            spdlog::info("[utxo_build] Full validation OK for {}-{}", batch_start, batch_end);
         }
 
         // Parse and process UTXO delta


### PR DESCRIPTION
Follow-up to #550.

## Batch/checkpoint alignment

UTXO-build batches were sized independently of the checkpoint, so a single batch
could span `max_checkpoint_height`. When that happened, the post-checkpoint
validator saw only the above-checkpoint heights of the batch, while the prevouts
they reference may have been created by the below-checkpoint heights of the same
batch — whose UTXO delta is applied only after validation. That left the
validator's prevout view incomplete for batches beginning just past the boundary.

This caps every batch at `max_checkpoint_height` so no batch straddles it:

- The below-checkpoint remainder is built merkle-only and its UTXO delta is
  applied first.
- The next batch then starts strictly above the checkpoint and is validated in
  full against a UTXO-Z that already contains every below-checkpoint output.

With the straddle removed, the validation gate simplifies to
`batch_start > checkpoint_height` (validate the whole batch, no per-height slice).

## Build-info

`--version` now reports the embedded-bloom configuration (present/absent and its
checkpoint height) alongside the UTXO-Z mode, via
`blockchain::embedded_bloom_available()` / `embedded_bloom_checkpoint_height()`.

## Verification

Fresh low-checkpoint IBD (checkpoint capped at 225430): full validation of
225431→251430 with zero failures; the boundary batch ends exactly at the
checkpoint height and the run crosses the UTXO-Z container rotation cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Version information now reports whether an embedded UTXO filter is available and, when present, its checkpoint height.

- **Bug Fixes**
  - Improved UTXO synchronization around checkpoint boundaries.
  - Added full validation for batches beyond the checkpoint to ensure accurate processing and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->