### PR TITLE
blockchain: track the finalized block (BCHN-style)

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -190,6 +190,7 @@ set(kth_sources_just_legacy
   src/validate/validate_input.cpp
   src/validate/validate_transaction.cpp
   src/settings.cpp
+  src/finalization.cpp
   src/utxo_builder.cpp
 )
 
@@ -233,6 +234,7 @@ set(kth_headers
   include/kth/blockchain/pools/block_pool.hpp
   include/kth/blockchain/pools/header_organizer.hpp
   include/kth/blockchain/pools/transaction_organizer.hpp
+  include/kth/blockchain/finalization.hpp
   include/kth/blockchain/settings.hpp
 )
 
@@ -299,6 +301,7 @@ if (ENABLE_TEST)
         test/utxoz_roundtrip.cpp
         test/verify_script_context.cpp
         test/batch_sigchecks.cpp
+        test/finalization.cpp
     )
 
     # Disabled until ported to v1.0 APIs:

--- a/src/blockchain/include/kth/blockchain.hpp
+++ b/src/blockchain/include/kth/blockchain.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <kth/blockchain/define.hpp>
+#include <kth/blockchain/finalization.hpp>
 #include <kth/blockchain/header_index.hpp>
 #include <kth/blockchain/settings.hpp>
 #include <kth/blockchain/utxo_builder.hpp>

--- a/src/blockchain/include/kth/blockchain/finalization.hpp
+++ b/src/blockchain/include/kth/blockchain/finalization.hpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_FINALIZATION_HPP
+#define KTH_BLOCKCHAIN_FINALIZATION_HPP
+
+#include <cstdint>
+
+#include <kth/blockchain/define.hpp>
+#include <kth/database/header_index.hpp>
+
+namespace kth::blockchain {
+
+// Tracks the finalized block, mirroring BCHN's CChainState::pindexFinalized
+// (validation.cpp FindBlockToFinalize / IsBlockFinalized).
+//
+// The finalized block is the deepest block on the active chain that is both
+//   (a) at least `max_reorg_depth` blocks below the active block-validation tip
+//       (BCHN -maxreorgdepth, default 10), and
+//   (b) old enough: its header was received at least `finalization_delay`
+//       seconds ago (BCHN -finalizationdelay, default 2h). A reception time of 0
+//       means "loaded from the store at startup" and is always eligible.
+//
+// It advances only forward during normal operation and constrains reorgs: no
+// reorg may cross it (see FindMostWorkChain / ContextualCheckBlockHeader in
+// BCHN). Finalization is disabled when max_reorg_depth < 0.
+//
+// This type holds only the finalized index and reads the header_index; it does
+// not own or mutate chain state. Thread-safety is the caller's responsibility
+// (advance/retreat are single-writer, like the rest of the header sync path).
+struct KB_API finalization {
+    using index_t = database::header_index::index_t;
+    static constexpr index_t null_index = database::header_index::null_index;
+
+    finalization(database::header_index const& index,
+                 int32_t max_reorg_depth,
+                 int64_t finalization_delay_seconds,
+                 int64_t startup_time_unix);
+
+    // Advance the finalized pointer. `active_tip_idx` anchors the active chain
+    // (its ancestors are the active chain). `block_valid_height` is how far blocks
+    // have been validated. `now` is wall-clock unix seconds. No-op if nothing new
+    // is eligible; never moves the pointer backward.
+    void maybe_advance(index_t active_tip_idx, int32_t block_valid_height, int64_t now);
+
+    // The finalized block, or null_index if nothing is finalized yet.
+    [[nodiscard]] index_t finalized() const { return finalized_idx_; }
+
+    // Height of the finalized block, or -1 if nothing is finalized yet.
+    [[nodiscard]] int32_t finalized_height() const;
+
+    // BCHN IsBlockFinalized: true iff `idx` is an ancestor of (or equal to) the
+    // finalized block — i.e. it is buried at/below the finalization point.
+    [[nodiscard]] bool is_finalized(index_t idx) const;
+
+    // True iff `idx` descends from (has as an ancestor) the finalized block, i.e.
+    // sits on the finalized chain at/above the finalization point. Used to admit
+    // headers/branches: BCHN rejects a header whose parent fails this. With no
+    // finalized block yet, everything is admissible (returns true).
+    [[nodiscard]] bool descends_from_finalized(index_t idx) const;
+
+    // Retreat the finalized pointer when a finalized block is disconnected or
+    // invalidated (BCHN sets pindexFinalized = pindexDelete->pprev). Only the
+    // execution layer calls this.
+    void retreat_to(index_t to_idx);
+
+private:
+    database::header_index const& index_;
+    int32_t const max_reorg_depth_;
+    int64_t const finalization_delay_;
+    int64_t const startup_time_;
+    index_t finalized_idx_{null_index};
+};
+
+} // namespace kth::blockchain
+
+#endif // KTH_BLOCKCHAIN_FINALIZATION_HPP

--- a/src/blockchain/src/finalization.cpp
+++ b/src/blockchain/src/finalization.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/blockchain/finalization.hpp>
+
+namespace kth::blockchain {
+
+using database::header_index;
+
+finalization::finalization(header_index const& index,
+                           int32_t max_reorg_depth,
+                           int64_t finalization_delay_seconds,
+                           int64_t startup_time_unix)
+    : index_(index)
+    , max_reorg_depth_(max_reorg_depth)
+    , finalization_delay_(finalization_delay_seconds)
+    , startup_time_(startup_time_unix)
+{}
+
+void finalization::maybe_advance(index_t active_tip_idx, int32_t block_valid_height, int64_t now) {
+    // Finalization disabled (BCHN -maxreorgdepth = -1).
+    if (max_reorg_depth_ < 0) {
+        return;
+    }
+
+    if (active_tip_idx == null_index) {
+        return;
+    }
+
+    // Startup guard: don't finalize anything until the node has been up for at
+    // least finalization_delay (BCHN protects a freshly started node).
+    if (now < startup_time_ + finalization_delay_) {
+        return;
+    }
+
+    // Depth rule: the candidate is the active-chain block max_reorg_depth below
+    // the validated tip.
+    int32_t const candidate_height = block_valid_height - max_reorg_depth_;
+    if (candidate_height < 0) {
+        return;
+    }
+
+    // Nothing above the current finalized block to finalize. Guards against a
+    // caller passing a lower block_valid_height (the walk below would otherwise
+    // move the pointer backward). During normal forward sync this never trips.
+    if (finalized_idx_ != null_index && candidate_height <= finalized_height()) {
+        return;
+    }
+
+    index_t candidate = index_.get_ancestor(active_tip_idx, candidate_height);
+    if (candidate == null_index) {
+        return;
+    }
+
+    // Time rule: walk down from the candidate toward the current finalized block
+    // and finalize the first block whose header is old enough. Stopping at the
+    // current finalized block keeps the pointer monotonic (never moves backward).
+    index_t idx = candidate;
+    while (idx != null_index && idx != finalized_idx_) {
+        uint32_t const received = index_.get_received_time(idx);
+        // received == 0 => loaded from the store => always eligible.
+        if (now >= int64_t(received) + finalization_delay_) {
+            finalized_idx_ = idx;
+            return;
+        }
+        idx = index_.get_parent_index(idx);
+    }
+}
+
+int32_t finalization::finalized_height() const {
+    if (finalized_idx_ == null_index) {
+        return -1;
+    }
+    return index_.get_height(finalized_idx_);
+}
+
+bool finalization::is_finalized(index_t idx) const {
+    if (finalized_idx_ == null_index || idx == null_index) {
+        return false;
+    }
+    // idx is an ancestor of (or equal to) the finalized block.
+    int32_t const h = index_.get_height(idx);
+    return index_.get_ancestor(finalized_idx_, h) == idx;
+}
+
+bool finalization::descends_from_finalized(index_t idx) const {
+    // Nothing finalized yet: everything is admissible.
+    if (finalized_idx_ == null_index) {
+        return true;
+    }
+    if (idx == null_index) {
+        return false;
+    }
+    int32_t const fh = index_.get_height(finalized_idx_);
+    if (index_.get_height(idx) < fh) {
+        return false;
+    }
+    // The finalized block is an ancestor of (or equal to) idx.
+    return index_.get_ancestor(idx, fh) == finalized_idx_;
+}
+
+void finalization::retreat_to(index_t to_idx) {
+    finalized_idx_ = to_idx;
+}
+
+} // namespace kth::blockchain

--- a/src/blockchain/test/finalization.cpp
+++ b/src/blockchain/test/finalization.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <vector>
+
+#include <kth/blockchain.hpp>
+
+using namespace kth;
+using namespace kth::blockchain;
+using kth::database::header_index;
+
+namespace {
+
+constexpr int32_t max_reorg_depth = 10;
+constexpr int64_t delay = 7200;          // finalization delay (2h), BCHN default
+constexpr int64_t now = 1'000'000;       // fixed wall-clock for determinism
+
+hash_digest make_hash(uint32_t id) {
+    hash_digest h{};
+    h[0] = uint8_t(id);
+    h[1] = uint8_t(id >> 8);
+    h[2] = uint8_t(id >> 16);
+    h[3] = uint8_t(id >> 24);
+    return h;
+}
+
+domain::chain::header make_header(hash_digest const& prev, uint32_t id) {
+    return domain::chain::header{1, prev, make_hash(id + 100000), id * 600, 0x1d00ffff, id};
+}
+
+// Build a linear chain of `length` headers off `first_prev`, all with reception
+// time `received`. Returns the per-height index_t vector (index 0 = first block).
+std::vector<header_index::index_t> build_chain(
+    header_index& index, size_t length, hash_digest first_prev, uint32_t id_base, uint32_t received) {
+    std::vector<header_index::index_t> idxs;
+    hash_digest prev = first_prev;
+    for (uint32_t i = 0; i < length; ++i) {
+        auto hdr = make_header(prev, id_base + i);
+        auto hash = kth::domain::chain::hash(hdr);
+        auto r = index.add(hash, hdr);
+        REQUIRE(r.inserted);
+        index.set_received_time(r.index, received);
+        idxs.push_back(r.index);
+        prev = hash;
+    }
+    return idxs;
+}
+
+} // namespace
+
+// =============================================================================
+// finalization — depth + time rules (mirrors BCHN FindBlockToFinalize)
+// =============================================================================
+
+TEST_CASE("finalization advances to tip minus max_reorg_depth", "[finalization]") {
+    header_index index;
+    auto chain = build_chain(index, 20, null_hash, 0, /*received=*/0);  // 0 = from disk
+    finalization f(index, max_reorg_depth, delay, /*startup=*/0);
+
+    f.maybe_advance(chain.back(), /*block_valid_height=*/19, now);
+
+    // Disk-loaded headers (received 0) are immediately eligible, so the finalized
+    // block is exactly the depth candidate: 19 - 10 = 9.
+    REQUIRE(f.finalized_height() == 9);
+    REQUIRE(f.finalized() == chain[9]);
+}
+
+TEST_CASE("finalization respects the header-age (time) rule", "[finalization]") {
+    header_index index;
+    // Every header too recent to finalize (received `now`), except height 3.
+    auto chain = build_chain(index, 20, null_hash, 0, /*received=*/uint32_t(now));
+    index.set_received_time(chain[3], uint32_t(now - (delay + 800)));  // old enough
+    finalization f(index, max_reorg_depth, delay, /*startup=*/0);
+
+    f.maybe_advance(chain.back(), 19, now);
+
+    // Depth candidate is height 9, but 9..4 are too recent; the walk descends to
+    // the first time-eligible block, height 3.
+    REQUIRE(f.finalized_height() == 3);
+}
+
+TEST_CASE("finalization does nothing during the startup window", "[finalization]") {
+    header_index index;
+    auto chain = build_chain(index, 20, null_hash, 0, 0);
+    finalization f(index, max_reorg_depth, delay, /*startup=*/now);  // just started
+
+    f.maybe_advance(chain.back(), 19, now);   // now < startup + delay
+
+    REQUIRE(f.finalized() == finalization::null_index);
+    REQUIRE(f.finalized_height() == -1);
+}
+
+TEST_CASE("finalization is disabled when max_reorg_depth < 0", "[finalization]") {
+    header_index index;
+    auto chain = build_chain(index, 20, null_hash, 0, 0);
+    finalization f(index, /*max_reorg_depth=*/-1, delay, 0);
+
+    f.maybe_advance(chain.back(), 19, now);
+
+    REQUIRE(f.finalized() == finalization::null_index);
+}
+
+TEST_CASE("finalization pointer is monotonic", "[finalization]") {
+    header_index index;
+    auto chain = build_chain(index, 30, null_hash, 0, 0);
+    finalization f(index, max_reorg_depth, delay, 0);
+
+    f.maybe_advance(chain.back(), 25, now);
+    REQUIRE(f.finalized_height() == 15);
+
+    // A lower validated height must NOT move the pointer backward.
+    f.maybe_advance(chain.back(), 18, now);
+    REQUIRE(f.finalized_height() == 15);
+
+    // A higher validated height advances it.
+    f.maybe_advance(chain.back(), 29, now);
+    REQUIRE(f.finalized_height() == 19);
+}
+
+// =============================================================================
+// finalization — queries used by reorg admission
+// =============================================================================
+
+TEST_CASE("finalization is_finalized / descends_from_finalized", "[finalization]") {
+    header_index index;
+    auto chain = build_chain(index, 20, null_hash, 0, 0);
+    finalization f(index, max_reorg_depth, delay, 0);
+    f.maybe_advance(chain.back(), 19, now);
+    REQUIRE(f.finalized_height() == 9);
+
+    // is_finalized: at/below the finalization point on its chain.
+    REQUIRE(f.is_finalized(chain[9]));      // the finalized block itself
+    REQUIRE(f.is_finalized(chain[5]));      // an ancestor
+    REQUIRE_FALSE(f.is_finalized(chain[12])); // above the finalized point
+
+    // descends_from_finalized: at/above the finalization point on its chain.
+    REQUIRE(f.descends_from_finalized(chain[15]));
+    REQUIRE(f.descends_from_finalized(chain[9]));
+    REQUIRE_FALSE(f.descends_from_finalized(chain[5]));  // below the finalized point
+}
+
+TEST_CASE("finalization rejects a branch forking below the finalized block", "[finalization]") {
+    header_index index;
+    auto chain = build_chain(index, 20, null_hash, 0, 0);
+    finalization f(index, max_reorg_depth, delay, 0);
+    f.maybe_advance(chain.back(), 19, now);
+    REQUIRE(f.finalized_height() == 9);
+
+    // Side branch off height 3 (below the finalized height 9). Its headers do not
+    // descend from the finalized block, so header admission must reject them.
+    auto branch = build_chain(index, 12, index.get_hash(chain[3]), /*id_base=*/500, 0);
+    REQUIRE_FALSE(f.descends_from_finalized(branch.back()));
+
+    // A branch off height 12 (above the finalized point) is admissible.
+    auto ok_branch = build_chain(index, 3, index.get_hash(chain[12]), /*id_base=*/700, 0);
+    REQUIRE(f.descends_from_finalized(ok_branch.back()));
+}
+
+TEST_CASE("finalization retreat_to moves the pointer back on disconnect", "[finalization]") {
+    header_index index;
+    auto chain = build_chain(index, 20, null_hash, 0, 0);
+    finalization f(index, max_reorg_depth, delay, 0);
+    f.maybe_advance(chain.back(), 19, now);
+    REQUIRE(f.finalized_height() == 9);
+
+    f.retreat_to(chain[5]);
+    REQUIRE(f.finalized_height() == 5);
+
+    f.retreat_to(finalization::null_index);
+    REQUIRE(f.finalized() == finalization::null_index);
+}

--- a/src/database/include/kth/database/header_index.hpp
+++ b/src/database/include/kth/database/header_index.hpp
@@ -235,6 +235,20 @@ struct KD_API header_index {
     /// @param pos Byte offset within rev*.dat (same file number as block).
     void set_undo_pos(index_t idx, uint32_t pos);
 
+    // =========================================================================
+    // Header reception time (for finalization)
+    // =========================================================================
+
+    /// Record the wall-clock time (unix seconds) at which this header was first
+    /// received from the network. 0 means "known before this session" (loaded
+    /// from the store at startup), which BCHN treats as immediately finalizable.
+    /// Mirrors BCHN's CBlockIndex::nTimeReceived.
+    void set_received_time(index_t idx, uint32_t unix_seconds);
+
+    /// Get the header's reception time (unix seconds), or 0 if never set.
+    [[nodiscard]]
+    uint32_t get_received_time(index_t idx) const;
+
     /// Get file number for block.
     /// @return File number or -1 if no data.
     [[nodiscard]]
@@ -346,6 +360,10 @@ private:
     std::vector<int16_t> file_numbers_;    // -1 = no data
     std::vector<uint32_t> data_positions_; // Position in blk*.dat
     std::vector<uint32_t> undo_positions_; // Position in rev*.dat
+
+    // Wall-clock reception time (unix seconds) per header; 0 = loaded from store
+    // at startup (immediately finalizable). Used by finalization's time rule.
+    std::vector<uint32_t> header_received_times_;
 
     // Index counter
     std::atomic<index_t> next_idx_{0};

--- a/src/database/src/header_index.cpp
+++ b/src/database/src/header_index.cpp
@@ -38,6 +38,9 @@ header_index::header_index(size_t capacity)
     data_positions_.resize(capacity_, 0);
     undo_positions_.resize(capacity_, 0);
 
+    // Reception time (0 = loaded from store / not yet set)
+    header_received_times_.resize(capacity_, 0);
+
     // Reserve hash map capacity
     hash_to_idx_.reserve(capacity_);
 }
@@ -242,6 +245,14 @@ void header_index::set_block_pos(index_t idx, int16_t file, uint32_t pos) {
 
 void header_index::set_undo_pos(index_t idx, uint32_t pos) {
     undo_positions_[idx] = pos;
+}
+
+void header_index::set_received_time(index_t idx, uint32_t unix_seconds) {
+    header_received_times_[idx] = unix_seconds;
+}
+
+uint32_t header_index::get_received_time(index_t idx) const {
+    return header_received_times_[idx];
 }
 
 int16_t header_index::get_file_number(index_t idx) const {


### PR DESCRIPTION
Foundation for reorg handling. Validated against **BCHN v29** (`validation.cpp`: `FindBlockToFinalize`, `IsBlockFinalized`, `ContextualCheckBlockHeader`, `FindMostWorkChain`).

## Why
Reorg handling must be anchored on a **finalized block**, not a fixed depth. BCHN auto-finalizes the block `maxreorgdepth` (10) below the validated tip once its header is `finalizationdelay` (2h) old, then refuses to reorg across it and rejects headers that fork below it. KTH tracked no such thing. This adds the tracker; a fixed `reorganization_limit` guard (the placeholder in #566) is the wrong bound.

## What
`kth::blockchain::finalization` — holds the finalized index, reads `header_index`, mutates no chain state:
- `maybe_advance(active_tip, block_valid_height, now)` — depth rule (`block_valid_height - max_reorg_depth`) + time rule (walk down to the first block whose header is ≥ `finalization_delay` old). Monotonic forward (guard rejects a lower validated height); disabled at `max_reorg_depth < 0`.
- `is_finalized(idx)` — buried at/below the point (BCHN `IsBlockFinalized`).
- `descends_from_finalized(idx)` — on the finalized chain at/above the point; this is the check BCHN's `ContextualCheckBlockHeader` applies to incoming headers.
- `retreat_to(idx)` — backs the pointer out on disconnect/invalidate (BCHN `pindexFinalized = pindexDelete->pprev`).

`header_index` gains a per-entry **reception time** (`CBlockIndex::nTimeReceived` analogue). `0` = loaded from the store at startup → immediately eligible, matching BCHN's disk-loaded blocks.

## Scope
Tracker + unit tests only — no behavior change to the running node. Tests cover the depth rule, time rule, startup window, disabled mode, monotonicity, the `is_finalized`/`descends_from_finalized` queries, branch-below-finalized rejection, and `retreat_to`.

## Next
Wiring reworks #566 (draft): advance the tracker on block-tip advance; in `add_headers` reject headers not descending from the finalized block (BCHN `-finalizeheaders`, DoS the peer) and bound reorg candidates to forks above the finalized block. Then the execution layer (undo data, block disconnect, UTXO-Z rewind, orchestrator rewind).