### PR TITLE
blockchain: detect header-chain forks / reorg candidates

### DIFF
--- a/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
@@ -24,6 +24,13 @@ struct header_organize_result {
     size_t headers_added{0};
     size_t index_size{0};
     size_t index_memory_bytes{0};
+
+    // Fork detection (headers-first): set when a stored side branch reaches
+    // strictly greater cumulative chain work than the active header tip, i.e. a
+    // reorganization candidate. The active tip is NOT switched here — executing
+    // the switch (disconnecting blocks, rewinding UTXO-Z) is a separate layer.
+    bool reorg_candidate{false};
+    int32_t reorg_fork_height{-1};   // height of the common ancestor, or -1
 };
 
 /// Header organizer for headers-first sync.
@@ -136,6 +143,11 @@ private:
     header_index& index_;
     std::atomic<bool> stopped_{false};
     validate_header validator_;
+
+    // Maximum fork depth (tip height - fork height) we bother storing/comparing a
+    // side branch at. Deeper forks are treated as stale, bounding index growth
+    // against branch spam. From settings.reorganization_limit.
+    uint32_t reorg_limit_;
 
     // Current tip state
     index_t tip_index_{header_index::null_index};

--- a/src/blockchain/src/pools/header_organizer.cpp
+++ b/src/blockchain/src/pools/header_organizer.cpp
@@ -22,6 +22,7 @@ header_organizer::header_organizer(header_index& index, settings const& settings
                                    domain::config::network network)
     : index_(index)
     , validator_(settings, network)
+    , reorg_limit_(settings.reorganization_limit)
 {}
 
 // =============================================================================
@@ -92,52 +93,53 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
         spdlog::error("[header_organizer] add_headers() called with uninitialized tip_index_ — call sync_tip() first");
         return {error::operation_failed, 0, 0, 0};
     }
-    hash_digest prev_hash = tip_hash_;
-    int32_t height = index_.get_height(tip_index_) + 1;
 
-    spdlog::debug("[header_organizer] Starting validation at height {}, tip_hash: {}, tip_index: {}",
-        height, encode_hash(tip_hash_), tip_index_);
+    // Determine the batch anchor: the index entry the first header builds on.
+    //   (1) anchor == tip                        -> forward extension of the active chain.
+    //   (2) anchor is a known entry below the tip -> a side branch (fork). It is
+    //       validated and stored against its OWN ancestor (not the tip) so difficulty
+    //       / MTP / checkpoint context is correct, and its cumulative work is compared
+    //       against the tip. A strictly-heavier branch is flagged as a reorg candidate,
+    //       but the active tip is NOT switched here — executing the switch (block
+    //       disconnect + UTXO-Z rewind) is a separate layer.
+    //   (3) anchor unknown                       -> orphan; validation surfaces the
+    //       missing-parent error as before (previously the ABC/BCHN duplicate-retry
+    //       case, which now falls out of the side-branch handling below).
+    auto const first_prev_hash = headers.front().previous_block_hash();
+    bool const extends_tip = (first_prev_hash == tip_hash_);
 
-    // 2026-01-28: Fix for duplicate/stale header batches causing "missing parent" errors.
-    // Symptom: After ABC peer fails checkpoint and sync retries with BCHN peer, BCHN headers
-    // are added successfully. But then a DUPLICATE retry request (from the ABC peer's
-    // channel_stopped event) causes the BCHN peer to send headers starting from an older
-    // point. The organizer tried to validate these at the current tip height, causing
-    // "missing parent" errors and banning innocent BCHN peers.
-    //
-    // Fix: Check if the first header's prev_hash matches our current tip. If not, check if
-    // it matches an older block in our chain. If so, these are stale/duplicate headers
-    // that can be silently skipped.
-    if (!headers.empty()) {
-        auto const first_prev_hash = headers.front().previous_block_hash();
-        spdlog::debug("[header_organizer] First header prev_hash: {}",
-            encode_hash(first_prev_hash));
-
-        if (first_prev_hash != tip_hash_) {
-            // First header doesn't connect to our tip - check if it's a stale request
-            auto const existing_idx = index_.find(first_prev_hash);
-            if (existing_idx != header_index::null_index) {
-                // The prev_hash exists in our chain but is not the tip - stale request
-                auto const existing_height = index_.get_height(existing_idx);
-                auto const tip_height = index_.get_height(tip_index_);
-
-                if (existing_height < tip_height) {
-                    // 2026-02-02: Return stale_chain error instead of success.
-                    // This prevents the coordinator from marking header sync as "complete"
-                    // when it receives a stale batch (which has headers_added = 0).
-                    // The coordinator will see this error and continue syncing instead of stopping.
-                    spdlog::info("[header_organizer] Skipping stale header batch: first header connects to "
-                        "height {} but tip is at height {} - likely duplicate retry request",
-                        existing_height, tip_height);
-                    result.error = error::stale_chain;  // Signal stale batch, not end of chain
-                    result.index_size = index_.size();
-                    result.index_memory_bytes = index_.memory_usage();
-                    return result;
-                }
+    index_t anchor_idx = tip_index_;
+    if ( ! extends_tip) {
+        anchor_idx = index_.find(first_prev_hash);
+        if (anchor_idx == header_index::null_index) {
+            // Unknown parent (orphan batch): validate against the tip so the
+            // missing-parent error is raised and the batch rejected, as before.
+            anchor_idx = tip_index_;
+        } else {
+            // Side branch. Bound the fork depth we bother storing/comparing so a peer
+            // cannot grow the index with (PoW-backed) branches far below the tip.
+            auto const tip_height = index_.get_height(tip_index_);
+            auto const anchor_height = index_.get_height(anchor_idx);
+            if (anchor_height < tip_height &&
+                uint32_t(tip_height - anchor_height) > reorg_limit_) {
+                spdlog::info("[header_organizer] Skipping header batch on a fork {} blocks below the tip "
+                    "(reorg limit {}) — treated as stale", tip_height - anchor_height, reorg_limit_);
+                result.error = error::stale_chain;
+                result.index_size = index_.size();
+                result.index_memory_bytes = index_.memory_usage();
+                return result;
             }
-            // If prev_hash doesn't exist at all, let validation handle it (orphan block)
         }
     }
+
+    // Running parent starts at the anchor (the tip for a forward extension, the fork
+    // ancestor for a side branch) and advances as each header is stored.
+    index_t parent_idx = anchor_idx;
+    index_t branch_head_idx = anchor_idx;
+    int32_t height = index_.get_height(anchor_idx) + 1;
+
+    spdlog::debug("[header_organizer] Starting validation at height {}, anchor_index {}, extends_tip {}",
+        height, anchor_idx, extends_tip);
 
     for (auto const& header : headers) {
         // Compute hash first (needed for validation)
@@ -145,10 +147,10 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
         auto const hash = domain::chain::hash(header);
         KTH_STATS_TIME_END(global_sync_stats(), hash, hash_time_ns, hash_calls);
 
-        // Validate header with full chain-state validation
+        // Validate header with full chain-state validation against its running parent.
         // This includes: PoW check, difficulty, checkpoint, version, MTP
         KTH_STATS_TIME_START(validate);
-        auto const ec = validate_full(header, hash, height, tip_index_);
+        auto const ec = validate_full(header, hash, height, parent_idx);
         KTH_STATS_TIME_END(global_sync_stats(), validate, validate_time_ns, validate_calls);
 
         if (ec) {
@@ -162,30 +164,47 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
         auto const add_result = index_.add(hash, header);
         KTH_STATS_TIME_END(global_sync_stats(), index_add, index_add_time_ns, index_add_calls);
 
+        parent_idx = add_result.index;
+        branch_head_idx = add_result.index;
+        ++height;
+
         if (add_result.inserted) {
-            tip_index_ = add_result.index;
-            tip_hash_ = hash;
-            prev_hash = hash;
-            ++height;
             ++result.headers_added;
-
-            // Mark as valid header
             index_.add_status(add_result.index, header_status::valid_header);
-
             if (add_result.capacity_warning) {
                 spdlog::warn("[header_organizer] Header index at 95% capacity!");
             }
         } else {
-            // Header already existed - this shouldn't happen in normal sync
-            spdlog::debug("[header_organizer] Header already exists at index {}",
-                add_result.index);
+            // Already known (duplicate/retry batch, or a re-announced branch header).
+            spdlog::debug("[header_organizer] Header already exists at index {}", add_result.index);
         }
+    }
 
-        // Log progress every 1000 headers
-        // if (result.headers_added > 0 && result.headers_added % 1000 == 0) {
-        //     spdlog::debug("[header_organizer] Validated {} headers, height {}...",
-        //         result.headers_added, height - 1);
-        // }
+    // Decide the active tip. A forward extension advances it linearly. A side branch
+    // only becomes the tip if it has strictly greater cumulative work — and even then
+    // the actual switch is deferred to the execution layer, so here we only flag the
+    // reorg candidate and keep the coordinator syncing (stale_chain, no forward count).
+    if (extends_tip) {
+        tip_index_ = branch_head_idx;
+        tip_hash_ = index_.get_hash(branch_head_idx);
+    } else if ( ! result.error) {
+        auto const branch_work = index_.get_chain_work(branch_head_idx);
+        auto const tip_work = index_.get_chain_work(tip_index_);
+        if (branch_work > tip_work) {
+            auto const fork_idx = index_.find_fork(branch_head_idx, tip_index_);
+            result.reorg_candidate = true;
+            result.reorg_fork_height = (fork_idx == header_index::null_index)
+                ? -1 : index_.get_height(fork_idx);
+            spdlog::warn("[header_organizer] Reorg candidate: side branch (head height {}) has greater "
+                "cumulative work than the active tip (height {}); fork at height {}. Active tip NOT "
+                "switched — block-disconnect / UTXO-Z rewind not yet implemented.",
+                index_.get_height(branch_head_idx), index_.get_height(tip_index_),
+                result.reorg_fork_height);
+        }
+        // The active tip did not advance: signal keep-syncing without reporting forward
+        // progress (preserves the coordinator contract for stale/duplicate batches).
+        result.error = error::stale_chain;
+        result.headers_added = 0;
     }
 
     spdlog::debug("[header_organizer] Validation complete: {} headers added, total size {}",

--- a/src/blockchain/test/header_organizer.cpp
+++ b/src/blockchain/test/header_organizer.cpp
@@ -150,6 +150,89 @@ TEST_CASE("header_organizer empty batch returns success with zero count", "[head
     REQUIRE(result.headers_added == 0);
 }
 
+// =============================================================================
+// Fork detection tests (headers-first reorg, detection layer)
+// =============================================================================
+
+// Build a side branch off `fork_prev` (the fork ancestor's hash) using header ids
+// starting at `id_base` so the hashes never collide with the main chain.
+domain::message::header::list make_branch(hash_digest fork_prev, size_t length, uint32_t id_base) {
+    domain::message::header::list branch;
+    hash_digest prev = fork_prev;
+    for (size_t i = 0; i < length; ++i) {
+        auto hdr = make_header_with_prev(prev, id_base + uint32_t(i));
+        prev = kth::domain::chain::hash(hdr);
+        branch.push_back(std::move(hdr));
+    }
+    return branch;
+}
+
+TEST_CASE("header_organizer flags a heavier side branch as a reorg candidate", "[header_organizer][fork]") {
+    // Main chain: heights 0..9 (tip at 9). All headers share the same target, so
+    // cumulative work is proportional to height.
+    header_index index;
+    (void)build_chain(index, 10);
+    auto const fork_prev = index.get_hash(5);   // fork ancestor at height 5
+
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+    auto const tip_height_before = organizer.header_height();
+
+    // Branch of 6 blocks off height 5 -> branch head at height 11 with more total
+    // work than the height-9 tip (6 branch blocks vs 4 tip blocks above the fork).
+    auto branch = make_branch(fork_prev, 6, 200);
+    auto result = organizer.add_headers(branch);
+
+    // Detected, but the active tip is NOT switched (execution layer pending).
+    REQUIRE(result.reorg_candidate);
+    REQUIRE(result.reorg_fork_height == 5);
+    REQUIRE(result.error == error::stale_chain);
+    REQUIRE(result.headers_added == 0);
+    REQUIRE(organizer.header_height() == tip_height_before);   // tip unchanged
+    REQUIRE(index.size() == 16);                               // branch stored (10 + 6)
+}
+
+TEST_CASE("header_organizer does not flag a lighter side branch", "[header_organizer][fork]") {
+    header_index index;
+    (void)build_chain(index, 10);              // tip at height 9
+    auto const fork_prev = index.get_hash(5);
+
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    // Branch of 3 blocks off height 5 -> head at height 8, less work than the tip.
+    auto branch = make_branch(fork_prev, 3, 300);
+    auto result = organizer.add_headers(branch);
+
+    REQUIRE_FALSE(result.reorg_candidate);
+    REQUIRE(result.reorg_fork_height == -1);
+    REQUIRE(result.error == error::stale_chain);   // still "keep syncing"
+    REQUIRE(result.headers_added == 0);
+}
+
+TEST_CASE("header_organizer ignores a fork deeper than the reorg limit", "[header_organizer][fork]") {
+    header_index index;
+    (void)build_chain(index, 10);              // tip at height 9
+    auto const fork_prev = index.get_hash(5);  // depth from tip = 4
+
+    auto settings = make_test_settings();
+    settings.reorganization_limit = 2;         // fork depth 4 > 2 -> ignore
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    auto branch = make_branch(fork_prev, 6, 400);
+    auto result = organizer.add_headers(branch);
+
+    REQUIRE(result.error == error::stale_chain);
+    REQUIRE_FALSE(result.reorg_candidate);
+    REQUIRE(index.size() == 10);               // branch NOT stored (bounded growth)
+}
+
 TEST_CASE("header_organizer duplicate headers in same batch", "[header_organizer][stale]") {
     // Setup
     header_index index;


### PR DESCRIPTION
First step toward reorg handling in the headers-first sync path. **Detection only — no chain switch.**

## Problem
Headers-first sync only ever extended a single linear chain. In `header_organizer::add_headers`, a batch that connected to an ancestor *below* the tip was dropped as `stale_chain` **without comparing its cumulative work**, so a competing greater-work fork was silently discarded and never even stored. The `header_index` already tracks per-entry cumulative chain work and can represent branches (`add()` links by `previous_block_hash`), but nothing fed it fork data or compared it.

## Change
`add_headers` is now branch-aware:
- It anchors the batch on the parent of its first header — the tip for a forward extension, the **fork ancestor** for a side branch — and validates each header against its *running parent*, so difficulty / MTP / checkpoint context comes from the branch, not the global tip.
- Side branches are stored in the `header_index`, bounded by `settings.reorganization_limit` (fork depth) to keep the index from growing on deep-fork spam.
- When a stored branch reaches **strictly greater cumulative work** than the active tip, it is reported as a reorg candidate (`reorg_candidate` / `reorg_fork_height`) and logged.

## What this does NOT do
The active tip is **not** switched. Executing a reorg (downloading the branch bodies, disconnecting blocks, rewinding UTXO-Z) is a separate layer — switching the header tip without it would validate new-branch blocks against the old chain's UTXO state. So this stops short at detection + storage + signal.

## Safety
The coordinator contract is preserved: a non-advancing batch still returns `stale_chain` with no forward count, so IBD is unchanged. Forward extensions and the stale/duplicate-retry path behave exactly as before (existing tests still green).

## Tests
Adds `[header_organizer][fork]` cases: heavier branch flagged as a candidate (tip unchanged, branch stored), lighter branch not flagged, fork deeper than the reorg limit ignored (not stored). Full blockchain suite green (1095 assertions).