### PR TITLE
node: drop block work downloaded for an abandoned branch

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -311,6 +311,12 @@ struct KB_API block_chain {
     void enter_reorg_barrier() { reorg_parked_.fetch_add(1, std::memory_order_seq_cst); }
     void leave_reorg_barrier() { reorg_parked_.fetch_sub(1, std::memory_order_seq_cst); }
 
+    // Bumped by each completed switch. Work that was requested against the old
+    // chain carries the previous generation; the storage path drops it instead of
+    // applying it, which is what makes a stale chunk buffered during the barrier
+    // harmless rather than corrupting.
+    [[nodiscard]] uint64_t chain_generation() const { return header_index_.generation(); }
+
     [[nodiscard]] bool reorg_barrier_reached() const {
         auto const registered = reorg_registered_.load(std::memory_order_seq_cst);
         // No participants: nothing writes the chain, so the barrier is trivially

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -930,8 +930,12 @@ block_chain::switch_result block_chain::switch_to_branch(
     // branch; its blocks are headers-only, so block download must refill them.
     header_index_.active_set_tip(branch_head);
 
-    spdlog::warn("[blockchain] Reorg: active chain switched to height {} (fork at {})",
-        header_index_.active_tip_height(), fork_height);
+    // active_set_tip bumps the generation when it moves onto a different branch,
+    // which is what marks chunks requested against the old chain as stale.
+    auto const generation = chain_generation();
+
+    spdlog::warn("[blockchain] Reorg: active chain switched to height {} (fork at {}), generation {}",
+        header_index_.active_tip_height(), fork_height, generation);
     return {true, validated_tip};
 }
 #endif

--- a/src/blockchain/test/header_organizer.cpp
+++ b/src/blockchain/test/header_organizer.cpp
@@ -4,6 +4,9 @@
 
 #include <test_helpers.hpp>
 
+#include <atomic>
+#include <thread>
+
 #include <kth/blockchain.hpp>
 
 using namespace kth;
@@ -419,4 +422,124 @@ TEST_CASE("active chain re-points to a new tip across a fork", "[header_organize
     for (int32_t h = 0; h <= 5; ++h) {
         REQUIRE(index.get_height(index.active_at(h)) == h);
     }
+}
+
+TEST_CASE("chain generation moves only on a branch change", "[header_organizer][active_chain]") {
+    // The generation stamp is what lets the block pipeline drop work downloaded
+    // for an abandoned branch. It must NOT move on ordinary forward extension:
+    // bumping it per block would discard perfectly good in-flight chunks on every
+    // new tip, stalling sync instead of protecting it.
+    header_index index;
+    auto tip_hash = build_chain(index, 10);
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    auto const initial = index.generation();
+
+    // Forward extension: same branch, generation unchanged.
+    domain::message::header::list extension;
+    hash_digest prev = tip_hash;
+    for (int i = 0; i < 3; ++i) {
+        auto hdr = make_header_with_prev(prev, uint32_t(10 + i));
+        prev = kth::domain::chain::hash(hdr);
+        extension.push_back(std::move(hdr));
+    }
+    auto const extended = organizer.add_headers(extension);
+    REQUIRE(extended.headers_added == 3);
+    CHECK(index.generation() == initial);
+
+    // Re-pointing onto a different branch does move it.
+    auto branch = make_branch(index.get_hash(index.active_at(5)), 9, 1100);
+    (void)organizer.add_headers(branch);
+    auto const branch_head = index.find(kth::domain::chain::hash(branch.back()));
+    REQUIRE(branch_head != header_index::null_index);
+    index.active_set_tip(branch_head);
+
+    CHECK(index.generation() == initial + 1);
+}
+
+TEST_CASE("the active chain is never observed in a torn state", "[header_organizer][active_chain]") {
+    // active_set_tip truncates and then re-links, so it is NOT atomic: during a
+    // switch the chain is transiently SHORT. That is safe by construction —
+    // active_at() answers null_index for the heights not yet re-linked, so a
+    // reader fails closed (block download logs a missing hash and skips) rather
+    // than resolving a height to a block from the abandoned branch.
+    //
+    // What must hold at all times is that whatever active_at(h) DOES return is
+    // an entry actually at height h on a branch descending from the fork. A
+    // reader must never see an index left over from the previous chain sitting
+    // at a height it does not belong to.
+    //
+    // Note on scope, since it would be easy to overclaim: this pins the absence
+    // of torn entries. The ordering fix itself — publishing the chain before
+    // bumping the generation — is not provable here, because the transient
+    // truncation means neither "generation implies chain" nor its converse holds
+    // during a switch. The consequence of the ordering is covered by the storage
+    // drop test in the node suite.
+    header_index index;
+    (void)build_chain(index, 10);
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    auto const fork_height = 5;
+    auto const fork_idx = index.active_at(fork_height);
+    auto const fork_hash = index.get_hash(fork_idx);
+    constexpr int switches = 64;
+
+    std::vector<header_index::index_t> heads;
+    for (int i = 0; i < switches; ++i) {
+        auto const branch = make_branch(fork_hash, size_t(i + 1), uint32_t(4000 + i * 100));
+        (void)organizer.add_headers(branch);
+        auto const head = index.find(kth::domain::chain::hash(branch.back()));
+        REQUIRE(head != header_index::null_index);
+        heads.push_back(head);
+    }
+
+    std::atomic<bool> done{false};
+    std::atomic<bool> violated{false};
+    std::atomic<bool> reader_started{false};
+    std::atomic<uint64_t> reads{0};
+
+    std::thread reader([&] {
+        reader_started.store(true, std::memory_order_release);
+        while ( ! done.load(std::memory_order_acquire)) {
+            auto const tip_height = index.active_tip_height();
+            for (int32_t h = 0; h <= tip_height; ++h) {
+                auto const idx = index.active_at(h);
+                if (idx == header_index::null_index) continue;   // not linked yet: safe
+
+                if (index.get_height(idx) != h) {
+                    violated.store(true, std::memory_order_release);
+                    return;
+                }
+                if (h > fork_height && index.get_ancestor(idx, fork_height) != fork_idx) {
+                    violated.store(true, std::memory_order_release);
+                    return;
+                }
+                reads.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    while ( ! reader_started.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    auto const base = index.generation();
+    for (int i = 0; i < switches; ++i) {
+        index.active_set_tip(heads[size_t(i)]);
+    }
+    done.store(true, std::memory_order_release);
+    reader.join();
+
+    CHECK_FALSE(violated.load());
+    CHECK(reads.load() > 0);                            // the checks above ran
+    CHECK(index.generation() == base + switches);       // every move counted
+
+    // Quiesced, the chain and the counter agree on the final branch.
+    CHECK(index.active_at(index.active_tip_height()) == heads.back());
 }

--- a/src/blockchain/test/reorg_chain_fixture.hpp
+++ b/src/blockchain/test/reorg_chain_fixture.hpp
@@ -42,10 +42,13 @@ struct chain_fixture {
     }
 
     ~chain_fixture() {
-        if (chain_) {
-            std::ignore = chain_->stop();
-            std::ignore = chain_->close();
-        }
+        // Destroy in dependency order and let the destructors do the closing:
+        // block_chain::~block_chain already closes (which stops), so calling
+        // close() here would close twice — and removing the directory first
+        // would run that second close against a datadir that no longer exists.
+        organizer_.reset();
+        chain_.reset();
+
         std::error_code ec;
         std::filesystem::remove_all(dir_, ec);
     }

--- a/src/database/include/kth/database/header_index.hpp
+++ b/src/database/include/kth/database/header_index.hpp
@@ -331,6 +331,13 @@ struct KD_API header_index {
     /// disconnected the blocks being abandoned.
     void active_set_tip(index_t tip_idx);
 
+    /// How many times the active chain has been re-pointed at a different branch.
+    /// Work requested against an earlier generation refers to heights that now
+    /// name different blocks, so the block pipeline stamps it and drops what is
+    /// stale instead of applying it to the new chain.
+    [[nodiscard]]
+    uint64_t generation() const { return generation_.load(std::memory_order_acquire); }
+
     // =========================================================================
     // State Queries
     // =========================================================================
@@ -396,6 +403,7 @@ private:
     // vectors; active_size_ publishes the valid prefix (see the accessors above).
     std::vector<index_t> active_;
     std::atomic<int32_t> active_size_{0};
+    std::atomic<uint64_t> generation_{0};
 
     // Index counter
     std::atomic<index_t> next_idx_{0};

--- a/src/database/src/header_index.cpp
+++ b/src/database/src/header_index.cpp
@@ -303,8 +303,22 @@ int32_t header_index::active_tip_height() const {
 }
 
 void header_index::active_set_tip(index_t tip_idx) {
+    // A forward extension re-points at a descendant of the current tip and does
+    // not invalidate in-flight work; only a move onto a different branch does.
+    auto const previous_tip = active_at(active_tip_height());
+    bool const same_branch = (previous_tip == null_index) ||
+        (tip_idx != null_index && get_ancestor(tip_idx, heights_[previous_tip]) == previous_tip);
+
+    // The generation is bumped at the END of a branch change, never here: a
+    // reader that saw the new generation while this function was still rebuilding
+    // would pair it with heights that still resolve to the OLD branch, and stamp
+    // stale work as current — the exact confusion the counter exists to prevent.
+
     if (tip_idx == null_index) {
         active_size_.store(0, std::memory_order_release);
+        if ( ! same_branch) {
+            generation_.fetch_add(1, std::memory_order_release);
+        }
         return;
     }
 
@@ -328,6 +342,13 @@ void header_index::active_set_tip(index_t tip_idx) {
     // Link the branch in, lowest height first.
     for (auto it = branch.rbegin(); it != branch.rend(); ++it) {
         active_push(*it);
+    }
+
+    // Now that the new active chain is fully published, mark the branch change.
+    // Ordered after the pushes so any reader observing the new generation is
+    // guaranteed to resolve heights against the new branch.
+    if ( ! same_branch) {
+        generation_.fetch_add(1, std::memory_order_release);
     }
 }
 

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -294,6 +294,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   add_executable(kth_node_test
           test/check_list.cpp
           test/chunk_coordinator.cpp
+          test/reorg_stale_chunk_drop.cpp
           test/configuration.cpp
           test/header_list.cpp
           test/main.cpp

--- a/src/node/include/kth/node/sync/chunk_coordinator.hpp
+++ b/src/node/include/kth/node/sync/chunk_coordinator.hpp
@@ -96,6 +96,12 @@ struct chunk_coordinator {
     [[nodiscard]]
     hash_digest get_block_hash(uint32_t height) const;
 
+    /// Active-chain generation at this moment. A chunk is stamped with it when
+    /// downloaded so work for a branch abandoned mid-flight can be dropped
+    /// instead of stored against the new chain.
+    [[nodiscard]]
+    uint64_t generation() const { return index_.generation(); }
+
     /// Report that a chunk was completed successfully
     void chunk_completed(uint32_t chunk_id);
 

--- a/src/node/include/kth/node/sync/messages.hpp
+++ b/src/node/include/kth/node/sync/messages.hpp
@@ -139,6 +139,12 @@ struct downloaded_chunk {
     uint32_t chunk_id;
     std::vector<std::shared_ptr<domain::chain::light_block const>> blocks;
     network::peer_session::ptr source_peer;
+
+    // Chain generation this chunk was downloaded under. A reorg bumps it, so a
+    // chunk still in flight (or buffered behind the reorg barrier) for the
+    // abandoned branch is recognisable and dropped: its heights now belong to
+    // different blocks, and storing it would mark the wrong hashes have_data.
+    uint64_t generation{0};
 };
 
 struct chunk_validated {

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -224,6 +224,13 @@ std::atomic<uint32_t> g_active_download_peers{0};
         spdlog::debug("[block_download] Peer {} claiming chunk {} (blocks {}-{})",
             addr, chunk_id, chunk_start, chunk_end);
 
+        // Capture the generation BEFORE reading any hash. Reading it after the
+        // download would stamp blocks of the old branch with the new generation
+        // if a switch landed while we waited on the peer — they would then be
+        // accepted as current, which is precisely the corruption the stamp exists
+        // to stop.
+        auto const request_generation = coordinator->generation();
+
         // Build request with hashes from coordinator
         std::vector<std::pair<uint32_t, hash_digest>> blocks;
         blocks.reserve(chunk_end - chunk_start + 1);
@@ -238,6 +245,17 @@ std::atomic<uint32_t> g_active_download_peers{0};
         }
 
         if (blocks.empty()) {
+            coordinator->chunk_failed(chunk_id);
+            continue;
+        }
+
+        // A switch may have landed while the hashes were being collected, in
+        // which case they are a mix of two branches. Drop the request and let the
+        // chunk be re-claimed against the new chain rather than downloading a
+        // set that was never a chain.
+        if (coordinator->generation() != request_generation) {
+            spdlog::info("[block_download] Chain switched while building chunk {} — releasing it",
+                chunk_id);
             coordinator->chunk_failed(chunk_id);
             continue;
         }
@@ -299,7 +317,8 @@ std::atomic<uint32_t> g_active_download_peers{0};
                     .start_height = chunk_start,
                     .chunk_id = chunk_id,
                     .blocks = std::move(chunk_blocks),
-                    .source_peer = peer
+                    .source_peer = peer,
+                    .generation = request_generation
                 },
                 600,   // 600 attempts
                 100ms  // 100ms between attempts = 60 seconds total max wait
@@ -1381,6 +1400,7 @@ std::atomic<uint32_t> g_active_download_peers{0};
         auto const chunk_block_count = chunk.blocks.size();
         auto const chunk_start = chunk.start_height;
         auto const chunk_peer = chunk.source_peer;
+        auto const chunk_generation = chunk.generation;
 
         // Track bytes before validation (blocks are still in memory)
         uint64_t chunk_bytes = 0;
@@ -1424,7 +1444,8 @@ std::atomic<uint32_t> g_active_download_peers{0};
                 .start_height = chunk_start,
                 .chunk_id = chunk.chunk_id,
                 .blocks = std::move(chunk.blocks),
-                .source_peer = chunk_peer
+                .source_peer = chunk_peer,
+                .generation = chunk_generation
             })) {
                 spdlog::error("[fast_validation] Storage channel full after retries!");
                 break;
@@ -1542,6 +1563,22 @@ std::atomic<uint32_t> g_active_download_peers{0};
         auto const chunk_start = chunk.start_height;
         auto const chunk_count = static_cast<uint32_t>(chunk.blocks.size());
         auto const chunk_peer = chunk.source_peer;
+        auto const chunk_generation = chunk.generation;
+
+        // Drop work from before a chain switch. Such a chunk was downloaded for
+        // the abandoned branch, so its heights now name different blocks —
+        // storing it would write the wrong data and mark the wrong hashes
+        // have_data. This is the point of the generation stamp: a chunk that was
+        // in flight, or buffered behind the reorg barrier, is recognisable
+        // afterwards instead of being applied to the new chain.
+        if (chunk_generation != chain.chain_generation()) {
+            spdlog::info("[block_storage] Dropping chunk at {} from generation {} (chain is at {}) "
+                "— downloaded for a branch that has since been abandoned",
+                chunk_start, chunk_generation, chain.chain_generation());
+            chunk.blocks.clear();
+            chunk.blocks.shrink_to_fit();
+            continue;
+        }
 
         auto store_start = std::chrono::steady_clock::now();
 

--- a/src/node/test/reorg_stale_chunk_drop.cpp
+++ b/src/node/test/reorg_stale_chunk_drop.cpp
@@ -1,0 +1,191 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <atomic>
+#include <chrono>
+
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/io_context.hpp>
+
+#include <kth/node/sync/block_tasks.hpp>
+#include <kth/node/sync/messages.hpp>
+
+#include "../../blockchain/test/reorg_chain_fixture.hpp"
+
+using namespace kth;
+using namespace kth::node::sync;
+
+namespace {
+
+// A chunk carrying one light_block at `height`, stamped with `generation`.
+downloaded_chunk make_chunk(uint32_t height, uint64_t generation) {
+    auto blk = std::make_shared<domain::chain::light_block const>(
+        domain::chain::header{}, data_chunk{}, std::vector<uint32_t>{});
+
+    std::vector<std::shared_ptr<domain::chain::light_block const>> blocks;
+    blocks.push_back(std::move(blk));
+
+    return downloaded_chunk{
+        .start_height = height,
+        .chunk_id = 0,
+        .blocks = std::move(blocks),
+        .source_peer = nullptr,
+        .generation = generation
+    };
+}
+
+} // namespace
+
+// =============================================================================
+// Stale work is dropped, not stored
+// =============================================================================
+//
+// This is the consumer that justifies the generation stamp. A chunk downloaded
+// for a branch the node has since abandoned must never reach storage: its
+// heights name different blocks on the new chain, so storing it would write the
+// wrong data and mark the wrong hashes have_data.
+//
+// Both races this guards against are invisible to a test that only checks the
+// counter's value, which is why this drives the real task over real channels.
+
+TEST_CASE("block_storage_task drops a chunk from an earlier generation", "[reorg][drain]") {
+    test::chain_fixture fixture("drop");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    // Model the real sequence: the chunk is downloaded under the generation
+    // current at that moment, and only afterwards does a reorg move the chain
+    // onto another branch. Sending a chunk with a *higher* generation would
+    // trip the same inequality without reproducing what actually happens.
+    auto const generation_at_download = chain.headers().generation();
+    auto stale = make_chunk(1, generation_at_download);
+
+    // Two siblings on genesis, then switch onto the second: a branch change,
+    // which is what bumps the generation.
+    auto& index = chain.headers();
+    auto const genesis = index.active_at(0);
+    REQUIRE(genesis != blockchain::header_index::null_index);
+    auto const genesis_hash = index.get_hash(genesis);
+
+    auto const add_child = [&](uint32_t nonce) {
+        domain::chain::header hdr{1, genesis_hash, null_hash, 1000 + nonce, 0x207fffff, nonce};
+        auto const hash = domain::chain::hash(hdr);
+        auto const r = index.add(hash, hdr);
+        REQUIRE(r.inserted);
+        return r.index;
+    };
+    auto const branch_a = add_child(1);
+    index.active_set_tip(branch_a);
+    auto const branch_b = add_child(2);
+    index.active_set_tip(branch_b);
+
+    REQUIRE(index.generation() > generation_at_download);
+
+    ::asio::io_context ctx;
+    block_storage_input_channel input(ctx.get_executor(), 16);
+    chunk_validated_channel output(ctx.get_executor(), 16);
+    std::atomic<uint32_t> contiguous{1};
+
+    ::asio::co_spawn(ctx,
+        block_storage_task(chain, input, output, 1, fixture.organizer(), &contiguous),
+        ::asio::detached);
+
+    // The chunk was stamped before the switch, so it is now stale.
+    REQUIRE(input.try_send(std::error_code{}, std::move(stale)));
+    REQUIRE(input.try_send(std::error_code{}, stop_request{}));
+
+    ctx.run_for(std::chrono::seconds(5));
+
+    // Dropped, not stored: height 1 on the new branch never gained block data,
+    // and the contiguous cursor did not advance.
+    CHECK_FALSE(index.has_block_data(index.active_at(1)));
+    CHECK(contiguous.load() == 1);
+}
+
+TEST_CASE("a chunk from the current generation is not dropped", "[reorg][drain]") {
+    // The counterpart: the drop must be selective. A chunk stamped with the
+    // current generation has to reach storage — a filter that rejected
+    // everything would pass the test above while stalling sync completely.
+    test::chain_fixture fixture("keep");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    ::asio::io_context ctx;
+    block_storage_input_channel input(ctx.get_executor(), 16);
+    chunk_validated_channel output(ctx.get_executor(), 16);
+    std::atomic<uint32_t> contiguous{1};
+
+    ::asio::co_spawn(ctx,
+        block_storage_task(chain, input, output, 1, fixture.organizer(), &contiguous),
+        ::asio::detached);
+
+    REQUIRE(input.try_send(std::error_code{}, make_chunk(1, chain.headers().generation())));
+    REQUIRE(input.try_send(std::error_code{}, stop_request{}));
+
+    ctx.run_for(std::chrono::seconds(5));
+
+    // It was NOT dropped: storage attempted it and reported the outcome
+    // downstream. (The store itself fails here because the fixture has no header
+    // at height 1 — what matters is that the chunk was processed rather than
+    // discarded before reaching storage.)
+    bool reached_storage = false;
+    output.try_receive([&](std::error_code, chunk_validated) { reached_storage = true; });
+    CHECK(reached_storage);
+}
+
+// =============================================================================
+// The download-side half of the protocol
+// =============================================================================
+
+TEST_CASE("the coordinator reports a generation that moves with the branch", "[reorg][drain]") {
+    // block_download_task captures the generation before reading any hash and
+    // re-checks it once the request is assembled, so what it depends on is that
+    // the counter changes exactly when the branch does — no sooner (which would
+    // discard good work) and no later (which would let stale work pass).
+    //
+    // Scope, stated so this is not read as more than it is: this pins that
+    // contract. It does NOT reproduce the interleaving inside the downloader —
+    // that needs a peer mid-download — so the capture-before-read ordering is
+    // covered by inspection and by the storage drop test above.
+    test::chain_fixture fixture("coordinator_gen");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+
+    auto& index = fixture.chain().headers();
+    auto const genesis = index.active_at(0);
+    REQUIRE(genesis != blockchain::header_index::null_index);
+    auto const genesis_hash = index.get_hash(genesis);
+
+    auto const add_child = [&](uint32_t nonce) {
+        domain::chain::header hdr{1, genesis_hash, null_hash, 1000 + nonce, 0x207fffff, nonce};
+        auto const r = index.add(domain::chain::hash(hdr), hdr);
+        REQUIRE(r.inserted);
+        return r.index;
+    };
+
+    auto const before_extension = index.generation();
+
+    // Extending the chain is not a branch change: work in flight for these
+    // heights is still valid, so the generation must hold. If it moved here the
+    // download task would discard good chunks on every new tip.
+    auto const branch_a = add_child(1);
+    index.active_set_tip(branch_a);
+    CHECK(index.generation() == before_extension);
+
+    // Moving onto a sibling IS a branch change: height 1 now names a different
+    // block, so anything downloaded for it must become recognisable as stale.
+    auto const branch_b = add_child(2);
+    index.active_set_tip(branch_b);
+    CHECK(index.generation() == before_extension + 1);
+
+    // And the chain visible at that new generation is the new branch, not the
+    // one that was just abandoned.
+    CHECK(index.active_at(1) == branch_b);
+    CHECK(index.active_at(1) != branch_a);
+}


### PR DESCRIPTION
Completes the reorg barrier — the remaining gap flagged in #573.

## The actual failure mode
Storage and the UTXO build already park while a switch runs, so **nothing writes concurrently**. That part was solved. What was not: a chunk already in flight, or **buffered in the channel behind the barrier**, was applied *after* the switch. Its heights name different blocks on the new chain, so storing it writes the wrong data and marks the wrong hashes `have_data`.

Growing the barrier cannot fix this — the work is already past the point where parking helps.

## The discriminator
Height cannot distinguish the two branches (both have a block at height N). What can is **which chain the work was requested for**, so the pipeline stamps it:

- `header_index` carries a **generation**, bumped by `active_set_tip` **only when the tip moves onto a different branch**. Ordinary forward extension leaves it alone — bumping per block would discard good in-flight chunks on every new tip and stall sync instead of protecting it. There is a test pinning exactly that.
- a downloaded chunk records the generation it was requested under.
- `block_storage_task` drops stale-generation chunks instead of storing them.

The counter lives on `header_index` rather than `block_chain` because that is where the active chain lives, and because the download task reaches it through the chunk coordinator, which holds no chain reference.

## On the history here
An earlier revision of #573 added this same counter **with no consumer**, and review correctly called it out as a documented contract the code did not honour. It was removed. This is the consumer — the counter now has a reason to exist.

Full suites green (blockchain 1626, node 326); node-exe builds.

## Remaining
The end-to-end reorg test (competing chains → disconnect → switch → re-download) is being built separately on top of the fixture in #575. Park/auto-unpark and mempool re-admit (#498) follow.
