### PR TITLE
blockchain: hold off on a branch that would rewind the chain deeply

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -196,6 +196,7 @@ set(kth_sources_just_legacy
   src/validate/validate_transaction.cpp
   src/settings.cpp
   src/finalization.cpp
+  src/parking.cpp
   src/utxo_builder.cpp
 )
 
@@ -240,6 +241,7 @@ set(kth_headers
   include/kth/blockchain/pools/header_organizer.hpp
   include/kth/blockchain/pools/transaction_organizer.hpp
   include/kth/blockchain/finalization.hpp
+  include/kth/blockchain/parking.hpp
   include/kth/blockchain/settings.hpp
 )
 
@@ -307,6 +309,7 @@ if (ENABLE_TEST)
         test/verify_script_context.cpp
         test/batch_sigchecks.cpp
         test/finalization.cpp
+        test/parking.cpp
         test/block_undo.cpp
         test/reorg_undo_roundtrip.cpp
         test/reorg_e2e.cpp

--- a/src/blockchain/include/kth/blockchain.hpp
+++ b/src/blockchain/include/kth/blockchain.hpp
@@ -20,6 +20,7 @@
 
 #include <kth/blockchain/define.hpp>
 #include <kth/blockchain/finalization.hpp>
+#include <kth/blockchain/parking.hpp>
 #include <kth/blockchain/header_index.hpp>
 #include <kth/blockchain/settings.hpp>
 #include <kth/blockchain/utxo_builder.hpp>

--- a/src/blockchain/include/kth/blockchain/parking.hpp
+++ b/src/blockchain/include/kth/blockchain/parking.hpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_PARKING_HPP
+#define KTH_BLOCKCHAIN_PARKING_HPP
+
+#include <cstdint>
+
+#include <kth/blockchain/define.hpp>
+#include <kth/database/header_index.hpp>
+
+namespace kth::blockchain::parking {
+
+// Deep-reorg parking (BCHN -parkdeepreorg / -automaticunparking).
+//
+// Greater cumulative work is not, by itself, enough to move the node onto
+// another branch. A branch that would rewind more than one block from the
+// *validated* chain is "parked": it stays in the index, keeps accumulating
+// work, and only activates once it clears the threshold below. This is what
+// stops a node from following a short-lived heavier fork, and it is why an
+// attacker needs a sustained majority rather than a momentary work lead.
+//
+// BCHN parks a block at AcceptBlock and clears the flag in FindMostWorkChain.
+// KTH is header-first: the decision is recomputed from chain work every time a
+// branch is evaluated as a reorg candidate, so there is no park bit to persist
+// and no unpark step — a branch that clears the threshold is simply not parked
+// on that evaluation.
+//
+// Heights and indices here are those of the *validated* chain (BCHN's m_chain),
+// not the header tip. A branch that forks above the validated tip rewinds no
+// validated block, so it is never parked: switching to it costs nothing.
+
+using index_t = database::header_index::index_t;
+
+// BCHN AcceptBlock: park iff activating the branch would rewind more than one
+// block, i.e. `pindexFork->nHeight + 1 < m_chain.Height()`.
+[[nodiscard]]
+constexpr bool is_deep_reorg(int32_t fork_height, int32_t validated_tip_height) {
+    return fork_height + 1 < validated_tip_height;
+}
+
+// Work a parked branch must exceed to activate (BCHN FindMostWorkChain's
+// `requiredWork`): the validated tip's work plus, again, everything the
+// validated chain gained since the fork — twice the post-fork work.
+//
+// For forks one to three blocks deep the penalty is instead half a single
+// block's work. A near-tip race is ordinary network behaviour, not an attack,
+// and demanding a 2x lead there would leave the node stranded on a branch the
+// rest of the network has already abandoned.
+//
+// `fork_idx` must be an ancestor of `validated_tip_idx`; both must be valid.
+[[nodiscard]]
+uint256_t required_work(database::header_index const& index,
+                        index_t fork_idx,
+                        index_t validated_tip_idx);
+
+} // namespace kth::blockchain::parking
+
+#endif // KTH_BLOCKCHAIN_PARKING_HPP

--- a/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
@@ -90,12 +90,22 @@ struct KB_API header_organizer {
 
     /// Notify the organizer that blocks are validated up to `block_valid_height`,
     /// advancing the finalized block per BCHN's depth + header-age rules. Called
-    /// by the block-download/validation path as it advances the validated tip.
+    /// by the block-download/validation path as it advances the validated tip,
+    /// and by the reorg execution once a switch rewinds it — deep-reorg parking
+    /// measures against this height, so a value left over from the abandoned
+    /// branch would park forks that sit above where the chain now reaches.
+    /// Finalization only ever moves forward, so a rewind does not retreat it.
     void note_block_validated(int32_t block_valid_height);
 
     /// Height of the finalized block, or -1 if nothing is finalized yet.
     [[nodiscard]]
     int32_t finalized_height() const { return finalizer_.finalized_height(); }
+
+    /// How far blocks are validated, as last reported, or -1 before the first
+    /// report. This is the height deep-reorg parking measures rewind depth
+    /// against.
+    [[nodiscard]]
+    int32_t validated_height() const { return block_valid_height_.load(std::memory_order_acquire); }
 
     /// Read-only view of the finalization state (for header/reorg admission).
     [[nodiscard]]
@@ -171,6 +181,12 @@ private:
                        int32_t height,
                        header_index::index_t parent_idx) const;
 
+    // Deep-reorg parking (BCHN -parkdeepreorg): true when a heavier branch
+    // forking at `fork_idx` must not be promoted to a reorg candidate yet.
+    // See parking.hpp for the rule.
+    [[nodiscard]]
+    bool parked(index_t fork_idx, int32_t fork_height, uint256_t const& branch_work) const;
+
     // Members
     header_index& index_;
     std::atomic<bool> stopped_{false};
@@ -179,6 +195,15 @@ private:
     // Tracks the finalized block (BCHN parity). Advanced by note_block_validated;
     // read via finalized_state() for header/reorg admission.
     finalization finalizer_;
+
+    // How far blocks are validated (BCHN's m_chain.Height()), or -1 before the
+    // first notification. Deep-reorg parking measures rewind depth against this,
+    // not against the header tip.
+    //
+    // Written by the block-storage path and by reorg execution, read from the
+    // header path (parked, during add_headers). Those run on different threads,
+    // so the field is atomic and every read takes a single snapshot.
+    std::atomic<int32_t> block_valid_height_{-1};
 
     // Current tip. Two writers now: header organization, and reorg execution
     // through adopt_tip. Atomic so a reader never sees a torn value, and guarded

--- a/src/blockchain/include/kth/blockchain/settings.hpp
+++ b/src/blockchain/include/kth/blockchain/settings.hpp
@@ -32,19 +32,21 @@ struct KB_API settings {
     uint32_t notify_limit_hours = 24;
     uint32_t reorganization_limit = 256;
     // Finalization (BCHN parity). A block is finalized once it is `max_reorg_depth`
-    // deep and its header is `finalization_delay_seconds` old. Currently the node
-    // only tracks the finalized block; enforcement (refusing to reorg across it,
-    // rejecting headers below it) is not wired yet. max_reorg_depth < 0 disables
-    // finalization entirely.
+    // deep and its header is `finalization_delay_seconds` old. Headers forking below
+    // the finalized block are rejected, which bounds any reorg to this depth; within
+    // it, deep-reorg parking (parking.hpp) governs whether a heavier branch is
+    // followed. max_reorg_depth < 0 disables finalization entirely.
     int32_t max_reorg_depth = 10;                       // BCHN -maxreorgdepth
     int64_t finalization_delay_seconds = 2 * 60 * 60;   // BCHN -finalizationdelay (2h)
     // Minimum seconds between block-template rebuilds while the mempool churns
     // (a new tip always rebuilds immediately). Mirrors bitcoind's 5s.
     uint32_t gbt_template_refresh_seconds = 5;
     infrastructure::config::checkpoint::list checkpoints;
-    // Derived fields — populated by settings(network) constructor.
-    // If using settings() default and setting checkpoints manually,
-    // call sort_checkpoints() to sync these.
+    // Derived fields — populated by the settings(network) constructor, and read
+    // by validation instead of `checkpoints` above. Nothing re-derives them:
+    // changing `checkpoints` afterwards leaves these describing the old list, so
+    // set all three together (there is no sort_checkpoints(), despite what this
+    // comment used to promise).
     infrastructure::config::checkpoint::list checkpoints_sorted;  // Pre-sorted by height
     size_t max_checkpoint_height = 0;                             // Pre-computed max
     bool fix_checkpoints = true;

--- a/src/blockchain/src/parking.cpp
+++ b/src/blockchain/src/parking.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/blockchain/parking.hpp>
+
+#include <kth/infrastructure/utility/assert.hpp>
+
+namespace kth::blockchain::parking {
+
+using database::header_index;
+
+uint256_t required_work(header_index const& index,
+                        index_t fork_idx,
+                        index_t validated_tip_idx) {
+
+    // Preconditions, enforced in release too: everything below reads the index by
+    // these values and subtracts one work from the other. A null or out-of-range
+    // index is an out-of-bounds read, and a fork that is not on the tip's chain
+    // makes the subtraction wrap — a threshold no branch can ever clear, or one
+    // every branch clears. Neither is something to carry on from quietly.
+    KTH_CONTRACT(fork_idx != header_index::null_index);
+    KTH_CONTRACT(validated_tip_idx != header_index::null_index);
+    KTH_CONTRACT(fork_idx < index.size());
+    KTH_CONTRACT(validated_tip_idx < index.size());
+    KTH_CONTRACT(index.get_height(fork_idx) <= index.get_height(validated_tip_idx));
+    KTH_CONTRACT(index.get_ancestor(validated_tip_idx, index.get_height(fork_idx)) == fork_idx);
+
+    auto const fork_work = index.get_chain_work(fork_idx);
+    auto const tip_work = index.get_chain_work(validated_tip_idx);
+
+    // The general rule: twice what the validated chain gained since the fork.
+    auto const full = tip_work + (tip_work - fork_work);
+
+    auto const depth = index.get_height(validated_tip_idx) - index.get_height(fork_idx);
+    if (depth < 1 || depth > 3) {
+        return full;
+    }
+
+    // Shallow fork: charge half of one block's work instead. Walking back to the
+    // fork's child makes the penalty one block wide at any of the three depths,
+    // which is how BCHN's fallthrough chain over `case 3: case 2: case 1:`
+    // reaches the same value.
+    auto extra_idx = validated_tip_idx;
+    for (int32_t i = 1; i < depth; ++i) {
+        extra_idx = index.get_parent_index(extra_idx);
+        if (extra_idx == header_index::null_index) {
+            // Broken ancestry: charge the full penalty rather than let a branch
+            // through on a threshold computed from a chain we cannot walk.
+            return full;
+        }
+    }
+
+    return tip_work + ((index.get_chain_work(extra_idx) - fork_work) >> 1);
+}
+
+} // namespace kth::blockchain::parking

--- a/src/blockchain/src/pools/header_organizer.cpp
+++ b/src/blockchain/src/pools/header_organizer.cpp
@@ -9,6 +9,7 @@
 #include <kth/infrastructure/utility/stats.hpp>
 #include <kth/infrastructure/utility/timer.hpp>
 
+#include <kth/blockchain/parking.hpp>
 #include <kth/blockchain/settings.hpp>
 #include <kth/blockchain/validate/validate_header.hpp>
 #include <kth/domain.hpp>
@@ -28,6 +29,10 @@ header_organizer::header_organizer(header_index& index, settings const& settings
 {}
 
 void header_organizer::note_block_validated(int32_t block_valid_height) {
+    // Deep-reorg parking measures against the validated chain, not the header
+    // tip, so the organizer has to remember how far blocks actually reach.
+    block_valid_height_.store(block_valid_height, std::memory_order_release);
+
     auto const before = finalizer_.finalized_height();
     finalizer_.maybe_advance(tip_index(), block_valid_height, static_cast<int64_t>(zulu_time()));
     auto const after = finalizer_.finalized_height();
@@ -279,19 +284,33 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
     }
 
     if ( ! extends_tip && ! result.error) {
+        // Under the tip lock, and only while the tip is still the one this batch
+        // was validated against. The fork is derived from that tip and the parking
+        // rule then reads the active chain: taken from either side of a switch,
+        // the two would describe different branches, and the fork would not be an
+        // ancestor of the validated tip the rule measures against.
+        std::lock_guard<std::mutex> const lock(tip_mutex_);
         auto const branch_work = index_.get_chain_work(branch_head_idx);
         auto const tip_work = index_.get_chain_work(tip_idx);
-        if (branch_work > tip_work) {
+        if (tip_index_.load(std::memory_order_acquire) != tip_idx) {
+            spdlog::warn("[header_organizer] The tip moved while this batch validated; not judging "
+                "the branch against a chain that is no longer active");
+        } else if (branch_work > tip_work) {
             auto const fork_idx = index_.find_fork(branch_head_idx, tip_idx);
-            result.reorg_candidate = true;
-            result.reorg_branch_head = branch_head_idx;
-            result.reorg_fork_height = (fork_idx == header_index::null_index)
+            auto const fork_height = (fork_idx == header_index::null_index)
                 ? -1 : index_.get_height(fork_idx);
-            spdlog::warn("[header_organizer] Reorg candidate: side branch (head height {}) has greater "
-                "cumulative work than the active tip (height {}); fork at height {}. Active tip NOT "
-                "switched — execution layer pending.",
-                index_.get_height(branch_head_idx), index_.get_height(tip_idx),
-                result.reorg_fork_height);
+
+            // A parked branch is left exactly where it is: stored, still gaining
+            // work, not a candidate. The lines below then report the batch as
+            // non-advancing, which is already what a heavier branch does.
+            if ( ! parked(fork_idx, fork_height, branch_work)) {
+                result.reorg_candidate = true;
+                result.reorg_branch_head = branch_head_idx;
+                result.reorg_fork_height = fork_height;
+                spdlog::warn("[header_organizer] Reorg candidate: side branch (head height {}) has "
+                    "greater cumulative work than the active tip (height {}); fork at height {}",
+                    index_.get_height(branch_head_idx), index_.get_height(tip_idx), fork_height);
+            }
         }
         // The active tip did not advance: signal keep-syncing without reporting forward
         // progress (preserves the coordinator contract for stale/duplicate batches).
@@ -313,6 +332,45 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
     result.index_memory_bytes = index_.memory_usage();
 
     return result;
+}
+
+bool header_organizer::parked(index_t fork_idx, int32_t fork_height, uint256_t const& branch_work) const {
+    // One snapshot for the whole decision: the block-storage path can advance
+    // this while the decision is being made, and mixing two readings of it would
+    // compare a depth against one height and a threshold against another.
+    auto const validated_height = block_valid_height_.load(std::memory_order_acquire);
+
+    // No fork point (disjoint branches — should not happen with a shared genesis)
+    // or nothing validated yet: no validated block would be rewound, so there is
+    // nothing to park. The disjoint case is reported as fork height -1, which the
+    // execution layer refuses anyway.
+    if (fork_idx == header_index::null_index || validated_height < 0) {
+        return false;
+    }
+
+    // Above the validated tip the branch costs no rewind at all.
+    if ( ! parking::is_deep_reorg(fork_height, validated_height)) {
+        return false;
+    }
+
+    auto const validated_tip_idx = index_.active_at(validated_height);
+    if (validated_tip_idx == header_index::null_index) {
+        // The active chain is mid-switch or shorter than the validated height.
+        // Fail closed: refuse to promote a branch against a chain we cannot read.
+        spdlog::warn("[header_organizer] Parking branch: no active entry at validated height {}",
+            validated_height);
+        return true;
+    }
+
+    auto const required = parking::required_work(index_, fork_idx, validated_tip_idx);
+    if (branch_work > required) {
+        return false;
+    }
+
+    spdlog::warn("[header_organizer] Parking branch forking at height {}: it would rewind {} validated "
+        "blocks and has not accumulated twice the work the active chain gained since the fork",
+        fork_height, validated_height - fork_height);
+    return true;
 }
 
 // =============================================================================

--- a/src/blockchain/test/header_organizer.cpp
+++ b/src/blockchain/test/header_organizer.cpp
@@ -284,13 +284,16 @@ TEST_CASE("header_organizer allows a branch forking above the finalized block", 
     organizer.note_block_validated(29);
     REQUIRE(organizer.finalized_height() == 19);
 
+    auto const size_before = index.size();
     // 8 blocks off height 22 (above finalized) -> head at height 30, out-works the tip.
     auto branch = make_branch(index.get_hash(22), 8, 600);
     auto result = organizer.add_headers(branch);
 
+    // Admitted and stored. Whether it also becomes a reorg candidate is a separate
+    // question, decided by deep-reorg parking (see test/parking.cpp) — this branch
+    // rewinds 7 validated blocks on one block of surplus work, so it is parked.
     REQUIRE(result.error != error::finalized_header_violation);
-    REQUIRE(result.reorg_candidate);
-    REQUIRE(result.reorg_fork_height == 22);
+    REQUIRE(index.size() == size_before + 8);
 }
 
 TEST_CASE("header_organizer does not penalize re-sent known headers below the finalized block", "[header_organizer][finalization]") {

--- a/src/blockchain/test/parking.cpp
+++ b/src/blockchain/test/parking.cpp
@@ -1,0 +1,267 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <kth/blockchain.hpp>
+
+using namespace kth;
+using namespace kth::blockchain;
+using kth::database::header_index;
+
+namespace {
+
+hash_digest make_hash(uint32_t id) {
+    hash_digest h{};
+    h[0] = uint8_t(id);
+    h[1] = uint8_t(id >> 8);
+    h[2] = uint8_t(id >> 16);
+    h[3] = uint8_t(id >> 24);
+    return h;
+}
+
+// Every header carries the same difficulty, so one block is worth one unit of
+// work and the thresholds below can be written in whole blocks.
+domain::chain::header make_header(hash_digest const& prev, uint32_t id) {
+    return domain::chain::header{1, prev, make_hash(id + 100000), id * 600, 0x1d00ffff, id};
+}
+
+// A linear chain of `length` headers off null_hash. Index == height here, which
+// is what lets the tests name entries by height.
+hash_digest build_chain(header_index& index, size_t length) {
+    hash_digest prev = null_hash;
+    for (uint32_t i = 0; i < length; ++i) {
+        auto hdr = make_header(prev, i);
+        prev = kth::domain::chain::hash(hdr);
+        REQUIRE(index.add(prev, hdr).inserted);
+    }
+    return prev;
+}
+
+domain::message::header::list make_branch(hash_digest fork_prev, size_t length, uint32_t id_base) {
+    domain::message::header::list branch;
+    hash_digest prev = fork_prev;
+    for (uint32_t i = 0; i < length; ++i) {
+        auto hdr = make_header(prev, id_base + i);
+        prev = kth::domain::chain::hash(hdr);
+        branch.push_back(std::move(hdr));
+    }
+    return branch;
+}
+
+settings make_test_settings() {
+    settings s(domain::config::network::mainnet);
+    // Clears the list the config exposes, not the sorted copy validation reads
+    // (settings(network) derives that one). Header validation therefore still
+    // sees mainnet's checkpoints and skips proof-of-work for these heights,
+    // which is the only reason headers with made-up hashes are accepted here.
+    //
+    // These tests are about the parking rule, not header validation, so that is
+    // survivable — but it is a property of the shared helper, not of the headers,
+    // and worth knowing before reading a passing run as "these headers are
+    // valid". test/header_organizer.cpp leans on the same thing; both want the
+    // regtest miner now that there is one.
+    s.checkpoints.clear();
+    s.finalization_delay_seconds = 0;   // finalize as soon as depth allows
+    return s;
+}
+
+} // namespace
+
+// =============================================================================
+// is_deep_reorg — what counts as "more than one block rewound"
+// =============================================================================
+
+// Rewinding one block or none is not a deep reorg; two or more is. Asserted at
+// compile time because callers rely on it being a pure height comparison.
+static_assert( ! parking::is_deep_reorg(29, 29));   // fork is the validated tip
+static_assert( ! parking::is_deep_reorg(28, 29));   // one block rewound
+static_assert(parking::is_deep_reorg(27, 29));      // two blocks rewound
+static_assert(parking::is_deep_reorg(0, 29));
+
+// A branch forking *above* the validated tip rewinds nothing, however far the
+// headers run ahead — the IBD case, where headers lead blocks by a wide margin.
+static_assert( ! parking::is_deep_reorg(500'000, 100'000));
+
+// =============================================================================
+// required_work — BCHN FindMostWorkChain's unpark threshold
+// =============================================================================
+
+TEST_CASE("a deep fork must carry twice the work gained since the fork", "[parking]") {
+    header_index index;
+    (void)build_chain(index, 10);   // heights 0..9
+
+    // uint256_t is an expression-template number, so every computed value below is
+    // given an explicit type: `auto`, or an expression written inline in a CHECK,
+    // captures the expression tree and reads it after its temporaries are gone.
+    //
+    // The entry at height 0 has no parent in the index, so it carries no work and
+    // work(h) == h blocks. Only differences matter to the rule, and the offset is
+    // the same for every branch.
+    uint256_t const w = index.get_chain_work(1);           // one block's work
+    uint256_t const nine_blocks = 9 * w;
+    REQUIRE(index.get_chain_work(9) == nine_blocks);       // pins the linear-work assumption
+
+    // Fork at height 5, validated tip at height 9: the chain gained 4 blocks since
+    // the fork, so the branch needs those 4 again on top of the tip.
+    uint256_t const thirteen_blocks = 13 * w;
+    CHECK(parking::required_work(index, 5, 9) == thirteen_blocks);
+
+    // Depth 10 (the deepest reorg finalization allows): 10 blocks on top of a tip
+    // that is itself 10 blocks past the fork.
+    header_index deep;
+    (void)build_chain(deep, 21);
+    uint256_t const thirty_blocks = 30 * deep.get_chain_work(1);
+    CHECK(parking::required_work(deep, 10, 20) == thirty_blocks);
+}
+
+TEST_CASE("a fork one to three blocks deep is charged half a block", "[parking]") {
+    header_index index;
+    (void)build_chain(index, 10);
+    uint256_t const w = index.get_chain_work(1);
+    uint256_t const expected = 9 * w + (w >> 1);
+
+    // All three walk back to the fork's child, so the penalty is one block wide
+    // regardless of depth. A near-tip race is normal network behaviour: demanding
+    // a 2x lead there would strand the node on a branch already abandoned.
+    CHECK(parking::required_work(index, 8, 9) == expected);   // depth 1
+    CHECK(parking::required_work(index, 7, 9) == expected);   // depth 2
+    CHECK(parking::required_work(index, 6, 9) == expected);   // depth 3
+
+    // Depth 4 crosses over to the full penalty, which is strictly harsher.
+    CHECK(parking::required_work(index, 5, 9) > expected);
+}
+
+// =============================================================================
+// header_organizer — promotion is gated on the threshold
+// =============================================================================
+
+TEST_CASE("a heavier branch forking deep is not promoted to a reorg candidate", "[parking][fork]") {
+    header_index index;
+    (void)build_chain(index, 30);                 // tip at height 29
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+    organizer.note_block_validated(29);
+
+    // Off height 22, 8 blocks: head at height 30 with 31 blocks of work, which
+    // beats the 30-block tip — but rewinds 7 validated blocks with a single block
+    // of surplus. The threshold is 37; this is a branch to wait on, not follow.
+    auto branch = make_branch(index.get_hash(22), 8, 200);
+    auto const result = organizer.add_headers(branch);
+
+    CHECK_FALSE(result.reorg_candidate);
+    CHECK(result.error == error::stale_chain);
+    CHECK(organizer.header_height() == 29);       // still on the original chain
+
+    // Parked, not rejected: the headers are stored so the branch can keep
+    // accumulating work and be reconsidered on the next batch.
+    CHECK(index.size() == 38);
+}
+
+TEST_CASE("a parked branch is promoted once it clears the threshold", "[parking][fork]") {
+    header_index index;
+    (void)build_chain(index, 30);
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+    organizer.note_block_validated(29);
+
+    // Same fork point, but 15 blocks: head at height 37, 38 blocks of work against
+    // a threshold of 37. Nothing was unparked — the branch is simply not parked on
+    // this evaluation, which is how the recomputed rule expresses BCHN's unpark.
+    auto branch = make_branch(index.get_hash(22), 15, 300);
+    auto const result = organizer.add_headers(branch);
+
+    CHECK(result.reorg_candidate);
+    CHECK(result.reorg_fork_height == 22);
+    CHECK(result.reorg_branch_head == index.find(kth::domain::chain::hash(branch.back())));
+}
+
+TEST_CASE("a branch forking above the validated tip is never parked", "[parking][fork]") {
+    header_index index;
+    (void)build_chain(index, 30);
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    // Blocks lag headers, as during IBD. A fork at height 25 rewinds no validated
+    // block, so greater work is enough on its own.
+    organizer.note_block_validated(20);
+
+    auto branch = make_branch(index.get_hash(25), 6, 400);
+    auto const result = organizer.add_headers(branch);
+
+    CHECK(result.reorg_candidate);
+    CHECK(result.reorg_fork_height == 25);
+}
+
+TEST_CASE("a one-block reorg is not parked", "[parking][fork]") {
+    header_index index;
+    (void)build_chain(index, 30);
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+    organizer.note_block_validated(29);
+
+    // Two blocks off height 28: the ordinary case of two miners finding a block at
+    // once and one branch pulling ahead. Parking this would leave the node behind
+    // the network for no benefit.
+    auto branch = make_branch(index.get_hash(28), 2, 500);
+    auto const result = organizer.add_headers(branch);
+
+    CHECK(result.reorg_candidate);
+    CHECK(result.reorg_fork_height == 28);
+}
+
+TEST_CASE("a rewound validated height releases a branch it had parked", "[parking][fork]") {
+    // What a reorg leaves behind: the switch rewinds the validated tip to the
+    // fork, and the rule has to measure against the new height. Reading a height
+    // left over from the branch the node just abandoned would keep charging a
+    // rewind cost for validated blocks that are no longer connected.
+    header_index index;
+    (void)build_chain(index, 30);
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    organizer.note_block_validated(29);
+    REQUIRE(organizer.validated_height() == 29);
+
+    auto branch = make_branch(index.get_hash(22), 8, 700);
+    REQUIRE_FALSE(organizer.add_headers(branch).reorg_candidate);   // parked: 7 blocks rewound
+
+    // A switch rewound the validated tip to 15. The same branch now forks above
+    // it, so it rewinds nothing and greater work is enough on its own.
+    organizer.note_block_validated(15);
+    CHECK(organizer.validated_height() == 15);
+
+    // Re-presenting the branch is what a peer's next announcement does; the
+    // headers are already stored, so this re-runs the decision on them.
+    auto const result = organizer.add_headers(branch);
+    CHECK(result.reorg_candidate);
+    CHECK(result.reorg_fork_height == 22);
+}
+
+TEST_CASE("nothing is parked before the first block is validated", "[parking][fork]") {
+    header_index index;
+    (void)build_chain(index, 30);
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    // No note_block_validated yet: at startup the node has validated nothing, so
+    // there is no validated chain to measure a rewind against.
+    auto branch = make_branch(index.get_hash(22), 8, 600);
+    auto const result = organizer.add_headers(branch);
+
+    CHECK(result.reorg_candidate);
+    CHECK(result.reorg_fork_height == 22);
+}

--- a/src/node/src/sync/reorg.cpp
+++ b/src/node/src/sync/reorg.cpp
@@ -195,6 +195,15 @@ bool persist_active_headers(
                 }
             }
         }
+
+        // The switch rewound the validated tip to the fork. Tell the organizer
+        // before the pause is lifted: deep-reorg parking measures depth against
+        // that height, so a value left over from the abandoned branch would park
+        // a fork sitting above where the chain now actually reaches — and the
+        // next header batch can arrive as soon as the pause is gone.
+        if (outcome.validated_tip) {
+            organizer.note_block_validated(static_cast<int32_t>(*outcome.validated_tip));
+        }
     }
 
     co_return reorg_outcome{outcome, fatal};

--- a/src/node/test/reorg_cycle.cpp
+++ b/src/node/test/reorg_cycle.cpp
@@ -288,6 +288,12 @@ TEST_CASE("the node reorganizes onto a heavier branch and back to a consistent s
     REQUIRE(outcome.validated_tip);
     CHECK(*outcome.validated_tip == trunk_len);
 
+    // The organizer heard about the rewind. Deep-reorg parking measures depth
+    // against this height, and the next header batch can arrive as soon as the
+    // switch releases the pause — so a height left over from the branch just
+    // abandoned would be read before anything corrected it.
+    CHECK(fixture.organizer().validated_height() == int32_t(trunk_len));
+
     // A's block is disconnected: its coinbase is out of the set and the coinbase it
     // spent is back, at the height it was originally created — not at 101, which
     // would misdate its maturity and its median-time-past.


### PR DESCRIPTION
Greater cumulative work was enough, on its own, to make a side branch a reorg candidate. That is not the rule BCH runs: a branch that would rewind more than one validated block is *parked* and only followed once it carries twice the work the active chain gained since the fork. Without it a node follows any momentary work lead, and an attacker needs a brief spike rather than a sustained majority.

## What this adds

`blockchain/parking.hpp` + `src/parking.cpp`, holding the two halves of the BCHN rule:

- `is_deep_reorg(fork_height, validated_tip_height)` — BCHN's `AcceptBlock` test (`-parkdeepreorg`): park iff activating the branch would rewind more than one block.
- `required_work(index, fork_idx, validated_tip_idx)` — the threshold `FindMostWorkChain` computes to unpark: the validated tip's work plus everything the chain gained since the fork, again.

`header_organizer` gates candidate promotion on them. A parked branch is stored and keeps accumulating work; it is simply not reported as a candidate, and the batch reports `stale_chain` — which is already what a heavier branch reports today.

## Two details worth calling out

**Depth is measured against the validated chain, not the header tip.** That is what BCHN's `m_chain.Height()` is. A branch forking *above* the validated tip rewinds no validated block, so it is never parked — during IBD, where headers lead blocks by a wide margin, that is the ordinary case and parking stays out of the way entirely. The organizer picks the height up from `note_block_validated`.

**Forks one to three blocks deep are charged half a block**, not the full 2x (BCHN's fallthrough over `case 3: case 2: case 1:`). Two miners finding a block at once is normal network behaviour; demanding a sustained lead there would strand the node behind a chain everyone else has already moved to.

## No park bit

BCHN sets a status flag on the block and clears it in `FindMostWorkChain`. KTH is header-first, so the decision is recomputed from chain work on every evaluation of the branch: nothing to persist, no unpark step, and a branch that has since gained enough work is simply not parked on that pass.

## Interaction with finalization

Headers forking below the finalized block are already rejected outright (#570), so in practice parking governs fork depths 2..`max_reorg_depth` — exactly the window BCH leaves open. The stale comment in `settings.hpp` claiming finalization enforcement "is not wired yet" is corrected here.

## Tests

`test/parking.cpp`:
- `is_deep_reorg` boundaries as `static_assert`s, including the fork-above-the-validated-tip (IBD) case.
- `required_work` at depths 1–3 (all equal, half a block), depth 4 (crosses to the full penalty), and depth 10 — the deepest reorg finalization allows.
- Organizer-level: a heavier branch forking 7 blocks deep on one block of surplus is **not** promoted but **is** stored; the same fork with 15 blocks clears the threshold and is promoted; a fork above the validated tip is never parked; a one-block reorg is never parked; nothing is parked before the first block is validated.

One existing finalization test forked 7 validated blocks deep with a single block of surplus, so it is now parked. It asserts admission and storage — what it is named for — and points at the parking tests for promotion.

Local: `kth_blockchain_test` 1935 assertions / 176 cases, `kth_node_test` 350 / 108, `node-exe` builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection against deep chain reorganizations that could rewind already validated blocks without sufficient accumulated work.
  * Added tracking and reporting of the latest validated block height.
  * Added work-threshold calculations for evaluating competing chains.

* **Bug Fixes**
  * Improved reorganization handling, including validated-height updates after successful switches.
  * Branches that do not meet deep-reorganization requirements are now parked instead of becoming reorganization candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->