### PR TITLE
test: reorganize a real chain end to end, and fix what that found

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -14,6 +14,7 @@
 #include <expected>
 #include <mutex>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include <kth/infrastructure/utility/atomic.hpp>
@@ -149,6 +150,18 @@ struct KB_API block_chain {
     code organize_headers_batch(domain::chain::header::list const& headers, size_t start_height);
 
 #if ! defined(KTH_DB_READONLY)
+    /// Make the persisted by-height headers describe `headers` from
+    /// `start_height` up, and nothing above them. This is how a reorganization
+    /// updates that table: all of it or none, so a failed write cannot leave the
+    /// replaced range naming two branches at once.
+    ///
+    /// A write, so it follows the layers below it out of read-only builds.
+    /// (organize_headers_batch above is not guarded, and so fails to link
+    /// rather than to compile in such a build — pre-existing, left alone here.)
+    code replace_headers_from(domain::chain::header::list const& headers, size_t start_height);
+#endif // ! defined(KTH_DB_READONLY)
+
+#if ! defined(KTH_DB_READONLY)
     [[nodiscard]]
     ::asio::awaitable<code> push(transaction_const_ptr tx);
 
@@ -245,16 +258,26 @@ struct KB_API block_chain {
     [[nodiscard]]
     database::disconnect_result disconnect_block(uint32_t height);
 
-    // Switch the active chain onto `branch_head`, forking at `fork_height`.
+    // Rewind the UTXO state to `fork_height` so the chain can move onto
+    // `branch_head`.
     //
-    // Disconnects the abandoned blocks newest-first (restoring their spent
-    // outputs from undo data), then re-points the active chain at the new branch.
-    // The caller is responsible for re-driving block download for the new branch:
-    // its blocks are headers-only at this point, so the validated tip ends at
-    // fork_height.
+    // Disconnects the abandoned blocks newest-first, restoring their spent
+    // outputs from undo data, and rolls the height markers back to the fork.
+    //
+    // It does NOT publish the new branch: the height mapping and the organizer's
+    // tip have to move together, under the organizer's lock, or a header batch
+    // that validated against the old tip can publish between the two halves and
+    // leave them naming different branches. header_organizer::adopt_tip does
+    // both; call it as soon as this returns (node::sync::execute_reorg is the
+    // one place that owns the whole sequence). Until then the chain still reads
+    // as the old branch above the fork, which is why this must run with the
+    // writers quiesced.
     //
     // Must be called with the UTXO build quiesced (see reorg_pause below): it
     // rewrites the UTXO set and the height markers.
+    // The caller is responsible for re-driving block download for the new branch:
+    // its blocks are headers-only at this point, so the validated tip ends at
+    // fork_height.
     struct switch_result {
         bool ok{false};
         // Height the validated tip ended at, when it is known. On an aborted
@@ -316,6 +339,13 @@ struct KB_API block_chain {
     // applying it, which is what makes a stale chunk buffered during the barrier
     // harmless rather than corrupting.
     [[nodiscard]] uint64_t chain_generation() const { return header_index_.generation(); }
+
+    // Parked and registered counts, for a caller that has to report why the
+    // barrier was never reached.
+    [[nodiscard]] std::pair<size_t, size_t> reorg_barrier_state() const {
+        return {reorg_parked_.load(std::memory_order_seq_cst),
+                reorg_registered_.load(std::memory_order_seq_cst)};
+    }
 
     [[nodiscard]] bool reorg_barrier_reached() const {
         auto const registered = reorg_registered_.load(std::memory_order_seq_cst);

--- a/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/header_organizer.hpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <mutex>
 #include <memory>
 
 #include <kth/blockchain/define.hpp>
@@ -73,6 +74,20 @@ struct KB_API header_organizer {
     /// Call after header_index has been initialized (e.g., with genesis).
     void sync_tip();
 
+    /// Adopt `tip_idx` as the header tip, after the execution layer switched the
+    /// active chain onto it. The organizer decides whether an incoming batch
+    /// extends the chain or forks it by comparing against the tip it remembers;
+    /// left pointing at the abandoned branch it would read every subsequent
+    /// batch as another fork and ask for a switch that cannot be executed.
+    ///
+    /// Publishes both halves of the tip — the index the organizer remembers and
+    /// the height mapping the rest of the node reads — under one lock. The switch
+    /// leaves the mapping to this call for exactly that reason: a header batch
+    /// that validated against the old tip decides whether to publish under the
+    /// same lock, so the two can no longer interleave into a state where the tip
+    /// names one branch and the heights name another.
+    void adopt_tip(index_t tip_idx);
+
     /// Notify the organizer that blocks are validated up to `block_valid_height`,
     /// advancing the finalized block per BCHN's depth + header-age rules. Called
     /// by the block-download/validation path as it advances the validated tip.
@@ -118,15 +133,17 @@ struct KB_API header_organizer {
 
     /// Get the current tip index.
     [[nodiscard]]
-    index_t tip_index() const { return tip_index_; }
+    index_t tip_index() const { return tip_index_.load(std::memory_order_acquire); }
 
     /// Get the current header tip height.
     [[nodiscard]]
     int32_t header_height() const;
 
-    /// Get the hash of the header tip.
+    /// Get the hash of the header tip. Read from the index rather than cached:
+    /// the tip moves from two places (header organization and reorg execution),
+    /// and a second copy of it would be a second thing to keep in step.
     [[nodiscard]]
-    hash_digest const& header_tip_hash() const { return tip_hash_; }
+    hash_digest header_tip_hash() const { return index_.get_hash(tip_index()); }
 
     /// Get the timestamp of the header tip.
     /// Used for BCHN-style progress calculation.
@@ -163,9 +180,13 @@ private:
     // read via finalized_state() for header/reorg admission.
     finalization finalizer_;
 
-    // Current tip state
-    index_t tip_index_{header_index::null_index};
-    hash_digest tip_hash_{null_hash};
+    // Current tip. Two writers now: header organization, and reorg execution
+    // through adopt_tip. Atomic so a reader never sees a torn value, and guarded
+    // by tip_mutex_ where it is published, because the hazard is not only tearing
+    // — a batch that validated against the old tip must not put it back after a
+    // switch replaced it.
+    std::atomic<index_t> tip_index_{header_index::null_index};
+    mutable std::mutex tip_mutex_;
 };
 
 } // namespace kth::blockchain

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -629,6 +629,14 @@ code block_chain::organize_headers_batch(domain::chain::header::list const& head
 
 #if ! defined(KTH_DB_READONLY)
 
+code block_chain::replace_headers_from(domain::chain::header::list const& headers, size_t start_height) {
+    if (stopped()) {
+        return error::service_stopped;
+    }
+
+    return database_.replace_headers_from(headers, start_height);
+}
+
 ::asio::awaitable<code> block_chain::push(transaction_const_ptr tx) {
     using result_channel = ::asio::experimental::concurrent_channel<void(std::error_code, code)>;
     auto channel = std::make_shared<result_channel>(priority_pool_.get_executor(), 1);
@@ -926,16 +934,15 @@ block_chain::switch_result block_chain::switch_to_branch(
         }
     }
 
-    // Re-point the active chain. From here "the block at height N" means the new
-    // branch; its blocks are headers-only, so block download must refill them.
-    header_index_.active_set_tip(branch_head);
-
-    // active_set_tip bumps the generation when it moves onto a different branch,
-    // which is what marks chunks requested against the old chain as stale.
-    auto const generation = chain_generation();
-
-    spdlog::warn("[blockchain] Reorg: active chain switched to height {} (fork at {}), generation {}",
-        header_index_.active_tip_height(), fork_height, generation);
+    // The active chain is NOT re-pointed here. Publishing the new tip is the
+    // organizer's (see header_organizer::adopt_tip), because the header path
+    // publishes there too: a batch that validated against the old tip decides
+    // whether to publish under the organizer's lock, and a switch that published
+    // the height mapping outside that lock could land between that decision and
+    // its write — leaving the tip on one branch and the height mapping on the
+    // other. The caller adopts the branch head as soon as this returns.
+    spdlog::warn("[blockchain] Reorg: UTXO state rewound to the fork at {}; the branch head is "
+        "published by the caller", fork_height);
     return {true, validated_tip};
 }
 #endif

--- a/src/blockchain/src/pools/header_organizer.cpp
+++ b/src/blockchain/src/pools/header_organizer.cpp
@@ -29,7 +29,7 @@ header_organizer::header_organizer(header_index& index, settings const& settings
 
 void header_organizer::note_block_validated(int32_t block_valid_height) {
     auto const before = finalizer_.finalized_height();
-    finalizer_.maybe_advance(tip_index_, block_valid_height, static_cast<int64_t>(zulu_time()));
+    finalizer_.maybe_advance(tip_index(), block_valid_height, static_cast<int64_t>(zulu_time()));
     auto const after = finalizer_.finalized_height();
     if (after != before) {
         spdlog::info("[header_organizer] Finalized block advanced to height {}", after);
@@ -74,16 +74,41 @@ void header_organizer::sync_tip() {
             best_idx = i;
         }
     }
-    tip_index_ = best_idx;
-    tip_hash_ = index_.get_hash(tip_index_);
+    {
+        std::lock_guard<std::mutex> const lock(tip_mutex_);
+        tip_index_.store(best_idx, std::memory_order_release);
 
-    // Materialize the active chain (height -> index) for this tip. The index also
-    // holds side branches, so the rest of the node can only address blocks by
-    // height through this mapping.
-    index_.active_set_tip(tip_index_);
+        // Materialize the active chain (height -> index) for this tip. The index also
+        // holds side branches, so the rest of the node can only address blocks by
+        // height through this mapping.
+        index_.active_set_tip(best_idx);
+    }
 
     spdlog::info("[header_organizer] Synced tip: index {}, hash {}, active height {}",
-        tip_index_, encode_hash(tip_hash_), index_.active_tip_height());
+        best_idx, encode_hash(index_.get_hash(best_idx)), index_.active_tip_height());
+}
+
+void header_organizer::adopt_tip(index_t tip_idx) {
+    if (tip_idx == header_index::null_index) {
+        spdlog::error("[header_organizer] adopt_tip called with a null index; keeping tip {}", tip_index());
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> const lock(tip_mutex_);
+        tip_index_.store(tip_idx, std::memory_order_release);
+
+        // The height mapping moves with the tip, under the same lock. The switch
+        // deliberately leaves this to us: publishing it there would let a header
+        // batch that validated against the old tip slip its own publication in
+        // between, and the two would end up naming different branches.
+        //
+        // active_set_tip bumps the chain generation when this is a branch change,
+        // which is what marks work requested against the old chain as stale.
+        index_.active_set_tip(tip_idx);
+    }
+    spdlog::info("[header_organizer] Adopted tip: index {}, hash {}, height {}, generation {}",
+        tip_idx, encode_hash(index_.get_hash(tip_idx)), index_.get_height(tip_idx),
+        index_.generation());
 }
 
 // =============================================================================
@@ -105,10 +130,16 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
 
     spdlog::debug("[header_organizer] add_headers() called with {} headers", headers.size());
 
-    if (tip_index_ == database::header_index::null_index) {
+    // One snapshot of the tip for the whole batch: reorg execution can adopt a
+    // new one while this runs, and deciding "extends the tip" against one value
+    // and anchoring against another would store the batch on the wrong parent.
+    // Whether it is still the tip when the batch is published is re-checked below.
+    auto const tip_idx = tip_index();
+    if (tip_idx == database::header_index::null_index) {
         spdlog::error("[header_organizer] add_headers() called with uninitialized tip_index_ — call sync_tip() first");
         return {error::operation_failed, 0, 0, 0};
     }
+    auto const tip_hash = index_.get_hash(tip_idx);
 
     // Determine the batch anchor: the index entry the first header builds on.
     //   (1) anchor == tip                        -> forward extension of the active chain.
@@ -118,15 +149,15 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
     //   (3) anchor unknown                       -> orphan; validation surfaces the
     //       missing-parent error (this is also the old ABC/BCHN duplicate-retry case).
     auto const first_prev_hash = headers.front().previous_block_hash();
-    bool const extends_tip = (first_prev_hash == tip_hash_);
+    bool const extends_tip = (first_prev_hash == tip_hash);
 
-    index_t anchor_idx = tip_index_;
+    index_t anchor_idx = tip_idx;
     if ( ! extends_tip) {
         anchor_idx = index_.find(first_prev_hash);
         if (anchor_idx == header_index::null_index) {
             // Unknown parent (orphan): validate against the tip so the missing-parent
             // error is raised and the batch rejected, as before.
-            anchor_idx = tip_index_;
+            anchor_idx = tip_idx;
         }
     }
 
@@ -229,17 +260,29 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
     // only becomes the tip if it has strictly greater cumulative work — and even then
     // the actual switch is deferred to the execution layer, so here we only flag the
     // reorg candidate and keep the coordinator syncing (stale_chain, no forward count).
+    bool published = false;
     if (extends_tip) {
-        tip_index_ = branch_head_idx;
-        tip_hash_ = index_.get_hash(branch_head_idx);
-        // Extend the active chain over the headers just linked in. Walks back only
-        // as far as the newly added run, since everything below is already active.
-        index_.active_set_tip(tip_index_);
-    } else if ( ! result.error) {
+        std::lock_guard<std::mutex> const lock(tip_mutex_);
+        // Still the tip this batch was validated against? A switch that executed
+        // while it validated has already moved the chain and re-pointed the active
+        // heights; publishing here would put the abandoned branch back.
+        if (tip_index_.load(std::memory_order_acquire) == tip_idx) {
+            tip_index_.store(branch_head_idx, std::memory_order_release);
+            // Extend the active chain over the headers just linked in. Walks back only
+            // as far as the newly added run, since everything below is already active.
+            index_.active_set_tip(branch_head_idx);
+            published = true;
+        } else {
+            spdlog::warn("[header_organizer] The tip moved while this batch validated; keeping the "
+                "chain the switch published and reporting no progress");
+        }
+    }
+
+    if ( ! extends_tip && ! result.error) {
         auto const branch_work = index_.get_chain_work(branch_head_idx);
-        auto const tip_work = index_.get_chain_work(tip_index_);
+        auto const tip_work = index_.get_chain_work(tip_idx);
         if (branch_work > tip_work) {
-            auto const fork_idx = index_.find_fork(branch_head_idx, tip_index_);
+            auto const fork_idx = index_.find_fork(branch_head_idx, tip_idx);
             result.reorg_candidate = true;
             result.reorg_branch_head = branch_head_idx;
             result.reorg_fork_height = (fork_idx == header_index::null_index)
@@ -247,11 +290,18 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
             spdlog::warn("[header_organizer] Reorg candidate: side branch (head height {}) has greater "
                 "cumulative work than the active tip (height {}); fork at height {}. Active tip NOT "
                 "switched — execution layer pending.",
-                index_.get_height(branch_head_idx), index_.get_height(tip_index_),
+                index_.get_height(branch_head_idx), index_.get_height(tip_idx),
                 result.reorg_fork_height);
         }
         // The active tip did not advance: signal keep-syncing without reporting forward
         // progress (preserves the coordinator contract for stale/duplicate batches).
+        result.error = error::stale_chain;
+        result.headers_added = 0;
+    }
+
+    if (extends_tip && ! published) {
+        // Same contract as a batch that did not advance the tip: the coordinator
+        // keeps syncing and asks again from wherever the chain now is.
         result.error = error::stale_chain;
         result.headers_added = 0;
     }
@@ -270,17 +320,19 @@ header_organize_result header_organizer::add_headers(domain::message::header::li
 // =============================================================================
 
 int32_t header_organizer::header_height() const {
-    if (tip_index_ == header_index::null_index) {
+    auto const idx = tip_index();
+    if (idx == header_index::null_index) {
         return -1;  // No headers yet (only genesis)
     }
-    return index_.get_height(tip_index_);
+    return index_.get_height(idx);
 }
 
 uint32_t header_organizer::tip_timestamp() const {
-    if (tip_index_ == header_index::null_index) {
+    auto const idx = tip_index();
+    if (idx == header_index::null_index) {
         return 0;
     }
-    return index_.get_timestamp(tip_index_);
+    return index_.get_timestamp(idx);
 }
 
 // =============================================================================

--- a/src/blockchain/test/header_organizer.cpp
+++ b/src/blockchain/test/header_organizer.cpp
@@ -340,6 +340,50 @@ TEST_CASE("header_organizer rejects a new header after a known one on a sub-fina
     REQUIRE(index.size() == size_before);          // nothing stored
 }
 
+TEST_CASE("adopting a tip republishes the heights with it", "[header_organizer][fork]") {
+    // The two halves of the tip — the index the organizer remembers, and the
+    // height mapping everything else reads — must never name different branches.
+    //
+    // They could: the switch used to publish the mapping itself, so a header
+    // batch that validated against the old tip could publish its own extension
+    // in between, and adopt_tip would then move only the index. This reproduces
+    // that end state directly (extend the old tip, then adopt the branch) rather
+    // than racing for the interleaving that produces it.
+    header_index index;
+    (void)build_chain(index, 10);                  // tip at height 9
+    auto settings = make_test_settings();
+    header_organizer organizer(index, settings, domain::config::network::mainnet);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    // A side branch off height 5, stored but not active.
+    auto branch = make_branch(index.get_hash(5), 6, 800);
+    REQUIRE(organizer.add_headers(branch).reorg_candidate);
+    auto const branch_head = index.find(kth::domain::chain::hash(branch.back()));
+    REQUIRE(branch_head != header_index::null_index);
+
+    // An extension of the old tip publishes, as it would while a switch is being
+    // executed elsewhere.
+    domain::message::header::list extension;
+    extension.push_back(make_header_with_prev(index.get_hash(9), 999));
+    REQUIRE(organizer.add_headers(extension).headers_added == 1);
+    REQUIRE(index.active_tip_height() == 10);
+
+    // Now the switch's tip lands. Both halves move.
+    organizer.adopt_tip(branch_head);
+
+    CHECK(organizer.tip_index() == branch_head);
+    CHECK(index.active_tip_height() == index.get_height(branch_head));
+    CHECK(index.active_at(index.get_height(branch_head)) == branch_head);
+
+    // And every height above the fork names the branch, not the extension.
+    for (int32_t h = 6; h <= index.get_height(branch_head); ++h) {
+        auto const idx = index.active_at(h);
+        REQUIRE(idx != header_index::null_index);
+        CHECK(index.get_ancestor(branch_head, h) == idx);
+    }
+}
+
 // =============================================================================
 // Active chain (height -> index)
 // =============================================================================

--- a/src/blockchain/test/regtest_miner.hpp
+++ b/src/blockchain/test/regtest_miner.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_TEST_REGTEST_MINER_HPP
+#define KTH_BLOCKCHAIN_TEST_REGTEST_MINER_HPP
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <kth/domain/chain/block.hpp>
+#include <kth/domain/chain/header.hpp>
+#include <kth/domain/chain/input.hpp>
+#include <kth/domain/chain/output.hpp>
+#include <kth/domain/chain/script.hpp>
+#include <kth/domain/chain/transaction.hpp>
+#include <kth/domain/machine/operation.hpp>
+#include <kth/infrastructure/machine/number.hpp>
+#include <kth/domain/wallet/ec_public.hpp>
+#include <kth/infrastructure/math/elliptic_curve.hpp>
+#include <kth/infrastructure/math/hash.hpp>
+
+namespace kth::test {
+
+// Blocks that actually satisfy consensus, built in-process.
+//
+// The reorg tests need competing chains whose blocks pass the same validation a
+// peer's blocks would: real proof of work, real merkle roots, real signatures on
+// a real spend of a matured coinbase. Anything weaker and the test would be
+// exercising the paths that skip validation rather than the ones that run it.
+//
+// Regtest makes this cheap: the target is so loose that a nonce is found in a
+// couple of tries, so a hundred blocks cost milliseconds.
+
+// Regtest's proof-of-work limit — the difficulty every block here carries.
+inline constexpr uint32_t regtest_bits = 0x207fffff;
+
+// One key for the whole test chain: every coinbase pays to it, so any earlier
+// coinbase can be spent later without threading key material through the test.
+inline ec_secret const& miner_secret() {
+    static ec_secret const secret =
+        "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"_hash;
+    return secret;
+}
+
+inline domain::wallet::ec_public const& miner_public() {
+    static domain::wallet::ec_public const public_key = [] {
+        ec_compressed point{};
+        secret_to_public(point, miner_secret());
+        return domain::wallet::ec_public::from_verified_point(point, true);
+    }();
+    return public_key;
+}
+
+// The P2PKH script every mined output pays to.
+inline domain::chain::script const& miner_script() {
+    static domain::chain::script const locking = [] {
+        auto const key_hash = bitcoin_short_hash(miner_public().to_data());
+        return domain::chain::script(domain::chain::script::to_pay_public_key_hash_pattern(key_hash));
+    }();
+    return locking;
+}
+
+// The coinbase input script: the block height, then a salt that keeps otherwise
+// identical coinbases (and so their txids, and so the blocks) distinct across
+// branches. `operation`'s minimal encoding gives OP_1..OP_16 below height 17 and
+// a minimal number push above it, which is what is_coinbase_pattern expects.
+inline domain::chain::script coinbase_script(uint32_t height, uint32_t salt) {
+    auto const height_number = infrastructure::machine::number::from_int(int64_t(height));
+    domain::machine::operation::list ops;
+    ops.emplace_back(height_number->data(), true);
+    ops.emplace_back(data_chunk{uint8_t(salt), uint8_t(salt >> 8), uint8_t(salt >> 16), uint8_t(salt >> 24)}, false);
+    return domain::chain::script(std::move(ops));
+}
+
+inline domain::chain::transaction coinbase_tx(uint32_t height, uint32_t salt, uint64_t value) {
+    domain::chain::input::list inputs;
+    inputs.emplace_back(domain::chain::output_point{null_hash, domain::chain::point::null_index},
+                        coinbase_script(height, salt), 0xffffffff);
+
+    domain::chain::output::list outputs;
+    outputs.emplace_back(value, miner_script(), domain::chain::token_data_opt{});
+
+    return domain::chain::transaction(1, 0, std::move(inputs), std::move(outputs));
+}
+
+// A P2PKH spend of `prev_tx`'s output `index`, paying `value` back to the same
+// key. Whatever is left over is the fee, which the next coinbase may claim.
+inline domain::chain::transaction spend_p2pkh(
+    domain::chain::transaction const& prev_tx, uint32_t index, uint64_t value,
+    domain::script_flags_t active_flags) {
+
+    auto const prev_value = prev_tx.outputs()[index].value();
+    auto const prev_hash = prev_tx.hash();
+
+    // Signed over the finished transaction, so the input goes in unsigned first
+    // and is replaced once the endorsement exists.
+    domain::chain::input::list inputs;
+    inputs.emplace_back(domain::chain::output_point{prev_hash, index}, domain::chain::script{}, 0xffffffff);
+
+    domain::chain::output::list outputs;
+    outputs.emplace_back(value, miner_script(), domain::chain::token_data_opt{});
+
+    domain::chain::transaction unsigned_tx(1, 0, std::move(inputs), std::move(outputs));
+
+    // BCH replay protection: the fork id must be in the sighash type, and the
+    // prevout value is part of what is signed.
+    auto const sighash_type = uint8_t(infrastructure::machine::sighash_algorithm::forkid_all);
+
+    auto endorsement = domain::chain::script::create_endorsement(
+        miner_secret(), miner_script(), unsigned_tx, 0, sighash_type, active_flags, prev_value);
+    if ( ! endorsement) {
+        throw std::runtime_error("regtest_miner: could not sign the spend");
+    }
+
+    domain::chain::input::list signed_inputs;
+    signed_inputs.emplace_back(
+        domain::chain::output_point{prev_hash, index},
+        domain::chain::script(domain::chain::script::to_pay_public_key_hash_pattern_unlocking(
+            *endorsement, miner_public())),
+        0xffffffff);
+
+    return domain::chain::transaction(1, 0, std::move(signed_inputs),
+                                      domain::chain::output::list(unsigned_tx.outputs()));
+}
+
+// Mine a block on top of `prev`. `txs` are appended after the coinbase, and the
+// coinbase claims the subsidy plus their fees.
+inline domain::chain::block mine_block(
+    hash_digest const& prev, uint32_t height, uint32_t timestamp, uint32_t salt,
+    std::vector<domain::chain::transaction> txs, uint64_t fees) {
+
+    domain::chain::transaction::list all;
+    all.reserve(txs.size() + 1);
+    all.push_back(coinbase_tx(height, salt,
+        domain::chain::block::subsidy(height, /*retarget*/ false) + fees));
+    for (auto& tx : txs) {
+        all.push_back(std::move(tx));
+    }
+
+    domain::chain::block candidate(
+        domain::chain::header{0x20000000, prev, null_hash, timestamp, regtest_bits, 0}, std::move(all));
+
+    auto const merkle = candidate.generate_merkle_root();
+
+    // Grind on the header alone — a block's hash is its header's, so there is no
+    // need to rebuild the transaction list per attempt. At regtest difficulty
+    // roughly every other nonce works, so this is a handful of hashes rather than
+    // a mining loop. Bounded all the same: an exhausted nonce range means the
+    // target is not what this expects, and that should fail loudly rather than
+    // wrap around forever.
+    for (uint64_t nonce = 0; nonce <= std::numeric_limits<uint32_t>::max(); ++nonce) {
+        domain::chain::header header{0x20000000, prev, merkle, timestamp, regtest_bits, uint32_t(nonce)};
+        if (header.is_valid_proof_of_work(domain::chain::hash(header), /*retarget*/ false)) {
+            return domain::chain::block(std::move(header),
+                domain::chain::transaction::list(candidate.transactions()));
+        }
+    }
+
+    throw std::runtime_error("regtest_miner: no nonce satisfied the regtest target");
+}
+
+} // namespace kth::test
+
+#endif // KTH_BLOCKCHAIN_TEST_REGTEST_MINER_HPP

--- a/src/database/include/kth/database/data_base.hpp
+++ b/src/database/include/kth/database/data_base.hpp
@@ -86,6 +86,11 @@ public:
     /// start_height is the height of the first header in the list.
     code push_headers_batch(domain::chain::header::list const& headers, size_t start_height);
 
+    /// Make the by-height table describe `headers` from `start_height` up, and
+    /// nothing above them, in one transaction.
+    /// See internal_database::replace_headers_from.
+    code replace_headers_from(domain::chain::header::list const& headers, size_t start_height);
+
     //bool set_database_flags(bool fast);
 
     // ==========================================================================

--- a/src/database/include/kth/database/databases/header_database.ipp
+++ b/src/database/include/kth/database/databases/header_database.ipp
@@ -55,10 +55,33 @@ result_code internal_database_basis<Clock>::push_header_only(domain::chain::head
     auto key = kth_db_make_value(sizeof(height), &height);
     auto value = kth_db_make_value(valuearr.size(), valuearr.data());
 
+    // APPEND is the sequential-sync fast path: it assumes the new key is above
+    // every existing one, which holds while the chain only grows.
     auto res = kth_db_put(db_txn, dbi_block_header_, &key, &value, KTH_DB_APPEND);
     if (res == KTH_DB_KEYEXIST) {
-        spdlog::info("[database] Duplicate key inserting header [push_header_only] {}", res);
-        return result_code::duplicated_key;
+        // The height is already occupied, which means a reorganization put a
+        // different block there. Rewrite it: leaving the abandoned header would
+        // make every reader that addresses blocks by height — median time past,
+        // staleness, the RPC surface — answer from the branch the node left.
+        //
+        // Drop the displaced header's hash -> height entry first. This table
+        // describes the chain by height, so a hash that is no longer at any
+        // height does not belong in it: left behind, a lookup for the abandoned
+        // block would resolve to its old height and return whichever block now
+        // occupies it — a different header than the one asked for. Side-branch
+        // headers remain addressable through the header index.
+        if (auto const displaced = get_header(height, db_txn); displaced) {
+            auto displaced_hash = kth::domain::chain::hash(*displaced);
+            auto displaced_key = kth_db_make_value(displaced_hash.size(), displaced_hash.data());
+            auto const del = kth_db_del(db_txn, dbi_block_header_by_hash_, &displaced_key, NULL);
+            if (del != KTH_DB_SUCCESS && del != KTH_DB_NOTFOUND) {
+                spdlog::info("[database] Error dropping the displaced header by hash "
+                    "[push_header_only] {}", del);
+                return result_code::other;
+            }
+        }
+
+        res = kth_db_put(db_txn, dbi_block_header_, &key, &value, 0);
     }
     if (res != KTH_DB_SUCCESS) {
         spdlog::info("[database] Error inserting header [push_header_only] {}", res);
@@ -70,8 +93,9 @@ result_code internal_database_basis<Clock>::push_header_only(domain::chain::head
 
     res = kth_db_put(db_txn, dbi_block_header_by_hash_, &key_by_hash, &key, KTH_DB_NOOVERWRITE);
     if (res == KTH_DB_KEYEXIST) {
-        spdlog::info("[database] Duplicate key inserting header by hash [push_header_only] {}", res);
-        return result_code::duplicated_key;
+        // Already indexed, and a block's height never changes, so re-persisting
+        // the same header is a no-op rather than a conflict.
+        return result_code::success;
     }
     if (res != KTH_DB_SUCCESS) {
         spdlog::info("[database] Error inserting header by hash [push_header_only] {}", res);
@@ -278,6 +302,66 @@ result_code internal_database_basis<Clock>::remove_block_header(hash_digest cons
     }
     if (res != KTH_DB_SUCCESS) {
         spdlog::info("[database] Erro deleting block header by hash in LMDB [remove_block_header] - kth_db_del: {}", res);
+        return result_code::other;
+    }
+
+    return result_code::success;
+}
+
+template <typename Clock>
+result_code internal_database_basis<Clock>::replace_headers_from(
+    domain::chain::header::list const& headers, uint32_t start_height) {
+
+    if (start_height == 0) {
+        spdlog::error("[database] Refusing to replace headers from genesis [replace_headers_from]");
+        return result_code::other;
+    }
+
+    if (headers.empty()) {
+        spdlog::error("[database] Refusing to replace headers with none [replace_headers_from]");
+        return result_code::other;
+    }
+
+    KTH_DB_txn* db_txn;
+    auto res = kth_db_txn_begin(env_, NULL, 0, &db_txn);
+    if (res != KTH_DB_SUCCESS) {
+        return result_code::other;
+    }
+
+    uint32_t height = start_height;
+    for (auto const& header : headers) {
+        auto const written = push_header_only(header, height, db_txn);
+        if (written != result_code::success) {
+            kth_db_txn_abort(db_txn);
+            return written;
+        }
+        ++height;
+    }
+
+    // `height` is now one past the last header written: the new tip. Walk up
+    // until a height is absent — heights are contiguous, so the first gap is the
+    // end of the table — dropping what the abandoned branch left behind.
+    for (uint32_t h = height; ; ++h) {
+        auto const displaced = get_header(h, db_txn);
+        if ( ! displaced) {
+            break;
+        }
+        auto const hash = kth::domain::chain::hash(*displaced);
+        auto const removed = remove_block_header(hash, h, db_txn);
+        if (removed != result_code::success) {
+            kth_db_txn_abort(db_txn);
+            return removed;
+        }
+    }
+
+    auto const result = set_property_height(property_code::last_header_height, height - 1, db_txn);
+    if (result != result_code::success) {
+        kth_db_txn_abort(db_txn);
+        return result;
+    }
+
+    res = kth_db_txn_commit(db_txn);
+    if (res != KTH_DB_SUCCESS) {
         return result_code::other;
     }
 

--- a/src/database/include/kth/database/databases/internal_database.hpp
+++ b/src/database/include/kth/database/databases/internal_database.hpp
@@ -110,6 +110,25 @@ struct KD_API internal_database_basis {
     // Headers-first sync: store multiple headers in a single transaction (batch)
     // start_height is the height of the first header in the list
     result_code push_headers_batch(domain::chain::header::list const& headers, uint32_t start_height);
+
+    /// Make the by-height table describe `headers` from `start_height` up, and
+    /// nothing above them: writes each header, drops every height past the last
+    /// one (with its hash -> height entry), and sets the last-header height.
+    ///
+    /// One transaction, because a reorganization needs all of it or none. Written
+    /// halfway, the table would name the new branch over part of the replaced
+    /// range and the abandoned one over the rest — an inconsistency no later pass
+    /// would notice, since each height holds a header that parses.
+    ///
+    /// Both halves are needed: a branch with more work can have fewer blocks (it
+    /// was mined at higher difficulty), so the chain can end lower than it did and
+    /// leave heights behind that are on no chain at all.
+    ///
+    /// `start_height` must be at least 1 — genesis anchors the chain — and
+    /// `headers` must not be empty: "replace with nothing from here up" would
+    /// mean deleting the chain from that height, which is not what any caller
+    /// means by it. Both are refused before the transaction opens.
+    result_code replace_headers_from(domain::chain::header::list const& headers, uint32_t start_height);
 #endif
 
     // DEPRECATED: UTXO storage moved to UTXOZ

--- a/src/database/src/data_base.cpp
+++ b/src/database/src/data_base.cpp
@@ -289,6 +289,14 @@ code data_base::push_headers_batch(header::list const& headers, size_t start_hei
     return error::success;
 }
 
+code data_base::replace_headers_from(header::list const& headers, size_t start_height) {
+    auto res = internal_db_->replace_headers_from(headers, uint32_t(start_height));
+    if ( ! succeed(res)) {
+        return error::operation_failed;
+    }
+    return error::success;
+}
+
 // =============================================================================
 // DEPRECATED: Block storage moved to flat files (blk*.dat)
 // Genesis block is now stored in flat files

--- a/src/domain/src/chain/script.cpp
+++ b/src/domain/src/chain/script.cpp
@@ -808,8 +808,10 @@ operation::list script::to_pay_public_key_hash_pattern(short_hash const& hash) {
 }
 
 operation::list script::to_pay_public_key_hash_pattern_unlocking(endorsement const& end, wallet::ec_public const& pubkey) {
+    // Signature then public key, and nothing else: the locking script consumes
+    // both, leaving a single true on the stack. A leading OP_0 (the dummy
+    // multisig needs) would survive to the end and fail CLEANSTACK.
     return operation::list {
-        operation(opcode::push_size_0),
         operation(end),
         operation(pubkey.to_data())
     };
@@ -818,8 +820,9 @@ operation::list script::to_pay_public_key_hash_pattern_unlocking(endorsement con
 operation::list script::to_pay_public_key_hash_pattern_unlocking_placeholder(size_t endorsement_size, size_t pubkey_size) {
     data_chunk placeholder_signature(endorsement_size, 0);
     data_chunk placeholder_pubkey(pubkey_size, 0);
+    // Same shape as the real unlocking script above, so a size estimate built
+    // from this matches what the spend will actually serialize to.
     return operation::list {
-        operation(opcode::push_size_0),
         operation(std::move(placeholder_signature)),
         operation(std::move(placeholder_pubkey))
     };

--- a/src/domain/test/chain/script.cpp
+++ b/src/domain/test/chain/script.cpp
@@ -1318,3 +1318,43 @@ void run_bchn_test(bchn_script_test const& test) {
 }
 
 
+
+// =============================================================================
+// P2PKH unlocking pattern
+// =============================================================================
+//
+// The shape is consensus-visible: an extra element left on the stack fails
+// CLEANSTACK, and the size estimate coin selection builds from the placeholder
+// has to match what the real spend serializes to.
+
+TEST_CASE("p2pkh unlocking script is the signature then the public key", "[script]") {
+    ec_secret const secret = "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333"_hash;
+    ec_compressed point{};
+    REQUIRE(secret_to_public(point, secret));
+    auto const pubkey = wallet::ec_public::from_verified_point(point, true);
+
+    endorsement const signature(72, 0x30);
+    auto const ops = script::to_pay_public_key_hash_pattern_unlocking(signature, pubkey);
+
+    REQUIRE(ops.size() == 2);
+    CHECK(ops[0].data() == data_chunk(signature));
+    CHECK(ops[1].data() == pubkey.to_data());
+
+    // No leading dummy: that is what multisig needs, and it would survive to the
+    // end of the script here.
+    CHECK(ops[0].code() != opcode::push_size_0);
+}
+
+TEST_CASE("the p2pkh unlocking placeholder serializes to the size of a real spend", "[script]") {
+    ec_secret const secret = "ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333"_hash;
+    ec_compressed point{};
+    REQUIRE(secret_to_public(point, secret));
+    auto const pubkey = wallet::ec_public::from_verified_point(point, true);
+
+    endorsement const signature(72, 0x30);
+    script const real(script::to_pay_public_key_hash_pattern_unlocking(signature, pubkey));
+    script const placeholder(script::to_pay_public_key_hash_pattern_unlocking_placeholder(
+        signature.size(), pubkey.to_data().size()));
+
+    CHECK(placeholder.serialized_size(true) == real.serialized_size(true));
+}

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -157,6 +157,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     src/sync/header_tasks.cpp
     src/sync/block_tasks.cpp
     src/sync/orchestrator.cpp
+    src/sync/reorg.cpp
 
     # Mining helpers shared by the JSON-RPC server and other template consumers.
     src/mining/job_store.cpp
@@ -294,6 +295,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   add_executable(kth_node_test
           test/check_list.cpp
           test/chunk_coordinator.cpp
+          test/reorg_cycle.cpp
           test/reorg_stale_chunk_drop.cpp
           test/configuration.cpp
           test/header_list.cpp

--- a/src/node/include/kth/node/full_node.hpp
+++ b/src/node/include/kth/node/full_node.hpp
@@ -39,6 +39,7 @@
 // =============================================================================
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 
 #include <kth/blockchain.hpp>
@@ -96,6 +97,17 @@ public:
 
     /// Stop the node.
     void stop();
+
+    /// A condition the node cannot go on from, reported from inside its own
+    /// tasks: the persisted chain and the chain in memory no longer describe the
+    /// same thing (see node::sync::reorg_outcome::fatal).
+    ///
+    /// Stops the node, and tells whoever owns its lifecycle so the process can
+    /// wind down instead of idling with nothing left to do. Without a handler
+    /// the node still stops; the owner just never hears about it.
+    using fatal_handler = std::function<void(std::string const&)>;
+    void set_fatal_handler(fatal_handler handler);
+    void notify_fatal(std::string const& reason);
 
     /// Block until all work is complete.
     void join();
@@ -198,6 +210,7 @@ private:
     // Configuration references (stored in configuration object)
     node::settings const& node_settings_;
     blockchain::settings const& chain_settings_;
+    fatal_handler fatal_handler_;
     domain::config::network network_type_;
 
     // Core components (composition, not inheritance)

--- a/src/node/include/kth/node/sync/orchestrator.hpp
+++ b/src/node/include/kth/node/sync/orchestrator.hpp
@@ -5,6 +5,7 @@
 #ifndef KTH_NODE_SYNC_ORCHESTRATOR_HPP
 #define KTH_NODE_SYNC_ORCHESTRATOR_HPP
 
+#include <functional>
 #include <asio/awaitable.hpp>
 
 #include <kth/blockchain.hpp>
@@ -35,11 +36,16 @@ namespace kth::node::sync {
 //
 // =============================================================================
 
+// `on_fatal` reports a condition sync cannot go on from — the persisted chain
+// and the chain in memory describing different branches after a reorganization.
+// Sync stops sending work the moment it fires; winding the process down is the
+// node owner's, so that logic is not half-repeated here.
 ::asio::awaitable<void> sync_orchestrator(
     blockchain::block_chain& chain,
     blockchain::header_organizer& organizer,
     kth::node::p2p_node& network,
-    domain::config::network network_type
+    domain::config::network network_type,
+    std::function<void(std::string const&)> on_fatal
 );
 
 } // namespace kth::node::sync

--- a/src/node/include/kth/node/sync/reorg.hpp
+++ b/src/node/include/kth/node/sync/reorg.hpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_SYNC_REORG_HPP
+#define KTH_NODE_SYNC_REORG_HPP
+
+#include <cstdint>
+#include <functional>
+
+#include <asio/awaitable.hpp>
+
+#include <kth/blockchain/interface/block_chain.hpp>
+#include <kth/blockchain/pools/header_organizer.hpp>
+
+namespace kth::node::sync {
+
+// Retires a reorg-barrier participant on every exit path. A leaked registration
+// leaves the registered count above the parked count forever, so no later switch
+// can ever reach the barrier.
+//
+// Every task that writes chain state holds one for its lifetime: block storage,
+// the UTXO build, and header persistence. While one is registered and not parked,
+// a switch waits — which is what keeps a write that is already under way from
+// landing after the chain moved out from under it.
+struct reorg_participation {
+    explicit reorg_participation(blockchain::block_chain& chain) : chain_(chain) {
+        chain_.register_reorg_participant();
+    }
+    ~reorg_participation() { chain_.unregister_reorg_participant(); }
+    reorg_participation(reorg_participation const&) = delete;
+    reorg_participation& operator=(reorg_participation const&) = delete;
+private:
+    blockchain::block_chain& chain_;
+};
+
+// Rewrite the by-height header table over [from_height, to_height] from the
+// active chain.
+//
+// That table is what `get_header(height)` answers from, and it is written by
+// append during sync, so nothing updates it when a switch replaces the block at
+// a height. Until it is rewritten, median time past, the staleness check and the
+// RPC surface all keep reading the branch the node abandoned.
+//
+// Returns false if it stopped early: a height that is not on the active chain, a
+// failed write, or the chain moving underneath it (checked per batch, so a run
+// racing a switch stops instead of interleaving two branches in one table).
+[[nodiscard]]
+bool persist_active_headers(
+    blockchain::block_chain& chain,
+    blockchain::header_index const& index,
+    uint32_t from_height,
+    uint32_t to_height);
+
+// What a switch left behind, and whether the node can carry on from it.
+struct reorg_outcome {
+    blockchain::block_chain::switch_result result;
+
+    // The chain moved but its persisted description did not, and nothing repairs
+    // that while the node runs: the by-height header table is what the header
+    // index is rebuilt from at startup, so carrying on means running with the two
+    // disagreeing and coming back up on the abandoned branch after a restart —
+    // with the UTXO set already rewound below it.
+    //
+    // The caller owns the node's lifecycle, so it is the caller that must shut it
+    // down: stop the network, and send no further work.
+    bool fatal{false};
+};
+
+// Move the node onto another branch.
+//
+// The switch itself is one call, but it cannot stand alone: the tasks that write
+// chain state have to be parked first (the switch rewrites the UTXO set), and
+// the organizer's notion of the tip has to move with the chain afterwards — it
+// is what decides whether the next header batch extends the chain or forks it,
+// so an organizer left on the abandoned branch would read every later batch as
+// another fork and ask for a switch whose fork height no longer matches.
+//
+// Keeping that sequence in one place is what lets it be driven the same way in a
+// test as in the coordinator.
+//
+// `abort` is polled while waiting at the barrier (node shutdown); when it fires
+// the switch is not attempted and a failed result is returned, leaving the chain
+// untouched. So does waiting past the barrier deadline: a writer that never
+// parks is a bug, and holding the pause open forever on top of it would stall
+// sync silently.
+::asio::awaitable<reorg_outcome> execute_reorg(
+    blockchain::block_chain& chain,
+    blockchain::header_organizer& organizer,
+    blockchain::header_index::index_t branch_head,
+    uint32_t fork_height,
+    std::function<bool()> abort);
+
+} // namespace kth::node::sync
+
+#endif // KTH_NODE_SYNC_REORG_HPP

--- a/src/node/src/executor/executor.cpp
+++ b/src/node/src/executor/executor.cpp
@@ -170,6 +170,15 @@ void executor::start_async(start_handler handler) {
     // Create the node
     node_ = std::make_shared<kth::node::full_node>(config_);
 
+    // The node reports conditions it cannot go on from (see full_node::notify_fatal)
+    // from inside its own tasks. It stops itself; ending the process is this
+    // executor's, and it is the same wind-down a stop request takes — the node
+    // has no second, partial copy of it.
+    node_->set_fatal_handler([this](std::string const& reason) {
+        spdlog::critical("[node] Shutting down: {}", reason);
+        stop_async({});
+    });
+
     // Start IO thread
     start_io_thread();
 
@@ -220,7 +229,11 @@ void executor::start_async(start_handler handler) {
             auto executor = co_await ::asio::this_coro::executor;
             ::asio::steady_timer timer(executor);
             uint64_t heartbeat_count = 0;
-            while (state_.load() == state::running) {
+            // Also stops when the node stopped on its own: a fatal condition
+            // reported from inside it ends run(), and a heartbeat that only
+            // watched this executor's state would keep the `&&` below from ever
+            // completing — no join, no shutdown, a process with nothing to do.
+            while (state_.load() == state::running && node_ && ! node_->stopped()) {
                 timer.expires_after(std::chrono::seconds(10));
                 auto [ec] = co_await timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
                 if (ec) {

--- a/src/node/src/full_node.cpp
+++ b/src/node/src/full_node.cpp
@@ -267,7 +267,8 @@ full_node::~full_node() {
     // run on the network pool's 32 threads instead of the single io_thread.
     co_await ::asio::co_spawn(
         network_.thread_pool().get_executor(),
-        sync::sync_orchestrator(chain_, organizer, network_, network_type_),
+        sync::sync_orchestrator(chain_, organizer, network_, network_type_,
+            [this](std::string const& reason) { notify_fatal(reason); }),
         ::asio::use_awaitable
     );
 
@@ -275,6 +276,25 @@ full_node::~full_node() {
     spdlog::info("[full_node] run_sync() ENDED");
 }
 #endif
+
+void full_node::set_fatal_handler(fatal_handler handler) {
+    fatal_handler_ = std::move(handler);
+}
+
+void full_node::notify_fatal(std::string const& reason) {
+    spdlog::critical("[node] Cannot continue: {}", reason);
+
+    // Stop first, so the node's own tasks wind down even when nobody installed a
+    // handler — a library embedding the node still gets a node that stops.
+    stop();
+
+    if (fatal_handler_) {
+        fatal_handler_(reason);
+    } else {
+        spdlog::warn("[node] No fatal handler installed; the node stopped but its owner was not "
+            "told, so the process may stay up with nothing left to do");
+    }
+}
 
 void full_node::stop() {
 #if ! defined(__EMSCRIPTEN__)

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -36,26 +36,9 @@
 #include <kth/blockchain/utxo_builder.hpp>
 #include <kth/blockchain/validate/batch_validate.hpp>
 #include <kth/network/protocols_coro.hpp>
+#include <kth/node/sync/reorg.hpp>
 
 namespace kth::node::sync {
-
-namespace {
-
-// Retires a reorg-barrier participant on every exit path. A leaked registration
-// leaves reorg_registered_ above reorg_parked_ forever, so no later switch can
-// ever reach the barrier.
-struct reorg_participation {
-    explicit reorg_participation(blockchain::block_chain& chain) : chain_(chain) {
-        chain_.register_reorg_participant();
-    }
-    ~reorg_participation() { chain_.unregister_reorg_participant(); }
-    reorg_participation(reorg_participation const&) = delete;
-    reorg_participation& operator=(reorg_participation const&) = delete;
-private:
-    blockchain::block_chain& chain_;
-};
-
-} // namespace
 
 namespace {
 
@@ -1606,11 +1589,18 @@ std::atomic<uint32_t> g_active_download_peers{0};
 
             // Advance contiguous_height using header_index have_data flags.
             // store_chunk() already set have_data for each stored block.
-            // idx == height during IBD (headers added sequentially).
+            //
+            // By height through the active chain: the index numbers entries in
+            // arrival order, so once a side branch is stored an entry's index is
+            // no longer its height. Walking the index directly would count the
+            // abandoned branch's blocks as contiguous and push the validated tip
+            // past where the chain actually reaches.
             auto const prev_contiguous = contiguous_height;
             auto const& hdr = chain.headers();
-            while (hdr.has_status(static_cast<blockchain::header_index::index_t>(contiguous_height),
-                                  blockchain::header_status::have_data)) {
+            while (true) {
+                auto const idx = hdr.active_at(static_cast<int32_t>(contiguous_height));
+                if (idx == blockchain::header_index::null_index) break;
+                if ( ! hdr.has_status(idx, blockchain::header_status::have_data)) break;
                 ++contiguous_height;
             }
 

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -4,6 +4,8 @@
 
 #include <kth/node/sync/orchestrator.hpp>
 
+#include <kth/node/sync/reorg.hpp>
+
 #include <chrono>
 #include <thread>
 
@@ -61,6 +63,26 @@ static bool is_bannable_error(code const& ec) {
     }
 }
 
+// The hash of the block at `height` on the active chain.
+//
+// A locator is built from a height, and the header index numbers its entries in
+// arrival order — so once a side branch is stored an entry's index is no longer
+// its height. Casting one to the other would ask peers to continue from whatever
+// block happens to sit at that index, which after a fork is a block the node did
+// not take.
+static
+hash_digest active_hash_at(blockchain::header_index const& index, uint32_t height) {
+    auto const idx = index.active_at(static_cast<int32_t>(height));
+    if (idx == blockchain::header_index::null_index) {
+        // Every height up to the header tip is on the active chain, so this means
+        // the chain is shorter than the coordinator believes. Say so: the request
+        // below will start from genesis, which is recoverable but wasteful.
+        spdlog::error("[sync_coordinator] Height {} is not on the active chain", height);
+        return null_hash;
+    }
+    return index.get_hash(idx);
+}
+
 // =============================================================================
 // Header Persistence (background task)
 // =============================================================================
@@ -80,36 +102,37 @@ static
     spdlog::info("[header_persist] Starting: {} headers ({} to {})", total, start_height, end_height);
 
     auto const start_time = std::chrono::steady_clock::now();
-    constexpr size_t batch_size = 1000;
+    constexpr uint32_t chunk = 10000;
 
-    size_t persisted = 0;
+    // This task writes the by-height header table, which a switch rewrites, so it
+    // takes part in the barrier. While it is registered and not parked a switch
+    // waits — which is what stops a chunk already under way from committing the
+    // old branch on top of the new one. Checking the generation alone could not:
+    // the switch can land between the check and the commit.
+    reorg_participation const participation(chain);
+
     uint32_t height = start_height;
-
     while (height <= end_height) {
-        domain::chain::header::list batch;
-        auto const batch_end = std::min(height + uint32_t(batch_size) - 1, end_height);
-        batch.reserve(batch_end - height + 1);
+        auto const chunk_end = std::min(height + chunk - 1, end_height);
 
-        for (uint32_t h = height; h <= batch_end; ++h) {
-            batch.push_back(index.get_header(h));
-        }
-
-        auto const ec = chain.organize_headers_batch(batch, height);
-        if (ec) {
-            spdlog::warn("[header_persist] Failed at height {}: {}", height, ec.message());
+        // Park, then give up: the switch rewrites the range it replaced itself,
+        // and a later header sync re-persists whatever is above it.
+        if (chain.reorg_pause_requested()) {
+            spdlog::info("[header_persist] A reorg is executing; stopping at height {}", height);
+            chain.enter_reorg_barrier();
+            while (chain.reorg_pause_requested() && ! chain.stopped()) {
+                ::asio::steady_timer timer(co_await ::asio::this_coro::executor);
+                timer.expires_after(std::chrono::milliseconds(50));
+                co_await timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
+            }
+            chain.leave_reorg_barrier();
             co_return;
         }
 
-        persisted += batch.size();
-        height = batch_end + 1;
-
-        // Log progress every 100000 headers
-        if (persisted % 100000 < batch_size) {
-            auto const elapsed = std::chrono::steady_clock::now() - start_time;
-            auto const elapsed_secs = std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
-            auto const rate = elapsed_secs > 0 ? persisted / elapsed_secs : persisted;
-            spdlog::info("[header_persist] {}/{} ({}/s)", persisted, total, rate);
+        if ( ! persist_active_headers(chain, index, height, chunk_end)) {
+            co_return;
         }
+        height = chunk_end + 1;
 
         // Yield to allow other coroutines to run
         co_await ::asio::post(co_await ::asio::this_coro::executor, ::asio::use_awaitable);
@@ -117,8 +140,8 @@ static
 
     auto const elapsed = std::chrono::steady_clock::now() - start_time;
     auto const elapsed_secs = std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
-    auto const rate = elapsed_secs > 0 ? persisted / elapsed_secs : persisted;
-    spdlog::info("[header_persist] Complete: {} headers in {}s ({}/s)", persisted, elapsed_secs, rate);
+    auto const rate = elapsed_secs > 0 ? total / elapsed_secs : total;
+    spdlog::info("[header_persist] Complete: {} headers in {}s ({}/s)", total, elapsed_secs, rate);
 }
 
 // =============================================================================
@@ -129,7 +152,8 @@ static
     blockchain::block_chain& chain,
     blockchain::header_organizer& organizer,
     kth::node::p2p_node& network,
-    domain::config::network network_type
+    domain::config::network network_type,
+    std::function<void(std::string const&)> on_fatal
 ) {
     auto executor = co_await ::asio::this_coro::executor;
 
@@ -806,8 +830,7 @@ static
         auto exec = co_await ::asio::this_coro::executor;
 
         // Trigger parallel header sync (supervisor manages chunk coordination)
-        auto from_hash = organizer.index().get_hash(
-            static_cast<blockchain::header_index::index_t>(headers_synced_to));
+        auto from_hash = active_hash_at(organizer.index(), headers_synced_to);
 
         spdlog::debug("[sync_coordinator] Starting parallel header sync from height {}", headers_synced_to);
         if (!header_download_input.try_send(std::error_code{}, header_request{
@@ -875,17 +898,27 @@ static
                     auto const fork_height = uint32_t(result->reorg_fork_height);
                     spdlog::warn("[sync_coordinator] Reorg requested: fork at height {}", fork_height);
 
-                    // Quiesce the UTXO build: the switch rewrites the UTXO set.
-                    chain.request_reorg_pause(true);
-                    while ( ! chain.reorg_barrier_reached() && ! network.stopped()) {
-                        ::asio::steady_timer wait_timer(exec);
-                        wait_timer.expires_after(std::chrono::milliseconds(50));
-                        co_await wait_timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
+                    auto const reorg = co_await execute_reorg(
+                        chain, organizer, result->reorg_branch_head, fork_height,
+                        [&network] { return network.stopped(); });
+
+                    if (reorg.fatal) {
+                        // The chain moved but its persisted description did not.
+                        // Syncing on would build on a view a restart will not come
+                        // back to, so stop here: no counters, no new ranges, and
+                        // wind the node down. Stopping the network is what every
+                        // other task is watching, and the stop bridge turns it
+                        // into the stop_request this loop exits on.
+                        // Report and stop taking work. Winding the process down
+                        // is the node owner's — it holds the lifecycle, and half
+                        // of a shutdown started from here would be a second,
+                        // partial copy of it.
+                        on_fatal("a reorganization left the persisted chain and the active chain "
+                            "describing different branches");
+                        break;
                     }
 
-                    auto const outcome = network.stopped()
-                        ? blockchain::block_chain::switch_result{}
-                        : co_await chain.switch_to_branch_async(result->reorg_branch_head, fork_height);
+                    auto const outcome = reorg.result;
                     auto const switched = outcome.ok;
 
                     // Resync from the tip the switch actually reports, so a partially
@@ -900,8 +933,6 @@ static
                         // headers-only heights on every poll.
                         contiguous_height->store(blocks_synced_to + 1, std::memory_order_release);
                     }
-
-                    chain.request_reorg_pause(false);
 
                     auto const new_tip = switched ? chain.headers().active_tip_height() : -1;
                     if (switched && new_tip > int32_t(blocks_synced_to)) {
@@ -949,8 +980,7 @@ static
                     }
 
                     // Retry header sync with a different peer
-                    auto retry_hash = organizer.index().get_hash(
-                        static_cast<blockchain::header_index::index_t>(headers_synced_to));
+                    auto retry_hash = active_hash_at(organizer.index(), headers_synced_to);
 
                     spdlog::info("[sync_coordinator] Retrying header sync from height {} with different peer, from_hash={}",
                         headers_synced_to, encode_hash(retry_hash));
@@ -979,8 +1009,7 @@ static
                     }
 
                     // Request next batch of headers (sequential sync)
-                    auto next_hash = organizer.index().get_hash(
-                        static_cast<blockchain::header_index::index_t>(headers_synced_to));
+                    auto next_hash = active_hash_at(organizer.index(), headers_synced_to);
 
                     if (!header_download_input.try_send(std::error_code{}, header_request{
                         .from_height = headers_synced_to,
@@ -1002,8 +1031,7 @@ static
                         if (timer_ec || network.stopped()) break;
 
                         // Retry header sync
-                        auto retry_hash = organizer.index().get_hash(
-                            static_cast<blockchain::header_index::index_t>(headers_synced_to));
+                        auto retry_hash = active_hash_at(organizer.index(), headers_synced_to);
 
                         if (!header_download_input.try_send(std::error_code{}, header_request{
                             .from_height = headers_synced_to,
@@ -1067,8 +1095,7 @@ static
                         header_sync_start = std::chrono::steady_clock::now();
                         headers_at_start = headers_synced_to;
 
-                        auto next_hash = organizer.index().get_hash(
-                            static_cast<blockchain::header_index::index_t>(headers_synced_to));
+                        auto next_hash = active_hash_at(organizer.index(), headers_synced_to);
 
                         if (!header_download_input.try_send(std::error_code{}, header_request{
                             .from_height = headers_synced_to,
@@ -1121,8 +1148,7 @@ static
                         headers_at_start = headers_synced_to;
                         slow_sync_started = false;  // allow next FAST→SLOW transition after a full re-sync
 
-                        auto next_hash = organizer.index().get_hash(
-                            static_cast<blockchain::header_index::index_t>(headers_synced_to));
+                        auto next_hash = active_hash_at(organizer.index(), headers_synced_to);
 
                         if (!header_download_input.try_send(std::error_code{}, header_request{
                             .from_height = headers_synced_to,
@@ -1203,8 +1229,7 @@ static
                         headers_at_start = headers_synced_to;
                         slow_sync_started = false;
 
-                        auto next_hash = organizer.index().get_hash(
-                            static_cast<blockchain::header_index::index_t>(headers_synced_to));
+                        auto next_hash = active_hash_at(organizer.index(), headers_synced_to);
 
                         if (!header_download_input.try_send(std::error_code{}, header_request{
                             .from_height = headers_synced_to,

--- a/src/node/src/sync/reorg.cpp
+++ b/src/node/src/sync/reorg.cpp
@@ -1,0 +1,203 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/node/sync/reorg.hpp>
+
+#include <algorithm>
+#include <chrono>
+
+#include <asio/as_tuple.hpp>
+#include <asio/steady_timer.hpp>
+#include <asio/this_coro.hpp>
+#include <asio/use_awaitable.hpp>
+
+#include <spdlog/spdlog.h>
+
+namespace kth::node::sync {
+
+bool persist_active_headers(
+    blockchain::block_chain& chain,
+    blockchain::header_index const& index,
+    uint32_t from_height,
+    uint32_t to_height) {
+
+    if (from_height > to_height) {
+        return true;
+    }
+
+    constexpr uint32_t batch_size = 1000;
+
+    // The chain this run describes. A switch replaces what sits at these heights,
+    // so a run that outlives one would write part of one branch and part of
+    // another into the same table.
+    auto const generation = chain.chain_generation();
+
+    for (uint32_t height = from_height; height <= to_height; ) {
+        auto const batch_end = std::min(height + batch_size - 1, to_height);
+
+        domain::chain::header::list batch;
+        batch.reserve(batch_end - height + 1);
+        for (uint32_t h = height; h <= batch_end; ++h) {
+            // By height through the active chain: the index numbers entries in
+            // arrival order, so an entry's index stopped being its height the
+            // moment the first side branch was stored.
+            auto const idx = index.active_at(static_cast<int32_t>(h));
+            if (idx == blockchain::header_index::null_index) {
+                spdlog::warn("[header_persist] Height {} is not on the active chain; stopping", h);
+                return false;
+            }
+            batch.push_back(index.get_header(idx));
+        }
+
+        if (chain.chain_generation() != generation) {
+            spdlog::info("[header_persist] The chain moved while persisting {}-{}; stopping",
+                from_height, to_height);
+            return false;
+        }
+
+        if (auto const ec = chain.organize_headers_batch(batch, height); ec) {
+            spdlog::warn("[header_persist] Failed at height {}: {}", height, ec.message());
+            return false;
+        }
+
+        height = batch_end + 1;
+    }
+
+    return true;
+}
+
+::asio::awaitable<reorg_outcome> execute_reorg(
+    blockchain::block_chain& chain,
+    blockchain::header_organizer& organizer,
+    blockchain::header_index::index_t branch_head,
+    uint32_t fork_height,
+    std::function<bool()> abort) {
+
+    auto executor = co_await ::asio::this_coro::executor;
+
+    // Quiesce the writers: the switch rewrites the UTXO set and the validated
+    // height, so it must run alone. Lifting the pause is tied to the scope: a
+    // pause left on stops every registered writer for the rest of the run, and
+    // there are several ways out of here (an abort, a throw from the switch).
+    struct pause_scope {
+        blockchain::block_chain& chain;
+        explicit pause_scope(blockchain::block_chain& c) : chain(c) { chain.request_reorg_pause(true); }
+        ~pause_scope() { chain.request_reorg_pause(false); }
+        pause_scope(pause_scope const&) = delete;
+        pause_scope& operator=(pause_scope const&) = delete;
+    } const pause(chain);
+
+    // Bounded: a registered writer that never parks is a bug, and waiting on it
+    // forever would hold the pause open and stall sync with nothing in the log.
+    // Long enough that a legitimately slow batch — a UTXO build parks between
+    // batches, and one batch runs full validation over a hundred blocks — is not
+    // cut off.
+    constexpr auto barrier_deadline = std::chrono::minutes(5);
+    auto const wait_started = std::chrono::steady_clock::now();
+    bool timed_out = false;
+
+    while ( ! chain.reorg_barrier_reached() && ! abort()) {
+        if (std::chrono::steady_clock::now() - wait_started > barrier_deadline) {
+            timed_out = true;
+            break;
+        }
+        ::asio::steady_timer wait_timer(executor);
+        wait_timer.expires_after(std::chrono::milliseconds(50));
+        co_await wait_timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
+    }
+
+    if (timed_out) {
+        auto const [parked, registered] = chain.reorg_barrier_state();
+        spdlog::error("[reorg] Gave up waiting for the reorg barrier after {} minutes: {} of {} "
+            "writers parked. The chain was not touched; the branch will be reconsidered when it is "
+            "announced again", barrier_deadline.count(), parked, registered);
+        co_return reorg_outcome{};
+    }
+
+    if (abort()) {
+        spdlog::info("[reorg] Aborted while waiting for the barrier; the chain was not touched");
+        co_return reorg_outcome{};
+    }
+
+    auto const outcome = co_await chain.switch_to_branch_async(branch_head, fork_height);
+
+    // Set wherever the chain and its persisted description end up disagreeing.
+    // Every such case is the same condition: the header table describes a branch
+    // the node is no longer on, and nothing repairs it while it runs.
+    bool fatal = false;
+
+    if (outcome.ok) {
+        organizer.adopt_tip(branch_head);
+
+        // Make the by-height header table describe the new branch over the range
+        // the switch replaced, and nothing above it — here rather than later,
+        // because the writers are still parked, so this is the one moment nothing
+        // else reads those heights or appends past them. The background persist
+        // that runs at the end of a header sync covers new heights, not heights
+        // whose block changed.
+        //
+        // The whole range goes in one call, and the database writes it in one
+        // transaction: written halfway, the table would name the new branch over
+        // part of the range and the abandoned one over the rest, and nothing
+        // later would notice — every height would still hold a header that
+        // parses. The range is bounded by the reorg depth, so it is one write.
+        auto const& index = chain.headers();
+        auto const new_tip_height = index.active_tip_height();
+
+        // The branch head is above the fork — switch_to_branch refuses anything
+        // else, and adopt_tip just published it — so anything else here means the
+        // chain is not where the switch says it is. Say so and write nothing.
+        if (new_tip_height <= int32_t(fork_height)) {
+            spdlog::critical("[reorg] The active chain ends at {}, at or below the fork at {}, after "
+                "a switch that reported success; the header table still describes the abandoned "
+                "branch", new_tip_height, fork_height);
+            fatal = true;
+        } else {
+            domain::chain::header::list branch;
+            branch.reserve(static_cast<size_t>(new_tip_height - int32_t(fork_height)));
+            for (int32_t h = int32_t(fork_height) + 1; h <= new_tip_height; ++h) {
+                auto const idx = index.active_at(h);
+                if (idx == blockchain::header_index::null_index) {
+                    spdlog::critical("[reorg] Height {} is not on the active chain right after the "
+                        "switch; the header table still describes the abandoned branch", h);
+                    branch.clear();
+                    fatal = true;
+                    break;
+                }
+                branch.push_back(index.get_header(idx));
+            }
+
+            if ( ! branch.empty()) {
+                if (auto const ec = chain.replace_headers_from(branch, fork_height + 1); ec) {
+                    // The transaction aborted, so nothing was written: the
+                    // persisted headers still describe the branch the node just
+                    // left — whole, but wrong.
+                    //
+                    // That is not something to carry on from. The header index is
+                    // rebuilt from this table at startup, so the node would run
+                    // with its chain and its persisted view of it disagreeing, and
+                    // a restart would come back up on the abandoned branch with
+                    // the UTXO set already rewound below it. Nothing repairs the
+                    // range on its own either: the background persist covers
+                    // heights above where it started, not heights whose block
+                    // changed underneath it.
+                    //
+                    // Report it as fatal and let the caller wind the node down.
+                    // The next start loads the old branch, finds its blocks
+                    // validated only to the fork, and re-syncs — the heavier
+                    // branch arrives again and the switch is retried, from a state
+                    // that is at least consistent with itself.
+                    spdlog::critical("[reorg] Could not rewrite the header table over {}-{}: {}. "
+                        "The persisted headers no longer describe the active chain",
+                        fork_height + 1, new_tip_height, ec.message());
+                    fatal = true;
+                }
+            }
+        }
+    }
+
+    co_return reorg_outcome{outcome, fatal};
+}
+
+} // namespace kth::node::sync

--- a/src/node/test/reorg_cycle.cpp
+++ b/src/node/test/reorg_cycle.cpp
@@ -1,0 +1,375 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <chrono>
+#include <vector>
+
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/io_context.hpp>
+
+#include <kth/node/sync/block_tasks.hpp>
+#include <kth/node/sync/messages.hpp>
+#include <kth/node/sync/reorg.hpp>
+
+#include "../../blockchain/test/regtest_miner.hpp"
+#include "../../blockchain/test/reorg_chain_fixture.hpp"
+
+using namespace kth;
+using namespace kth::node::sync;
+
+// =============================================================================
+// The reorganization, end to end
+// =============================================================================
+//
+// A trunk to height 100, a block at 101 that spends a coinbase matured on that
+// trunk, and a competing branch of three blocks from 100 that outweighs it. The
+// node connects the first chain, switches to the second, and connects that —
+// through the same tasks the sync coordinator drives, against the same header
+// index, flat-file store, undo files and UTXO-Z the node runs on.
+//
+// Every block here satisfies consensus (real proof of work, real merkle roots, a
+// real signature over a real prevout), so the connect path runs full validation
+// rather than the shortcuts a synthetic block would slip through.
+
+namespace {
+
+// Blocks are spaced two minutes apart and the chain ends near the present. The
+// node treats an old tip as "still in IBD" and then batches UTXO work a thousand
+// blocks at a time, so a chain stuck in 2011 would never build anything here.
+constexpr uint32_t block_spacing = 120;
+
+// Serialize a mined block the way a peer would send it and parse it back the way
+// the node does, so what reaches storage arrived through the same code path as a
+// block off the wire.
+std::shared_ptr<domain::chain::light_block const> to_light(domain::chain::block const& blk) {
+    data_chunk raw(blk.serialized_size());
+    byte_writer writer(raw);
+    auto const written = blk.to_data(writer);
+    REQUIRE(written);
+
+    byte_reader reader(raw);
+    auto light = domain::chain::light_block::from_data(reader, true);
+    REQUIRE(light);
+    return std::make_shared<domain::chain::light_block const>(std::move(*light));
+}
+
+// Write the headers into the internal database, standing in for the node's
+// header-persist task, which runs when a header sync completes. get_header(height)
+// reads that table, and the UTXO build needs it twice over: to rebuild its
+// median-time-past window, and to decide whether the chain is still far enough
+// behind to batch a thousand blocks at a time. Without it the build sits idle.
+//
+// Deliberately NOT called after the switch below: rewriting the heights a reorg
+// replaced is the reorg's own job, and doing it here would paper over whether it
+// actually happens.
+void persist_headers(test::chain_fixture& fixture, std::vector<domain::chain::block> const& blocks,
+                     uint32_t start_height) {
+    domain::chain::header::list batch;
+    batch.reserve(blocks.size());
+    for (auto const& blk : blocks) {
+        batch.push_back(blk.header());
+    }
+    REQUIRE( ! fixture.chain().organize_headers_batch(batch, start_height));
+}
+
+domain::message::header::list headers_of(std::vector<domain::chain::block> const& blocks) {
+    domain::message::header::list headers;
+    headers.reserve(blocks.size());
+    for (auto const& blk : blocks) {
+        headers.push_back(blk.header());
+    }
+    return headers;
+}
+
+// Run the real storage and UTXO-build tasks over `blocks`, a contiguous run
+// starting at `start_height` whose headers are already in the index and in the
+// by-height table. This is the node's connect path: bodies through
+// block_storage_task, then utxo_build_task reading them back off disk to
+// validate them, apply the UTXO delta and write the undo records.
+void connect_bodies(test::chain_fixture& fixture, std::vector<domain::chain::block> const& blocks,
+                    uint32_t start_height) {
+
+    auto& chain = fixture.chain();
+    auto const end_height = start_height + uint32_t(blocks.size()) - 1;
+
+    ::asio::io_context ctx;
+    block_storage_input_channel input(ctx.get_executor(), 16);
+    chunk_validated_channel output(ctx.get_executor(), 256);
+    std::atomic<uint32_t> contiguous{start_height};
+
+    std::vector<std::shared_ptr<domain::chain::light_block const>> light;
+    light.reserve(blocks.size());
+    for (auto const& blk : blocks) {
+        light.push_back(to_light(blk));
+    }
+
+    ::asio::co_spawn(ctx,
+        block_storage_task(chain, input, output, start_height, fixture.organizer(), &contiguous),
+        ::asio::detached);
+
+    ::asio::co_spawn(ctx,
+        utxo_build_task(chain, contiguous, start_height, domain::config::network::regtest,
+            [&chain, end_height] {
+                auto const built = chain.get_utxo_built_height();
+                return built && *built >= end_height;
+            }),
+        ::asio::detached);
+
+    REQUIRE(input.try_send(std::error_code{}, downloaded_chunk{
+        .start_height = start_height,
+        .chunk_id = 0,
+        .blocks = std::move(light),
+        .source_peer = nullptr,
+        .generation = chain.headers().generation()
+    }));
+    REQUIRE(input.try_send(std::error_code{}, stop_request{}));
+
+    ctx.run_for(std::chrono::seconds(120));
+
+    // Fail here if the tasks stalled, rather than at a height assertion further
+    // down that would point at the wrong thing.
+    auto const built = chain.get_utxo_built_height();
+    REQUIRE(built);
+    REQUIRE(*built >= end_height);
+
+    // Drain what the storage task reported, so nothing is left owning blocks.
+    while (output.try_receive([](std::error_code, chunk_validated) {})) {}
+}
+
+// UTXO-Z answers a miss with "queued", not "absent": the lookup is deferred to a
+// sweep. Concluding a UTXO is gone without draining that queue would report
+// whatever the sweep had not reached yet.
+bool utxo_present(blockchain::block_chain& chain, hash_digest const& txid, uint32_t index,
+                  uint32_t at_height) {
+    if (chain.get_utxo(domain::chain::output_point{txid, index}, at_height)) {
+        return true;
+    }
+    auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{txid.data(), 32}, index);
+    auto const [found, missing] = chain.utxo_process_pending_lookups();
+    return found.contains(key);
+}
+
+} // namespace
+
+// =============================================================================
+// The miner
+// =============================================================================
+
+TEST_CASE("the miner produces blocks that satisfy regtest consensus", "[reorg][cycle]") {
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const b1 = test::mine_block(genesis.hash(), 1, genesis.header().timestamp() + 600, 0, {}, 0);
+
+    CHECK(b1.header().is_valid_proof_of_work(b1.hash(), false));
+    CHECK(b1.header().previous_block_hash() == genesis.hash());
+    CHECK(b1.generate_merkle_root() == b1.header().merkle());
+    REQUIRE(b1.transactions().size() == 1);
+    CHECK(b1.transactions().front().is_coinbase());
+    CHECK(b1.is_valid_coinbase_script(1));
+}
+
+// =============================================================================
+// The full cycle
+// =============================================================================
+
+TEST_CASE("the node reorganizes onto a heavier branch and back to a consistent state", "[reorg][cycle]") {
+    test::chain_fixture fixture("cycle");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+    auto& index = chain.headers();
+
+    constexpr uint32_t trunk_len = 100;
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+
+    // -------------------------------------------------------------------------
+    // The trunk: heights 1..100, shared by both branches.
+    // -------------------------------------------------------------------------
+    std::vector<domain::chain::block> trunk;
+    auto prev = genesis.hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+
+    auto const trunk_result = fixture.organizer().add_headers(headers_of(trunk));
+    REQUIRE(trunk_result.headers_added == trunk_len);
+    persist_headers(fixture, trunk, 1);
+    connect_bodies(fixture, trunk, 1);
+
+    {
+        auto const heights = chain.get_last_heights();
+        REQUIRE(heights);
+        REQUIRE(heights->block == trunk_len);
+        auto const built = chain.get_utxo_built_height();
+        REQUIRE(built);
+        REQUIRE(*built == trunk_len);
+    }
+
+    // -------------------------------------------------------------------------
+    // Branch A: one block at 101 spending the coinbase of block 1, which matures
+    // exactly here — 101 - 1 == 100 confirmations.
+    // -------------------------------------------------------------------------
+    auto const& matured_coinbase = trunk.front().transactions().front();
+    auto const matured_txid = matured_coinbase.hash();
+    constexpr uint64_t fee = 1000;
+
+    auto const spend = test::spend_p2pkh(matured_coinbase, 0,
+        matured_coinbase.outputs()[0].value() - fee, chain.chain_settings().enabled_flags());
+    auto const spend_txid = spend.hash();
+
+    auto const a101 = test::mine_block(trunk.back().hash(), 101,
+        base_time + 101 * block_spacing, 1, {spend}, fee);
+    std::vector<domain::chain::block> const branch_a{a101};
+
+    auto const a_result = fixture.organizer().add_headers(headers_of(branch_a));
+    REQUIRE(a_result.headers_added == 1);
+    persist_headers(fixture, branch_a, 101);
+    connect_bodies(fixture, branch_a, 101);
+
+    {
+        auto const heights = chain.get_last_heights();
+        REQUIRE(heights);
+        REQUIRE(heights->block == 101);
+        auto const built = chain.get_utxo_built_height();
+        REQUIRE(built);
+        REQUIRE(*built == 101);
+    }
+
+    // The spend really happened: the coinbase it consumed is gone from the set and
+    // the output it created is in it. Without this the reorg below would be undoing
+    // nothing and every assertion after it would pass vacuously.
+    CHECK_FALSE(utxo_present(chain, matured_txid, 0, 101));
+    CHECK(utxo_present(chain, spend_txid, 0, 101));
+    CHECK(utxo_present(chain, a101.transactions().front().hash(), 0, 101));
+
+    // -------------------------------------------------------------------------
+    // Branch B: three blocks from height 100, outweighing A's single one.
+    // -------------------------------------------------------------------------
+    std::vector<domain::chain::block> branch_b;
+    prev = trunk.back().hash();
+    for (uint32_t h = 101; h <= 103; ++h) {
+        branch_b.push_back(test::mine_block(prev, h, base_time + h * block_spacing + 60, 2, {}, 0));
+        prev = branch_b.back().hash();
+    }
+
+    auto const generation_before = index.generation();
+    auto const b_result = fixture.organizer().add_headers(headers_of(branch_b));
+    REQUIRE(b_result.reorg_candidate);
+    REQUIRE(b_result.reorg_fork_height == int32_t(trunk_len));
+    REQUIRE(b_result.reorg_branch_head == index.find(branch_b.back().hash()));
+
+    // -------------------------------------------------------------------------
+    // The switch, through the same call the coordinator makes. No task is running
+    // here, so the barrier is satisfied at once — its own behaviour is covered by
+    // the drain tests.
+    // -------------------------------------------------------------------------
+    reorg_outcome reorg;
+    {
+        ::asio::io_context switch_ctx;
+        ::asio::co_spawn(switch_ctx,
+            execute_reorg(chain, fixture.organizer(), b_result.reorg_branch_head, trunk_len,
+                [] { return false; }),
+            [&reorg](std::exception_ptr, reorg_outcome result) {
+                reorg = result;
+            });
+        switch_ctx.run_for(std::chrono::seconds(30));
+    }
+    auto const outcome = reorg.result;
+
+    // Nothing about this switch leaves the node in a state it cannot continue
+    // from: the header table was rewritten and agrees with the chain.
+    CHECK_FALSE(reorg.fatal);
+    REQUIRE(outcome.ok);
+    REQUIRE(outcome.validated_tip);
+    CHECK(*outcome.validated_tip == trunk_len);
+
+    // A's block is disconnected: its coinbase is out of the set and the coinbase it
+    // spent is back, at the height it was originally created — not at 101, which
+    // would misdate its maturity and its median-time-past.
+    CHECK_FALSE(utxo_present(chain, a101.transactions().front().hash(), 0, trunk_len));
+    CHECK_FALSE(utxo_present(chain, spend_txid, 0, trunk_len));
+    CHECK(utxo_present(chain, matured_txid, 0, trunk_len));
+
+    // The by-height header table names B's blocks already — rewritten by the
+    // switch itself, while the writers were still parked. Nothing else would do
+    // it: the background persist covers new heights, not heights whose block
+    // changed, so without this every reader that addresses blocks by height
+    // (median time past, the staleness check, the RPC surface) would keep
+    // answering from the branch the node just left.
+    for (uint32_t h = 101; h <= 103; ++h) {
+        auto const persisted = chain.get_header(h);
+        REQUIRE(persisted);
+        CHECK(domain::chain::hash(*persisted) == branch_b[h - 101].hash());
+    }
+
+    // And the displaced header is no longer reachable by hash through that table.
+    // Leaving its hash -> height entry would answer a lookup for A101 with B101 —
+    // a different header than the one asked for.
+    CHECK_FALSE(chain.get_height(a101.hash()));
+
+    // The chain is on B — all the way to 103, since the switch re-points the
+    // active chain onto the whole branch and leaves 101..103 headers-only for
+    // block download to refill. The generation moved with it, so work in flight
+    // for A is recognisable as stale.
+    CHECK(index.active_tip_height() == 103);
+    CHECK(index.generation() > generation_before);
+    {
+        auto const heights = chain.get_last_heights();
+        REQUIRE(heights);
+        CHECK(heights->block == trunk_len);
+    }
+
+    // -------------------------------------------------------------------------
+    // Connect B's bodies, the way the coordinator re-drives download after a switch.
+    // -------------------------------------------------------------------------
+    connect_bodies(fixture, branch_b, 101);
+
+    {
+        auto const heights = chain.get_last_heights();
+        REQUIRE(heights);
+        CHECK(heights->block == 103);
+        auto const built = chain.get_utxo_built_height();
+        REQUIRE(built);
+        CHECK(*built == 103);
+    }
+
+    // Heights now name B's blocks.
+    for (uint32_t h = 101; h <= 103; ++h) {
+        auto const idx = index.active_at(int32_t(h));
+        REQUIRE(idx != blockchain::header_index::null_index);
+        CHECK(index.get_hash(idx) == branch_b[h - 101].hash());
+    }
+
+    // The abandoned block is still on disk. Its bytes are what a later switch back
+    // to A would have to replay, and nothing in the reorg path deletes them.
+    auto const abandoned = index.find(a101.hash());
+    REQUIRE(abandoned != blockchain::header_index::null_index);
+    CHECK(index.has_block_data(abandoned));
+
+    // Final UTXO state: B's coinbases are present, A left nothing behind, and the
+    // coinbase A spent is unspent again.
+    for (auto const& blk : branch_b) {
+        CHECK(utxo_present(chain, blk.transactions().front().hash(), 0, 103));
+    }
+    CHECK_FALSE(utxo_present(chain, a101.transactions().front().hash(), 0, 103));
+    CHECK_FALSE(utxo_present(chain, spend_txid, 0, 103));
+    CHECK(utxo_present(chain, matured_txid, 0, 103));
+
+    // -------------------------------------------------------------------------
+    // Sync continues. A header extending the new tip is a plain extension — if the
+    // organizer were still anchored on the abandoned branch it would read this as
+    // yet another fork and ask for a switch that can never be executed.
+    // -------------------------------------------------------------------------
+    auto const b104 = test::mine_block(branch_b.back().hash(), 104,
+        base_time + 104 * block_spacing + 60, 2, {}, 0);
+    auto const extension = fixture.organizer().add_headers(headers_of({b104}));
+
+    CHECK(extension.headers_added == 1);
+    CHECK_FALSE(extension.reorg_candidate);
+    CHECK(fixture.organizer().header_height() == 104);
+}


### PR DESCRIPTION
Everything built for reorg support so far was verified in pieces. This stands up the whole cycle against the real stack.

## The scenario

- A trunk to height 100.
- **Branch A**: one block at 101 spending the coinbase of block 1 — which matures exactly there (101 − 1 = 100 confirmations).
- **Branch B**: three blocks from height 100, outweighing A's single one.
- Connect A, switch to B, connect B.

Driven through the same tasks the sync coordinator drives (`block_storage_task`, `utxo_build_task`, `execute_reorg`) against the same header index, flat-file block store, undo files and UTXO-Z the node runs on.

The blocks satisfy consensus — real proof of work, real merkle roots, a real signature over a real prevout — so the connect path runs **full validation** rather than the shortcuts a synthetic block slips through. Regtest makes that cheap: a hundred blocks are mined in milliseconds. `test/regtest_miner.hpp` holds the miner; blocks are serialized and re-parsed as `light_block` so what reaches storage arrived the same way a block off the wire does.

## What it verifies

The spend really happened before the reorg (the coinbase it consumed is out of the set, the output it created is in) — without that the undo below would be undoing nothing and everything after it would pass vacuously. Then, after the switch: A's coinbase and its spend are gone from the UTXO set, the coinbase A spent is back **at its original creation height** (not at 101, which would misdate its maturity and its median time past), heights 101–103 name B's blocks, the validated tip and the UTXO-built height both reach 103, A's abandoned block is still on disk, and a header extending the new tip is read as a plain extension.

## The five defects it found

All five are on the path a real reorg takes; none is reachable by a test that stops at the pieces.

**1. The header table cannot be rewritten at a height.** Headers are written with LMDB's `APPEND`, which assumes keys only ever grow, so after a switch the abandoned branch's header stays at that height forever — and every reader that addresses blocks by height (median time past, staleness, the RPC surface) answers from the branch the node left. The duplicate was logged and then swallowed as success. A collision now rewrites the entry; the sequential path keeps `APPEND`.

**2. `block_storage_task` walked the header index by height.** The index numbers entries in arrival order, so since side branches are stored (#570) an entry's index is not its height. The contiguous scan counted the abandoned branch's blocks and pushed the validated tip one past where the chain actually reached — visible in the test as `last_block_height` = 104 on a 103-block chain. Resolved through the active chain now.

**3. `persist_headers_to_db` had the same confusion**, and persisted whichever header happened to sit at that index.

**4. The organizer kept the abandoned branch as its tip.** It decides fork-versus-extension by comparing against the tip it remembers; left behind, it reads every later batch as another fork and asks for a switch whose fork height no longer matches — so `switch_to_branch` rejects it and **header sync stops advancing for good**. Adds `header_organizer::adopt_tip`, and `node::sync::execute_reorg` to hold the sequence (park the writers at the barrier, switch, move the tip) in one place — which is also what lets the test drive the same thing the coordinator does instead of a re-implementation of it.

**5. `to_pay_public_key_hash_pattern_unlocking` emitted a leading `OP_0`.** That is the dummy multisig needs; in P2PKH it survives to the end of the script and fails `CLEANSTACK`. The placeholder used for size estimates carried it too, so coin selection was estimating one byte over. No production caller builds real unlocking scripts with it today, which is why nothing had failed yet.

## Scope

The barrier is satisfied trivially here (no task is running at the moment of the switch) — its own behaviour is covered by the drain tests in #576. Compact UTXO mode is not exercised: it needs a separate build configuration, so it stays a follow-up.

Local: `kth_blockchain_test` 1919 assertions / 176 cases, `kth_node_test` 616 / 110 (the cycle itself is 266 assertions), `kth_domain_test` 1008351 / 3821, `node-exe` builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer support for switching to a heavier blockchain branch during synchronization.
  * Improved header persistence and recovery after chain reorganizations.
  * Added regtest helpers for creating valid transactions and mining blocks.

* **Bug Fixes**
  * Prevented abandoned side-branch blocks from extending validated storage ranges.
  * Corrected P2PKH unlocking scripts by removing an unnecessary multisig placeholder.
  * Improved consistency when adopting a new chain tip.

* **Tests**
  * Added end-to-end coverage for reorganizations, including UTXO rollback, restoration, and continued block connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->