### PR TITLE
blockchain: record undo data and disconnect blocks (reorg execution, part 1)

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -302,6 +302,7 @@ if (ENABLE_TEST)
         test/verify_script_context.cpp
         test/batch_sigchecks.cpp
         test/finalization.cpp
+        test/block_undo.cpp
     )
 
     # Disabled until ported to v1.0 APIs:

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -199,6 +199,53 @@ struct KB_API block_chain {
     std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxo_entry>, std::vector<utxoz::raw_outpoint>>
     utxo_process_pending_lookups();
 
+    // =========================================================================
+    // Reorg undo
+    // =========================================================================
+
+    // Read a UTXO's stored payload verbatim (no resolution). Same two-phase
+    // contract as find(): key_not_found means "queued", not "absent" — resolve
+    // with utxo_process_pending_lookups_raw().
+    [[nodiscard]]
+    std::expected<database::utxoz_database::raw_stored, database::result_code>
+    find_utxo_raw(utxoz::raw_outpoint const& key, uint32_t height) const;
+
+    // Raw counterpart of utxo_process_pending_lookups(): resolves the deferred
+    // queue without reconstructing utxo_entry objects.
+    [[nodiscard]]
+    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxoz_database::raw_stored>,
+              std::vector<utxoz::raw_outpoint>>
+    utxo_process_pending_lookups_raw();
+
+#if ! defined(KTH_DB_READONLY)
+    // Persist a block's undo data and record its position on the header index.
+    // The undo record shares the block's file number, so the block must already
+    // be stored (have_data) when this is called.
+    [[nodiscard]]
+    bool store_block_undo(database::header_index::index_t idx,
+                          database::block_undo const& undo,
+                          hash_digest const& prev_hash);
+#endif
+
+    // Read back a block's undo data, if any was recorded.
+    [[nodiscard]]
+    std::expected<database::block_undo, database::result_code>
+    read_block_undo(database::header_index::index_t idx, hash_digest const& prev_hash) const;
+
+#if ! defined(KTH_DB_READONLY)
+    // Disconnect the block at `height` from the active chain, reverting its
+    // effect on the UTXO set: the outputs it created are removed (recomputed by
+    // re-reading the block) and the outputs it spent are restored from its undo
+    // data, with their original creation heights.
+    //
+    // Only the UTXO set and the height markers are touched — the block data stays
+    // on disk, so the block can be reconnected without re-downloading. `height`
+    // must be the current validated tip: blocks are disconnected one at a time,
+    // newest first.
+    [[nodiscard]]
+    database::disconnect_result disconnect_block(uint32_t height);
+#endif
+
     void utxo_compact();
     void utxo_print_statistics();
     void utxo_print_sizing_report();

--- a/src/blockchain/include/kth/blockchain/utxo_builder.hpp
+++ b/src/blockchain/include/kth/blockchain/utxo_builder.hpp
@@ -21,6 +21,7 @@
 #include <utxoz/types.hpp>
 
 #include <kth/blockchain/define.hpp>
+#include <kth/database/block_undo.hpp>
 #include <kth/database/databases/internal_database.hpp>
 #include <kth/database/databases/utxo_entry.hpp>
 #include <kth/database/databases/utxoz_database.hpp>
@@ -41,6 +42,9 @@ struct point_fast_hasher {
 };
 
 namespace kth::blockchain {
+
+// Forward declaration (capture_block_undo reads UTXO-Z through the chain).
+struct block_chain;
 
 // =============================================================================
 // Minimal block representation for UTXO indexing
@@ -151,6 +155,31 @@ KB_API utxo_raw_delta process_compact_block_utxos(
     int16_t file_number,
     uint32_t block_data_pos,
     database::utxo_bloom_filter const* bloom = nullptr
+);
+
+// Build the undo record for one block: every output the block spends that
+// existed BEFORE it, captured so the block can later be disconnected.
+//
+// `block_delta` is the block's OWN delta (from process_compact_block_utxos), not
+// a merged batch delta: outputs created and spent inside the same block have
+// already cancelled out there, and that is correct — they did not exist before
+// the block, so disconnecting must not restore them.
+//
+// Values are resolved in two places because a spent output's parent may not be
+// in UTXO-Z yet:
+//   - `batch_delta` — the accumulated delta for blocks already processed in this
+//     batch but not yet applied; a parent created there is still only in memory.
+//   - UTXO-Z — everything older, read verbatim (no resolution) via find_raw,
+//     honouring its two-phase contract (a miss is queued, not absent).
+//
+// Returns an error if any spent output cannot be located, since undo data that
+// silently drops entries would corrupt the UTXO set on disconnect.
+[[nodiscard]]
+KB_API std::expected<database::block_undo, database::result_code> capture_block_undo(
+    utxo_raw_delta const& block_delta,
+    utxo_raw_delta const& batch_delta,
+    block_chain& chain,
+    uint32_t height
 );
 
 // =============================================================================

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -4,6 +4,7 @@
 
 #include <kth/blockchain/interface/block_chain.hpp>
 
+#include <kth/blockchain/utxo_builder.hpp>
 #include <kth/database/flat_file_pos.hpp>
 
 #include <algorithm>
@@ -686,6 +687,159 @@ std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxo_entry>, 
 block_chain::utxo_process_pending_lookups() {
     return utxoz_db_.process_pending_lookups();
 }
+
+// =============================================================================
+// REORG UNDO
+// =============================================================================
+
+std::expected<database::utxoz_database::raw_stored, database::result_code>
+block_chain::find_utxo_raw(utxoz::raw_outpoint const& key, uint32_t height) const {
+    return utxoz_db_.find_raw(key, height);
+}
+
+std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxoz_database::raw_stored>,
+          std::vector<utxoz::raw_outpoint>>
+block_chain::utxo_process_pending_lookups_raw() {
+    return utxoz_db_.process_pending_lookups_raw();
+}
+
+#if ! defined(KTH_DB_READONLY)
+bool block_chain::store_block_undo(database::header_index::index_t idx,
+                                   database::block_undo const& undo,
+                                   hash_digest const& prev_hash) {
+    // The undo record lives in the rev*.dat file matching the block's blk*.dat,
+    // and the header index stores only the offset — so the block must be on disk.
+    auto const file_number = header_index_.get_file_number(idx);
+    if (file_number < 0) {
+        spdlog::error("[blockchain] store_block_undo: no block data for index {}", idx);
+        return false;
+    }
+
+    auto const pos = block_store_->write_undo(undo, file_number, prev_hash);
+    if (pos.is_null()) {
+        spdlog::error("[blockchain] store_block_undo: failed to write undo for index {}", idx);
+        return false;
+    }
+
+    header_index_.set_undo_pos(idx, pos.pos);
+    header_index_.add_status(idx, database::header_status::have_undo);
+    return true;
+}
+#endif
+
+std::expected<database::block_undo, database::result_code>
+block_chain::read_block_undo(database::header_index::index_t idx, hash_digest const& prev_hash) const {
+    if ( ! header_index_.has_undo_data(idx)) {
+        return std::unexpected(database::result_code::key_not_found);
+    }
+
+    database::flat_file_pos const pos{
+        header_index_.get_file_number(idx),
+        header_index_.get_undo_pos(idx)
+    };
+    return block_store_->read_undo(pos, prev_hash);
+}
+
+#if ! defined(KTH_DB_READONLY)
+database::disconnect_result block_chain::disconnect_block(uint32_t height) {
+    // Genesis anchors the chain and has no parent to roll back to.
+    if (height == 0) {
+        spdlog::error("[blockchain] disconnect_block: refusing to disconnect genesis");
+        return database::disconnect_result::failed;
+    }
+
+    // Blocks are disconnected newest-first, so `height` must be the validated tip.
+    // Disconnecting out of order would restore outputs that a later block still
+    // spends, silently corrupting the UTXO set. Fail closed: if the tip cannot be
+    // read, we cannot prove this is the tip, so we must not proceed.
+    auto const heights = database_.internal_db().get_last_heights();
+    if ( ! heights) {
+        spdlog::error("[blockchain] disconnect_block: cannot read the validated tip");
+        return database::disconnect_result::failed;
+    }
+    if (height != heights->block) {
+        spdlog::error("[blockchain] disconnect_block: height {} is not the validated tip ({})",
+            height, heights->block);
+        return database::disconnect_result::failed;
+    }
+
+    // TODO(reorg): height -> index by cast. This holds while headers form a
+    // single linear sequence, but the index numbers entries by arrival, so a
+    // stored side branch shifts later entries. The explicit active chain
+    // (height -> index) that fixes this lands with the chain switch.
+    auto const idx = static_cast<database::header_index::index_t>(height);
+
+    if ( ! header_index_.has_block_data(idx)) {
+        spdlog::error("[blockchain] disconnect_block: no block data at height {}", height);
+        return database::disconnect_result::failed;
+    }
+
+    // The outputs the block created are not stored in the undo record: they are
+    // recomputed here by re-reading the block, which is why undo data only needs
+    // to carry what was spent.
+    database::flat_file_pos const pos{
+        header_index_.get_file_number(idx),
+        header_index_.get_data_pos(idx)
+    };
+    auto raw = block_store_->read_block_raw(pos);
+    if ( ! raw) {
+        spdlog::error("[blockchain] disconnect_block: cannot read block at height {}", height);
+        return database::disconnect_result::failed;
+    }
+
+    auto parsed = parse_utxo_block(byte_span{raw->data(), raw->size()});
+    if ( ! parsed) {
+        spdlog::error("[blockchain] disconnect_block: cannot parse block at height {}", height);
+        return database::disconnect_result::failed;
+    }
+
+    auto undo = read_block_undo(idx, header_index_.get_prev_block_hash(idx));
+    if ( ! undo) {
+        spdlog::error("[blockchain] disconnect_block: no undo data at height {} (block below the "
+            "checkpoint, or connected before undo data was recorded)", height);
+        return database::disconnect_result::failed;
+    }
+
+    // The inverse of a delta is another delta: restore what was spent, remove
+    // what was created.
+    utxo_raw_delta inverse;
+    inverse.inserts.reserve(undo->spent.size());
+    inverse.deletes.reserve(parsed->outputs.size());
+
+    for (auto const& entry : undo->spent) {
+        inverse.inserts.emplace(entry.key, utxo_raw_value{entry.value, entry.height});
+    }
+    for (auto const& out : parsed->outputs) {
+        inverse.deletes.emplace(out.key, height);
+    }
+
+    // An output both created and spent inside this block was never in the set;
+    // erasing it is a no-op, and it is absent from the undo record by construction.
+    auto const result = utxoz_db_.apply_delta_raw(inverse.inserts, inverse.deletes);
+    if (result != database::result_code::success) {
+        spdlog::error("[blockchain] disconnect_block: failed to apply inverse delta at height {}", height);
+        return database::disconnect_result::unclean;
+    }
+
+    // Roll the markers back to the parent block. The UTXO set is already reverted
+    // at this point, so a failed marker write leaves the two disagreeing — report
+    // it rather than claiming a clean disconnect.
+    auto const parent = height - 1;
+    auto const block_marker = database_.internal_db().set_last_block_height(parent);
+    auto const utxo_marker = database_.internal_db().set_utxo_built_height(parent);
+    if (block_marker != database::result_code::success ||
+        utxo_marker != database::result_code::success) {
+        spdlog::error("[blockchain] disconnect_block: UTXO set rolled back to {} but the height "
+            "markers could not be updated", parent);
+        return database::disconnect_result::unclean;
+    }
+
+    spdlog::info("[blockchain] Disconnected block at height {} ({} outputs removed, {} restored)",
+        height, parsed->outputs.size(), undo->spent.size());
+
+    return database::disconnect_result::ok;
+}
+#endif
 
 void block_chain::utxo_compact() {
     utxoz_db_.compact();

--- a/src/blockchain/src/pools/header_organizer.cpp
+++ b/src/blockchain/src/pools/header_organizer.cpp
@@ -76,8 +76,14 @@ void header_organizer::sync_tip() {
     }
     tip_index_ = best_idx;
     tip_hash_ = index_.get_hash(tip_index_);
-    spdlog::info("[header_organizer] Synced tip: index {}, hash {}",
-        tip_index_, encode_hash(tip_hash_));
+
+    // Materialize the active chain (height -> index) for this tip. The index also
+    // holds side branches, so the rest of the node can only address blocks by
+    // height through this mapping.
+    index_.active_set_tip(tip_index_);
+
+    spdlog::info("[header_organizer] Synced tip: index {}, hash {}, active height {}",
+        tip_index_, encode_hash(tip_hash_), index_.active_tip_height());
 }
 
 // =============================================================================
@@ -226,6 +232,9 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
     if (extends_tip) {
         tip_index_ = branch_head_idx;
         tip_hash_ = index_.get_hash(branch_head_idx);
+        // Extend the active chain over the headers just linked in. Walks back only
+        // as far as the newly added run, since everything below is already active.
+        index_.active_set_tip(tip_index_);
     } else if ( ! result.error) {
         auto const branch_work = index_.get_chain_work(branch_head_idx);
         auto const tip_work = index_.get_chain_work(tip_index_);

--- a/src/blockchain/src/utxo_builder.cpp
+++ b/src/blockchain/src/utxo_builder.cpp
@@ -282,6 +282,57 @@ utxo_raw_delta process_compact_block_utxos(
     return delta;
 }
 
+std::expected<database::block_undo, database::result_code> capture_block_undo(
+    utxo_raw_delta const& block_delta,
+    utxo_raw_delta const& batch_delta,
+    block_chain& chain,
+    uint32_t height
+) {
+    database::block_undo undo;
+    undo.spent.reserve(block_delta.deletes.size());
+
+    // Spent outputs still missing after the first pass, to be resolved by the
+    // deferred sweep (find_raw's key_not_found only means "queued").
+    std::vector<utxoz::raw_outpoint> deferred;
+
+    for (auto const& [key, _] : block_delta.deletes) {
+        // Parent created earlier in this same batch: it lives only in the
+        // in-flight delta, UTXO-Z has not seen it yet.
+        if (auto it = batch_delta.inserts.find(key); it != batch_delta.inserts.end()) {
+            undo.spent.push_back({key, it->second.data, it->second.height});
+            continue;
+        }
+
+        auto stored = chain.find_utxo_raw(key, height);
+        if (stored) {
+            undo.spent.push_back({key, std::move(stored->value), stored->height});
+        } else {
+            deferred.push_back(key);
+        }
+    }
+
+    if ( ! deferred.empty()) {
+        auto [resolved, missing] = chain.utxo_process_pending_lookups_raw();
+
+        for (auto const& key : deferred) {
+            auto it = resolved.find(key);
+            if (it == resolved.end()) {
+                // The block spends an output the UTXO set does not have. Either
+                // the block should not have validated, or the set is corrupt —
+                // either way, undo data that silently dropped it would corrupt
+                // the set further on disconnect.
+                spdlog::error("[utxo_builder] capture_block_undo: spent output not found at height {} "
+                    "({} of {} deferred lookups unresolved) — cannot build undo data",
+                    height, missing.size(), deferred.size());
+                return std::unexpected(database::result_code::key_not_found);
+            }
+            undo.spent.push_back({key, it->second.value, it->second.height});
+        }
+    }
+
+    return undo;
+}
+
 // =============================================================================
 // utxo_delta implementation
 // =============================================================================

--- a/src/blockchain/test/block_undo.cpp
+++ b/src/blockchain/test/block_undo.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <kth/database/block_undo.hpp>
+
+using namespace kth;
+using namespace kth::database;
+
+namespace {
+
+utxoz::raw_outpoint make_key(uint8_t seed) {
+    utxoz::raw_outpoint key{};
+    for (size_t i = 0; i < key.size(); ++i) {
+        key[i] = uint8_t(seed + i);
+    }
+    return key;
+}
+
+// A compact-mode payload: {file_number(4 LE), tx_offset(4 LE)}.
+std::vector<uint8_t> make_compact_value(uint32_t file_number, uint32_t offset) {
+    std::vector<uint8_t> value(8);
+    std::memcpy(value.data(), &file_number, 4);
+    std::memcpy(value.data() + 4, &offset, 4);
+    return value;
+}
+
+} // namespace
+
+// =============================================================================
+// block_undo serialization — the on-disk reorg undo record
+// =============================================================================
+
+TEST_CASE("block_undo round-trips through serialization", "[block_undo]") {
+    block_undo original;
+    original.spent.push_back({make_key(1), make_compact_value(0, 4096), 700000});
+    original.spent.push_back({make_key(50), make_compact_value(3, 123456789), 12345});
+    original.spent.push_back({make_key(200), make_compact_value(32767, 0), 1});
+
+    auto const data = original.to_data();
+    REQUIRE(data.size() == original.serialized_size());
+
+    byte_reader reader(data);
+    auto parsed = block_undo::from_data(reader);
+    REQUIRE(parsed);
+    REQUIRE(parsed->spent.size() == 3);
+
+    for (size_t i = 0; i < 3; ++i) {
+        REQUIRE(parsed->spent[i].key == original.spent[i].key);
+        REQUIRE(parsed->spent[i].value == original.spent[i].value);
+        // The ORIGINAL creation height must survive exactly: restoring a spent
+        // output with the wrong height would corrupt both its maturity and the
+        // median-time-past window used to resolve it.
+        REQUIRE(parsed->spent[i].height == original.spent[i].height);
+    }
+}
+
+TEST_CASE("block_undo round-trips when empty", "[block_undo]") {
+    // A block whose only transaction is the coinbase spends nothing.
+    block_undo original;
+
+    auto const data = original.to_data();
+    REQUIRE(data.size() == original.serialized_size());
+
+    byte_reader reader(data);
+    auto parsed = block_undo::from_data(reader);
+    REQUIRE(parsed);
+    REQUIRE(parsed->spent.empty());
+}
+
+TEST_CASE("block_undo round-trips a variable-length payload", "[block_undo]") {
+    // Full mode stores the serialized entry rather than an 8-byte reference, so
+    // the record must not assume a fixed payload width.
+    block_undo original;
+    original.spent.push_back({make_key(7), std::vector<uint8_t>(137, 0xAB), 500000});
+
+    auto const data = original.to_data();
+    byte_reader reader(data);
+    auto parsed = block_undo::from_data(reader);
+
+    REQUIRE(parsed);
+    REQUIRE(parsed->spent.size() == 1);
+    REQUIRE(parsed->spent[0].value.size() == 137);
+    REQUIRE(parsed->spent[0].value == original.spent[0].value);
+    REQUIRE(parsed->spent[0].height == 500000);
+}
+
+TEST_CASE("block_undo rejects truncated data", "[block_undo]") {
+    block_undo original;
+    original.spent.push_back({make_key(9), make_compact_value(1, 64), 42});
+
+    auto data = original.to_data();
+    data.resize(data.size() - 4);   // clip the height off the last record
+
+    byte_reader reader(data);
+    auto parsed = block_undo::from_data(reader);
+    REQUIRE( ! parsed);
+}

--- a/src/database/include/kth/database/block_undo.hpp
+++ b/src/database/include/kth/database/block_undo.hpp
@@ -9,73 +9,66 @@
 #include <expected>
 #include <vector>
 
+#include <utxoz/types.hpp>
+
 #include <kth/database/define.hpp>
 #include <kth/database/databases/result_code.hpp>
-#include <kth/database/databases/utxo_entry.hpp>
 #include <kth/domain.hpp>
 
 namespace kth::database {
 
-/// Undo information for a single transaction.
-/// Contains the UTXOs that were spent by this transaction's inputs.
-struct KD_API tx_undo {
-    std::vector<utxo_entry> prev_outputs;
+/// One output spent by a block, recorded so the block can be disconnected.
+///
+/// `value` is the UTXO storage payload verbatim — in compact mode the 8-byte
+/// {file_number, tx_offset} reference, in full mode the serialized entry — which
+/// is exactly the shape apply_delta_raw's insert range consumes. Restoring a
+/// spent output is therefore just re-inserting this record; no reconstruction of
+/// the output is needed, and none is possible in compact mode (the storage holds
+/// a reference into the block files, not the output bytes).
+///
+/// `height` is the output's ORIGINAL creation height, not the height of the block
+/// that spent it. It must round-trip exactly: in compact mode the height also
+/// drives the median-time-past window used when the UTXO is later resolved.
+struct KD_API spent_output {
+    utxoz::raw_outpoint key{};
+    std::vector<uint8_t> value;
+    uint32_t height{0};
 
     /// Serialized size in bytes.
     [[nodiscard]]
     size_t serialized_size() const;
 
-    /// Deserialize from reader.
     [[nodiscard]]
-    static std::expected<tx_undo, database::result_code> from_data(byte_reader& reader);
-
-    /// Serialize.
-    [[nodiscard]]
-    expect<void> to_data(byte_writer& writer) const {
-        if (auto r = writer.write_variable_little_endian(prev_outputs.size()); ! r) return r;
-        for (auto const& entry : prev_outputs) {
-            if (auto r = entry.to_data(writer); ! r) return r;
-        }
-        return {};
-    }
+    static std::expected<spent_output, result_code> from_data(byte_reader& reader);
 
     [[nodiscard]]
-    data_chunk to_data() const;
+    expect<void> to_data(byte_writer& writer) const;
 };
 
-/// Undo information for a block.
-/// Contains tx_undo for all transactions except the coinbase.
+/// Undo information for a block: every output the block spent, keyed by outpoint.
+///
+/// The order of `spent` is unspecified — entries are identified by `key`, not by
+/// position, and do NOT line up with the block's inputs (outputs a block both
+/// creates and spends have no entry at all). Consumers must match by key.
+///
+/// Outputs *created* by the block are deliberately not recorded: they are
+/// recomputable by re-reading the block from the flat files, so storing them
+/// would roughly double the undo size for no gain (this mirrors BCHN).
 struct KD_API block_undo {
-    std::vector<tx_undo> tx_undos;
+    std::vector<spent_output> spent;
 
     /// Serialized size in bytes.
     [[nodiscard]]
     size_t serialized_size() const;
 
-    /// Deserialize from reader.
     [[nodiscard]]
-    static std::expected<block_undo, database::result_code> from_data(byte_reader& reader);
+    static std::expected<block_undo, result_code> from_data(byte_reader& reader);
 
-    /// Serialize.
     [[nodiscard]]
-    expect<void> to_data(byte_writer& writer) const {
-        if (auto r = writer.write_variable_little_endian(tx_undos.size()); ! r) return r;
-        for (auto const& tx : tx_undos) {
-            if (auto r = tx.to_data(writer); ! r) return r;
-        }
-        return {};
-    }
+    expect<void> to_data(byte_writer& writer) const;
 
     [[nodiscard]]
     data_chunk to_data() const;
-
-    /// Create block undo from a block and the UTXOs it spends.
-    /// @param block The block being connected.
-    /// @param spent_utxos Map of output_point -> utxo_entry for all inputs.
-    [[nodiscard]]
-    static block_undo from_block(
-        domain::chain::block const& block,
-        std::function<utxo_entry(domain::chain::output_point const&)> const& get_utxo);
 };
 
 /// Result of disconnecting a block using undo data.

--- a/src/database/include/kth/database/databases/utxoz_database.hpp
+++ b/src/database/include/kth/database/databases/utxoz_database.hpp
@@ -124,6 +124,41 @@ struct KD_API utxoz_database {
     result_code erase(domain::chain::point const& point, uint32_t height = 0);
 
     // =============================================================================
+    // Raw access (reorg undo capture / restore)
+    // =============================================================================
+
+    /// A UTXO exactly as stored, without resolving it into a utxo_entry.
+    /// `value` is the storage-native payload — in compact mode the 8-byte
+    /// {file_number, tx_offset} reference, in full mode the serialized entry — so
+    /// it can be fed straight back into apply_delta_raw's insert range. `height` is
+    /// the entry's ORIGINAL creation height, which restoring must preserve.
+    struct raw_stored {
+        std::vector<uint8_t> value;
+        uint32_t height;
+    };
+
+    /// Read a UTXO's stored payload without resolving it (compact mode does not
+    /// touch the flat block files here; only resolve/find does).
+    ///
+    /// Two-phase contract, same as find(): a key_not_found result only means "not
+    /// in the active version file, queued for the deferred sweep" — it is NOT proof
+    /// of absence. Drain the queue with process_pending_lookups_raw() before
+    /// concluding a UTXO is missing.
+    ///
+    /// @param key Raw outpoint key.
+    /// @param height Access height (statistics only; does not affect the result).
+    [[nodiscard]]
+    std::expected<raw_stored, result_code> find_raw(utxoz::raw_outpoint const& key, uint32_t height = 0) const;
+
+    /// Resolve the deferred-lookup queue, returning payloads verbatim (no
+    /// utxo_entry reconstruction — the cheap counterpart of
+    /// process_pending_lookups()).
+    /// @return pair of (resolved entries keyed by outpoint, keys that truly don't exist)
+    [[nodiscard]]
+    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, raw_stored>, std::vector<utxoz::raw_outpoint>>
+    process_pending_lookups_raw();
+
+    // =============================================================================
     // Batch Operations (for UTXO set building)
     // =============================================================================
 

--- a/src/database/include/kth/database/header_index.hpp
+++ b/src/database/include/kth/database/header_index.hpp
@@ -292,6 +292,46 @@ struct KD_API header_index {
     index_t find_fork(index_t idx_a, index_t idx_b) const;
 
     // =========================================================================
+    // Active chain (height -> index)
+    // =========================================================================
+    //
+    // The index stores every known header, side branches included, so an entry's
+    // index is NOT its height: entries are numbered in arrival order. The active
+    // chain is the subset that currently forms the best chain, addressed by
+    // height — it is what "the block at height N" means to block download, the
+    // UTXO build and block storage. Equivalent to BCHN's CChain, as distinct
+    // from mapBlockIndex.
+    //
+    // Concurrency: appended/truncated by the header path (single writer) and read
+    // from the block-download and UTXO-build paths. Reads are lock-free: the
+    // backing vector is pre-allocated to capacity and `active_size_` publishes
+    // how much of it is valid, so a reader never observes a partially written
+    // entry. Truncation lowers the published size first, so a concurrent reader
+    // can only ever see a *shorter* chain, never a stale entry.
+
+    /// Append `idx` as the new active tip (forward extension).
+    void active_push(index_t idx);
+
+    /// Drop everything above `height`, keeping [0, height]. Used when a reorg
+    /// rewinds the active chain to the fork point.
+    void active_truncate(int32_t height);
+
+    /// Index of the active-chain header at `height`, or null_index if `height` is
+    /// beyond the active tip.
+    [[nodiscard]]
+    index_t active_at(int32_t height) const;
+
+    /// Height of the active tip, or -1 if the active chain is empty.
+    [[nodiscard]]
+    int32_t active_tip_height() const;
+
+    /// Re-point the active chain at `tip_idx`: truncate to the fork with the
+    /// current chain, then re-link every entry from the fork up to `tip_idx`.
+    /// This is the chain switch; the caller is responsible for having already
+    /// disconnected the blocks being abandoned.
+    void active_set_tip(index_t tip_idx);
+
+    // =========================================================================
     // State Queries
     // =========================================================================
 
@@ -351,6 +391,11 @@ private:
     // Wall-clock reception time (unix seconds) per header; 0 = loaded from store
     // at startup (immediately finalizable). Used by finalization's time rule.
     std::vector<uint32_t> header_received_times_;
+
+    // Active chain: height -> entry index. Pre-allocated to capacity like the SoA
+    // vectors; active_size_ publishes the valid prefix (see the accessors above).
+    std::vector<index_t> active_;
+    std::atomic<int32_t> active_size_{0};
 
     // Index counter
     std::atomic<index_t> next_idx_{0};

--- a/src/database/src/block_undo.cpp
+++ b/src/database/src/block_undo.cpp
@@ -5,40 +5,52 @@
 #include <kth/database/block_undo.hpp>
 
 #include <kth/infrastructure/message/message_tools.hpp>
+
 namespace kth::database {
 
 // =============================================================================
-// tx_undo
+// spent_output
 // =============================================================================
 
-size_t tx_undo::serialized_size() const {
-    size_t size = infrastructure::message::variable_uint_size(prev_outputs.size());
-    for (auto const& entry : prev_outputs) {
-        size += entry.serialized_size();
+size_t spent_output::serialized_size() const {
+    return std::tuple_size<utxoz::raw_outpoint>::value                      // key
+         + infrastructure::message::variable_uint_size(value.size())        // value length
+         + value.size()                                                     // value
+         + sizeof(uint32_t);                                                // height
+}
+
+expect<void> spent_output::to_data(byte_writer& writer) const {
+    if (auto r = writer.write_bytes(key); ! r) return r;
+    if (auto r = writer.write_variable_little_endian(value.size()); ! r) return r;
+    if (auto r = writer.write_bytes(value); ! r) return r;
+    return writer.write_little_endian<uint32_t>(height);
+}
+
+std::expected<spent_output, result_code> spent_output::from_data(byte_reader& reader) {
+    spent_output result;
+
+    auto key = reader.read_array<std::tuple_size<utxoz::raw_outpoint>::value>();
+    if ( ! key) {
+        return std::unexpected(result_code::other);
     }
-    return size;
-}
+    result.key = *key;
 
-data_chunk tx_undo::to_data() const {
-    return kth::to_data_chunk(*this);
-}
-
-std::expected<tx_undo, database::result_code> tx_undo::from_data(byte_reader& reader) {
-    tx_undo result;
-
-    auto const count = reader.read_variable_little_endian();
-    if ( ! count) {
+    auto const size = reader.read_variable_little_endian();
+    if ( ! size) {
         return std::unexpected(result_code::other);
     }
 
-    result.prev_outputs.reserve(*count);
-    for (uint64_t i = 0; i < *count; ++i) {
-        auto entry = utxo_entry::from_data(reader);
-        if ( ! entry) {
-            return std::unexpected(result_code::other);
-        }
-        result.prev_outputs.push_back(std::move(*entry));
+    auto value = reader.read_bytes(*size);
+    if ( ! value) {
+        return std::unexpected(result_code::other);
     }
+    result.value.assign(value->begin(), value->end());
+
+    auto const height = reader.read_little_endian<uint32_t>();
+    if ( ! height) {
+        return std::unexpected(result_code::other);
+    }
+    result.height = *height;
 
     return result;
 }
@@ -48,18 +60,26 @@ std::expected<tx_undo, database::result_code> tx_undo::from_data(byte_reader& re
 // =============================================================================
 
 size_t block_undo::serialized_size() const {
-    size_t size = infrastructure::message::variable_uint_size(tx_undos.size());
-    for (auto const& tx : tx_undos) {
-        size += tx.serialized_size();
+    size_t size = infrastructure::message::variable_uint_size(spent.size());
+    for (auto const& entry : spent) {
+        size += entry.serialized_size();
     }
     return size;
+}
+
+expect<void> block_undo::to_data(byte_writer& writer) const {
+    if (auto r = writer.write_variable_little_endian(spent.size()); ! r) return r;
+    for (auto const& entry : spent) {
+        if (auto r = entry.to_data(writer); ! r) return r;
+    }
+    return {};
 }
 
 data_chunk block_undo::to_data() const {
     return kth::to_data_chunk(*this);
 }
 
-std::expected<block_undo, database::result_code> block_undo::from_data(byte_reader& reader) {
+std::expected<block_undo, result_code> block_undo::from_data(byte_reader& reader) {
     block_undo result;
 
     auto const count = reader.read_variable_little_endian();
@@ -67,41 +87,15 @@ std::expected<block_undo, database::result_code> block_undo::from_data(byte_read
         return std::unexpected(result_code::other);
     }
 
-    result.tx_undos.reserve(*count);
+    // No reserve(): `count` comes straight off disk, so trusting it would let a
+    // corrupt record throw length_error/bad_alloc instead of returning a decode
+    // failure. The loop below fails cleanly as soon as the reader runs dry.
     for (uint64_t i = 0; i < *count; ++i) {
-        auto tx = tx_undo::from_data(reader);
-        if ( ! tx) {
-            return std::unexpected(result_code::other);
+        auto entry = spent_output::from_data(reader);
+        if ( ! entry) {
+            return std::unexpected(entry.error());
         }
-        result.tx_undos.push_back(std::move(*tx));
-    }
-
-    return result;
-}
-
-block_undo block_undo::from_block(
-    domain::chain::block const& block,
-    std::function<utxo_entry(domain::chain::output_point const&)> const& get_utxo)
-{
-    block_undo result;
-    auto const& txs = block.transactions();
-
-    // Skip coinbase (index 0), process all other transactions
-    if (txs.size() > 1) {
-        result.tx_undos.reserve(txs.size() - 1);
-
-        for (size_t tx_idx = 1; tx_idx < txs.size(); ++tx_idx) {
-            auto const& tx = txs[tx_idx];
-            tx_undo tx_undo_data;
-            tx_undo_data.prev_outputs.reserve(tx.inputs().size());
-
-            for (auto const& input : tx.inputs()) {
-                auto const& prevout = input.previous_output();
-                tx_undo_data.prev_outputs.push_back(get_utxo(prevout));
-            }
-
-            result.tx_undos.push_back(std::move(tx_undo_data));
-        }
+        result.spent.push_back(std::move(*entry));
     }
 
     return result;

--- a/src/database/src/databases/utxoz_database.cpp
+++ b/src/database/src/databases/utxoz_database.cpp
@@ -120,6 +120,68 @@ result_code utxoz_database::erase(domain::chain::point const& point, uint32_t he
     return erased > 0 ? result_code::success : result_code::key_not_found;
 }
 
+namespace {
+
+#ifdef KTH_UTXOZ_COMPACT_MODE
+// Pack a compact reference the way apply_delta_raw expects it to arrive:
+// {file_number(4 LE), tx_offset(4 LE)}.
+std::vector<uint8_t> pack_compact_ref(uint32_t file_number, uint32_t offset) {
+    std::vector<uint8_t> value(8);
+    std::memcpy(value.data(), &file_number, 4);
+    std::memcpy(value.data() + 4, &offset, 4);
+    return value;
+}
+#endif
+
+} // namespace
+
+std::expected<utxoz_database::raw_stored, result_code>
+utxoz_database::find_raw(utxoz::raw_outpoint const& key, uint32_t height) const {
+    if ( ! is_open()) {
+        return std::unexpected(result_code::other);
+    }
+
+    auto result = db_->find(key, height);
+    if ( ! result) {
+        // Not in the active version file. May still be resolved by the deferred
+        // sweep — the caller must not treat this as absence.
+        return std::unexpected(result_code::key_not_found);
+    }
+
+#ifdef KTH_UTXOZ_COMPACT_MODE
+    return raw_stored{pack_compact_ref(result->file_number, result->offset), result->block_height};
+#else
+    return raw_stored{result->data, result->block_height};
+#endif
+}
+
+std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxoz_database::raw_stored>, std::vector<utxoz::raw_outpoint>>
+utxoz_database::process_pending_lookups_raw() {
+    boost::unordered_flat_map<utxoz::raw_outpoint, raw_stored> resolved;
+    std::vector<utxoz::raw_outpoint> failed;
+
+    if ( ! is_open()) {
+        return {std::move(resolved), std::move(failed)};
+    }
+
+    auto [found, fail] = db_->process_pending_lookups();
+    resolved.reserve(found.size());
+    for (auto const& [key, res] : found) {
+#ifdef KTH_UTXOZ_COMPACT_MODE
+        resolved.emplace(key, raw_stored{pack_compact_ref(res.file_number, res.offset), res.block_height});
+#else
+        resolved.emplace(key, raw_stored{res.data, res.block_height});
+#endif
+    }
+
+    failed.reserve(fail.size());
+    for (auto const& e : fail) {
+        failed.push_back(e.key);
+    }
+
+    return {std::move(resolved), std::move(failed)};
+}
+
 result_code utxoz_database::clear() {
     if ( ! is_open()) {
         return result_code::other;

--- a/src/database/src/header_index.cpp
+++ b/src/database/src/header_index.cpp
@@ -41,6 +41,9 @@ header_index::header_index(size_t capacity)
     // Reception time (0 = loaded from store / not yet set)
     header_received_times_.resize(capacity_, 0);
 
+    // Active chain (height -> index), empty until headers are linked in
+    active_.resize(capacity_, null_index);
+
     // Reserve hash map capacity
     hash_to_idx_.reserve(capacity_);
 }
@@ -245,6 +248,77 @@ void header_index::set_block_pos(index_t idx, int16_t file, uint32_t pos) {
 
 void header_index::set_undo_pos(index_t idx, uint32_t pos) {
     undo_positions_[idx] = pos;
+}
+
+// =============================================================================
+// Active chain
+// =============================================================================
+
+void header_index::active_push(index_t idx) {
+    auto const size = active_size_.load(std::memory_order_relaxed);
+    if (size_t(size) >= capacity_) {
+        return;
+    }
+    // Write the entry, then publish it: a reader that sees the new size is
+    // guaranteed to see the entry too.
+    active_[size] = idx;
+    active_size_.store(size + 1, std::memory_order_release);
+}
+
+void header_index::active_truncate(int32_t height) {
+    auto const new_size = height + 1;
+    if (new_size < 0) {
+        active_size_.store(0, std::memory_order_release);
+        return;
+    }
+    if (new_size < active_size_.load(std::memory_order_relaxed)) {
+        // Shrinking only: a concurrent reader can see a shorter chain, never a
+        // stale entry.
+        active_size_.store(new_size, std::memory_order_release);
+    }
+}
+
+header_index::index_t header_index::active_at(int32_t height) const {
+    if (height < 0) {
+        return null_index;
+    }
+    if (height >= active_size_.load(std::memory_order_acquire)) {
+        return null_index;
+    }
+    return active_[height];
+}
+
+int32_t header_index::active_tip_height() const {
+    return active_size_.load(std::memory_order_acquire) - 1;
+}
+
+void header_index::active_set_tip(index_t tip_idx) {
+    if (tip_idx == null_index) {
+        active_size_.store(0, std::memory_order_release);
+        return;
+    }
+
+    // Walk the new branch back to the first entry already on the active chain —
+    // that is the fork point. Collect the branch on the way so it can be linked
+    // in ascending order afterwards.
+    std::vector<index_t> branch;
+    index_t idx = tip_idx;
+    while (idx != null_index) {
+        auto const h = heights_[idx];
+        if (active_at(h) == idx) {
+            break;   // fork point: this entry is already active
+        }
+        branch.push_back(idx);
+        idx = parent_indices_[idx];
+    }
+
+    auto const fork_height = (idx == null_index) ? -1 : heights_[idx];
+    active_truncate(fork_height);
+
+    // Link the branch in, lowest height first.
+    for (auto it = branch.rbegin(); it != branch.rend(); ++it) {
+        active_push(*it);
+    }
 }
 
 void header_index::set_received_time(index_t idx, uint32_t unix_seconds) {

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1818,6 +1818,15 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             batch_end = checkpoint_height;
         }
 
+        // Above the checkpoint every block's undo data is captured and can only be
+        // written after the batch's delta is applied, so the whole batch is held in
+        // memory first. Cap the batch there: a full block can spend tens of
+        // thousands of outputs, so an unbounded batch would hold hundreds of MB.
+        static constexpr uint32_t max_undo_batch_len = 100;
+        if (batch_start > checkpoint_height && batch_end - batch_start + 1 > max_undo_batch_len) {
+            batch_end = batch_start + max_undo_batch_len - 1;
+        }
+
         // Read raw blocks from flat files
         auto raw_result = chain.fetch_blocks_raw(batch_start, batch_end);
         if ( ! raw_result) {
@@ -1873,6 +1882,14 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
 
         // Parse and process UTXO delta
         blockchain::utxo_raw_delta delta;
+        // Undo records for this batch, persisted only after the delta is applied.
+        struct pending_undo_entry {
+            blockchain::header_index::index_t idx;
+            database::block_undo undo;
+            hash_digest prev_hash;
+        };
+        std::vector<pending_undo_entry> pending_undo;
+
         for (uint32_t i = 0; i < raw_result->size(); ++i) {
             uint32_t h = batch_start + i;
             uint32_t mtp = calculate_mtp(timestamp_window);
@@ -1893,6 +1910,22 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
                 chain.headers().get_file_number(idx),
                 chain.headers().get_data_pos(idx),
                 block_bloom);
+
+            // Capture undo data so this block can be disconnected on a reorg.
+            // Only above the checkpoint: below it the bloom prunes the delta, so
+            // the block is not disconnectable in principle (and reorgs only ever
+            // happen near the tip). Captured from the block's OWN delta, before
+            // merge collapses same-batch spends, and before the batch is applied.
+            if (h > checkpoint_height) {
+                auto undo = blockchain::capture_block_undo(block_delta, delta, chain, h);
+                if ( ! undo) {
+                    spdlog::error("[utxo_build] Failed to capture undo data at height {}", h);
+                    co_return;
+                }
+                pending_undo.emplace_back(idx, std::move(*undo),
+                                          chain.headers().get_prev_block_hash(idx));
+            }
+
             delta.merge(std::move(block_delta));
 
             // Update MTP window from raw block header (timestamp at offset 68)
@@ -1909,6 +1942,16 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             auto result = chain.apply_utxo_delta_raw(delta.inserts, delta.deletes);
             if (result != database::result_code::success) {
                 spdlog::error("[utxo_build] Failed to apply UTXO delta at batch {}", batch_start);
+                co_return;
+            }
+        }
+
+        // Persist undo data AFTER the delta is applied and BEFORE the built-height
+        // marker advances, so a crash can only leave undo data for a block that is
+        // already connected — never a connected block without undo data.
+        for (auto& entry : pending_undo) {
+            if ( ! chain.store_block_undo(entry.idx, entry.undo, entry.prev_hash)) {
+                spdlog::error("[utxo_build] Failed to store undo data for index {}", entry.idx);
                 co_return;
             }
         }


### PR DESCRIPTION
Storage side of reorg execution: the node can now **undo a connected block**. Detection (finalization + reorg candidates, #567/#568/#570) already landed; this is what a chain switch will stand on. **Nothing calls `disconnect_block` yet** — the only runtime change is that undo data is written.

## The design problem
The existing `block_undo` stored `utxo_entry` (full output data), which **cannot be restored in compact mode** — the default build. UTXO-Z there holds an 8-byte `{file_number, tx_offset}` reference into the block files, and its insert takes exactly those fields, not an output.

So the record became storage-native: `{key, value, height}` where `value` is the payload **verbatim** (compact reference, or serialized entry in full mode). That is the same shape `apply_delta_raw`'s insert range consumes, which gives the neat property that **the inverse of a delta is just another delta** — no new UTXO-Z write path was needed.

`height` is the output's **original creation height** and must round-trip exactly: in compact mode it also drives the median-time-past window when the UTXO is later resolved.

Outputs *created* by a block are deliberately not recorded — they're recomputed by re-reading the block, halving the undo size (mirrors BCHN).

## Capture
- `utxoz_database::find_raw` / `process_pending_lookups_raw`: read a stored payload **without resolving it** against the flat files. Compact `find` is already a pure hash hit; only KTH's resolve step was expensive. Both honour `find()`'s two-phase contract, where `key_not_found` means *queued*, not *absent*.
- `capture_block_undo` works off a block's **own** delta, before `merge`:
  - outputs created **and** spent inside one block correctly produce **no** undo entry — they didn't exist before the block, so a disconnect must not restore them;
  - a parent created earlier in the **same batch** is read from the in-flight delta, because UTXO-Z hasn't seen it yet.
- Wired into `utxo_build_task` **above the checkpoint only**: below it the bloom prunes the delta, so those blocks aren't disconnectable in principle (and reorgs only happen near the tip).
- Ordering is crash-safe: undo is persisted **after** the delta is applied and **before** the built-height marker advances, so a crash can't leave a connected block without undo data.

## Disconnect
`block_chain::disconnect_block(height)` builds the inverse delta — restore the spent outputs at their original heights, remove the outputs the block created — then rolls the height markers back. Block data stays on disk, so a disconnected block can be reconnected without re-downloading.

Also adds `store_block_undo` / `read_block_undo` (`block_store_` is private) and finally wires `header_index`'s `undo_pos` / `have_undo`, which were allocated but never written.

## Tests
`[block_undo]` round-trip: multi-entry, empty (coinbase-only block), variable-length payload (full mode), and truncation rejection. Full suites green (blockchain 1480); node-exe + c-api build.

## Not in this PR
The live chain switch (orchestrator rewind + consuming `reorg_candidate`), deep-reorg park/auto-unpark, and mempool re-admit (#498). They all build directly on this and are the natural next step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blockchain reorganization support, including active-chain switching and block disconnection with UTXO rollback.
  * Added undo-data capture, storage, retrieval, and restoration for spent outputs.
  * Added raw UTXO lookup and deferred-lookup processing.
  * Improved chain synchronization when advancing or switching tips.

* **Tests**
  * Added comprehensive block undo serialization and validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->