### PR TITLE
c-api: expose the UTXO-Z mode and embedded-bloom build info

### DIFF
--- a/src/c-api/include/kth/capi/node_info.h
+++ b/src/c-api/include/kth/capi/node_info.h
@@ -48,6 +48,20 @@ char const* kth_node_db_type(kth_db_mode_t mode);
 KTH_EXPORT
 uint32_t kth_node_cppapi_build_timestamp(void);
 
+// Build configuration of the UTXO storage / IBD optimizations.
+
+// Whether UTXO-Z was built in compact mode (KTH_UTXOZ_COMPACT_MODE) vs full mode.
+KTH_EXPORT
+kth_bool_t kth_node_utxoz_compact_mode(void);
+
+// Whether this build embeds a UTXO bloom filter (KTH_HAS_EMBEDDED_BLOOM).
+KTH_EXPORT
+kth_bool_t kth_node_embedded_bloom_available(void);
+
+// Checkpoint height baked into the embedded bloom filter, or 0 if none.
+KTH_EXPORT
+uint32_t kth_node_embedded_bloom_checkpoint_height(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/c-api/src/node_info.cpp
+++ b/src/c-api/src/node_info.cpp
@@ -18,6 +18,8 @@
 // #ifndef __EMSCRIPTEN__
 #include <kth/node/executor/executor_info.hpp>
 #include <kth/domain/version.hpp>
+#include <kth/database/define.hpp>
+#include <kth/blockchain/utxo_builder.hpp>
 // #endif
 
 extern "C" {
@@ -84,6 +86,18 @@ uint32_t kth_node_cppapi_build_timestamp() {
 // #else
 //     return 0;
 // #endif
+}
+
+kth_bool_t kth_node_utxoz_compact_mode() {
+    return kth::database::utxoz_compact_mode() ? 1 : 0;
+}
+
+kth_bool_t kth_node_embedded_bloom_available() {
+    return kth::blockchain::embedded_bloom_available() ? 1 : 0;
+}
+
+uint32_t kth_node_embedded_bloom_checkpoint_height() {
+    return kth::blockchain::embedded_bloom_checkpoint_height();
 }
 
 } // extern "C"


### PR DESCRIPTION
Expose the UTXO storage / IBD build configuration through the C-API node-info,
mirroring what the node's `--version` banner already prints:

- `kth_bool_t kth_node_utxoz_compact_mode(void)` — UTXO-Z compact vs full mode.
- `kth_bool_t kth_node_embedded_bloom_available(void)` — whether this build
  embeds a UTXO bloom filter.
- `uint32_t kth_node_embedded_bloom_checkpoint_height(void)` — the checkpoint
  height baked into the embedded bloom, or 0 if none.

Thin wrappers over `kth::database::utxoz_compact_mode()`,
`kth::blockchain::embedded_bloom_available()` and
`embedded_bloom_checkpoint_height()`. Builds and links.
