### PR TITLE
test: reorganize, restart, and refuse to write — the reorg paths that end a run

### DIFF
--- a/src/blockchain/test/reorg_chain_fixture.hpp
+++ b/src/blockchain/test/reorg_chain_fixture.hpp
@@ -80,7 +80,25 @@ struct chain_fixture {
             return false;
         }
         organizer_->sync_tip();
+
+        // Same as full_node::run_sync: the organizer learns how far blocks are
+        // validated at startup, since nothing else tells it until a new block is
+        // stored and deep-reorg parking measures against that height.
+        if (auto const heights = chain_->get_last_heights(); heights) {
+            organizer_->note_block_validated(static_cast<int32_t>(heights->block));
+        }
         return true;
+    }
+
+    // Close the chain and bring it back up on the same directory, which is what a
+    // process restart does: the header index is rebuilt from the persisted
+    // by-height headers, and the active chain is materialized again by sync_tip().
+    // Nothing in memory survives, so whatever the node comes back on is whatever
+    // was written to disk.
+    [[nodiscard]] bool restart() {
+        organizer_.reset();
+        chain_.reset();
+        return start();
     }
 
     [[nodiscard]] blockchain::header_organizer& organizer() { return *organizer_; }

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -295,6 +295,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   add_executable(kth_node_test
           test/check_list.cpp
           test/chunk_coordinator.cpp
+          test/fatal_shutdown.cpp
           test/reorg_cycle.cpp
           test/reorg_stale_chunk_drop.cpp
           test/configuration.cpp

--- a/src/node/include/kth/node/sync/reorg.hpp
+++ b/src/node/include/kth/node/sync/reorg.hpp
@@ -84,12 +84,22 @@ struct reorg_outcome {
 // untouched. So does waiting past the barrier deadline: a writer that never
 // parks is a bug, and holding the pause open forever on top of it would stall
 // sync silently.
+//
+// `persist` writes the replaced range of the by-height header table, and is a
+// parameter because that write is the step that decides whether the switch can
+// be lived with: if it fails, the chain and its persisted description disagree
+// and the node has to come down (see reorg_outcome::fatal). Production passes
+// block_chain::replace_headers_from; a test passes one that fails, which is the
+// only way to reach that path without corrupting a database on purpose.
+using header_persister = std::function<code(domain::chain::header::list const&, size_t)>;
+
 ::asio::awaitable<reorg_outcome> execute_reorg(
     blockchain::block_chain& chain,
     blockchain::header_organizer& organizer,
     blockchain::header_index::index_t branch_head,
     uint32_t fork_height,
-    std::function<bool()> abort);
+    std::function<bool()> abort,
+    header_persister persist);
 
 } // namespace kth::node::sync
 

--- a/src/node/src/full_node.cpp
+++ b/src/node/src/full_node.cpp
@@ -260,6 +260,19 @@ full_node::~full_node() {
     // Sync tip from chain's header index
     organizer.sync_tip();
 
+    // Tell it how far blocks are already validated. Nothing else does until the
+    // first newly stored block, and deep-reorg parking measures depth against
+    // this height: left at "nothing validated yet", a node that just came up
+    // would follow any branch with more work no matter how deep it forks — in
+    // exactly the window where finalization is not protecting either, since it
+    // needs headers older than the finalization delay to have any effect.
+    if (auto const heights = chain_.get_last_heights(); heights) {
+        organizer.note_block_validated(static_cast<int32_t>(heights->block));
+    } else {
+        spdlog::error("[full_node] Could not read the validated height at startup; deep-reorg "
+            "parking stays inactive until the first block is stored");
+    }
+
     spdlog::info("[node] Starting CSP-based sync system...");
 
     // Run the CSP sync orchestrator on the network thread pool.

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -900,7 +900,10 @@ static
 
                     auto const reorg = co_await execute_reorg(
                         chain, organizer, result->reorg_branch_head, fork_height,
-                        [&network] { return network.stopped(); });
+                        [&network] { return network.stopped(); },
+                        [&chain](domain::chain::header::list const& headers, size_t start_height) {
+                            return chain.replace_headers_from(headers, start_height);
+                        });
 
                     if (reorg.fatal) {
                         // The chain moved but its persisted description did not.

--- a/src/node/src/sync/reorg.cpp
+++ b/src/node/src/sync/reorg.cpp
@@ -14,6 +14,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include <kth/infrastructure/utility/assert.hpp>
+
 namespace kth::node::sync {
 
 bool persist_active_headers(
@@ -72,7 +74,13 @@ bool persist_active_headers(
     blockchain::header_organizer& organizer,
     blockchain::header_index::index_t branch_head,
     uint32_t fork_height,
-    std::function<bool()> abort) {
+    std::function<bool()> abort,
+    header_persister persist) {
+
+    // Before anything is touched: without somewhere to write the replaced range,
+    // a switch has no way to become survivable, and finding that out after the
+    // chain has already moved is finding out too late.
+    KTH_CONTRACT(persist);
 
     auto executor = co_await ::asio::this_coro::executor;
 
@@ -169,7 +177,7 @@ bool persist_active_headers(
             }
 
             if ( ! branch.empty()) {
-                if (auto const ec = chain.replace_headers_from(branch, fork_height + 1); ec) {
+                if (auto const ec = persist(branch, fork_height + 1); ec) {
                     // The transaction aborted, so nothing was written: the
                     // persisted headers still describe the branch the node just
                     // left — whole, but wrong.

--- a/src/node/test/fatal_shutdown.cpp
+++ b/src/node/test/fatal_shutdown.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+
+#include <kth/node/configuration.hpp>
+#include <kth/node/full_node.hpp>
+
+using namespace kth;
+
+// =============================================================================
+// Reporting a condition the node cannot go on from
+// =============================================================================
+//
+// Sync discovers such a condition from inside the node's own tasks (a switch
+// whose persisted description could not be written — see reorg_outcome::fatal),
+// but ending the process belongs to whoever owns the node. full_node is the
+// hinge: it stops itself and hands the reason on.
+//
+// What is pinned here is the handing on: that the reason reaches the owner,
+// unchanged, and that a node without a handler is still safe to report to.
+//
+// Neither side of it is. Above, the coordinator's `if (reorg.fatal) on_fatal(…)`
+// is not exercised: the reorg tests call execute_reorg directly and read the
+// flag themselves, which is not the same as watching the coordinator act on it.
+// Below, the executor's stop path — state to stopping, the heartbeat ending,
+// join() — needs a running node with a network that no test stands up. Both
+// halves are wired by inspection only, and saying otherwise here would make a
+// passing run look like more than it is.
+//
+// Not pinned: that notify_fatal stops the node. A node that never started
+// already reports stopped(), so on an unstarted one that assertion would hold
+// before the call as much as after — it would look like evidence and be none.
+
+namespace {
+
+std::filesystem::path make_dir() {
+    auto const p = std::filesystem::temp_directory_path() /
+        ("kth_fatal_" + std::to_string(getpid()));
+    std::error_code ec;
+    std::filesystem::remove_all(p, ec);
+    std::filesystem::create_directories(p, ec);
+    return p;
+}
+
+node::configuration make_config(std::filesystem::path const& dir) {
+    node::configuration cfg{domain::config::network::regtest};
+    cfg.database.directory = dir;
+    cfg.database.db_max_size = 16ULL << 20;   // 16 MiB, as the runtime example uses
+    cfg.network.threads = 0;                  // no network threads: nothing is started here
+    return cfg;
+}
+
+} // namespace
+
+TEST_CASE("a fatal condition reaches the node's owner verbatim", "[node][fatal]") {
+    auto const dir = make_dir();
+    node::full_node node{make_config(dir)};
+
+    std::string reported;
+    int calls = 0;
+    node.set_fatal_handler([&](std::string const& reason) { reported = reason; ++calls; });
+
+    node.notify_fatal("the persisted chain and the active chain describe different branches");
+
+    // Once, and verbatim: the reason is what the owner logs and what an operator
+    // has to act on, so it must arrive as it was written rather than as a class
+    // of error the caller has to guess at.
+    CHECK(calls == 1);
+    CHECK(reported == "the persisted chain and the active chain describe different branches");
+
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+}
+
+TEST_CASE("reporting a fatal condition with no handler installed is safe", "[node][fatal]") {
+    // Embedding the node as a library without installing a handler is allowed:
+    // notify_fatal still stops the node, and only the telling of it is optional.
+    // Reporting must therefore not depend on someone having listened.
+    auto const dir = make_dir();
+    node::full_node node{make_config(dir)};
+
+    REQUIRE_NOTHROW(node.notify_fatal("no handler installed"));
+
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+}

--- a/src/node/test/reorg_cycle.cpp
+++ b/src/node/test/reorg_cycle.cpp
@@ -140,6 +140,13 @@ void connect_bodies(test::chain_fixture& fixture, std::vector<domain::chain::blo
     while (output.try_receive([](std::error_code, chunk_validated) {})) {}
 }
 
+// What the coordinator passes: the real write, through the chain.
+header_persister real_persister(blockchain::block_chain& chain) {
+    return [&chain](domain::chain::header::list const& headers, size_t start_height) {
+        return chain.replace_headers_from(headers, start_height);
+    };
+}
+
 // UTXO-Z answers a miss with "queued", not "absent": the lookup is deferred to a
 // sweep. Concluding a UTXO is gone without draining that queue would report
 // whatever the sweep had not reached yet.
@@ -273,7 +280,7 @@ TEST_CASE("the node reorganizes onto a heavier branch and back to a consistent s
         ::asio::io_context switch_ctx;
         ::asio::co_spawn(switch_ctx,
             execute_reorg(chain, fixture.organizer(), b_result.reorg_branch_head, trunk_len,
-                [] { return false; }),
+                [] { return false; }, real_persister(chain)),
             [&reorg](std::exception_ptr, reorg_outcome result) {
                 reorg = result;
             });
@@ -378,4 +385,259 @@ TEST_CASE("the node reorganizes onto a heavier branch and back to a consistent s
     CHECK(extension.headers_added == 1);
     CHECK_FALSE(extension.reorg_candidate);
     CHECK(fixture.organizer().header_height() == 104);
+}
+
+// =============================================================================
+// The chain the node comes back on
+// =============================================================================
+
+TEST_CASE("a restart after a reorganization comes back on the branch that won", "[reorg][cycle]") {
+    // The header index is rebuilt at startup from the persisted by-height headers,
+    // so those are what decides which chain the node resumes. A switch that moved
+    // the chain in memory without rewriting them would look fine for as long as
+    // the process lived, and come back up on the branch it had abandoned — with
+    // the UTXO set already rewound below it.
+    //
+    // Short chain on purpose: this is about what survives a restart, not about
+    // spending a matured coinbase, which the cycle above covers.
+    test::chain_fixture fixture("restart");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+
+    constexpr uint32_t trunk_len = 12;
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+
+    std::vector<domain::chain::block> trunk;
+    auto prev = genesis.hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+    REQUIRE(fixture.organizer().add_headers(headers_of(trunk)).headers_added == trunk_len);
+    persist_headers(fixture, trunk, 1);
+    connect_bodies(fixture, trunk, 1);
+
+    // Branch A: one block on the trunk.
+    auto const a13 = test::mine_block(trunk.back().hash(), 13,
+        base_time + 13 * block_spacing, 1, {}, 0);
+    REQUIRE(fixture.organizer().add_headers(headers_of({a13})).headers_added == 1);
+    persist_headers(fixture, {a13}, 13);
+    connect_bodies(fixture, {a13}, 13);
+
+    // Branch B: three blocks from 12, outweighing it.
+    std::vector<domain::chain::block> branch_b;
+    prev = trunk.back().hash();
+    for (uint32_t h = 13; h <= 15; ++h) {
+        branch_b.push_back(test::mine_block(prev, h, base_time + h * block_spacing + 60, 2, {}, 0));
+        prev = branch_b.back().hash();
+    }
+    auto const b_result = fixture.organizer().add_headers(headers_of(branch_b));
+    REQUIRE(b_result.reorg_candidate);
+
+    reorg_outcome reorg;
+    {
+        ::asio::io_context switch_ctx;
+        ::asio::co_spawn(switch_ctx,
+            execute_reorg(fixture.chain(), fixture.organizer(), b_result.reorg_branch_head,
+                trunk_len, [] { return false; }, real_persister(fixture.chain())),
+            [&reorg](std::exception_ptr, reorg_outcome result) { reorg = result; });
+        switch_ctx.run_for(std::chrono::seconds(30));
+    }
+    REQUIRE(reorg.result.ok);
+    REQUIRE_FALSE(reorg.fatal);
+
+    connect_bodies(fixture, branch_b, 13);
+
+    // -------------------------------------------------------------------------
+    // Everything above is in memory as much as on disk. Drop it all.
+    // -------------------------------------------------------------------------
+    REQUIRE(fixture.restart());
+
+    auto& chain = fixture.chain();
+    auto& index = chain.headers();
+
+    // Rebuilt from disk: heights 13..15 name B's blocks, and the tip is B's head.
+    CHECK(index.active_tip_height() == 15);
+    for (uint32_t h = 13; h <= 15; ++h) {
+        auto const idx = index.active_at(int32_t(h));
+        REQUIRE(idx != blockchain::header_index::null_index);
+        CHECK(index.get_hash(idx) == branch_b[h - 13].hash());
+    }
+    CHECK(fixture.organizer().tip_index() == index.active_at(15));
+
+    // The abandoned branch is not in the index at all, which is worth stating
+    // rather than discovering: the index is rebuilt from the by-height table, and
+    // that table describes the active chain only. Side branches live in memory,
+    // so a restart forgets them. Their block bytes stay in the flat files, held
+    // by nothing, until a peer announces the branch again and the headers are
+    // re-downloaded. (BCHN persists its whole block index and does remember.)
+    CHECK(index.find(a13.hash()) == blockchain::header_index::null_index);
+
+    // The validated tip and the UTXO set came back together, at B's head.
+    {
+        auto const heights = chain.get_last_heights();
+        REQUIRE(heights);
+        CHECK(heights->block == 15);
+        auto const built = chain.get_utxo_built_height();
+        REQUIRE(built);
+        CHECK(*built == 15);
+    }
+
+    // And the organizer knows it. Nothing tells it until the first newly stored
+    // block, so a node that came up and was handed a deep, heavier branch before
+    // storing anything would measure the rewind against "nothing validated yet"
+    // and follow it — with finalization not protecting either, since it needs
+    // headers older than the finalization delay.
+    CHECK(fixture.organizer().validated_height() == 15);
+
+    // And the UTXO set is B's: its coinbases are there, A's is not.
+    for (auto const& blk : branch_b) {
+        CHECK(utxo_present(chain, blk.transactions().front().hash(), 0, 15));
+    }
+    CHECK_FALSE(utxo_present(chain, a13.transactions().front().hash(), 0, 15));
+
+    // Nothing that is on the chain is A's: every active height names a B block or
+    // a trunk one, so the switch did not leave the abandoned branch reachable by
+    // height either.
+    for (int32_t h = 13; h <= index.active_tip_height(); ++h) {
+        auto const idx = index.active_at(h);
+        REQUIRE(idx != blockchain::header_index::null_index);
+        CHECK(index.get_hash(idx) != a13.hash());
+    }
+}
+
+// =============================================================================
+// When the persisted description cannot be updated
+// =============================================================================
+
+TEST_CASE("a switch whose header write fails is fatal, and the restart is coherent", "[reorg][cycle]") {
+    // The write that makes a switch survivable is the one that re-describes the
+    // replaced heights. If it fails, the chain in memory and the chain on disk
+    // name different branches, and nothing repairs that while the node runs — so
+    // execute_reorg reports it as fatal and the owner brings the node down.
+    //
+    // Reaching that path needs the write to fail on demand, which is why the
+    // persister is a parameter rather than a call to the chain. Corrupting a real
+    // database to get here would test the corruption, not the handling.
+    test::chain_fixture fixture("fatal");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+
+    constexpr uint32_t trunk_len = 12;
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+
+    std::vector<domain::chain::block> trunk;
+    auto prev = genesis.hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+    REQUIRE(fixture.organizer().add_headers(headers_of(trunk)).headers_added == trunk_len);
+    persist_headers(fixture, trunk, 1);
+    connect_bodies(fixture, trunk, 1);
+
+    auto const a13 = test::mine_block(trunk.back().hash(), 13,
+        base_time + 13 * block_spacing, 1, {}, 0);
+    REQUIRE(fixture.organizer().add_headers(headers_of({a13})).headers_added == 1);
+    persist_headers(fixture, {a13}, 13);
+    connect_bodies(fixture, {a13}, 13);
+
+    std::vector<domain::chain::block> branch_b;
+    prev = trunk.back().hash();
+    for (uint32_t h = 13; h <= 15; ++h) {
+        branch_b.push_back(test::mine_block(prev, h, base_time + h * block_spacing + 60, 2, {}, 0));
+        prev = branch_b.back().hash();
+    }
+    auto const b_result = fixture.organizer().add_headers(headers_of(branch_b));
+    REQUIRE(b_result.reorg_candidate);
+
+    // -------------------------------------------------------------------------
+    // The switch, with a write that refuses.
+    // -------------------------------------------------------------------------
+    bool persist_called = false;
+    reorg_outcome reorg;
+    {
+        ::asio::io_context switch_ctx;
+        ::asio::co_spawn(switch_ctx,
+            execute_reorg(fixture.chain(), fixture.organizer(), b_result.reorg_branch_head,
+                trunk_len, [] { return false; },
+                [&persist_called](domain::chain::header::list const&, size_t) {
+                    persist_called = true;
+                    return code(error::operation_failed);
+                }),
+            [&reorg](std::exception_ptr, reorg_outcome result) { reorg = result; });
+        switch_ctx.run_for(std::chrono::seconds(30));
+    }
+
+    CHECK(persist_called);
+
+    // The switch itself succeeded — the UTXO set was rewound and the chain moved.
+    // What failed is describing that on disk, and it is that which is fatal.
+    CHECK(reorg.result.ok);
+    CHECK(reorg.fatal);
+
+    // Height 13 still answers with A's block, the branch the node was on before:
+    // a refused write leaves the table describing the old chain, and execute_reorg
+    // does not change it by some other route on the way out.
+    //
+    // Not what this shows: that the write itself is atomic. The persister here
+    // never reaches the database, so there is no transaction to have been left
+    // half-applied. Atomicity is replace_headers_from's, and it is not exercised
+    // from this test.
+    {
+        auto const persisted = fixture.chain().get_header(13);
+        REQUIRE(persisted);
+        CHECK(domain::chain::hash(*persisted) == a13.hash());
+    }
+
+    // No blocks are connected for B. In the node this is the coordinator refusing
+    // to send more work; here it is simply not sending any.
+
+    // -------------------------------------------------------------------------
+    // The restart the owner's shutdown leads to.
+    // -------------------------------------------------------------------------
+    REQUIRE(fixture.restart());
+
+    auto& chain = fixture.chain();
+    auto& index = chain.headers();
+
+    // Back on A, whole: the persisted table never described anything else.
+    CHECK(index.active_tip_height() == 13);
+    {
+        auto const idx = index.active_at(13);
+        REQUIRE(idx != blockchain::header_index::null_index);
+        CHECK(index.get_hash(idx) == a13.hash());
+    }
+
+    // The UTXO set and the validated height are where the switch left them — at
+    // the fork — so the node re-downloads A's block at 13 rather than trusting a
+    // UTXO state that no longer matches the chain it came back on.
+    {
+        auto const heights = chain.get_last_heights();
+        REQUIRE(heights);
+        CHECK(heights->block == trunk_len);
+        auto const built = chain.get_utxo_built_height();
+        REQUIRE(built);
+        CHECK(*built == trunk_len);
+    }
+
+    // A's coinbase at 13 is not in the set: its block was disconnected before the
+    // write failed, and the markers agree with that.
+    CHECK_FALSE(utxo_present(chain, a13.transactions().front().hash(), 0, trunk_len));
+
+    // The organizer came back knowing how far blocks are validated, so the retry
+    // below is judged with deep-reorg parking active rather than switched off.
+    CHECK(fixture.organizer().validated_height() == int32_t(trunk_len));
+
+    // And the heavier branch can be tried again. Its headers were forgotten with
+    // the restart (side branches are not persisted), so a peer re-announcing them
+    // is what a real node would see; the switch is then reachable exactly as
+    // before. It forks at the validated tip itself, so it rewinds nothing and
+    // parking does not hold it — which is the rule applying, not the rule being
+    // absent.
+    auto const retry = fixture.organizer().add_headers(headers_of(branch_b));
+    CHECK(retry.reorg_candidate);
+    CHECK(retry.reorg_fork_height == int32_t(trunk_len));
 }


### PR DESCRIPTION
Absorbs #580, which was merged into this branch (it was stacked on it). One commit, covering both.

The header index is rebuilt at startup from the persisted by-height headers, so those decide which chain the node resumes. A switch that moved the chain in memory without rewriting them would look right for as long as the process lived, and come back up on the branch it had abandoned — with the UTXO set already rewound below it. #578 added the handling for that; nothing exercised it, in either direction.

`chain_fixture::restart()` drops the chain and brings it up again on the same directory: nothing in memory survives, so what comes back is whatever was written to disk.

## The switch that succeeds

Trunk to 12, one block on A, three on B; switch, restart. Heights 13–15 name B's blocks, the organizer's tip is B's head, the validated tip **and** the UTXO-built height both return at 15, and the UTXO set holds B's coinbases and not A's.

## The switch whose header write fails

Reaching that needs the write to fail on demand. Corrupting a database would test the corruption, not the handling; filling LMDB's map would depend on page sizes and break on unrelated changes.

So `execute_reorg` takes the persister as a parameter — not a test flag: the write is what decides whether a switch can be lived with, and a caller that runs a reorg has to say where it goes, the same shape as the `abort` callback already there. The coordinator passes `block_chain::replace_headers_from`; the test passes one that refuses.

On refusal: the switch itself succeeded and it is describing that on disk which failed; the by-height table still answers with A's block, so nothing changed it on the way out (**not** that the write is atomic — that persister never reaches the database); the reorg is reported `fatal`; after a restart the node is on A, whole, with the validated tip and the UTXO-built height both back at the fork, so it re-downloads rather than trust a UTXO state that no longer matches the chain it came back on. The heavier branch can then be announced again and becomes a candidate again.

`test/fatal_shutdown.cpp` covers the hinge above that: `notify_fatal` hands the reason to the owner once and verbatim, and a node with no handler is still safe to report to. **What is not covered** is stated in the file: the coordinator acting on the flag, and the executor's own stop path, are wired by inspection only.

## What writing it turned up

**A defect.** The organizer was not told how far blocks are validated at startup. Nothing tells it until the first newly stored block, and deep-reorg parking measures rewind depth against that height — so a node that had just come up would treat any heavier branch as costing no rewind and follow it, however deep it forked. That is the same window in which finalization is not protecting either, since it needs headers older than the finalization delay. `full_node::run_sync` now reports the persisted validated height right after `sync_tip()`, the fixture does the same, and both tests assert it.

**And side branches do not survive a restart.** The by-height table is the only persisted header store and it describes the active chain alone, so the rebuilt index has no entry for the abandoned branch at all. Its block bytes stay in the flat files, held by nothing, until a peer announces the branch again. BCHN persists its whole block index and does remember. The node converges either way; the test now says so out loud.

Local: `kth_node_test` 775 assertions / 114 cases, `kth_blockchain_test` 1990 / 178.
