### PR TITLE
database, node: resume UTXO build from the persisted height

### DIFF
--- a/src/database/include/kth/database/databases/internal_database.ipp
+++ b/src/database/include/kth/database/databases/internal_database.ipp
@@ -513,7 +513,18 @@ bool internal_database_basis<Clock>::close() {
 
 template <typename Clock>
 std::expected<uint32_t, result_code> internal_database_basis<Clock>::get_utxo_built_height() const {
-    return get_property_height(property_code::utxo_built_height, nullptr);
+    // A read needs a live transaction: get_property_height forwards it straight to
+    // kth_db_get, and a null txn makes every lookup fail (key_not_found), so the
+    // persisted height was never actually read back and resume always fell through
+    // to the block-sync marker. Open a read-only transaction like get_last_heights.
+    KTH_DB_txn* db_txn;
+    if (kth_db_txn_begin(env_, NULL, KTH_DB_RDONLY, &db_txn) != KTH_DB_SUCCESS) {
+        return std::unexpected(result_code::other);
+    }
+
+    auto result = get_property_height(property_code::utxo_built_height, db_txn);
+    kth_db_txn_commit(db_txn);
+    return result;
 }
 
 template <typename Clock>

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -302,6 +302,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/performance.cpp
           test/reservation.cpp
           test/reservations.cpp
+          test/sync_decisions.cpp
           test/mining_job_store.cpp
           test/mining_block_submit.cpp
           test/sv2_framing.cpp

--- a/src/node/include/kth/node/sync/block_tasks.hpp
+++ b/src/node/include/kth/node/sync/block_tasks.hpp
@@ -6,7 +6,9 @@
 #define KTH_NODE_SYNC_BLOCK_TASKS_HPP
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
+#include <optional>
 
 #include <asio/awaitable.hpp>
 
@@ -15,6 +17,27 @@
 #include <kth/node/sync/messages.hpp>
 
 namespace kth::node::sync {
+
+// =============================================================================
+// UTXO-build sync decisions (pure; unit-tested in test/sync_decisions.cpp)
+// =============================================================================
+
+/// Resume floor for the UTXO builder: the height already built (the builder
+/// resumes at the next one). The persisted utxo-built height (`saved`) is
+/// authoritative — it is the last height whose UTXO delta was actually applied —
+/// and must win over `start_height`, which is derived from the block-sync marker
+/// (blocks downloaded) and can run ahead of what has been built. Only when there
+/// is no saved progress does it fall back to `start_height - 1`.
+[[nodiscard]]
+uint32_t resume_utxo_built_height(std::optional<uint32_t> saved, uint32_t start_height);
+
+/// Number of contiguous blocks the UTXO builder should process this iteration,
+/// or 0 to wait and poll. During IBD (`stale`) it requires a full `batch_size`
+/// window for throughput; once caught up to the tip (`!stale`) it drains whatever
+/// is available, down to a single block, so the trailing remainder and each
+/// newly-mined block are validated promptly instead of stalling for a full batch.
+[[nodiscard]]
+uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale);
 
 // =============================================================================
 // Pipeline Counters for debugging block loss

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1651,6 +1651,27 @@ std::atomic<uint32_t> g_active_download_peers{0};
 }
 
 // =============================================================================
+// UTXO-build sync decisions (pure; unit-tested in test/sync_decisions.cpp)
+// =============================================================================
+
+uint32_t resume_utxo_built_height(std::optional<uint32_t> saved, uint32_t start_height) {
+    if (saved) {
+        return *saved;
+    }
+    return start_height > 0 ? start_height - 1 : 0;
+}
+
+uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
+    if (available >= batch_size) {
+        return batch_size;
+    }
+    if (available >= 1 && ! stale) {
+        return available;
+    }
+    return 0;
+}
+
+// =============================================================================
 // Incremental UTXO Build Task
 // =============================================================================
 
@@ -1687,11 +1708,15 @@ std::atomic<uint32_t> g_active_download_peers{0};
         bloom_ptr = nullptr;
     }
 
-    // Resume from saved progress
-    uint32_t utxo_built_height = start_height > 0 ? start_height - 1 : 0;
-    auto saved = chain.get_utxo_built_height();
-    if (saved && *saved >= start_height) {
-        utxo_built_height = *saved;
+    // Resume from saved progress. The persisted utxo-built height is the
+    // authoritative floor (see resume_utxo_built_height): it must win over
+    // start_height, which is derived from the block-sync marker (blocks
+    // downloaded) and can run ahead of what has been built. See the header note.
+    auto const saved = chain.get_utxo_built_height();
+    std::optional<uint32_t> const saved_opt =
+        saved ? std::optional<uint32_t>(*saved) : std::nullopt;
+    uint32_t utxo_built_height = resume_utxo_built_height(saved_opt, start_height);
+    if (saved_opt) {
         spdlog::info("[utxo_build] Resuming from height {}", utxo_built_height);
     }
 
@@ -1721,19 +1746,13 @@ std::atomic<uint32_t> g_active_download_peers{0};
             ? current_contiguous - 1 - utxo_built_height
             : 0;
 
-        // Batch length depends on the sync regime:
-        //  - IBD (is_stale): wait for a full batch_size window before processing,
-        //    for throughput — small batches would add per-batch overhead over the
-        //    millions of blocks to catch up.
-        //  - No-IBD (caught up to the tip, is_stale() == false): process whatever is
-        //    available, down to a single block. This drains the final < batch_size
-        //    remainder at the tip and then fully validates each newly mined block as
-        //    it arrives (~1 every 10 min), instead of stalling until batch_size more
-        //    blocks accumulate. is_stale() keys off the top block's timestamp (a
-        //    domain property), so it stays within the module boundary.
-        uint32_t const batch_len = (available >= batch_size)
-            ? batch_size
-            : ((available >= 1 && ! chain.is_stale()) ? available : 0);
+        // Batch length by sync regime (see utxo_batch_len): a full batch_size
+        // window during IBD for throughput; once caught up to the tip, drain
+        // whatever is available down to a single block so the trailing remainder
+        // and each newly mined block are validated promptly. is_stale() keys off
+        // the top block's timestamp (a domain property), staying within the module
+        // boundary.
+        uint32_t const batch_len = utxo_batch_len(available, batch_size, chain.is_stale());
 
         if (batch_len == 0) {
             // Still in IBD and short of a full batch — wait and poll.

--- a/src/node/test/sync_decisions.cpp
+++ b/src/node/test/sync_decisions.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <optional>
+
+#include <kth/node/sync/block_tasks.hpp>
+
+using namespace kth::node::sync;
+
+// =============================================================================
+// resume_utxo_built_height — the persisted utxo-built height is authoritative
+// =============================================================================
+
+TEST_CASE("resume_utxo_built_height: saved wins even when below start_height", "[sync]") {
+    // The regression: block-sync ran ahead (start_height = 962191) while only
+    // 962146 was actually built. Resuming must floor at the built height, not at
+    // start_height - 1, or blocks (962146, 962190] get marked built without their
+    // outputs ever entering UTXO-Z.
+    CHECK(resume_utxo_built_height(std::optional<uint32_t>{962146}, 962191) == 962146u);
+}
+
+TEST_CASE("resume_utxo_built_height: saved wins when equal to start_height", "[sync]") {
+    CHECK(resume_utxo_built_height(std::optional<uint32_t>{1000}, 1000) == 1000u);
+}
+
+TEST_CASE("resume_utxo_built_height: saved wins when above start_height", "[sync]") {
+    CHECK(resume_utxo_built_height(std::optional<uint32_t>{2000}, 1500) == 2000u);
+}
+
+TEST_CASE("resume_utxo_built_height: saved zero is honoured, not treated as absent", "[sync]") {
+    CHECK(resume_utxo_built_height(std::optional<uint32_t>{0}, 5000) == 0u);
+}
+
+TEST_CASE("resume_utxo_built_height: no saved progress falls back to start_height - 1", "[sync]") {
+    CHECK(resume_utxo_built_height(std::nullopt, 1000) == 999u);
+    CHECK(resume_utxo_built_height(std::nullopt, 1) == 0u);
+    CHECK(resume_utxo_built_height(std::nullopt, 0) == 0u);
+}
+
+// =============================================================================
+// utxo_batch_len — batch sizing switches on the sync regime
+// =============================================================================
+
+constexpr uint32_t batch_size = 1000;
+
+TEST_CASE("utxo_batch_len: a full window is processed as batch_size", "[sync]") {
+    CHECK(utxo_batch_len(5000, batch_size, /*stale*/ true)  == batch_size);
+    CHECK(utxo_batch_len(5000, batch_size, /*stale*/ false) == batch_size);
+    CHECK(utxo_batch_len(batch_size, batch_size, true)      == batch_size);
+}
+
+TEST_CASE("utxo_batch_len: IBD waits for a full window (short window -> 0)", "[sync]") {
+    CHECK(utxo_batch_len(999, batch_size, /*stale*/ true) == 0u);
+    CHECK(utxo_batch_len(1,   batch_size, /*stale*/ true) == 0u);
+}
+
+TEST_CASE("utxo_batch_len: at the tip a short window is drained down to one block", "[sync]") {
+    CHECK(utxo_batch_len(44, batch_size, /*stale*/ false) == 44u);
+    CHECK(utxo_batch_len(1,  batch_size, /*stale*/ false) == 1u);
+    CHECK(utxo_batch_len(999, batch_size, /*stale*/ false) == 999u);
+}
+
+TEST_CASE("utxo_batch_len: nothing available -> wait, regardless of regime", "[sync]") {
+    CHECK(utxo_batch_len(0, batch_size, /*stale*/ false) == 0u);
+    CHECK(utxo_batch_len(0, batch_size, /*stale*/ true)  == 0u);
+}


### PR DESCRIPTION
Follow-up to #552.

## Problem

On restart the UTXO builder resumed from the block-sync marker (blocks
downloaded/stored) rather than from the height it had actually built. Block
storage runs ahead of the builder, so the blocks in between were marked built
without their outputs ever entering UTXO-Z. A later block spending one of those
outputs then failed with a spurious `previous output not found`.

## Two causes

1. **The persisted height was unreadable.** `get_utxo_built_height()` forwarded a
   null transaction to the underlying read, so every lookup returned
   `key_not_found` and the stored height was invisible — the builder never saw
   its own saved progress. Fixed to open a read-only transaction, the same way
   `get_last_heights()` already does.

2. **The floor was derived from the wrong marker.** `utxo_build_task` used
   `start_height - 1` (from the block-sync marker) as the built floor whenever the
   saved height was lower. The persisted utxo-built height is authoritative and
   must win; `start_height - 1` is only a fallback for a first run with no saved
   progress.

## Tests

The resume-floor and batch-sizing decisions are extracted into pure helpers
(`resume_utxo_built_height`, `utxo_batch_len`) and unit-tested
(`test/sync_decisions.cpp`), so the synchronization logic is exercised without
running a real sync — including the regression case (saved below start_height)
and the tip-drain sizing.

## Verification

A node resumed with the builder behind block storage now reads its built height,
replays the trailing blocks as one batch, and validates them and the current tip
with no missing prevouts.
