### PR TITLE
blockchain: address blocks by height through the active chain

### DIFF
--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -763,11 +763,11 @@ database::disconnect_result block_chain::disconnect_block(uint32_t height) {
         return database::disconnect_result::failed;
     }
 
-    // TODO(reorg): height -> index by cast. This holds while headers form a
-    // single linear sequence, but the index numbers entries by arrival, so a
-    // stored side branch shifts later entries. The explicit active chain
-    // (height -> index) that fixes this lands with the chain switch.
-    auto const idx = static_cast<database::header_index::index_t>(height);
+    auto const idx = header_index_.active_at(static_cast<int32_t>(height));
+    if (idx == database::header_index::null_index) {
+        spdlog::error("[blockchain] disconnect_block: height {} is not on the active chain", height);
+        return database::disconnect_result::failed;
+    }
 
     if ( ! header_index_.has_block_data(idx)) {
         spdlog::error("[blockchain] disconnect_block: no block data at height {}", height);
@@ -1178,11 +1178,12 @@ block_chain::fetch_blocks_raw(uint32_t from, uint32_t to) const {
     positions.reserve(to - from + 1);
 
     for (uint32_t h = from; h <= to; ++h) {
-        // In IBD mode, the header index matches the height
-        auto const idx = static_cast<header_index::index_t>(h);
+        // Resolve through the active chain — the index also holds side branches,
+        // numbered in arrival order, so an entry's index is not its height.
+        auto const idx = header_index_.active_at(static_cast<int32_t>(h));
 
-        if (idx >= header_index_.size()) {
-            spdlog::error("[blockchain] fetch_blocks_raw: Height {} exceeds header_index size {}", h, header_index_.size());
+        if (idx == header_index::null_index) {
+            spdlog::error("[blockchain] fetch_blocks_raw: Height {} is not on the active chain", h);
             return std::unexpected(database::result_code::key_not_found);
         }
 

--- a/src/blockchain/src/utxo_builder.cpp
+++ b/src/blockchain/src/utxo_builder.cpp
@@ -947,10 +947,11 @@ uint32_t embedded_bloom_checkpoint_height() {
                 uint32_t h = batch_start + static_cast<uint32_t>(i);
                 uint32_t mtp = calculate_mtp(timestamp_window);
 
-                // Get block position from header_index for compact mode.
-                // Precondition: during linear IBD, header_index is dense and index == height.
-                // This assumption holds because headers are inserted sequentially during sync.
-                auto const idx = static_cast<header_index::index_t>(h);
+                // Get block position from header_index for compact mode. Resolved
+                // through the active chain: the index also holds side branches,
+                // numbered in arrival order, so an entry's index is not its height.
+                auto const idx = chain.headers().active_at(static_cast<int32_t>(h));
+                KTH_ASSERT(idx != header_index::null_index);
                 KTH_ASSERT(chain.headers().get_height(idx) == static_cast<int32_t>(h));
                 auto const file_num = chain.headers().get_file_number(idx);
                 auto const data_pos = chain.headers().get_data_pos(idx);

--- a/src/blockchain/test/header_organizer.cpp
+++ b/src/blockchain/test/header_organizer.cpp
@@ -336,3 +336,87 @@ TEST_CASE("header_organizer rejects a new header after a known one on a sub-fina
     REQUIRE(result.headers_added == 0);
     REQUIRE(index.size() == size_before);          // nothing stored
 }
+
+// =============================================================================
+// Active chain (height -> index)
+// =============================================================================
+
+TEST_CASE("active chain maps heights to indices after a linear sync", "[header_organizer][active_chain]") {
+    header_index index;
+    (void)build_chain(index, 10);
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    REQUIRE(index.active_tip_height() == 9);
+    for (int32_t h = 0; h <= 9; ++h) {
+        auto const idx = index.active_at(h);
+        REQUIRE(idx != header_index::null_index);
+        REQUIRE(index.get_height(idx) == h);
+    }
+    REQUIRE(index.active_at(10) == header_index::null_index);
+}
+
+TEST_CASE("active chain stays correct when a side branch shifts indices", "[header_organizer][active_chain]") {
+    // The regression this structure exists for: the index numbers entries in
+    // arrival order, so storing a side branch used to make index != height for
+    // every later block, silently corrupting height-addressed lookups.
+    header_index index;
+    auto tip_hash = build_chain(index, 10);           // heights 0..9 at indices 0..9
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    // Store a 3-block side branch off height 5: it takes indices 10..12.
+    auto branch = make_branch(index.get_hash(index.active_at(5)), 3, 800);
+    (void)organizer.add_headers(branch);
+    REQUIRE(index.size() == 13);
+
+    // Now extend the MAIN chain: height 10 lands at index 13, not 10.
+    domain::message::header::list extension;
+    extension.push_back(make_header_with_prev(tip_hash, 10));
+    auto result = organizer.add_headers(extension);
+    REQUIRE(result.headers_added == 1);
+
+    auto const idx10 = index.active_at(10);
+    REQUIRE(idx10 != header_index::null_index);
+    REQUIRE(idx10 != 10);                             // the index HAS shifted
+    REQUIRE(index.get_height(idx10) == 10);           // but the mapping is right
+    REQUIRE(index.active_tip_height() == 10);
+
+    // The branch must not be on the active chain.
+    for (int32_t h = 0; h <= 10; ++h) {
+        REQUIRE(index.get_height(index.active_at(h)) == h);
+    }
+}
+
+TEST_CASE("active chain re-points to a new tip across a fork", "[header_organizer][active_chain]") {
+    header_index index;
+    (void)build_chain(index, 10);                     // tip height 9
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    auto const old_idx7 = index.active_at(7);
+
+    // A branch off height 5 that outgrows the current chain.
+    auto branch = make_branch(index.get_hash(index.active_at(5)), 7, 900);
+    (void)organizer.add_headers(branch);
+
+    // Switch the active chain onto the branch head (what a reorg will do once
+    // the abandoned blocks have been disconnected).
+    auto const branch_head = index.find(kth::domain::chain::hash(branch.back()));
+    REQUIRE(branch_head != header_index::null_index);
+    index.active_set_tip(branch_head);
+
+    REQUIRE(index.active_tip_height() == 12);         // 5 + 7
+    REQUIRE(index.active_at(12) == branch_head);
+    REQUIRE(index.active_at(7) != old_idx7);          // height 7 now on the branch
+    // Everything at or below the fork is untouched.
+    for (int32_t h = 0; h <= 5; ++h) {
+        REQUIRE(index.get_height(index.active_at(h)) == h);
+    }
+}

--- a/src/database/src/header_index.cpp
+++ b/src/database/src/header_index.cpp
@@ -6,6 +6,8 @@
 
 #include <cstring>
 
+#include <spdlog/spdlog.h>
+
 #include <kth/domain/chain/header.hpp>
 #include <kth/infrastructure/utility/stats.hpp>
 
@@ -257,6 +259,10 @@ void header_index::set_undo_pos(index_t idx, uint32_t pos) {
 void header_index::active_push(index_t idx) {
     auto const size = active_size_.load(std::memory_order_relaxed);
     if (size_t(size) >= capacity_) {
+        // Dropping silently would freeze the active chain while headers kept
+        // being indexed, so every later height would resolve to nothing.
+        spdlog::error("[header_index] Active chain is at capacity ({}); cannot extend to height {}",
+            capacity_, size);
         return;
     }
     // Write the entry, then publish it: a reader that sees the new size is
@@ -266,11 +272,15 @@ void header_index::active_push(index_t idx) {
 }
 
 void header_index::active_truncate(int32_t height) {
-    auto const new_size = height + 1;
-    if (new_size < 0) {
+    if (height < 0) {
+        // Fork below genesis: the whole active chain goes.
         active_size_.store(0, std::memory_order_release);
         return;
     }
+    if (height == std::numeric_limits<int32_t>::max()) {
+        return;   // height + 1 would overflow; nothing to truncate anyway
+    }
+    auto const new_size = height + 1;
     if (new_size < active_size_.load(std::memory_order_relaxed)) {
         // Shrinking only: a concurrent reader can see a shorter chain, never a
         // stale entry.

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1901,7 +1901,11 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
                 co_return;
             }
 
-            auto const idx = static_cast<blockchain::header_index::index_t>(h);
+            auto const idx = chain.headers().active_at(static_cast<int32_t>(h));
+            if (idx == blockchain::header_index::null_index) {
+                spdlog::error("[utxo_build] Height {} is not on the active chain", h);
+                co_return;
+            }
             // Prune with the bloom only up to the checkpoint; above it keep every
             // output (live UTXO set) so full validation can resolve prevouts.
             auto const* block_bloom = (h <= checkpoint_height) ? bloom_ptr : nullptr;

--- a/src/node/src/sync/chunk_coordinator.cpp
+++ b/src/node/src/sync/chunk_coordinator.cpp
@@ -114,7 +114,13 @@ std::pair<uint32_t, uint32_t> chunk_coordinator::chunk_range(uint32_t chunk_id) 
 }
 
 hash_digest chunk_coordinator::get_block_hash(uint32_t height) const {
-    return index_.get_hash(static_cast<blockchain::header_index::index_t>(height));
+    // Address by height through the active chain: the index also holds side
+    // branches, numbered in arrival order, so an entry's index is not its height.
+    auto const idx = index_.active_at(static_cast<int32_t>(height));
+    if (idx == blockchain::header_index::null_index) {
+        return null_hash;
+    }
+    return index_.get_hash(idx);
 }
 
 void chunk_coordinator::chunk_completed(uint32_t chunk_id) {


### PR DESCRIPTION
Closes a latent corruption in the height→index mapping, and puts to work a structure that landed unused.

## The bug
`header_index` numbers entries in **arrival order**, so an entry's index is *not* its height. That only coincided while headers formed a single linear sequence — and stopped holding once the organizer began **storing side branches** (#570): a stored branch takes the next free indices, shifting every later entry, after which every height-addressed lookup silently reads the **wrong header**.

Every consumer resolved height with a plain `static_cast`:

| Site | Consequence |
|---|---|
| `chunk_coordinator::get_block_hash` | block download requests wrong hashes |
| `utxo_builder` / `utxo_build_task` | wrong block position feeds the UTXO delta |
| `block_chain::fetch_blocks_raw` | wrong block read back |
| `block_chain::disconnect_block` | wrong block disconnected |

## The fix
All of them now resolve through `header_index::active_at(height)` — the explicit **active chain** (height → index), the piece KTH was missing next to BCHN's `CChain`/`mapBlockIndex` split. Each site now reports a height that isn't on the active chain rather than reading a wrong entry.

Reads stay lock-free on the hot path: the backing vector is pre-allocated to capacity and an atomic size publishes the valid prefix, so truncation can only make a concurrent reader see a *shorter* chain, never a stale entry.

## Note on provenance
The active chain structure itself (`active_push` / `active_truncate` / `active_at` / `active_set_tip`, maintained by `header_organizer`) was **committed by mistake as part of #571**, where it was neither described nor used. This is the change that was meant to accompany it. Nothing is reverted — it's simply put to work here.

## Tests
`[active_chain]`: linear mapping, the regression (a stored side branch shifts indices, heights must still resolve), and re-pointing the chain across a fork — the operation the tip switch will use. Full suite green (1566 assertions); node-exe builds.

## Next
The chain switch itself: disconnect down to the fork (#571's `disconnect_block`), `active_set_tip(branch_head)`, rewind the coordinator, re-drive download — plus wiring the reorg notification through to the mempool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blockchain handling when the active chain diverges from block arrival order or contains forks.
  * Corrected block retrieval, disconnection, synchronization, and UTXO processing for reordered or switched chains.
  * Invalid or unavailable block heights are now rejected safely instead of being treated as direct indexes.
  * Improved handling when the active chain reaches capacity and during chain truncation.

* **Tests**
  * Added regression coverage for chain reorganizations, side branches, and active-chain index mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->