### PR TITLE
node: validate the tip's trailing blocks without waiting for a full batch

### DIFF
--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1716,13 +1716,27 @@ std::atomic<uint32_t> g_active_download_peers{0};
     while ( ! chain.stopped()) {
         uint32_t current_contiguous = contiguous_height.load(std::memory_order_acquire);
 
-        // Need at least batch_size contiguous blocks ahead of what we've built
+        // Blocks stored and contiguous ahead of what we've built.
         uint32_t available = (current_contiguous > utxo_built_height + 1)
             ? current_contiguous - 1 - utxo_built_height
             : 0;
 
-        if (available < batch_size) {
-            // Not enough blocks yet — wait and poll
+        // Batch length depends on the sync regime:
+        //  - IBD (is_stale): wait for a full batch_size window before processing,
+        //    for throughput — small batches would add per-batch overhead over the
+        //    millions of blocks to catch up.
+        //  - No-IBD (caught up to the tip, is_stale() == false): process whatever is
+        //    available, down to a single block. This drains the final < batch_size
+        //    remainder at the tip and then fully validates each newly mined block as
+        //    it arrives (~1 every 10 min), instead of stalling until batch_size more
+        //    blocks accumulate. is_stale() keys off the top block's timestamp (a
+        //    domain property), so it stays within the module boundary.
+        uint32_t const batch_len = (available >= batch_size)
+            ? batch_size
+            : ((available >= 1 && ! chain.is_stale()) ? available : 0);
+
+        if (batch_len == 0) {
+            // Still in IBD and short of a full batch — wait and poll.
             ::asio::steady_timer timer(executor);
             timer.expires_after(poll_interval);
             co_await timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
@@ -1731,7 +1745,7 @@ std::atomic<uint32_t> g_active_download_peers{0};
 
         // Process one batch
         uint32_t batch_start = utxo_built_height + 1;
-        uint32_t batch_end = batch_start + batch_size - 1;
+        uint32_t batch_end = batch_start + batch_len - 1;
 
         // Never let a batch straddle the checkpoint. Cap it at the checkpoint so
         // the below-checkpoint remainder is built (merkle-only) as its own batch


### PR DESCRIPTION
Follow-up to #551.

## Problem

During IBD the UTXO builder (`utxo_build_task`) waits for a full `batch_size`
(1000) window of contiguous blocks before processing one batch — the right
tradeoff for throughput across the millions of blocks to catch up. But near the
tip that leaves the trailing (< `batch_size`) blocks unprocessed until the
network mines enough to complete a batch. A caught-up node therefore never
validates its most recent blocks: after a full sync the builder stopped ~44
blocks short of the tip and would not advance until ~1000 more blocks were mined
(~a week).

## Change

Switch the batch length on sync regime:

- **IBD** (`is_stale()`): unchanged — wait for a full `batch_size` window.
- **Caught up to the tip** (`is_stale() == false`): process whatever contiguous
  blocks are available, down to a single block. This validates the trailing
  remainder and then each newly mined block as it arrives (~1 / 10 min).

`is_stale()` keys off the top block's timestamp (a domain property), so the
regime switch stays within the blockchain/network module boundary. The existing
`validate_block_batch` path is reused as-is with a shorter block list — the same
validator that runs in IBD, so validation semantics are identical for a batch of
1 or 1000. IBD throughput is unaffected: while stale, a short window still waits.

## Notes

- Forward-only: this validates blocks that extend the active chain. Reorg
  handling at the tip is a separate, pre-existing gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved block synchronization responsiveness when caught up by processing available blocks without waiting for a full batch.
  * Retained full-batch processing during initial synchronization for efficient throughput.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->