### PR TITLE
blockchain: wire the finalized-block tracker into header sync

### DIFF
--- a/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include <kth/blockchain/define.hpp>
+#include <kth/blockchain/finalization.hpp>
 #include <kth/blockchain/header_index.hpp>
 #include <kth/blockchain/settings.hpp>
 #include <kth/blockchain/validate/validate_header.hpp>
@@ -63,6 +64,19 @@ struct KB_API header_organizer {
     /// Sync tip state from the header index.
     /// Call after header_index has been initialized (e.g., with genesis).
     void sync_tip();
+
+    /// Notify the organizer that blocks are validated up to `block_valid_height`,
+    /// advancing the finalized block per BCHN's depth + header-age rules. Called
+    /// by the block-download/validation path as it advances the validated tip.
+    void note_block_validated(int32_t block_valid_height);
+
+    /// Height of the finalized block, or -1 if nothing is finalized yet.
+    [[nodiscard]]
+    int32_t finalized_height() const { return finalizer_.finalized_height(); }
+
+    /// Read-only view of the finalization state (for header/reorg admission).
+    [[nodiscard]]
+    finalization const& finalized_state() const { return finalizer_; }
 
     /// Add a batch of headers to the organizer.
     /// Validates all headers and adds valid ones to the index.
@@ -136,6 +150,10 @@ private:
     header_index& index_;
     std::atomic<bool> stopped_{false};
     validate_header validator_;
+
+    // Tracks the finalized block (BCHN parity). Advanced by note_block_validated;
+    // read via finalized_state() for header/reorg admission.
+    finalization finalizer_;
 
     // Current tip state
     index_t tip_index_{header_index::null_index};

--- a/src/blockchain/include/kth/blockchain/settings.hpp
+++ b/src/blockchain/include/kth/blockchain/settings.hpp
@@ -31,6 +31,13 @@ struct KB_API settings {
     uint64_t minimum_output_satoshis = 500;
     uint32_t notify_limit_hours = 24;
     uint32_t reorganization_limit = 256;
+    // Finalization (BCHN parity). A block is finalized once it is `max_reorg_depth`
+    // deep and its header is `finalization_delay_seconds` old. Currently the node
+    // only tracks the finalized block; enforcement (refusing to reorg across it,
+    // rejecting headers below it) is not wired yet. max_reorg_depth < 0 disables
+    // finalization entirely.
+    int32_t max_reorg_depth = 10;                       // BCHN -maxreorgdepth
+    int64_t finalization_delay_seconds = 2 * 60 * 60;   // BCHN -finalizationdelay (2h)
     // Minimum seconds between block-template rebuilds while the mempool churns
     // (a new tip always rebuilds immediately). Mirrors bitcoind's 5s.
     uint32_t gbt_template_refresh_seconds = 5;

--- a/src/blockchain/src/pools/header_organizer.cpp
+++ b/src/blockchain/src/pools/header_organizer.cpp
@@ -7,6 +7,7 @@
 #include <spdlog/spdlog.h>
 
 #include <kth/infrastructure/utility/stats.hpp>
+#include <kth/infrastructure/utility/timer.hpp>
 
 #include <kth/blockchain/settings.hpp>
 #include <kth/blockchain/validate/validate_header.hpp>
@@ -22,7 +23,18 @@ header_organizer::header_organizer(header_index& index, settings const& settings
                                    domain::config::network network)
     : index_(index)
     , validator_(settings, network)
+    , finalizer_(index, settings.max_reorg_depth, settings.finalization_delay_seconds,
+                 static_cast<int64_t>(zulu_time()))
 {}
+
+void header_organizer::note_block_validated(int32_t block_valid_height) {
+    auto const before = finalizer_.finalized_height();
+    finalizer_.maybe_advance(tip_index_, block_valid_height, static_cast<int64_t>(zulu_time()));
+    auto const after = finalizer_.finalized_height();
+    if (after != before) {
+        spdlog::info("[header_organizer] Finalized block advanced to height {}", after);
+    }
+}
 
 // =============================================================================
 // Lifecycle
@@ -168,6 +180,10 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
             prev_hash = hash;
             ++height;
             ++result.headers_added;
+
+            // Record wall-clock reception time for the finalization time rule.
+            // (Headers loaded from the store at startup keep 0 = immediately eligible.)
+            index_.set_received_time(add_result.index, static_cast<uint32_t>(zulu_time()));
 
             // Mark as valid header
             index_.add_status(add_result.index, header_status::valid_header);

--- a/src/blockchain/test/header_organizer.cpp
+++ b/src/blockchain/test/header_organizer.cpp
@@ -150,6 +150,23 @@ TEST_CASE("header_organizer empty batch returns success with zero count", "[head
     REQUIRE(result.headers_added == 0);
 }
 
+TEST_CASE("header_organizer note_block_validated respects the startup window", "[header_organizer][finalization]") {
+    // A freshly constructed organizer is within the finalization startup window
+    // (uptime < finalization_delay), so no block finalizes even once blocks are
+    // validated well past the depth threshold. (The finalization rule itself is
+    // covered by the finalization component tests.)
+    header_index index;
+    (void)build_chain(index, 30);
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    REQUIRE(organizer.finalized_height() == -1);
+    organizer.note_block_validated(29);
+    REQUIRE(organizer.finalized_height() == -1);
+}
+
 TEST_CASE("header_organizer duplicate headers in same batch", "[header_organizer][stale]") {
     // Setup
     header_index index;

--- a/src/c-api/include/kth/capi/config/blockchain_helpers.hpp
+++ b/src/c-api/include/kth/capi/config/blockchain_helpers.hpp
@@ -27,6 +27,8 @@ Target blockchain_settings_to_common(Source const& x) {
     res.minimum_output_satoshis = x.minimum_output_satoshis;
     res.notify_limit_hours = x.notify_limit_hours;
     res.reorganization_limit = x.reorganization_limit;
+    res.max_reorg_depth = x.max_reorg_depth;
+    res.finalization_delay_seconds = x.finalization_delay_seconds;
     res.fix_checkpoints = x.fix_checkpoints;
     res.allow_collisions = x.allow_collisions;
     res.easy_blocks = x.easy_blocks;

--- a/src/c-api/include/kth/capi/config/blockchain_settings.h
+++ b/src/c-api/include/kth/capi/config/blockchain_settings.h
@@ -22,6 +22,8 @@ typedef struct {
     uint64_t minimum_output_satoshis;
     uint32_t notify_limit_hours;
     uint32_t reorganization_limit;
+    int32_t max_reorg_depth;
+    int64_t finalization_delay_seconds;
     kth_size_t checkpoint_count;
     kth_checkpoint* checkpoints;
     kth_bool_t fix_checkpoints;

--- a/src/database/include/kth/database/header_index.hpp
+++ b/src/database/include/kth/database/header_index.hpp
@@ -29,24 +29,11 @@ namespace kth::database {
 //   - Fork tracking and reorganization
 //   - Headers-first sync
 //
-// Memory layout (SoA - Structure of Arrays):
-// For ~1.18M blocks (default capacity):
-//   prev_block_hashes: 37.7 MB (1,179,648 x 32 bytes)
-//   parent_indices:     4.7 MB (1,179,648 x 4 bytes)
-//   skip_indices:       4.7 MB
-//   heights:            4.7 MB
-//   chain_works:       37.7 MB (1,179,648 x 32 bytes — uint256 cumulative work)
-//   statuses:           4.7 MB
-//   versions:           4.7 MB
-//   merkle_roots:      37.7 MB (1,179,648 x 32 bytes)
-//   timestamps:         4.7 MB
-//   bits:               4.7 MB
-//   nonces:             4.7 MB
-//   file_numbers:       2.4 MB (1,179,648 x 2 bytes)
-//   data_positions:     4.7 MB
-//   undo_positions:     4.7 MB
-//   ─────────────────────────────
-//   Total:            ~137 MB
+// Memory layout (SoA — one vector per field). At default capacity (~1.18M
+// entries) the footprint is dominated by the four 32-byte vectors — hashes,
+// prev_block_hashes, chain_works (uint256), merkle_roots (~37.7 MB each) — plus
+// ~a dozen 2-to-4-byte vectors. Roughly 174 bytes/entry ≈ 205 MB total, plus the
+// hash->index concurrent map. See the private members below for the full set.
 //
 // Thread safety:
 //   - Writers: CFM's bucket lock during insert_and_visit

--- a/src/node/include/kth/node/sync/block_tasks.hpp
+++ b/src/node/include/kth/node/sync/block_tasks.hpp
@@ -147,6 +147,7 @@ extern std::atomic<uint64_t> g_blocks_received_by_validation;
     block_storage_input_channel& input,
     chunk_validated_channel& output,
     uint32_t start_height,
+    blockchain::header_organizer& organizer,  // advance finalization as blocks validate
     std::atomic<uint32_t>* contiguous_out = nullptr  // publish contiguous height for utxo_build_task
 );
 

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1452,6 +1452,7 @@ std::atomic<uint32_t> g_active_download_peers{0};
     block_storage_input_channel& input,
     chunk_validated_channel& output,
     uint32_t start_height,
+    blockchain::header_organizer& organizer,
     std::atomic<uint32_t>* contiguous_out
 ) {
     spdlog::info("[block_storage] Task started at height {}", start_height);
@@ -1524,6 +1525,7 @@ std::atomic<uint32_t> g_active_download_peers{0};
             // Advance contiguous_height using header_index have_data flags.
             // store_chunk() already set have_data for each stored block.
             // idx == height during IBD (headers added sequentially).
+            auto const prev_contiguous = contiguous_height;
             auto const& hdr = chain.headers();
             while (hdr.has_status(static_cast<blockchain::header_index::index_t>(contiguous_height),
                                   blockchain::header_status::have_data)) {
@@ -1533,6 +1535,12 @@ std::atomic<uint32_t> g_active_download_peers{0};
             // Publish contiguous height for utxo_build_task
             if (contiguous_out) {
                 contiguous_out->store(contiguous_height, std::memory_order_release);
+            }
+
+            // Advance the finalized block as newly stored (batch-validated)
+            // blocks extend the contiguous validated range.
+            if (contiguous_height > prev_contiguous) {
+                organizer.note_block_validated(static_cast<int32_t>(contiguous_height - 1));
             }
         } else {
             // Store failed — release memory

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -621,6 +621,7 @@ static
         block_storage_input,
         stored_chunks,
         initial_block_height + 1,
+        organizer,
         contiguous_height.get()
     ));
 


### PR DESCRIPTION
Follow-up to #567 (finalization tracker). Makes it **live and observable**, no enforcement yet.

## What
- `header_organizer` owns a `finalization`, built from new settings `max_reorg_depth` (10) and `finalization_delay_seconds` (2h) — BCHN `-maxreorgdepth` / `-finalizationdelay` — with the node startup time.
- `add_headers` records each live header's wall-clock reception time (the finalization time rule). Headers loaded from the store at startup keep `0` = immediately eligible (BCHN disk-loaded blocks).
- `note_block_validated(height)` advances the finalized block as `block_storage_task` validates further, and logs when it moves. Called right after `set_last_block_height`.
- `finalized_state()` exposes the tracker for the upcoming admission logic.

## Concurrency
`block_storage_task` already reads the organizer's header index concurrently (`get_block_hash`), so this adds no new sharing except the finalized pointer, which `block_storage_task` alone writes. (When `add_headers` starts *reading* it in the enforcement PR, the pointer becomes `std::atomic`.)

## No behavior change
The finalized block is tracked + logged; nothing consumes it yet. On a fresh start the startup window (uptime < `finalization_delay`) suppresses finalization for 2h, matching BCHN.

## Next
Rework #566 (draft): in `add_headers`, reject headers not descending from the finalized block (BCHN `-finalizeheaders`, DoS the peer) and bound reorg-candidate detection to forks above the finalized block. Then the execution layer.

Settings added to the C-API blockchain settings struct + helper to stay in sync. Full blockchain suite green; node-exe + c-api build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added blockchain finalization tracking as validated blocks are processed.
  * Added configurable reorganization depth and finalization delay settings, defaulting to 10 blocks and two hours.
  * Exposed finalized height and finalization state through blockchain interfaces and configuration APIs.
* **Enhancements**
  * Header reception times are now recorded to support time-based finalization.
  * Finalization advances automatically as contiguous blocks are validated and stored.
* **Tests**
  * Added coverage confirming finalization remains within the startup window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->