### PR TITLE
db: drop the deleted store .ipp files from the CMakeLists source list

### DIFF
--- a/src/database/CMakeLists.txt
+++ b/src/database/CMakeLists.txt
@@ -146,15 +146,11 @@ set(kth_headers
   include/kth/database/block_undo.hpp
   include/kth/database/block_store.hpp
   include/kth/database/mempool_store.hpp
-  include/kth/database/databases/block_database.ipp
   include/kth/database/databases/property_code.hpp
   include/kth/database/databases/internal_database.ipp
-  include/kth/database/databases/reorg_database.ipp
   include/kth/database/databases/internal_database.hpp
   include/kth/database/databases/transaction_entry.hpp
-  include/kth/database/databases/history_database.ipp
   include/kth/database/databases/history_entry.hpp
-  include/kth/database/databases/transaction_database.ipp
   include/kth/database/databases/generic_db.hpp
   include/kth/database/databases/tools.hpp
   include/kth/database/databases/lmdb_helper.hpp
@@ -162,8 +158,6 @@ set(kth_headers
   include/kth/database/databases/header_abla_entry.hpp
   include/kth/database/databases/utxo_entry.hpp
   include/kth/database/databases/utxoz_database.hpp
-  include/kth/database/databases/spend_database.ipp
-  include/kth/database/databases/utxo_database.ipp
   include/kth/database/databases/header_database.ipp
   include/kth/database/settings.hpp
   # include/kth/database/unspent_outputs.hpp


### PR DESCRIPTION
Follow-up to #564. That PR removed the six dead LMDB store partials (`block_database.ipp`, `reorg_database.ipp`, `utxo_database.ipp`, `transaction_database.ipp`, `history_database.ipp`, `spend_database.ipp`) but left them listed as sources in `src/database/CMakeLists.txt`.

Incremental builds kept working off the cached CMake state, so this slipped through, but a **fresh `cmake` configure fails**:

```
CMake Error at src/database/CMakeLists.txt:174 (add_library):
  Cannot find source file: include/kth/database/databases/block_database.ipp
```

This removes the six stale entries. Configure + `make database`/`node-exe`/tests are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete database header references from the build configuration.
  * No user-facing functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->