### PR TITLE
blockchain: build the signature-checker context once per transaction

### DIFF
--- a/src/blockchain/include/kth/blockchain/validate/validate_input.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/validate_input.hpp
@@ -29,6 +29,15 @@ struct KB_API validate_input {
 
     static
     std::pair<code, size_t> verify_script(domain::chain::transaction const& tx, uint32_t input_index, domain::script_flags_t flags);
+
+    // Verify every input of `tx`, building the signature-checker context (the
+    // serialized transaction and the spent-output coins) ONCE and reusing it
+    // across inputs — that context depends only on the transaction, not on the
+    // input, so the per-input verify_script rebuilds it redundantly (O(inputs^2)).
+    // Returns the first input error (or success) and the transaction's total
+    // SigChecks. Every input's prevout cache must be populated by the caller.
+    static
+    std::pair<code, size_t> verify_transaction(domain::chain::transaction const& tx, domain::script_flags_t flags);
 };
 
 } // namespace kth::blockchain

--- a/src/blockchain/src/validate/batch_validate.cpp
+++ b/src/blockchain/src/validate/batch_validate.cpp
@@ -59,13 +59,14 @@ struct db_prevout {
     bool coinbase;
 };
 
-// One script-verification unit, filled during the serial pass and run in parallel.
+// One transaction to script-verify, filled during the serial pass and run in
+// parallel. Verifying a whole transaction (rather than a single input) lets the
+// signature-checker context be built once per tx instead of once per input.
 // Flags are the per-height consensus flags for the block the tx belongs to.
 struct verify_task {
     transaction const* tx;
-    uint32_t input_index;
     domain::script_flags_t flags;
-    size_t height;   // for diagnostics on failure
+    size_t height;   // for diagnostics and per-block SigChecks accounting
 };
 
 } // namespace
@@ -299,13 +300,16 @@ code validate_block_batch(
                 op.validation.confirmed = true;
 
                 in_value += out->value();
-                tasks.push_back(verify_task{&tx, ii, block_flags[i], height});
             }
 
             if (in_value < out_value) {
                 return error::spend_exceeds_value;
             }
             block_fees += (in_value - out_value);
+
+            // One script-verification unit per transaction (all its inputs share
+            // one signature-checker context).
+            tasks.push_back(verify_task{&tx, block_flags[i], height});
         }
 
         auto const reward = block::subsidy(height, settings.retarget) + block_fees;
@@ -315,10 +319,11 @@ code validate_block_batch(
     }
 
     // -----------------------------------------------------------------------
-    // Phase 2 (parallel): script/signature verification per input. Independent
-    // now that every prevout cache is populated; split across the hardware. Each
-    // input's SigChecks count is recorded and enforced against the per-tx /
-    // per-block limits in Phase 3 below.
+    // Phase 2 (parallel): script/signature verification, one transaction per task
+    // (its inputs share a signature-checker context). Independent now that every
+    // prevout cache is populated; split across the hardware. Each transaction's
+    // total SigChecks is recorded and enforced against the per-tx / per-block
+    // limits in Phase 3 below.
     // -----------------------------------------------------------------------
     if (tasks.empty()) {
         return error::success;
@@ -330,30 +335,37 @@ code validate_block_batch(
     std::atomic<bool> failed{false};
     std::mutex err_mutex;
     code first_error = error::success;
-    // SigChecks returned per input; each worker writes its own slot (no contention).
+    // Total SigChecks per transaction; each worker writes its own slot (no contention).
     std::vector<size_t> task_sigchecks(tasks.size(), 0);
 
     auto run_bucket = [&](size_t bucket) {
       try {
         for (size_t t = bucket; t < tasks.size() && ! failed.load(std::memory_order_relaxed); t += workers) {
             auto const& task = tasks[t];
-            auto const res = validate_input::verify_script(*task.tx, task.input_index, task.flags);
+            auto const res = validate_input::verify_transaction(*task.tx, task.flags);
             if (res.first != error::success) {
                 std::lock_guard<std::mutex> lk(err_mutex);
                 if ( ! failed.exchange(true)) {
                     first_error = res.first;
-                    // Decisive diagnostic: everything needed to reproduce the failing
-                    // input in a standalone verify_script test.
-                    auto const& in = task.tx->inputs()[task.input_index];
-                    auto const& pv = in.previous_output();
-                    spdlog::error("[batch_validate] script FAIL h={} err={} flags={:#x} tx={} in={} prevout={}:{} value={} prevout_script={} input_script={}",
-                        task.height, res.first.message(),
-                        static_cast<uint64_t>(task.flags),
-                        encode_hash(task.tx->hash()), task.input_index,
-                        encode_hash(pv.hash()), pv.index(),
-                        pv.validation.cache.value(),
-                        encode_base16(to_data_chunk(pv.validation.cache.script(), false)),
-                        encode_base16(to_data_chunk(in.script(), false)));
+                    // Re-run per input to pinpoint the culprit and emit a decisive
+                    // diagnostic (everything needed to reproduce it in a standalone
+                    // verify_script test). Only on failure, so it is off the hot path.
+                    auto const& inputs = task.tx->inputs();
+                    for (uint32_t ii = 0; ii < inputs.size(); ++ii) {
+                        if (validate_input::verify_script(*task.tx, ii, task.flags).first == error::success) {
+                            continue;
+                        }
+                        auto const& pv = inputs[ii].previous_output();
+                        spdlog::error("[batch_validate] script FAIL h={} err={} flags={:#x} tx={} in={} prevout={}:{} value={} prevout_script={} input_script={}",
+                            task.height, res.first.message(),
+                            static_cast<uint64_t>(task.flags),
+                            encode_hash(task.tx->hash()), ii,
+                            encode_hash(pv.hash()), pv.index(),
+                            pv.validation.cache.value(),
+                            encode_base16(to_data_chunk(pv.validation.cache.script(), false)),
+                            encode_base16(to_data_chunk(inputs[ii].script(), false)));
+                        break;
+                    }
                 }
                 return;
             }
@@ -384,29 +396,19 @@ code validate_block_batch(
     }
 
     // -----------------------------------------------------------------------
-    // Phase 3 (serial): enforce the SigChecks consensus limits from the per-input
-    // counts — max_tx_sigchecks per transaction and the dynamic ABLA limit per
-    // block. Tasks are emitted block-by-block then tx-by-tx then input-by-input,
-    // so a transaction's inputs are contiguous and each block's tasks form a run.
+    // Phase 3 (serial): enforce the SigChecks consensus limits from the per-tx
+    // totals — max_tx_sigchecks per transaction and the dynamic ABLA limit per
+    // block. Each task is one transaction, so there is one entry per task.
     // (BCHN stops as soon as a limiter is exceeded; validating the whole batch
     // first and checking the sums is equivalent for accept/reject, only less
     // DoS-optimal, which is acceptable on the IBD path.)
     // -----------------------------------------------------------------------
-    // Number transactions with a per-batch ordinal so the pure limiter can group
-    // a tx's inputs without knowing the transaction type. Inputs are emitted
-    // contiguously per tx, so the ordinal bumps whenever the tx pointer changes.
     std::vector<sigcheck_entry> entries;
     entries.reserve(tasks.size());
-    transaction const* prev_tx = nullptr;
-    size_t tx_index = 0;
     for (size_t t = 0; t < tasks.size(); ++t) {
-        if (t != 0 && tasks[t].tx != prev_tx) {
-            ++tx_index;
-        }
-        prev_tx = tasks[t].tx;
         entries.push_back(sigcheck_entry{
             tasks[t].height - start_height,
-            tx_index,
+            t,   // one task is one transaction
             static_cast<uint64_t>(task_sigchecks[t])});
     }
     return enforce_sigcheck_limits(entries, block_sigcheck_limit, max_tx_sigchecks);

--- a/src/blockchain/src/validate/validate_input.cpp
+++ b/src/blockchain/src/validate/validate_input.cpp
@@ -279,12 +279,65 @@ std::pair<code, size_t> validate_input::verify_script(transaction const& tx, uin
     return {convert_result(res), sig_checks};
 }
 
+std::pair<code, size_t> validate_input::verify_transaction(transaction const& tx, script_flags_t flags) {
+    constexpr bool prefix = false;
+
+    // The signature-checker context depends only on the transaction (the
+    // serialized tx and the spent-output coins), so build it once and reuse it for
+    // every input instead of rebuilding it per input as verify_script does.
+    auto const tx_data = kth::to_data_chunk(tx, true);
+    auto const coins = create_context_data(tx, true);
+    auto const native_flags = convert_flags(flags);
+
+    size_t total_sig_checks = 0;
+    auto const& inputs = tx.inputs();
+    for (uint32_t i = 0; i < inputs.size(); ++i) {
+        auto const& prevout = inputs[i].previous_output().validation;
+        auto const locking_script_data = kth::to_data_chunk(prevout.cache.script(), false);
+        auto const unlock_script_data = kth::to_data_chunk(inputs[i].script(), prefix);
+        auto const amount = prevout.cache.value();
+
+        size_t sig_checks;
+        auto const res = consensus::verify_script(
+            tx_data.data(),
+            tx_data.size(),
+            locking_script_data.data(),
+            locking_script_data.size(),
+            unlock_script_data.data(),
+            unlock_script_data.size(),
+            i,
+            native_flags,
+            sig_checks,
+            amount,
+            coins
+        );
+
+        auto const c = convert_result(res);
+        if (c != error::success) {
+            return {c, total_sig_checks};
+        }
+        total_sig_checks += sig_checks;
+    }
+
+    return {error::success, total_sig_checks};
+}
+
 #else //WITH_CONSENSUS
 
 // #error Not supported, build using -o consensus=True
 
 std::pair<code, size_t> validate_input::verify_script(transaction const& tx, uint32_t input_index, script_flags_t flags) {
     return {script::verify(tx, input_index, flags), 0};
+}
+
+std::pair<code, size_t> validate_input::verify_transaction(transaction const& tx, script_flags_t flags) {
+    for (uint32_t i = 0; i < tx.inputs().size(); ++i) {
+        auto const c = script::verify(tx, i, flags);
+        if (c != error::success) {
+            return {c, 0};
+        }
+    }
+    return {error::success, 0};
 }
 
 #endif //WITH_CONSENSUS


### PR DESCRIPTION
## Problem

`verify_script` is called once per input, and each call rebuilds the
signature-checker context — `to_data_chunk(tx, true)` (serialize the whole
transaction) and `create_context_data(tx)` (build the spent-output coins by
serializing every prevout). That context depends only on the transaction, not on
the input, so for a transaction with N inputs it is rebuilt N times: O(N^2) work
(and O(N^2) allocations) per transaction. Consolidation / many-input transactions
pay this quadratic cost on the IBD hot path.

## Change

- Add `validate_input::verify_transaction(tx, flags)`: builds the context once
  and reuses it across all of the transaction's inputs, returning the first input
  error (or success) and the transaction's total SigChecks.
- The batch validator now schedules one script-verification task per transaction
  instead of per input. The per-transaction / per-block SigChecks limits are
  enforced exactly as in #556 (each task contributes its tx total).
- On a script failure the worker re-runs the transaction input-by-input (only on
  failure, off the hot path) to emit the same decisive per-input diagnostic.

Verdicts are unchanged: the same `consensus::verify_script` call is made for every
input with the same arguments — `tx_data` and `coins` are deterministic functions
of the transaction, so building them once is bit-identical to building them per
input.

## Tests / validation

`kth_blockchain_test [sigchecks]` (the per-tx / per-block limit helper) still
passes. Correctness is being confirmed end to end by a full-validation IBD (no
false rejections; identical accept/reject to the per-input path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction validation consistency across individual and batch processing.
  * More accurately identifies the failing input when transaction validation fails.
  * Improved enforcement of transaction and block signature-check limits.

* **Performance**
  * Reduced repeated validation work by processing transaction verification more efficiently.
  * Improved signature-check accounting during batch validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->