### PR TITLE
chore: tune CodeRabbit config to cut review churn

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,16 @@
 reviews:
+  # Less nitpicky, fewer low-value comments (also lighter per review).
+  profile: chill
+  # We iterate with amend + force-push; don't gate merges on CR's status.
+  request_changes_workflow: false
+  high_level_summary: true
+  # Noise reduction.
+  poem: false
+  auto_review:
+    enabled: true
+    # Do NOT review while a PR is in draft. Iterate in draft, mark ready once,
+    # and CR reviews a single time — instead of one review per intermediate push.
+    drafts: false
   path_filters:
     # Review the Knuth source modules and their tests.
     - "src/infrastructure/**"


### PR DESCRIPTION
We were hitting CodeRabbit's hourly rate limit — not from the plan (the repo is on Pro Plus via the OSS program, 10 reviews/dev/hr) but from workflow: every push to an open non-draft PR triggers an incremental review, and we were amend+force-pushing once per addressed comment.

This tunes `.coderabbit.yaml`:
- `auto_review.drafts: false` — CR does not review while a PR is in **draft**, so iterating in draft spends no reviews; the PR is reviewed once when marked ready.
- `profile: chill` + `poem: false` — fewer low-value comments and less noise (also lighter per review).
- `request_changes_workflow: false` — we iterate with amend + force-push, so don't gate merges on CR's status.

Takes effect once merged to `master` (CR reads config from the base branch).