### PR TITLE
blockchain: enforce header finalization + detect reorg candidates

### DIFF
--- a/src/blockchain/include/kth/blockchain/finalization.hpp
+++ b/src/blockchain/include/kth/blockchain/finalization.hpp
@@ -5,6 +5,7 @@
 #ifndef KTH_BLOCKCHAIN_FINALIZATION_HPP
 #define KTH_BLOCKCHAIN_FINALIZATION_HPP
 
+#include <atomic>
 #include <cstdint>
 
 #include <kth/blockchain/define.hpp>
@@ -45,7 +46,7 @@ struct KB_API finalization {
     void maybe_advance(index_t active_tip_idx, int32_t block_valid_height, int64_t now);
 
     // The finalized block, or null_index if nothing is finalized yet.
-    [[nodiscard]] index_t finalized() const { return finalized_idx_; }
+    [[nodiscard]] index_t finalized() const { return finalized_idx_.load(std::memory_order_acquire); }
 
     // Height of the finalized block, or -1 if nothing is finalized yet.
     [[nodiscard]] int32_t finalized_height() const;
@@ -70,7 +71,9 @@ private:
     int32_t const max_reorg_depth_;
     int64_t const finalization_delay_;
     int64_t const startup_time_;
-    index_t finalized_idx_{null_index};
+    // Written only by the block-validation path (single writer), read from the
+    // header path (add_headers admission); atomic for that cross-thread read.
+    std::atomic<index_t> finalized_idx_{null_index};
 };
 
 } // namespace kth::blockchain

--- a/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
@@ -25,6 +25,13 @@ struct header_organize_result {
     size_t headers_added{0};
     size_t index_size{0};
     size_t index_memory_bytes{0};
+
+    // Fork detection (headers-first): set when a stored side branch that descends
+    // from the finalized block reaches strictly greater cumulative chain work than
+    // the active header tip — a reorganization candidate. The active tip is NOT
+    // switched here; executing the switch is a separate layer.
+    bool reorg_candidate{false};
+    int32_t reorg_fork_height{-1};   // height of the common ancestor, or -1
 };
 
 /// Header organizer for headers-first sync.

--- a/src/blockchain/src/finalization.cpp
+++ b/src/blockchain/src/finalization.cpp
@@ -41,10 +41,14 @@ void finalization::maybe_advance(index_t active_tip_idx, int32_t block_valid_hei
         return;
     }
 
+    // Single writer (block-validation path), so a relaxed load of our own pointer
+    // is fine here; the store below publishes with release for the header reader.
+    index_t const fin = finalized_idx_.load(std::memory_order_relaxed);
+
     // Nothing above the current finalized block to finalize. Guards against a
     // caller passing a lower block_valid_height (the walk below would otherwise
     // move the pointer backward). During normal forward sync this never trips.
-    if (finalized_idx_ != null_index && candidate_height <= finalized_height()) {
+    if (fin != null_index && candidate_height <= index_.get_height(fin)) {
         return;
     }
 
@@ -57,11 +61,11 @@ void finalization::maybe_advance(index_t active_tip_idx, int32_t block_valid_hei
     // and finalize the first block whose header is old enough. Stopping at the
     // current finalized block keeps the pointer monotonic (never moves backward).
     index_t idx = candidate;
-    while (idx != null_index && idx != finalized_idx_) {
+    while (idx != null_index && idx != fin) {
         uint32_t const received = index_.get_received_time(idx);
         // received == 0 => loaded from the store => always eligible.
         if (now >= int64_t(received) + finalization_delay_) {
-            finalized_idx_ = idx;
+            finalized_idx_.store(idx, std::memory_order_release);
             return;
         }
         idx = index_.get_parent_index(idx);
@@ -69,39 +73,42 @@ void finalization::maybe_advance(index_t active_tip_idx, int32_t block_valid_hei
 }
 
 int32_t finalization::finalized_height() const {
-    if (finalized_idx_ == null_index) {
+    index_t const fin = finalized_idx_.load(std::memory_order_acquire);
+    if (fin == null_index) {
         return -1;
     }
-    return index_.get_height(finalized_idx_);
+    return index_.get_height(fin);
 }
 
 bool finalization::is_finalized(index_t idx) const {
-    if (finalized_idx_ == null_index || idx == null_index) {
+    index_t const fin = finalized_idx_.load(std::memory_order_acquire);
+    if (fin == null_index || idx == null_index) {
         return false;
     }
     // idx is an ancestor of (or equal to) the finalized block.
     int32_t const h = index_.get_height(idx);
-    return index_.get_ancestor(finalized_idx_, h) == idx;
+    return index_.get_ancestor(fin, h) == idx;
 }
 
 bool finalization::descends_from_finalized(index_t idx) const {
+    index_t const fin = finalized_idx_.load(std::memory_order_acquire);
     // Nothing finalized yet: everything is admissible.
-    if (finalized_idx_ == null_index) {
+    if (fin == null_index) {
         return true;
     }
     if (idx == null_index) {
         return false;
     }
-    int32_t const fh = index_.get_height(finalized_idx_);
+    int32_t const fh = index_.get_height(fin);
     if (index_.get_height(idx) < fh) {
         return false;
     }
     // The finalized block is an ancestor of (or equal to) idx.
-    return index_.get_ancestor(idx, fh) == finalized_idx_;
+    return index_.get_ancestor(idx, fh) == fin;
 }
 
 void finalization::retreat_to(index_t to_idx) {
-    finalized_idx_ = to_idx;
+    finalized_idx_.store(to_idx, std::memory_order_release);
 }
 
 } // namespace kth::blockchain

--- a/src/blockchain/src/pools/header_organizer.cpp
+++ b/src/blockchain/src/pools/header_organizer.cpp
@@ -99,57 +99,45 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
 
     spdlog::debug("[header_organizer] add_headers() called with {} headers", headers.size());
 
-    // Current tip for validation
     if (tip_index_ == database::header_index::null_index) {
         spdlog::error("[header_organizer] add_headers() called with uninitialized tip_index_ — call sync_tip() first");
         return {error::operation_failed, 0, 0, 0};
     }
-    hash_digest prev_hash = tip_hash_;
-    int32_t height = index_.get_height(tip_index_) + 1;
 
-    spdlog::debug("[header_organizer] Starting validation at height {}, tip_hash: {}, tip_index: {}",
-        height, encode_hash(tip_hash_), tip_index_);
+    // Determine the batch anchor: the index entry the first header builds on.
+    //   (1) anchor == tip                        -> forward extension of the active chain.
+    //   (2) anchor is a known entry below the tip -> a side branch (fork). Validated
+    //       and stored against its OWN ancestor so difficulty / MTP / checkpoint
+    //       context is correct, then compared against the tip's work.
+    //   (3) anchor unknown                       -> orphan; validation surfaces the
+    //       missing-parent error (this is also the old ABC/BCHN duplicate-retry case).
+    auto const first_prev_hash = headers.front().previous_block_hash();
+    bool const extends_tip = (first_prev_hash == tip_hash_);
 
-    // 2026-01-28: Fix for duplicate/stale header batches causing "missing parent" errors.
-    // Symptom: After ABC peer fails checkpoint and sync retries with BCHN peer, BCHN headers
-    // are added successfully. But then a DUPLICATE retry request (from the ABC peer's
-    // channel_stopped event) causes the BCHN peer to send headers starting from an older
-    // point. The organizer tried to validate these at the current tip height, causing
-    // "missing parent" errors and banning innocent BCHN peers.
-    //
-    // Fix: Check if the first header's prev_hash matches our current tip. If not, check if
-    // it matches an older block in our chain. If so, these are stale/duplicate headers
-    // that can be silently skipped.
-    if (!headers.empty()) {
-        auto const first_prev_hash = headers.front().previous_block_hash();
-        spdlog::debug("[header_organizer] First header prev_hash: {}",
-            encode_hash(first_prev_hash));
-
-        if (first_prev_hash != tip_hash_) {
-            // First header doesn't connect to our tip - check if it's a stale request
-            auto const existing_idx = index_.find(first_prev_hash);
-            if (existing_idx != header_index::null_index) {
-                // The prev_hash exists in our chain but is not the tip - stale request
-                auto const existing_height = index_.get_height(existing_idx);
-                auto const tip_height = index_.get_height(tip_index_);
-
-                if (existing_height < tip_height) {
-                    // 2026-02-02: Return stale_chain error instead of success.
-                    // This prevents the coordinator from marking header sync as "complete"
-                    // when it receives a stale batch (which has headers_added = 0).
-                    // The coordinator will see this error and continue syncing instead of stopping.
-                    spdlog::info("[header_organizer] Skipping stale header batch: first header connects to "
-                        "height {} but tip is at height {} - likely duplicate retry request",
-                        existing_height, tip_height);
-                    result.error = error::stale_chain;  // Signal stale batch, not end of chain
-                    result.index_size = index_.size();
-                    result.index_memory_bytes = index_.memory_usage();
-                    return result;
-                }
-            }
-            // If prev_hash doesn't exist at all, let validation handle it (orphan block)
+    index_t anchor_idx = tip_index_;
+    if ( ! extends_tip) {
+        anchor_idx = index_.find(first_prev_hash);
+        if (anchor_idx == header_index::null_index) {
+            // Unknown parent (orphan): validate against the tip so the missing-parent
+            // error is raised and the batch rejected, as before.
+            anchor_idx = tip_index_;
         }
     }
+
+    // Running parent starts at the anchor (the tip for a forward extension, the fork
+    // ancestor for a side branch) and advances as each header is stored.
+    index_t parent_idx = anchor_idx;
+    index_t branch_head_idx = anchor_idx;
+    int32_t height = index_.get_height(anchor_idx) + 1;
+
+    // Whether parent_idx is known to descend from the finalized block. A child of a
+    // verified parent inherits the property, so a contiguous run of new headers costs
+    // one ancestor walk instead of one per header. Jumping to an already-known header
+    // (the `continue` below) moves the parent anywhere in the index, so it clears this.
+    bool parent_descends_finalized = false;
+
+    spdlog::debug("[header_organizer] Starting validation at height {}, anchor_index {}, extends_tip {}",
+        height, anchor_idx, extends_tip);
 
     for (auto const& header : headers) {
         // Compute hash first (needed for validation)
@@ -157,10 +145,47 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
         auto const hash = domain::chain::hash(header);
         KTH_STATS_TIME_END(global_sync_stats(), hash, hash_time_ns, hash_calls);
 
-        // Validate header with full chain-state validation
+        // Already known (duplicate/retry batch, or a re-announced branch header): it
+        // was validated when first added, so skip re-validation and just advance the
+        // running parent. Resync the height from the stored entry. This also covers
+        // the below-tip retry batch the old early-return special-cased.
+        if (auto const known_idx = index_.find(hash); known_idx != header_index::null_index) {
+            parent_idx = known_idx;
+            branch_head_idx = known_idx;
+            height = index_.get_height(known_idx) + 1;
+            // The parent moved to an arbitrary entry: re-verify before the next new header.
+            parent_descends_finalized = false;
+            spdlog::debug("[header_organizer] Header already exists at index {}", known_idx);
+            continue;
+        }
+
+        // Header finalization (BCHN ContextualCheckBlockHeader / -finalizeheaders):
+        // a NEW header whose parent does not descend from the finalized block extends
+        // a branch that forks below finalization. Reject the batch, store nothing more,
+        // and signal the caller to penalize the peer. Checked per NEW header (not just
+        // the batch anchor) so a getheaders reply that overlaps a known point and then
+        // continues onto a sub-finalized branch cannot slip new headers through.
+        //
+        // Already-known headers took the `continue` above (mirrors BCHN returning early
+        // for known headers), so honest stale-retry of buried headers is not penalized.
+        // While nothing is finalized yet (startup window / finalization disabled),
+        // descends_from_finalized() is always true and nothing is rejected — matching
+        // BCHN, where finalization is inactive until the node has been up long enough.
+        if ( ! parent_descends_finalized) {
+            if ( ! finalizer_.descends_from_finalized(parent_idx)) {
+                spdlog::warn("[header_organizer] Rejecting header that forks below the finalized block "
+                    "(parent height {}, finalized height {})",
+                    index_.get_height(parent_idx), finalizer_.finalized_height());
+                result.error = error::finalized_header_violation;
+                break;
+            }
+            parent_descends_finalized = true;
+        }
+
+        // Validate header with full chain-state validation against its running parent.
         // This includes: PoW check, difficulty, checkpoint, version, MTP
         KTH_STATS_TIME_START(validate);
-        auto const ec = validate_full(header, hash, height, tip_index_);
+        auto const ec = validate_full(header, hash, height, parent_idx);
         KTH_STATS_TIME_END(global_sync_stats(), validate, validate_time_ns, validate_calls);
 
         if (ec) {
@@ -174,34 +199,51 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
         auto const add_result = index_.add(hash, header);
         KTH_STATS_TIME_END(global_sync_stats(), index_add, index_add_time_ns, index_add_calls);
 
-        if (add_result.inserted) {
-            tip_index_ = add_result.index;
-            tip_hash_ = hash;
-            prev_hash = hash;
-            ++height;
-            ++result.headers_added;
+        // New header (known ones took the `continue` above), so this always inserts.
+        // The parent becomes this header, a child of a parent already verified to
+        // descend from the finalized block, so parent_descends_finalized still holds.
+        parent_idx = add_result.index;
+        branch_head_idx = add_result.index;
+        ++height;
+        ++result.headers_added;
 
-            // Record wall-clock reception time for the finalization time rule.
-            // (Headers loaded from the store at startup keep 0 = immediately eligible.)
-            index_.set_received_time(add_result.index, static_cast<uint32_t>(zulu_time()));
+        // Record wall-clock reception time for the finalization time rule.
+        // (Headers loaded from the store at startup keep 0 = immediately eligible.)
+        index_.set_received_time(add_result.index, static_cast<uint32_t>(zulu_time()));
 
-            // Mark as valid header
-            index_.add_status(add_result.index, header_status::valid_header);
+        // Mark as valid header
+        index_.add_status(add_result.index, header_status::valid_header);
 
-            if (add_result.capacity_warning) {
-                spdlog::warn("[header_organizer] Header index at 95% capacity!");
-            }
-        } else {
-            // Header already existed - this shouldn't happen in normal sync
-            spdlog::debug("[header_organizer] Header already exists at index {}",
-                add_result.index);
+        if (add_result.capacity_warning) {
+            spdlog::warn("[header_organizer] Header index at 95% capacity!");
         }
+    }
 
-        // Log progress every 1000 headers
-        // if (result.headers_added > 0 && result.headers_added % 1000 == 0) {
-        //     spdlog::debug("[header_organizer] Validated {} headers, height {}...",
-        //         result.headers_added, height - 1);
-        // }
+    // Decide the active tip. A forward extension advances it linearly. A side branch
+    // only becomes the tip if it has strictly greater cumulative work — and even then
+    // the actual switch is deferred to the execution layer, so here we only flag the
+    // reorg candidate and keep the coordinator syncing (stale_chain, no forward count).
+    if (extends_tip) {
+        tip_index_ = branch_head_idx;
+        tip_hash_ = index_.get_hash(branch_head_idx);
+    } else if ( ! result.error) {
+        auto const branch_work = index_.get_chain_work(branch_head_idx);
+        auto const tip_work = index_.get_chain_work(tip_index_);
+        if (branch_work > tip_work) {
+            auto const fork_idx = index_.find_fork(branch_head_idx, tip_index_);
+            result.reorg_candidate = true;
+            result.reorg_fork_height = (fork_idx == header_index::null_index)
+                ? -1 : index_.get_height(fork_idx);
+            spdlog::warn("[header_organizer] Reorg candidate: side branch (head height {}) has greater "
+                "cumulative work than the active tip (height {}); fork at height {}. Active tip NOT "
+                "switched — execution layer pending.",
+                index_.get_height(branch_head_idx), index_.get_height(tip_index_),
+                result.reorg_fork_height);
+        }
+        // The active tip did not advance: signal keep-syncing without reporting forward
+        // progress (preserves the coordinator contract for stale/duplicate batches).
+        result.error = error::stale_chain;
+        result.headers_added = 0;
     }
 
     spdlog::debug("[header_organizer] Validation complete: {} headers added, total size {}",

--- a/src/blockchain/test/header_organizer.cpp
+++ b/src/blockchain/test/header_organizer.cpp
@@ -197,3 +197,142 @@ TEST_CASE("header_organizer duplicate headers in same batch", "[header_organizer
     REQUIRE(result2.error == error::stale_chain);
     REQUIRE(result2.headers_added == 0);
 }
+
+// =============================================================================
+// Fork detection + finalization enforcement
+// =============================================================================
+
+namespace {
+
+// A side branch off `fork_prev` (the fork ancestor's hash), with ids from
+// `id_base` so hashes never collide with the main chain.
+domain::message::header::list make_branch(hash_digest fork_prev, size_t length, uint32_t id_base) {
+    domain::message::header::list branch;
+    hash_digest prev = fork_prev;
+    for (uint32_t i = 0; i < length; ++i) {
+        auto hdr = make_header_with_prev(prev, id_base + i);
+        prev = kth::domain::chain::hash(hdr);
+        branch.push_back(std::move(hdr));
+    }
+    return branch;
+}
+
+// Test settings with finalization forced to fire immediately (no 2h delay), so
+// note_block_validated can finalize deterministically without waiting.
+settings make_finalizing_settings() {
+    auto s = make_test_settings();
+    s.finalization_delay_seconds = 0;   // headers eligible the instant they're deep enough
+    // max_reorg_depth stays at its default (10).
+    return s;
+}
+
+} // namespace
+
+TEST_CASE("header_organizer flags a heavier side branch as a reorg candidate", "[header_organizer][fork]") {
+    header_index index;
+    (void)build_chain(index, 10);                 // tip at height 9
+    auto const fork_prev = index.get_hash(5);
+
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    // 6 blocks off height 5 -> head at height 11, more work than the height-9 tip.
+    auto branch = make_branch(fork_prev, 6, 200);
+    auto result = organizer.add_headers(branch);
+
+    REQUIRE(result.reorg_candidate);
+    REQUIRE(result.reorg_fork_height == 5);
+    REQUIRE(result.error == error::stale_chain);      // tip not switched
+    REQUIRE(result.headers_added == 0);
+    REQUIRE(organizer.header_height() == 9);
+    REQUIRE(index.size() == 16);                       // branch stored (10 + 6)
+}
+
+TEST_CASE("header_organizer rejects a new branch forking below the finalized block", "[header_organizer][finalization]") {
+    header_index index;
+    (void)build_chain(index, 30);                 // tip at height 29, received_time 0
+    auto settings = make_finalizing_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    organizer.note_block_validated(29);           // finalize 29 - 10 = 19
+    REQUIRE(organizer.finalized_height() == 19);
+
+    auto const size_before = index.size();
+    // New branch off height 15 (below the finalized height 19) -> rejected + penalize.
+    auto branch = make_branch(index.get_hash(15), 8, 500);
+    auto result = organizer.add_headers(branch);
+
+    REQUIRE(result.error == error::finalized_header_violation);
+    REQUIRE(result.headers_added == 0);
+    REQUIRE(index.size() == size_before);          // nothing stored
+}
+
+TEST_CASE("header_organizer allows a branch forking above the finalized block", "[header_organizer][finalization]") {
+    header_index index;
+    (void)build_chain(index, 30);                 // tip at height 29
+    auto settings = make_finalizing_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+    organizer.note_block_validated(29);
+    REQUIRE(organizer.finalized_height() == 19);
+
+    // 8 blocks off height 22 (above finalized) -> head at height 30, out-works the tip.
+    auto branch = make_branch(index.get_hash(22), 8, 600);
+    auto result = organizer.add_headers(branch);
+
+    REQUIRE(result.error != error::finalized_header_violation);
+    REQUIRE(result.reorg_candidate);
+    REQUIRE(result.reorg_fork_height == 22);
+}
+
+TEST_CASE("header_organizer does not penalize re-sent known headers below the finalized block", "[header_organizer][finalization]") {
+    header_index index;
+    (void)build_chain(index, 30);
+    auto settings = make_finalizing_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+    organizer.note_block_validated(29);
+    REQUIRE(organizer.finalized_height() == 19);
+
+    // Re-send already-known main-chain headers at heights 15..17 (below finalized).
+    // This is a stale duplicate, not a violation — must not be penalized.
+    domain::message::header::list known;
+    known.push_back(index.get_header(15));
+    known.push_back(index.get_header(16));
+    known.push_back(index.get_header(17));
+    auto result = organizer.add_headers(known);
+
+    REQUIRE(result.error == error::stale_chain);   // benign duplicate, not a violation
+    REQUIRE(result.headers_added == 0);
+}
+
+TEST_CASE("header_organizer rejects a new header after a known one on a sub-finalized branch", "[header_organizer][finalization]") {
+    header_index index;
+    (void)build_chain(index, 30);                 // tip 29, finalized -> 19
+    auto settings = make_finalizing_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+    organizer.note_block_validated(29);
+    REQUIRE(organizer.finalized_height() == 19);
+
+    auto const size_before = index.size();
+    // getheaders-overlap: a KNOWN main-chain header at height 15 (below the finalized
+    // height 19) followed by a NEW header forking off it. The known front must not let
+    // the new sub-finalized header bypass the finalization check.
+    domain::message::header::list batch;
+    batch.push_back(index.get_header(15));                             // known, below finalized
+    batch.push_back(make_header_with_prev(index.get_hash(15), 900));   // new, forks below finalized
+
+    auto result = organizer.add_headers(batch);
+
+    REQUIRE(result.error == error::finalized_header_violation);
+    REQUIRE(result.headers_added == 0);
+    REQUIRE(index.size() == size_before);          // nothing stored
+}

--- a/src/c-api/include/kth/capi/error.h
+++ b/src/c-api/include/kth/capi/error.h
@@ -51,6 +51,7 @@ typedef enum kth_error_code {
     kth_ec_insufficient_fee = 70,
     kth_ec_dusty_transaction = 76,
     kth_ec_stale_chain = 75,
+    kth_ec_finalized_header_violation = 88,
 
     // check header
     kth_ec_invalid_proof_of_work = 26,

--- a/src/infrastructure/include/kth/infrastructure/error.hpp
+++ b/src/infrastructure/include/kth/infrastructure/error.hpp
@@ -80,6 +80,7 @@ enum error_code_t {
     insufficient_fee = 70,
     dusty_transaction = 76,
     stale_chain = 75,
+    finalized_header_violation = 88,   // header forks below the finalized block (BCHN -finalizeheaders); 88-99 is a free gap before the op_* range (100+)
 
     // check header
     invalid_proof_of_work = 26,

--- a/src/infrastructure/src/error.cpp
+++ b/src/infrastructure/src/error.cpp
@@ -70,6 +70,7 @@ std::string error_category_impl::message(int ev) const noexcept {
         { error::insufficient_fee, "insufficient transaction fee" },
         { error::dusty_transaction, "output value too low" },
         { error::stale_chain, "blockchain too far behind" },
+        { error::finalized_header_violation, "header forks below the finalized block" },
 
         // check header
         { error::invalid_proof_of_work, "proof of work invalid" },

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -53,6 +53,7 @@ static bool is_bannable_error(code const& ec) {
         case error::not_found:              // Data not available yet
         case error::orphan_block:           // Just out of order, not invalid
         case error::orphan_transaction:
+        case error::stale_chain:            // Stale/duplicate batch, not malicious
             return false;
         default:
             // Any other error is a validation failure -> BAN


### PR DESCRIPTION
Makes the header sync path finalization-aware, on top of the finalized-block tracker (#567/#568). **Supersedes #566** (its `reorganization_limit` guard was a placeholder; the correct bound is the finalized block). Validated against BCHN v29 (`ContextualCheckBlockHeader`, `FindMostWorkChain`).

## `add_headers` is now branch-aware
- Anchors each batch on the parent of its first header (tip for a forward extension, the **fork ancestor** for a side branch) and validates every header against its running parent, so difficulty / MTP / checkpoint context comes from the branch, not the global tip.

## Header finalization (BCHN `-finalizeheaders`)
- A **new** branch that connects at/below the finalized block on a chain not containing it is **rejected outright** (nothing stored) with `error::finalized_header_violation`.
- The "new" guard mirrors BCHN returning early for already-known headers: an honest peer re-sending old headers that finalization has since buried is a stale duplicate, **not** a violation, and is not penalized (the 2026-01/02 ABC/BCHN case).

## Reorg-candidate detection
- A stored side branch that **descends from the finalized block** and out-works the tip is reported as a reorg candidate (`reorg_candidate` / `reorg_fork_height`). The active tip is **not** switched — execution (block disconnect + UTXO-Z rewind) is a separate layer.

## Supporting
- `error::finalized_header_violation` is bannable: the coordinator reports it to the reputation system and retries with another peer via the existing error path — no new plumbing.
- `is_bannable_error` now treats `stale_chain` as **benign** — fixes a pre-existing over-ban where honest peers sending stale/duplicate batches were scored 100.
- `finalization::finalized_idx_` is now `std::atomic` (header path reads it for admission; block-validation path is the single writer).

## Safety / tests
Coordinator contract preserved (non-advancing batch → `stale_chain`, no forward count) so IBD is unchanged. New `[header_organizer][fork]` / `[finalization]` cases: reorg candidate, reject-new-below-finalized, allow-above-finalized, don't-penalize-known-below-finalized. Full suites green (blockchain 1426, node 326).

Closes #566.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of competing blockchain branches, including detection of stronger alternatives without immediately switching the active chain.
  * Added clear reporting when a header branch conflicts with finalized blockchain data.
* **Bug Fixes**
  * Prevented reorganizations below finalized blocks.
  * Improved consistency of finalized-chain state during concurrent processing.
  * Stale-chain results are no longer treated as bannable errors.
* **Tests**
  * Added coverage for stronger forks, finalized-block restrictions, accepted branches, and previously known headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->