### PR TITLE
node: let utxo_build_task exit on the node stop signal to unblock shutdown

### DIFF
--- a/src/node/include/kth/node/sync/block_tasks.hpp
+++ b/src/node/include/kth/node/sync/block_tasks.hpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -163,7 +164,8 @@ extern std::atomic<uint64_t> g_blocks_received_by_validation;
     blockchain::block_chain& chain,
     std::atomic<uint32_t> const& contiguous_height,
     uint32_t start_height,
-    domain::config::network network
+    domain::config::network network,
+    std::function<bool()> should_stop  // node-owned stop signal (e.g. network.stopped())
 );
 
 } // namespace kth::node::sync

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1679,7 +1679,8 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
     blockchain::block_chain& chain,
     std::atomic<uint32_t> const& contiguous_height,
     uint32_t start_height,
-    domain::config::network network
+    domain::config::network network,
+    std::function<bool()> should_stop
 ) {
     spdlog::info("[utxo_build] Task started at height {}", start_height);
 
@@ -1738,7 +1739,13 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
     // pool thread to run the serial phase and orchestrate is enough.
     ::asio::thread_pool validation_pool(1);
 
-    while ( ! chain.stopped()) {
+    // Exit on the node-owned stop signal too, not only chain.stopped(): the chain
+    // is stopped in full_node::join(), which runs AFTER run() completes (all sync
+    // coroutines exited). Looping on chain.stopped() alone therefore deadlocks
+    // shutdown — this task would never exit, so run() never completes, so
+    // chain.stop() is never called. should_stop() reflects network.stopped(),
+    // the same signal every other sync coroutine uses.
+    while ( ! chain.stopped() && ! should_stop()) {
         uint32_t current_contiguous = contiguous_height.load(std::memory_order_acquire);
 
         // Blocks stored and contiguous ahead of what we've built.

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -629,7 +629,8 @@ static
         chain,
         *contiguous_height,
         initial_block_height + 1,
-        network_type
+        network_type,
+        [&network]() { return network.stopped(); }
     ));
 
     // Bridge: validated_chunks -> coordinator_events (carries validation errors only)


### PR DESCRIPTION
## Problem

On SIGINT the node logged `[p2p_node] run() ENDED` and then hung forever,
requiring `kill -KILL`.

Root cause: a circular shutdown dependency. `utxo_build_task` looped on
`chain.stopped()` alone. The chain is stopped in `full_node::join()`, which runs
only AFTER `run()` completes — i.e. after every sync coroutine has exited. So this
task could never exit (`chain.stopped()` stayed `false`), `run()` never completed,
`join()` never ran, and `chain.stop()` was never called. Every other sync
coroutine already exits on `network.stopped()` (set by `full_node::stop()` on
SIGINT); only this one waited for the chain.

## Change

Thread the node-owned stop predicate (`network.stopped()`) into `utxo_build_task`
and exit the build loop on it as well as `chain.stopped()`. The blockchain still
doesn't depend on the network — the node passes the predicate in through the
orchestrator (which owns the `p2p_node`).

## Validation

Fresh start → 25s (header sync, build loop polling) → SIGINT → the node tears down
cleanly and exits in ~7s (mempool dumped, threadpools destroyed, io_context
returned), instead of hanging.
