### PR TITLE
blockchain: enforce the per-transaction and per-block SigChecks limits

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -302,6 +302,7 @@ if (ENABLE_TEST)
         test/block_template_test.cpp
         test/utxoz_roundtrip.cpp
         test/verify_script_context.cpp
+        test/batch_sigchecks.cpp
     )
 
     # Disabled until ported to v1.0 APIs:

--- a/src/blockchain/include/kth/blockchain/validate/batch_validate.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/batch_validate.hpp
@@ -39,11 +39,12 @@ struct settings;
 // active at its height — not a fixed all-forks set.
 //
 // This stage verifies: input scripts/signatures, in-batch double spends, coinbase
-// maturity, fees (inputs >= outputs) and coinbase value (<= subsidy + fees). It
-// does NOT re-check block-level rules already covered by the fast path or applied
-// elsewhere (merkle root, ABLA block size, per-block sigcheck accounting, tx
-// duplicate / BIP30, coinbase input shape). The batch is NOT applied/persisted
-// here — the caller applies the UTXO delta only after this returns error::success.
+// maturity, fees (inputs >= outputs), coinbase value (<= subsidy + fees) and the
+// per-transaction / per-block SigChecks limits. It does NOT re-check block-level
+// rules already covered by the fast path or applied elsewhere (merkle root, ABLA
+// block size, tx duplicate / BIP30, coinbase input shape). The batch is NOT
+// applied/persisted here — the caller applies the UTXO delta only after this
+// returns error::success.
 //
 // Returns error::success, or the first consensus error encountered.
 KB_API
@@ -53,6 +54,27 @@ code validate_block_batch(
     domain::config::network network,
     std::vector<block_const_ptr> const& blocks,
     size_t start_height);
+
+// One input's SigChecks contribution to a validated batch, in emission order
+// (block by block, then transaction by transaction, then input by input — so a
+// transaction's inputs are contiguous and each block's inputs form a run).
+struct sigcheck_entry {
+    size_t block_index;   // index into block_limits; MUST be < block_limits.size()
+    size_t tx_index;      // per-batch transaction ordinal; groups a tx's inputs
+    uint64_t sigchecks;
+};
+
+// Enforce the BCH SigChecks consensus limits over a batch's per-input counts: at
+// most `tx_limit` per transaction and at most `block_limits[block_index]` per
+// block. `entries` must be in emission order. Returns error::success, or
+// error::transaction_sigchecks_limit / error::block_sigchecks_limit on the first
+// limit exceeded. Pure (no I/O) — unit-tested in test/batch_sigchecks.cpp.
+// Precondition (contract-checked): every entry's block_index < block_limits.size().
+[[nodiscard]] KB_API
+code enforce_sigcheck_limits(
+    std::vector<sigcheck_entry> const& entries,
+    std::vector<uint64_t> const& block_limits,
+    uint64_t tx_limit);
 
 } // namespace kth::blockchain
 

--- a/src/blockchain/src/validate/batch_validate.cpp
+++ b/src/blockchain/src/validate/batch_validate.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstring>
+#include <limits>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -19,6 +20,7 @@
 #include <kth/blockchain/validate/validate_header.hpp>
 #include <kth/blockchain/validate/validate_input.hpp>
 #include <kth/domain/constants.hpp>
+#include <kth/infrastructure/utility/assert.hpp>
 
 namespace kth::blockchain {
 
@@ -68,6 +70,36 @@ struct verify_task {
 
 } // namespace
 
+code enforce_sigcheck_limits(
+    std::vector<sigcheck_entry> const& entries,
+    std::vector<uint64_t> const& block_limits,
+    uint64_t tx_limit) {
+
+    std::vector<uint64_t> block_sigchecks(block_limits.size(), 0);
+    size_t cur_tx = std::numeric_limits<size_t>::max();
+    uint64_t tx_sigchecks = 0;
+
+    for (auto const& e : entries) {
+        // Precondition: every entry's block_index addresses block_limits.
+        KTH_CONTRACT(e.block_index < block_limits.size());
+
+        if (e.tx_index != cur_tx) {
+            cur_tx = e.tx_index;
+            tx_sigchecks = 0;
+        }
+        tx_sigchecks += e.sigchecks;
+        if (tx_sigchecks > tx_limit) {
+            return error::transaction_sigchecks_limit;
+        }
+
+        block_sigchecks[e.block_index] += e.sigchecks;
+        if (block_sigchecks[e.block_index] > block_limits[e.block_index]) {
+            return error::block_sigchecks_limit;
+        }
+    }
+    return error::success;
+}
+
 code validate_block_batch(
     block_chain& chain,
     settings const& settings,
@@ -88,6 +120,8 @@ code validate_block_batch(
 
     domain::chain::chain_state::ptr state;
     std::vector<domain::script_flags_t> block_flags(blocks.size());
+    // Per-block dynamic SigChecks limit (consensus), one per block in the batch.
+    std::vector<uint64_t> block_sigcheck_limit(blocks.size());
 
     boost::unordered_flat_map<bv_outpoint, created_output, bv_outpoint_hasher> created;
     boost::unordered_flat_set<bv_outpoint, bv_outpoint_hasher> spent;
@@ -141,6 +175,11 @@ code validate_block_batch(
             return error::operation_failed;
         }
         block_flags[i] = state->enabled_flags();
+        // Per-block dynamic SigChecks limit: the ABLA block-size limit at this
+        // height divided by the fixed ratio, matching BCHN's
+        // GetMaxBlockSigChecksCount(nMaxBlockSize).
+        block_sigcheck_limit[i] =
+            state->dynamic_max_block_size() / block_maxbytes_maxsigchecks_ratio;
 
         for (auto const& tx : block.transactions()) {
             if (tx.is_coinbase()) {
@@ -277,9 +316,9 @@ code validate_block_batch(
 
     // -----------------------------------------------------------------------
     // Phase 2 (parallel): script/signature verification per input. Independent
-    // now that every prevout cache is populated; split across the hardware.
-    // TODO: enforce the per-block dynamic sigchecks limit (ABLA); per-tx limit is
-    // enforced inside verify_script accumulation.
+    // now that every prevout cache is populated; split across the hardware. Each
+    // input's SigChecks count is recorded and enforced against the per-tx /
+    // per-block limits in Phase 3 below.
     // -----------------------------------------------------------------------
     if (tasks.empty()) {
         return error::success;
@@ -291,6 +330,8 @@ code validate_block_batch(
     std::atomic<bool> failed{false};
     std::mutex err_mutex;
     code first_error = error::success;
+    // SigChecks returned per input; each worker writes its own slot (no contention).
+    std::vector<size_t> task_sigchecks(tasks.size(), 0);
 
     auto run_bucket = [&](size_t bucket) {
       try {
@@ -316,6 +357,7 @@ code validate_block_batch(
                 }
                 return;
             }
+            task_sigchecks[t] = res.second;
         }
       } catch (std::exception const& e) {
         // A worker thread must not let an exception escape (std::terminate).
@@ -337,7 +379,37 @@ code validate_block_batch(
         th.join();
     }
 
-    return first_error;
+    if (first_error != error::success) {
+        return first_error;
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3 (serial): enforce the SigChecks consensus limits from the per-input
+    // counts — max_tx_sigchecks per transaction and the dynamic ABLA limit per
+    // block. Tasks are emitted block-by-block then tx-by-tx then input-by-input,
+    // so a transaction's inputs are contiguous and each block's tasks form a run.
+    // (BCHN stops as soon as a limiter is exceeded; validating the whole batch
+    // first and checking the sums is equivalent for accept/reject, only less
+    // DoS-optimal, which is acceptable on the IBD path.)
+    // -----------------------------------------------------------------------
+    // Number transactions with a per-batch ordinal so the pure limiter can group
+    // a tx's inputs without knowing the transaction type. Inputs are emitted
+    // contiguously per tx, so the ordinal bumps whenever the tx pointer changes.
+    std::vector<sigcheck_entry> entries;
+    entries.reserve(tasks.size());
+    transaction const* prev_tx = nullptr;
+    size_t tx_index = 0;
+    for (size_t t = 0; t < tasks.size(); ++t) {
+        if (t != 0 && tasks[t].tx != prev_tx) {
+            ++tx_index;
+        }
+        prev_tx = tasks[t].tx;
+        entries.push_back(sigcheck_entry{
+            tasks[t].height - start_height,
+            tx_index,
+            static_cast<uint64_t>(task_sigchecks[t])});
+    }
+    return enforce_sigcheck_limits(entries, block_sigcheck_limit, max_tx_sigchecks);
 }
 
 } // namespace kth::blockchain

--- a/src/blockchain/test/batch_sigchecks.cpp
+++ b/src/blockchain/test/batch_sigchecks.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <vector>
+
+#include <kth/blockchain/validate/batch_validate.hpp>
+
+using namespace kth;
+using namespace kth::blockchain;
+
+namespace {
+// Per-batch transaction ordinals used to group each tx's inputs.
+constexpr size_t tx1 = 0;
+constexpr size_t tx2 = 1;
+} // namespace
+
+// =============================================================================
+// enforce_sigcheck_limits — per-tx (max_tx_sigchecks) and per-block (ABLA) limits
+// =============================================================================
+
+TEST_CASE("enforce_sigcheck_limits: empty batch passes", "[sigchecks]") {
+    CHECK(enforce_sigcheck_limits({}, {1000}, 3000) == error::success);
+}
+
+TEST_CASE("enforce_sigcheck_limits: within both limits passes", "[sigchecks]") {
+    std::vector<sigcheck_entry> const e{
+        {0, tx1, 100}, {0, tx1, 100},   // tx1 = 200
+        {0, tx2, 300},                 // tx2 = 300  (block0 total = 500)
+    };
+    CHECK(enforce_sigcheck_limits(e, {1000}, 3000) == error::success);
+}
+
+TEST_CASE("enforce_sigcheck_limits: per-tx limit is the sum over a tx's inputs", "[sigchecks]") {
+    // Two inputs of one tx summing exactly to the limit: allowed.
+    CHECK(enforce_sigcheck_limits({{0, tx1, 1500}, {0, tx1, 1500}}, {1'000'000}, 3000)
+        == error::success);
+    // One more and the transaction is over the limit.
+    CHECK(enforce_sigcheck_limits({{0, tx1, 1500}, {0, tx1, 1501}}, {1'000'000}, 3000)
+        == error::transaction_sigchecks_limit);
+}
+
+TEST_CASE("enforce_sigcheck_limits: the per-tx counter resets between transactions", "[sigchecks]") {
+    // Two separate txs each at the limit are fine — they are not summed together.
+    CHECK(enforce_sigcheck_limits({{0, tx1, 3000}, {0, tx2, 3000}}, {1'000'000}, 3000)
+        == error::success);
+}
+
+TEST_CASE("enforce_sigcheck_limits: per-block limit is the sum over a block's txs", "[sigchecks]") {
+    // block limit 500; two txs summing exactly to 500: allowed.
+    CHECK(enforce_sigcheck_limits({{0, tx1, 200}, {0, tx2, 300}}, {500}, 3000)
+        == error::success);
+    // 501 over the block limit.
+    CHECK(enforce_sigcheck_limits({{0, tx1, 200}, {0, tx2, 301}}, {500}, 3000)
+        == error::block_sigchecks_limit);
+}
+
+TEST_CASE("enforce_sigcheck_limits: each block has its own independent limit", "[sigchecks]") {
+    std::vector<sigcheck_entry> const ok{
+        {0, tx1, 500},   // block0 = 500 (limit 500)
+        {1, tx2, 700},   // block1 = 700 (limit 700)
+    };
+    CHECK(enforce_sigcheck_limits(ok, {500, 700}, 3000) == error::success);
+
+    std::vector<sigcheck_entry> const over{
+        {0, tx1, 500},
+        {1, tx2, 701},   // block1 over its own limit
+    };
+    CHECK(enforce_sigcheck_limits(over, {500, 700}, 3000) == error::block_sigchecks_limit);
+}
+
+TEST_CASE("enforce_sigcheck_limits: tx limit is checked before block limit", "[sigchecks]") {
+    // A single tx over the per-tx limit fails with the tx error even though the
+    // block limit is generous.
+    CHECK(enforce_sigcheck_limits({{0, tx1, 3001}}, {1'000'000}, 3000)
+        == error::transaction_sigchecks_limit);
+}


### PR DESCRIPTION
## Problem

The post-checkpoint batch validator (`validate_block_batch`) verifies every input
and `verify_script` already returns each input's SigChecks count — but the count
was discarded, so neither consensus SigChecks limit was enforced:

- **per transaction**: at most `max_tx_sigchecks` (3000)
- **per block**: at most `dynamic_max_block_size() / 141` (the ABLA-scaled limit)

matching BCHN's `MAX_TX_SIGCHECKS` and
`GetMaxBlockSigChecksCount(nMaxBlockSize)` (`consensus/consensus.h`,
`BLOCK_MAXBYTES_MAXSIGCHECKS_RATIO = 141`).

## Change

- Phase 1 records each block's dynamic SigChecks limit (`dynamic_max_block_size /
  ratio`, the same size accessor `validate_block` already uses).
- Phase 2 (parallel) now stores each input's SigChecks count in its own slot (no
  contention).
- Phase 3 (serial) accumulates the counts per transaction and per block and
  enforces the limits, returning `transaction_sigchecks_limit` /
  `block_sigchecks_limit`. Validating the whole batch first and then checking the
  sums is equivalent to BCHN's early-exit limiter for accept/reject — only less
  DoS-optimal, which is fine on the IBD path.

## Tests

The accumulation is a pure helper (`enforce_sigcheck_limits`) unit-tested in
`test/batch_sigchecks.cpp`: per-tx summation and reset between transactions,
per-block summation, independent per-block limits, and the boundary cases (exact
limit passes, one over fails). No behavior change for historical blocks — their
sums are far under both limits, matching BCHN.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for transaction and block SigChecks limits during batch validation.
  * Added support for dynamic per-block SigChecks limits.
  * Exposed utilities for validating ordered SigChecks contributions.

* **Bug Fixes**
  * Correctly reports transaction- and block-level SigChecks limit violations.

* **Tests**
  * Added coverage for accumulation, reset behavior, boundaries, independent block limits, and error precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->