### PR TITLE
test: exercise the reorg undo round-trip against a real UTXO-Z database

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -75,7 +75,12 @@ endif()
 message(STATUS "Knuth: Header index capacity: ${KTH_HEADER_INDEX_CAPACITY}")
 add_definitions(-DKTH_HEADER_INDEX_CAPACITY=${KTH_HEADER_INDEX_CAPACITY})
 
-# UTXO-Z compact storage mode (8-byte refs instead of full output data)
+# UTXO-Z compact storage mode (8-byte refs instead of full output data).
+# The real default comes from Conan (conanfile.py: utxoz_compact=False); this
+# option only applies to standalone builds. It MUST agree with the value used by
+# the other modules — the write path (utxo_builder) and the storage layer
+# (utxoz_database) branch on this same macro, so a mismatch makes them disagree
+# on the stored value layout.
 option(KTH_UTXOZ_COMPACT_MODE "Use UTXO-Z compact storage mode" OFF)
 
 # Embedded UTXO bloom filter — .incbin via assembly
@@ -303,6 +308,7 @@ if (ENABLE_TEST)
         test/batch_sigchecks.cpp
         test/finalization.cpp
         test/block_undo.cpp
+        test/reorg_undo_roundtrip.cpp
     )
 
     # Disabled until ported to v1.0 APIs:

--- a/src/blockchain/include/kth/blockchain/utxo_builder.hpp
+++ b/src/blockchain/include/kth/blockchain/utxo_builder.hpp
@@ -18,6 +18,8 @@
 #include <asio/awaitable.hpp>
 #include <asio/thread_pool.hpp>
 
+#include <spdlog/spdlog.h>
+
 #include <utxoz/types.hpp>
 
 #include <kth/blockchain/define.hpp>
@@ -174,13 +176,63 @@ KB_API utxo_raw_delta process_compact_block_utxos(
 //
 // Returns an error if any spent output cannot be located, since undo data that
 // silently drops entries would corrupt the UTXO set on disconnect.
+// `source` is anything exposing the two raw lookups this needs:
+//     std::expected<utxoz_database::raw_stored, result_code> find_utxo_raw(key, height)
+//     pair<map<key, raw_stored>, vector<key>>              utxo_process_pending_lookups_raw()
+// block_chain satisfies it in production; a test can substitute a thin adapter
+// over a utxoz_database, which is what keeps this function directly testable.
+template <typename UtxoSource>
 [[nodiscard]]
-KB_API std::expected<database::block_undo, database::result_code> capture_block_undo(
+std::expected<database::block_undo, database::result_code> capture_block_undo(
     utxo_raw_delta const& block_delta,
     utxo_raw_delta const& batch_delta,
-    block_chain& chain,
+    UtxoSource& source,
     uint32_t height
-);
+) {
+    database::block_undo undo;
+    undo.spent.reserve(block_delta.deletes.size());
+
+    // Spent outputs still missing after the first pass, to be resolved by the
+    // deferred sweep (find_raw's key_not_found only means "queued").
+    std::vector<utxoz::raw_outpoint> deferred;
+
+    for (auto const& [key, _] : block_delta.deletes) {
+        // Parent created earlier in this same batch: it lives only in the
+        // in-flight delta, UTXO-Z has not seen it yet.
+        if (auto it = batch_delta.inserts.find(key); it != batch_delta.inserts.end()) {
+            undo.spent.push_back({key, it->second.data, it->second.height});
+            continue;
+        }
+
+        auto stored = source.find_utxo_raw(key, height);
+        if (stored) {
+            undo.spent.push_back({key, std::move(stored->value), stored->height});
+        } else {
+            deferred.push_back(key);
+        }
+    }
+
+    if ( ! deferred.empty()) {
+        auto [resolved, missing] = source.utxo_process_pending_lookups_raw();
+
+        for (auto const& key : deferred) {
+            auto it = resolved.find(key);
+            if (it == resolved.end()) {
+                // The block spends an output the UTXO set does not have. Either
+                // the block should not have validated, or the set is corrupt —
+                // either way, undo data that silently dropped it would corrupt
+                // the set further on disconnect.
+                spdlog::error("[utxo_builder] capture_block_undo: spent output not found at height {} "
+                    "({} of {} deferred lookups unresolved) — cannot build undo data",
+                    height, missing.size(), deferred.size());
+                return std::unexpected(database::result_code::key_not_found);
+            }
+            undo.spent.push_back({key, it->second.value, it->second.height});
+        }
+    }
+
+    return undo;
+}
 
 // =============================================================================
 // UTXO Delta (domain object path — used by sequential_direct strategy)

--- a/src/blockchain/src/utxo_builder.cpp
+++ b/src/blockchain/src/utxo_builder.cpp
@@ -282,57 +282,6 @@ utxo_raw_delta process_compact_block_utxos(
     return delta;
 }
 
-std::expected<database::block_undo, database::result_code> capture_block_undo(
-    utxo_raw_delta const& block_delta,
-    utxo_raw_delta const& batch_delta,
-    block_chain& chain,
-    uint32_t height
-) {
-    database::block_undo undo;
-    undo.spent.reserve(block_delta.deletes.size());
-
-    // Spent outputs still missing after the first pass, to be resolved by the
-    // deferred sweep (find_raw's key_not_found only means "queued").
-    std::vector<utxoz::raw_outpoint> deferred;
-
-    for (auto const& [key, _] : block_delta.deletes) {
-        // Parent created earlier in this same batch: it lives only in the
-        // in-flight delta, UTXO-Z has not seen it yet.
-        if (auto it = batch_delta.inserts.find(key); it != batch_delta.inserts.end()) {
-            undo.spent.push_back({key, it->second.data, it->second.height});
-            continue;
-        }
-
-        auto stored = chain.find_utxo_raw(key, height);
-        if (stored) {
-            undo.spent.push_back({key, std::move(stored->value), stored->height});
-        } else {
-            deferred.push_back(key);
-        }
-    }
-
-    if ( ! deferred.empty()) {
-        auto [resolved, missing] = chain.utxo_process_pending_lookups_raw();
-
-        for (auto const& key : deferred) {
-            auto it = resolved.find(key);
-            if (it == resolved.end()) {
-                // The block spends an output the UTXO set does not have. Either
-                // the block should not have validated, or the set is corrupt —
-                // either way, undo data that silently dropped it would corrupt
-                // the set further on disconnect.
-                spdlog::error("[utxo_builder] capture_block_undo: spent output not found at height {} "
-                    "({} of {} deferred lookups unresolved) — cannot build undo data",
-                    height, missing.size(), deferred.size());
-                return std::unexpected(database::result_code::key_not_found);
-            }
-            undo.spent.push_back({key, it->second.value, it->second.height});
-        }
-    }
-
-    return undo;
-}
-
 // =============================================================================
 // utxo_delta implementation
 // =============================================================================

--- a/src/blockchain/test/reorg_undo_roundtrip.cpp
+++ b/src/blockchain/test/reorg_undo_roundtrip.cpp
@@ -1,0 +1,209 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+
+#include <kth/blockchain/utxo_builder.hpp>
+#include <kth/database/databases/utxoz_database.hpp>
+
+using namespace kth;
+using namespace kth::blockchain;
+using namespace kth::database;
+
+namespace {
+
+std::filesystem::path fresh_dir(char const* tag) {
+    auto const p = std::filesystem::temp_directory_path() /
+        ("kth_reorg_undo_" + std::string(tag) + "_" + std::to_string(getpid()));
+    std::error_code ec;
+    std::filesystem::remove_all(p, ec);
+    REQUIRE(std::filesystem::create_directories(p, ec));
+    REQUIRE( ! ec);
+    return p;
+}
+
+utxoz::raw_outpoint make_outpoint(uint8_t seed, uint32_t index) {
+    hash_digest txid{};
+    txid[0] = seed;
+    txid[31] = uint8_t(0xFF - seed);
+    return utxoz::make_outpoint(std::span<uint8_t const, 32>(txid.data(), 32), index);
+}
+
+// The storage-native payload for one UTXO, matching what utxo_build produces:
+// 8 bytes {file_number, tx_offset} in compact mode, a serialized entry otherwise.
+std::vector<uint8_t> make_payload(uint32_t file_number, uint32_t tx_offset) {
+#ifdef KTH_UTXOZ_COMPACT_MODE
+    std::vector<uint8_t> value(8);
+    std::memcpy(value.data(), &file_number, 4);
+    std::memcpy(value.data() + 4, &tx_offset, 4);
+    return value;
+#else
+    // Full mode stores a variable-length payload. The exact bytes do not matter
+    // here — what is under test is that whatever was stored comes back unchanged,
+    // so an opaque payload of a distinctive length is enough.
+    std::vector<uint8_t> value(32 + (file_number % 16));
+    for (size_t i = 0; i < value.size(); ++i) {
+        value[i] = uint8_t(file_number + tx_offset + i);
+    }
+    return value;
+#endif
+}
+
+// The two raw lookups capture_block_undo needs, forwarded to a bare database.
+// In production block_chain provides these; here it keeps the test on the real
+// code path without standing up a whole chain.
+struct db_source {
+    utxoz_database& db;
+
+    auto find_utxo_raw(utxoz::raw_outpoint const& key, uint32_t height) const {
+        return db.find_raw(key, height);
+    }
+    auto utxo_process_pending_lookups_raw() {
+        return db.process_pending_lookups_raw();
+    }
+};
+
+} // namespace
+
+// =============================================================================
+// Reorg undo: capture -> erase -> restore
+// =============================================================================
+//
+// The correctness claim behind the undo record is that a spent output can be put
+// back EXACTLY as it was: same storage payload and, critically, the same ORIGINAL
+// creation height. Restoring with the spending block's height instead would
+// corrupt both coinbase maturity and (in compact mode) the median-time-past
+// window used when the UTXO is later resolved — silently, and only for outputs
+// that a reorg touched.
+//
+// This exercises that round-trip against a real UTXO-Z database, which is the
+// piece disconnect_block depends on.
+
+TEST_CASE("a spent UTXO is restored with its original payload and height", "[reorg][undo]") {
+    utxoz_database db;
+    REQUIRE(db.open(fresh_dir("restore"), true));
+
+    // Three UTXOs created at different heights — the height spread is the point:
+    // a restore that used one height for all of them would still pass a naive test.
+    struct fixture { utxoz::raw_outpoint key; uint32_t height; std::vector<uint8_t> value; };
+    std::vector<fixture> created{
+        {make_outpoint(1, 0), 100, make_payload(0, 4096)},
+        {make_outpoint(2, 1), 5000, make_payload(3, 123456)},
+        {make_outpoint(3, 7), 99999, make_payload(11, 7)},
+    };
+
+    boost::unordered_flat_map<utxoz::raw_outpoint, utxo_raw_value, outpoint_fast_hasher> inserts;
+    for (auto const& f : created) {
+        inserts.emplace(f.key, utxo_raw_value{f.value, f.height});
+    }
+    boost::unordered_flat_map<utxoz::raw_outpoint, uint32_t, outpoint_fast_hasher> no_deletes;
+    REQUIRE(db.apply_delta_raw(inserts, no_deletes) == result_code::success);
+
+    // --- capture: through the production path, not a hand-rolled equivalent ---
+    // The spending block's own delta: it deletes all three, creating nothing.
+    utxo_raw_delta block_delta;
+    for (auto const& f : created) {
+        block_delta.deletes.emplace(f.key, 200000u);   // spending height
+    }
+    utxo_raw_delta const empty_batch;
+
+    db_source source{db};
+    auto captured = capture_block_undo(block_delta, empty_batch, source, 200000u);
+    REQUIRE(captured.has_value());
+    REQUIRE(captured->spent.size() == created.size());
+
+    // Every record must carry the ORIGINAL creation height, not the spend height
+    // it was captured at. Match by key — the record's order is unspecified.
+    for (auto const& f : created) {
+        auto const it = std::find_if(captured->spent.begin(), captured->spent.end(),
+            [&](auto const& e) { return e.key == f.key; });
+        REQUIRE(it != captured->spent.end());
+        CHECK(it->height == f.height);
+        CHECK(it->value == f.value);
+        CHECK(it->height != 200000u);
+    }
+
+    // --- spend: the block being connected erases them ---
+    boost::unordered_flat_map<utxoz::raw_outpoint, utxo_raw_value, outpoint_fast_hasher> no_inserts;
+    boost::unordered_flat_map<utxoz::raw_outpoint, uint32_t, outpoint_fast_hasher> deletes;
+    for (auto const& f : created) {
+        deletes.emplace(f.key, 200000u);   // spending height, not the creation height
+    }
+    REQUIRE(db.apply_delta_raw(no_inserts, deletes) == result_code::success);
+
+    for (auto const& f : created) {
+        CHECK_FALSE(db.find_raw(f.key, 200001).has_value());
+    }
+
+    // --- disconnect: the inverse delta puts them back ---
+    boost::unordered_flat_map<utxoz::raw_outpoint, utxo_raw_value, outpoint_fast_hasher> restores;
+    for (auto const& u : captured->spent) {
+        restores.emplace(u.key, utxo_raw_value{u.value, u.height});
+    }
+    REQUIRE(db.apply_delta_raw(restores, no_deletes) == result_code::success);
+
+    // The set must be indistinguishable from before the spend.
+    for (auto const& f : created) {
+        auto stored = db.find_raw(f.key, 200002);
+        REQUIRE(stored.has_value());
+        CHECK(stored->value == f.value);
+        CHECK(stored->height == f.height);   // ORIGINAL height, not the spend height
+    }
+}
+
+TEST_CASE("outputs created and spent in the same block need no undo entry", "[reorg][undo]") {
+    // A block that creates an output and spends it internally leaves nothing in
+    // the UTXO set, so disconnecting it must NOT restore that output — it never
+    // existed beforehand. process_compact_block_utxos cancels the pair, which is
+    // what keeps it out of the undo record.
+    utxoz_database db;
+    REQUIRE(db.open(fresh_dir("internal"), true));
+
+    // Build a block that creates one output and spends it in the same block, and
+    // run it through the real producer — the cancellation is its behaviour, so a
+    // hand-built delta would not test anything.
+    hash_digest txid{};
+    txid[0] = 9;
+    txid[31] = 0xF6;
+    auto const internal = utxoz::make_outpoint(std::span<uint8_t const, 32>(txid.data(), 32), 0);
+
+    std::vector<uint8_t> raw_out(16, 0x11);
+    utxo_compact_block block;
+    block.outputs.push_back({internal, std::span<uint8_t const>(raw_out.data(), raw_out.size()),
+                             /*coinbase*/ false, /*tx_start*/ 0u});
+    block.inputs.push_back({internal});   // spent by a later tx in the same block
+
+    auto delta = process_compact_block_utxos(block, /*height*/ 700u, /*mtp*/ 12u,
+                                             /*file*/ 0, /*data_pos*/ 0u, nullptr);
+
+    // The producer cancels the pair: nothing to insert, and nothing to delete —
+    // which is what keeps the output out of the undo record.
+    CHECK(delta.inserts.empty());
+    CHECK(delta.deletes.empty());
+
+    db_source source{db};
+    utxo_raw_delta const empty_batch;
+    auto captured = capture_block_undo(delta, empty_batch, source, 700u);
+    REQUIRE(captured.has_value());
+    CHECK(captured->spent.empty());   // no entry => disconnect will not restore it
+
+    REQUIRE(db.apply_delta_raw(delta.inserts, delta.deletes) == result_code::success);
+    CHECK_FALSE(db.find_raw(internal, 701).has_value());
+}
+
+TEST_CASE("find_raw reports a miss for an unknown outpoint", "[reorg][undo]") {
+    // Undo capture treats a miss as "resolve through the deferred queue, then
+    // fail loudly" — it must not silently produce an empty record.
+    utxoz_database db;
+    REQUIRE(db.open(fresh_dir("miss"), true));
+
+    auto const missed = db.find_raw(make_outpoint(42, 3), 1);
+    REQUIRE_FALSE(missed.has_value());
+    CHECK(missed.error() == result_code::key_not_found);   // the documented contract
+}

--- a/src/database/CMakeLists.txt
+++ b/src/database/CMakeLists.txt
@@ -55,7 +55,13 @@ if (NOT GLOBAL_BUILD)
   find_package(domain REQUIRED)
 endif()
 
-option(KTH_UTXOZ_COMPACT_MODE "Use UTXO-Z compact storage mode" ON)
+# UTXO-Z compact storage mode (8-byte refs instead of full output data).
+# The real default comes from Conan (conanfile.py: utxoz_compact=False); this
+# option only applies to standalone builds. It MUST agree with the value used by
+# the other modules — the write path (utxo_builder) and the storage layer
+# (utxoz_database) branch on this same macro, so a mismatch makes them disagree
+# on the stored value layout.
+option(KTH_UTXOZ_COMPACT_MODE "Use UTXO-Z compact storage mode" OFF)
 
 find_package(lmdb 0.9.29 REQUIRED)
 find_package(utxoz REQUIRED)


### PR DESCRIPTION
First real execution of the reorg storage path. Everything merged so far (#571 undo/disconnect, #572 active chain, #573 chain switch) compiled and passed unit tests, but the undo record's central claim — **a spent output can be put back exactly as it was** — had never actually run.

## What it covers
- **capture → spend → restore** over three UTXOs created at **different heights**, asserting each returns with its **original creation height**, not the height of the block that spent it. The height spread is deliberate: a restore that reused one height for all of them would still pass a single-entry test. Getting this wrong would corrupt coinbase maturity and, in compact mode, the median-time-past window used when the UTXO is resolved — silently, and only for outputs a reorg touched.
- an output **created and spent inside one block** produces no undo entry (it did not exist before the block, so a disconnect must not restore it).
- `find_raw` reports a miss for an unknown outpoint, so capture fails loudly instead of writing an empty record.

Runs against a real `utxoz_database` on a temp directory, which is the layer `disconnect_block` depends on.

## Both storage modes
Green in **compact** (1581 assertions / 165 cases) and **full** (1606 / 166 — the extra case is the full-mode-only `utxoz_roundtrip` regression).

Worth flagging: I had been asserting compact was the default. It is not — `conanfile.py` sets `utxoz_compact=False`, so normal builds are **full mode** and the compact path had never been exercised at all. It has now.

## Config fix
`KTH_UTXOZ_COMPACT_MODE` disagreed between modules — `database` defaulted ON, `blockchain` OFF — while the real value comes from Conan. Both branch on that macro for the stored value layout, so a standalone build could compile the write path and the storage layer against **different formats**. Aligned to Conan's value, with a comment saying where the real default lives.

## Still not covered
This is the storage layer only. A full reorg (disconnect → switch → re-download) still has no end-to-end test — that needs a harness able to build competing chains and drive the sync pipeline, which is the next step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of UTXO reorganization undo handling, including restoration of spent outputs and their original creation heights.
  * Ensured outputs created and spent within the same block are excluded from undo data.
  * Added validation for unknown transaction outputs.

* **Documentation**
  * Clarified UTXO storage mode defaults and configuration requirements for standalone builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->