### PR TITLE
node: switch the active chain onto a heavier branch (reorg execution, part 2)

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -244,7 +244,79 @@ struct KB_API block_chain {
     // newest first.
     [[nodiscard]]
     database::disconnect_result disconnect_block(uint32_t height);
+
+    // Switch the active chain onto `branch_head`, forking at `fork_height`.
+    //
+    // Disconnects the abandoned blocks newest-first (restoring their spent
+    // outputs from undo data), then re-points the active chain at the new branch.
+    // The caller is responsible for re-driving block download for the new branch:
+    // its blocks are headers-only at this point, so the validated tip ends at
+    // fork_height.
+    //
+    // Must be called with the UTXO build quiesced (see reorg_pause below): it
+    // rewrites the UTXO set and the height markers.
+    struct switch_result {
+        bool ok{false};
+        // Height the validated tip ended at, when it is known. On an aborted
+        // disconnect this is how far it got — NOT where it started — so the caller
+        // must resync from it. Empty means the tip could not be determined at all
+        // (nothing was touched); the caller must then leave its counters alone
+        // rather than treat it as height 0.
+        std::optional<uint32_t> validated_tip;
+    };
+
+    [[nodiscard]]
+    switch_result switch_to_branch(database::header_index::index_t branch_head, uint32_t fork_height);
+
+    // Awaitable form of switch_to_branch: runs the disconnect on priority_pool_
+    // instead of the caller's executor. A switch reads, parses and reverts every
+    // abandoned block, so running it inline would stall the coordinator coroutine
+    // and everything else sharing that executor for the whole reorg.
+    [[nodiscard]]
+    ::asio::awaitable<switch_result> switch_to_branch_async(
+        database::header_index::index_t branch_head, uint32_t fork_height);
 #endif
+
+    // =========================================================================
+    // Reorg barrier
+    // =========================================================================
+    //
+    // A chain switch rewrites the UTXO set and the active chain while the block
+    // pipeline (download -> validation -> storage -> UTXO build) is writing
+    // against the chain being abandoned.
+    //
+    // A pause flag is checked by every participating task between units of work,
+    // and a count tracks how many are parked. The switching side raises the pause
+    // and waits until every registered participant is parked. A task that is
+    // mid-unit finishes it first, so the barrier is only ever crossed at a unit
+    // boundary. Unlike a pair of booleans this needs no store-load ordering
+    // argument: the count only moves when a task is genuinely parked.
+    //
+    // Scope, stated plainly: this covers the tasks that write chain state
+    // (block storage, UTXO build). The download and validation stages are NOT
+    // drained yet — see the PR description.
+    //
+    // Participation is by explicit registration, not a hardcoded count: the
+    // barrier is reached when every task that registered is parked. A task
+    // deregisters when it exits, so a retired task neither blocks the barrier
+    // forever nor counts as parked.
+
+    void register_reorg_participant() { reorg_registered_.fetch_add(1, std::memory_order_seq_cst); }
+    void unregister_reorg_participant() { reorg_registered_.fetch_sub(1, std::memory_order_seq_cst); }
+
+    void request_reorg_pause(bool paused) { reorg_pause_.store(paused, std::memory_order_seq_cst); }
+    [[nodiscard]] bool reorg_pause_requested() const { return reorg_pause_.load(std::memory_order_seq_cst); }
+
+    // Called by a registered task when it parks at / leaves the barrier.
+    void enter_reorg_barrier() { reorg_parked_.fetch_add(1, std::memory_order_seq_cst); }
+    void leave_reorg_barrier() { reorg_parked_.fetch_sub(1, std::memory_order_seq_cst); }
+
+    [[nodiscard]] bool reorg_barrier_reached() const {
+        auto const registered = reorg_registered_.load(std::memory_order_seq_cst);
+        // No participants: nothing writes the chain, so the barrier is trivially
+        // satisfied (also the state after shutdown).
+        return reorg_parked_.load(std::memory_order_seq_cst) >= registered;
+    }
 
     void utxo_compact();
     void utxo_print_statistics();
@@ -508,6 +580,11 @@ private:
 
     // Thread safe members
     std::atomic<bool> stopped_;
+
+    // Reorg barrier (see request_reorg_pause / enter_reorg_barrier above).
+    std::atomic<bool> reorg_pause_{false};
+    std::atomic<size_t> reorg_parked_{0};
+    std::atomic<size_t> reorg_registered_{0};
     settings const& settings_;
     time_t const notify_limit_seconds_;
     kth::atomic<block_const_ptr> last_block_;

--- a/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
@@ -32,6 +32,7 @@ struct header_organize_result {
     // switched here; executing the switch is a separate layer.
     bool reorg_candidate{false};
     int32_t reorg_fork_height{-1};   // height of the common ancestor, or -1
+    header_index::index_t reorg_branch_head{header_index::null_index};   // tip of the heavier branch
 };
 
 /// Header organizer for headers-first sync.

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -841,6 +841,119 @@ database::disconnect_result block_chain::disconnect_block(uint32_t height) {
 }
 #endif
 
+#if ! defined(KTH_DB_READONLY)
+block_chain::switch_result block_chain::switch_to_branch(
+    database::header_index::index_t branch_head, uint32_t fork_height) {
+
+    auto const heights = database_.internal_db().get_last_heights();
+    if ( ! heights) {
+        spdlog::error("[blockchain] switch_to_branch: cannot read the validated tip");
+        return {};
+    }
+
+    // Validate the target before touching anything: re-pointing the active chain
+    // at a bad index after the UTXO set is already rolled back would leave the
+    // node with no coherent chain at all.
+    if (branch_head == database::header_index::null_index) {
+        spdlog::error("[blockchain] switch_to_branch: null branch head");
+        return {false, heights->block};
+    }
+    if (header_index_.get_height(branch_head) <= int32_t(fork_height)) {
+        spdlog::error("[blockchain] switch_to_branch: branch head at height {} is not above the "
+            "fork at {}", header_index_.get_height(branch_head), fork_height);
+        return {false, heights->block};
+    }
+
+    // Do not take the caller's word for where the branch forks: derive it. A
+    // fork_height lower than the real one would disconnect fewer blocks than the
+    // switch needs, leaving UTXO effects of abandoned blocks active while the
+    // active tip moves onto the branch anyway.
+    auto const active_tip = header_index_.active_at(header_index_.active_tip_height());
+    auto const fork_idx = header_index_.find_fork(branch_head, active_tip);
+    if (fork_idx == database::header_index::null_index) {
+        spdlog::error("[blockchain] switch_to_branch: branch shares no ancestor with the active chain");
+        return {false, heights->block};
+    }
+
+    auto const real_fork = header_index_.get_height(fork_idx);
+    if (real_fork != int32_t(fork_height)) {
+        spdlog::error("[blockchain] switch_to_branch: fork height mismatch — caller says {}, the "
+            "branch actually forks at {}", fork_height, real_fork);
+        return {false, heights->block};
+    }
+
+    // Where the validated tip ends up. A fork above the validated tip disconnects
+    // nothing, so the tip does not move — reporting the fork height there would
+    // strand the still-missing blocks below it, never requested again.
+    uint32_t validated_tip = heights->block;
+
+    if (fork_height > heights->block) {
+        spdlog::info("[blockchain] Reorg: fork at {} is above the validated tip {}, nothing to disconnect",
+            fork_height, heights->block);
+    } else {
+        validated_tip = fork_height;
+
+        auto const to_disconnect = heights->block - fork_height;
+        spdlog::warn("[blockchain] Reorg: disconnecting {} block(s), {} down to {}",
+            to_disconnect, heights->block, fork_height + 1);
+
+        // Newest first: disconnecting out of order would restore outputs that a
+        // later block still spends.
+        for (uint32_t h = heights->block; h > fork_height; --h) {
+            auto const result = disconnect_block(h);
+
+            if (result == database::disconnect_result::unclean) {
+                // The inverse delta was applied but the markers could not be
+                // written: the UTXO set is at h-1 while the markers still say h.
+                // Reporting h as a resumable tip would re-download from a height
+                // whose UTXO state is already inconsistent, and nothing would ever
+                // repair it. Report "unknown" so the caller stops instead.
+                spdlog::error("[blockchain] Reorg: UTXO set and height markers diverged at {} "
+                    "(set is at {}, markers say {}); aborting without a resumable tip",
+                    h, h - 1, h);
+                return {false, std::nullopt};
+            }
+
+            if (result != database::disconnect_result::ok) {
+                // Clean failure: nothing was applied for this block, so the markers
+                // and the set agree at h. Report it so the caller resyncs there
+                // instead of assuming nothing moved (which would strand the rewound
+                // range, never re-downloaded).
+                spdlog::error("[blockchain] Reorg: failed to disconnect block at height {}, "
+                    "aborting the switch (validated tip is now {})", h, h);
+                return {false, h};
+            }
+        }
+    }
+
+    // Re-point the active chain. From here "the block at height N" means the new
+    // branch; its blocks are headers-only, so block download must refill them.
+    header_index_.active_set_tip(branch_head);
+
+    spdlog::warn("[blockchain] Reorg: active chain switched to height {} (fork at {})",
+        header_index_.active_tip_height(), fork_height);
+    return {true, validated_tip};
+}
+#endif
+
+::asio::awaitable<block_chain::switch_result> block_chain::switch_to_branch_async(
+    database::header_index::index_t branch_head, uint32_t fork_height) {
+
+    using result_channel = ::asio::experimental::concurrent_channel<void(std::error_code, switch_result)>;
+    result_channel done(co_await ::asio::this_coro::executor, 1);
+
+    ::asio::post(priority_pool_.get_executor(), [this, branch_head, fork_height, &done]() {
+        auto result = switch_to_branch(branch_head, fork_height);
+        std::ignore = done.try_send(std::error_code{}, result);
+    });
+
+    auto [ec, result] = co_await done.async_receive(::asio::as_tuple(::asio::use_awaitable));
+    if (ec) {
+        co_return switch_result{};
+    }
+    co_return result;
+}
+
 void block_chain::utxo_compact() {
     utxoz_db_.compact();
 }

--- a/src/blockchain/src/pools/header_organizer.cpp
+++ b/src/blockchain/src/pools/header_organizer.cpp
@@ -241,6 +241,7 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
         if (branch_work > tip_work) {
             auto const fork_idx = index_.find_fork(branch_head_idx, tip_index_);
             result.reorg_candidate = true;
+            result.reorg_branch_head = branch_head_idx;
             result.reorg_fork_height = (fork_idx == header_index::null_index)
                 ? -1 : index_.get_height(fork_idx);
             spdlog::warn("[header_organizer] Reorg candidate: side branch (head height {}) has greater "

--- a/src/node/include/kth/node/sync/messages.hpp
+++ b/src/node/include/kth/node/sync/messages.hpp
@@ -89,6 +89,13 @@ struct headers_validated {
     size_t count;
     code result;
     network::peer_session::ptr source_peer;  // For banning on checkpoint failure
+
+    // Set when the batch stored a side branch that out-works the active chain and
+    // descends from the finalized block. The coordinator performs the switch;
+    // the organizer only reports it.
+    bool reorg_candidate{false};
+    int32_t reorg_fork_height{-1};
+    uint32_t reorg_branch_head{0};
 };
 
 // -----------------------------------------------------------------------------

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -41,6 +41,24 @@ namespace kth::node::sync {
 
 namespace {
 
+// Retires a reorg-barrier participant on every exit path. A leaked registration
+// leaves reorg_registered_ above reorg_parked_ forever, so no later switch can
+// ever reach the barrier.
+struct reorg_participation {
+    explicit reorg_participation(blockchain::block_chain& chain) : chain_(chain) {
+        chain_.register_reorg_participant();
+    }
+    ~reorg_participation() { chain_.unregister_reorg_participant(); }
+    reorg_participation(reorg_participation const&) = delete;
+    reorg_participation& operator=(reorg_participation const&) = delete;
+private:
+    blockchain::block_chain& chain_;
+};
+
+} // namespace
+
+namespace {
+
 // MTP calculation for incremental UTXO build (same algorithm as utxo_builder)
 [[nodiscard]]
 uint32_t calculate_mtp(std::deque<uint32_t> const& timestamps) {
@@ -1457,6 +1475,10 @@ std::atomic<uint32_t> g_active_download_peers{0};
 ) {
     spdlog::info("[block_storage] Task started at height {}", start_height);
 
+    // This task marks blocks have_data and advances the validated height, both of
+    // which a chain switch rewrites, so it participates in the reorg barrier.
+    reorg_participation const storage_participation(chain);
+
     uint64_t chunks_stored = 0;
     uint64_t blocks_stored = 0;
     uint32_t max_stored_height = start_height > 0 ? start_height - 1 : 0;
@@ -1481,6 +1503,29 @@ std::atomic<uint32_t> g_active_download_peers{0};
     auto initial_rss = get_rss_mb();
 
     while (true) {
+        // Park BEFORE waiting for input. A paused pipeline delivers no chunk, so a
+        // check placed after the receive is never reached and the barrier would
+        // wait on a task that is itself waiting.
+        if (chain.reorg_pause_requested()) {
+            chain.enter_reorg_barrier();
+            while (chain.reorg_pause_requested() && ! chain.stopped()) {
+                ::asio::steady_timer pause_timer(co_await ::asio::this_coro::executor);
+                pause_timer.expires_after(std::chrono::milliseconds(50));
+                co_await pause_timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
+            }
+            chain.leave_reorg_barrier();
+
+            // The switch rewound the chain and reset the shared counter: re-derive
+            // the local cursors instead of carrying pre-switch values.
+            if (contiguous_out) {
+                contiguous_height = contiguous_out->load(std::memory_order_acquire);
+                max_stored_height = contiguous_height > 0 ? contiguous_height - 1 : 0;
+                spdlog::info("[block_storage] Resuming after reorg at contiguous height {}",
+                    contiguous_height);
+            }
+            continue;
+        }
+
         auto [ec, msg] = co_await input.async_receive(
             ::asio::as_tuple(::asio::use_awaitable));
         if (ec) {
@@ -1754,15 +1799,27 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
         spdlog::info("[utxo_build] Resuming from height {}", utxo_built_height);
     }
 
-    // Pre-load MTP timestamps
+    // This task writes the UTXO set, so a chain switch must wait for it. The guard
+    // retires it on every exit path — the batch loop has several co_returns.
+    reorg_participation const build_participation(chain);
+
+    // MTP window. Rebuilt from the active chain whenever the built height moves
+    // (a reorg rewinds it), since timestamps carried over from an abandoned
+    // branch would persist a wrong median_time_past into the UTXO entries.
     std::deque<uint32_t> timestamp_window;
-    uint32_t preload_start = (utxo_built_height > 11) ? (utxo_built_height - 11) : 0;
-    for (uint32_t h = preload_start; h <= utxo_built_height && h > 0; ++h) {
-        auto hdr = chain.get_header(h);
-        if (hdr) {
-            timestamp_window.push_back(hdr->timestamp());
+    auto reload_timestamp_window = [&](uint32_t up_to) {
+        timestamp_window.clear();
+        // 11 entries, matching what the incremental path keeps (it pops before
+        // pushing). A 12th would shift calculate_mtp's median element.
+        uint32_t const preload_start = (up_to > 10) ? (up_to - 10) : 0;
+        for (uint32_t h = preload_start; h <= up_to && h > 0; ++h) {
+            auto hdr = chain.get_header(h);
+            if (hdr) {
+                timestamp_window.push_back(hdr->timestamp());
+            }
         }
-    }
+    };
+    reload_timestamp_window(utxo_built_height);
 
     auto executor = co_await ::asio::this_coro::executor;
 
@@ -1779,6 +1836,29 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
     // chain.stop() is never called. should_stop() reflects network.stopped(),
     // the same signal every other sync coroutine uses.
     while ( ! chain.stopped() && ! should_stop()) {
+        // A chain switch rewrites the UTXO set, so it must run alone. Park at the
+        // barrier between batches — never mid-batch, so the UTXO set is always at
+        // a block boundary, which is what disconnect expects.
+        if (chain.reorg_pause_requested()) {
+            chain.enter_reorg_barrier();
+            while (chain.reorg_pause_requested() && ! chain.stopped() && ! should_stop()) {
+                ::asio::steady_timer timer(executor);
+                timer.expires_after(poll_interval);
+                co_await timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
+            }
+            chain.leave_reorg_barrier();
+
+            // The switch rewound the built height and re-pointed the active chain,
+            // so re-read the height and rebuild the MTP window from the new chain.
+            if (auto const built = chain.get_utxo_built_height(); built) {
+                spdlog::info("[utxo_build] Resuming after reorg: built height {} -> {}",
+                    utxo_built_height, *built);
+                utxo_built_height = *built;
+                reload_timestamp_window(utxo_built_height);
+            }
+            continue;
+        }
+
         uint32_t current_contiguous = contiguous_height.load(std::memory_order_acquire);
 
         // Blocks stored and contiguous ahead of what we've built.
@@ -1974,6 +2054,7 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
 
         spdlog::info("[utxo_build] UTXO built to height {}/{}", utxo_built_height, current_contiguous - 1);
     }
+
 
     // Final compaction
     spdlog::info("[utxo_build] Running final compaction...");

--- a/src/node/src/sync/header_tasks.cpp
+++ b/src/node/src/sync/header_tasks.cpp
@@ -400,7 +400,10 @@ using namespace ::asio::experimental::awaitable_operators;
                 .height = uint32_t(organizer.header_height()),
                 .count = result.headers_added,
                 .result = result.error,
-                .source_peer = downloaded->source_peer
+                .source_peer = downloaded->source_peer,
+                .reorg_candidate = result.reorg_candidate,
+                .reorg_fork_height = result.reorg_fork_height,
+                .reorg_branch_head = result.reorg_branch_head
             })) {
                 spdlog::warn("[header_validation] Channel full, headers_validated dropped");
                 break;

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -868,6 +868,64 @@ static
                 spdlog::debug("[sync_coordinator] Received: height={}, count={}, result={}",
                     result->height, result->count, result->result ? result->result.message() : "ok");
 
+                // A heavier branch was stored: switch the chain onto it. Handled
+                // before the error branch below, since a non-advancing batch also
+                // reports stale_chain.
+                if (result->reorg_candidate && result->reorg_fork_height >= 0) {
+                    auto const fork_height = uint32_t(result->reorg_fork_height);
+                    spdlog::warn("[sync_coordinator] Reorg requested: fork at height {}", fork_height);
+
+                    // Quiesce the UTXO build: the switch rewrites the UTXO set.
+                    chain.request_reorg_pause(true);
+                    while ( ! chain.reorg_barrier_reached() && ! network.stopped()) {
+                        ::asio::steady_timer wait_timer(exec);
+                        wait_timer.expires_after(std::chrono::milliseconds(50));
+                        co_await wait_timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
+                    }
+
+                    auto const outcome = network.stopped()
+                        ? blockchain::block_chain::switch_result{}
+                        : co_await chain.switch_to_branch_async(result->reorg_branch_head, fork_height);
+                    auto const switched = outcome.ok;
+
+                    // Resync from the tip the switch actually reports, so a partially
+                    // disconnected range is re-downloaded instead of stranded. When it
+                    // reports nothing the tip could not be read and nothing was
+                    // touched — leave the counters alone rather than treat that as
+                    // height 0, which would rewind the whole sync to genesis.
+                    if (outcome.validated_tip) {
+                        blocks_synced_to = *outcome.validated_tip;
+                        // The shared contiguous counter still holds the pre-switch
+                        // value; leaving it would make the UTXO build request
+                        // headers-only heights on every poll.
+                        contiguous_height->store(blocks_synced_to + 1, std::memory_order_release);
+                    }
+
+                    chain.request_reorg_pause(false);
+
+                    auto const new_tip = switched ? chain.headers().active_tip_height() : -1;
+                    if (switched && new_tip > int32_t(blocks_synced_to)) {
+                        // The new branch is headers-only from the fork up, so block
+                        // download refills from the rewound tip.
+                        headers_synced_to = uint32_t(new_tip);
+                        spdlog::warn("[sync_coordinator] Reorg complete: blocks rewound to {}, "
+                            "headers now at {}", blocks_synced_to, headers_synced_to);
+
+                        if ( ! co_await send_block_range(blocks_synced_to + 1, headers_synced_to)) {
+                            spdlog::error("[sync_coordinator] Reorg: failed to re-drive block download");
+                        }
+                    } else if (switched) {
+                        // Switched, but the new tip is not above the fork — nothing
+                        // to download. Leaves the chain shorter than it was, so make
+                        // it loud rather than silently idling.
+                        spdlog::error("[sync_coordinator] Reorg switched to a tip at {} which is not "
+                            "above the fork at {}", new_tip, fork_height);
+                    } else {
+                        spdlog::error("[sync_coordinator] Reorg aborted; staying on the current chain");
+                    }
+                    continue;
+                }
+
                 if (result->result) {
                     // Header validation failed - normal network behavior (peer on wrong chain)
                     spdlog::debug("[sync_coordinator] Header validation failed: {} from peer {}",


### PR DESCRIPTION
**The node now reorganizes.** Detection (#570) reported heavier branches and the storage layer (#571/#572) could undo blocks and address them by height — nothing joined the two. This does.

## The switch
- `header_organizer` now reports the **branch head** alongside the fork height, so a candidate is actionable rather than just observable.
- `block_chain::switch_to_branch(branch_head, fork_height)` disconnects the abandoned blocks **newest-first** (restoring their spent outputs from undo data), then re-points the active chain at the new branch. It **aborts on the first failed disconnect** instead of pressing on: the UTXO set stays consistent with whatever was disconnected, and the height markers say so.
- The sync coordinator drives it: quiesce the UTXO build → switch → rewind `blocks_synced_to` to the fork and `headers_synced_to` to the new tip → re-drive block download (the new branch is headers-only from the fork up).

## Quiescing
A switch rewrites the UTXO set, which `utxo_build_task` also writes. Two flags on `block_chain` form the handshake: the coordinator raises `reorg_pause` and waits for `utxo_build_idle`; the build task parks **between batches** — never mid-batch, so the UTXO set is always at a block boundary, which is exactly what disconnect expects — and re-reads the built height afterwards, since the switch rewinds it.

## Not in this PR
The reorg **notification to the mempool**. `block_organizer`'s broadcaster has had **no publisher** since the LMDB storage was removed, so `full_node::handle_reorganized` and `mempool::update_for_reorg` still never fire. Re-admitting transactions from disconnected blocks is #498.

## Testing caveat — please read
Unit suites are green (blockchain 1544, node 326) and everything builds, but **no real reorg has been exercised end-to-end**. There is no regtest harness that produces competing chains, so the disconnect→switch→re-download path has never actually run. I'd treat that harness as the gating item before trusting this on a node at the tip, and I'd rather say so than imply more confidence than the evidence supports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic switching to heavier, valid blockchain branches.
  * Added reorganization status reporting, including fork and branch details.
  * Coordinated UTXO processing pauses and resumed synchronization during reorganizations.
  * Reissued block downloads for the newly selected branch.
  * Added safeguards to prevent outdated synchronization work from affecting the active chain.

* **Bug Fixes**
  * Improved handling of competing branches that surpass the active chain.
  * Preserved accurate UTXO progress through pauses and chain reorganizations.
  * Improved recovery from partial or interrupted reorganizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->