### PR TITLE
node: tell the mempool when a block connects, and stop when the build cannot

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -302,6 +302,7 @@ if (ENABLE_TEST)
         test/block_pool.cpp
         test/branch.cpp
         test/validate_transaction.cpp
+        test/mempool_block_connect.cpp
         test/mempool_test.cpp
         test/mempool_persistence_test.cpp
         test/block_template_test.cpp

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -393,6 +393,26 @@ struct KB_API block_chain {
 
     /// The unconfirmed-transaction mempool. Owned here; the organizers admit to
     /// it (tx accept) and evict from it (block connect / reorg).
+    // A block was connected: drop the transactions it confirmed and any pooled
+    // transaction that conflicts with them (recursively, with descendants).
+    //
+    // This lives here, and not in the caller, because the mempool's writes are
+    // serialized by the validation mutex — the one the transaction organizer
+    // holds while admitting. Calling mempool::remove_for_block directly from the
+    // block-connect path would race an admission in flight. The lock is taken at
+    // high priority: connecting a block takes precedence over admitting, which is
+    // what a prioritized mutex is for.
+    //
+    // The raw form exists for the block-connect path, which holds bytes rather
+    // than parsed blocks: it parses only when there is something to remove, and
+    // decides that under the lock, so an admission cannot slip in between the
+    // decision and the removal. Returns an error if the bytes do not parse,
+    // rather than passing for a block with nothing to confirm.
+    code mempool_remove_for_block(byte_span raw);
+
+    // The same, for a caller that has already parsed the block.
+    void mempool_remove_for_block(domain::chain::block const& block);
+
     blockchain::mempool& mempool_ref();
     blockchain::mempool const& mempool_ref() const;
 

--- a/src/blockchain/include/kth/blockchain/utxo_builder.hpp
+++ b/src/blockchain/include/kth/blockchain/utxo_builder.hpp
@@ -174,13 +174,22 @@ KB_API utxo_raw_delta process_compact_block_utxos(
 //   - UTXO-Z — everything older, read verbatim (no resolution) via find_raw,
 //     honouring its two-phase contract (a miss is queued, not absent).
 //
-// Returns an error if any spent output cannot be located, since undo data that
-// silently drops entries would corrupt the UTXO set on disconnect.
+// Fails rather than drop an entry, since undo data missing one would corrupt the
+// UTXO set on disconnect. The two ways to fail are kept apart, because they mean
+// different things:
+//   key_not_found — the delta says an output is spent that the set does not
+//                   have, once the deferred sweep has run;
+//   anything else — the source could not be read at all.
+// Neither is interpreted here: this function does not know what the caller knows
+// about the block. One that knows it passed validation can conclude more from
+// the first than one that does not (see utxo_build_task).
+//
 // `source` is anything exposing the two raw lookups this needs:
 //     std::expected<utxoz_database::raw_stored, result_code> find_utxo_raw(key, height)
 //     pair<map<key, raw_stored>, vector<key>>              utxo_process_pending_lookups_raw()
 // block_chain satisfies it in production; a test can substitute a thin adapter
-// over a utxoz_database, which is what keeps this function directly testable.
+// over a utxoz_database — or one that fails on purpose, which is how the two
+// branches above are covered.
 template <typename UtxoSource>
 [[nodiscard]]
 std::expected<database::block_undo, database::result_code> capture_block_undo(
@@ -207,9 +216,20 @@ std::expected<database::block_undo, database::result_code> capture_block_undo(
         auto stored = source.find_utxo_raw(key, height);
         if (stored) {
             undo.spent.push_back({key, std::move(stored->value), stored->height});
-        } else {
-            deferred.push_back(key);
+            continue;
         }
+
+        // Only key_not_found means "queued for the deferred sweep". Anything else
+        // is a read that failed, and queueing it would turn a storage error into a
+        // missing output — the caller would be told the set does not have what the
+        // block spends, when what happened is that it could not be asked.
+        if (stored.error() != database::result_code::key_not_found) {
+            spdlog::error("[utxo_builder] capture_block_undo: reading a spent output failed at "
+                "height {}", height);
+            return std::unexpected(stored.error());
+        }
+
+        deferred.push_back(key);
     }
 
     if ( ! deferred.empty()) {
@@ -218,13 +238,17 @@ std::expected<database::block_undo, database::result_code> capture_block_undo(
         for (auto const& key : deferred) {
             auto it = resolved.find(key);
             if (it == resolved.end()) {
-                // The block spends an output the UTXO set does not have. Either
-                // the block should not have validated, or the set is corrupt —
-                // either way, undo data that silently dropped it would corrupt
-                // the set further on disconnect.
+                // The delta says this output is spent and the set does not have
+                // it. What that means depends on what the caller already knows
+                // about the block — this function does not know, and does not
+                // guess; it reports the fact and leaves the reading to whoever
+                // called (see the UTXO build, which knows the block validated).
+                //
+                // key_not_found means exactly this and nothing else now: a read
+                // that failed took the branch above.
                 spdlog::error("[utxo_builder] capture_block_undo: spent output not found at height {} "
-                    "({} of {} deferred lookups unresolved) — cannot build undo data",
-                    height, missing.size(), deferred.size());
+                    "({} of {} deferred lookups unresolved) — the delta and the UTXO set disagree "
+                    "about it", height, missing.size(), deferred.size());
                 return std::unexpected(database::result_code::key_not_found);
             }
             undo.spent.push_back({key, it->second.value, it->second.height});

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1016,6 +1016,48 @@ transaction_validation_store& block_chain::transaction_validations() const {
     return transaction_validations_;
 }
 
+namespace {
+
+// Holds the validation mutex at high priority for a scope. The exclusion the
+// mempool depends on must not rest on the body never throwing.
+struct validation_high_priority_lock {
+    explicit validation_high_priority_lock(prioritized_mutex& mutex) : mutex_(mutex) {
+        mutex_.lock_high_priority();
+    }
+    ~validation_high_priority_lock() { mutex_.unlock_high_priority(); }
+    validation_high_priority_lock(validation_high_priority_lock const&) = delete;
+    validation_high_priority_lock& operator=(validation_high_priority_lock const&) = delete;
+private:
+    prioritized_mutex& mutex_;
+};
+
+} // namespace
+
+code block_chain::mempool_remove_for_block(byte_span raw) {
+    validation_high_priority_lock const lock(validation_mutex_);
+
+    // Under the lock, so an admission cannot land between finding the pool empty
+    // and deciding there is nothing to do. Empty is the whole of initial sync,
+    // where parsing every block for this would be the only reason to parse it.
+    if (mempool_.size() == 0) {
+        return error::success;
+    }
+
+    byte_reader reader(raw);
+    auto block = domain::message::block::from_data(reader, 0u);
+    if ( ! block) {
+        return error::operation_failed;
+    }
+
+    mempool_.remove_for_block(*block);
+    return error::success;
+}
+
+void block_chain::mempool_remove_for_block(domain::chain::block const& block) {
+    validation_high_priority_lock const lock(validation_mutex_);
+    mempool_.remove_for_block(block);
+}
+
 blockchain::mempool& block_chain::mempool_ref() {
     return mempool_;
 }

--- a/src/blockchain/test/mempool_block_connect.cpp
+++ b/src/blockchain/test/mempool_block_connect.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <vector>
+
+#include <kth/blockchain/pools/mempool.hpp>
+#include <kth/domain.hpp>
+
+#include "reorg_chain_fixture.hpp"
+
+using namespace kth;
+using namespace kth::domain::chain;
+using kth::blockchain::mempool_entry;
+
+// =============================================================================
+// Telling the mempool a block was connected
+// =============================================================================
+//
+// The mempool's writes are serialized by the chain's validation mutex — the one
+// the transaction organizer holds while admitting. So the block-connect path
+// does not call mempool::remove_for_block itself; it asks the chain, which takes
+// that lock at high priority. These pin what the chain's operation does.
+//
+// The raw form exists because the connect path holds bytes, not parsed blocks,
+// and parsing every block during initial sync purely for a mempool that is empty
+// would be the only reason to parse it at all. It decides whether to parse under
+// the lock, so an admission cannot land between "nothing to remove" and the
+// removal.
+
+namespace {
+
+hash_digest make_hash(uint64_t seed) {
+    hash_digest h{};
+    for (int i = 0; i < 8; ++i) {
+        h[i] = static_cast<uint8_t>(seed >> (8 * i));
+    }
+    h[16] = static_cast<uint8_t>(seed >> 5);
+    h[31] = static_cast<uint8_t>(seed >> 11);
+    return h;
+}
+
+output_point op(uint64_t seed, uint32_t index) {
+    return output_point{make_hash(seed), index};
+}
+
+transaction make_tx(std::vector<output_point> const& prevouts, uint32_t num_outputs, uint64_t tag) {
+    input::list ins;
+    ins.reserve(prevouts.size());
+    for (auto const& po : prevouts) {
+        ins.emplace_back(po, script{}, 0xffffffffu);
+    }
+
+    output::list outs;
+    outs.reserve(num_outputs);
+    for (uint32_t i = 0; i < num_outputs; ++i) {
+        output o;
+        o.set_value(1000u + tag * 100u + i);
+        o.set_script(script{});
+        outs.push_back(std::move(o));
+    }
+
+    return transaction{1u, 0u, std::move(ins), std::move(outs)};
+}
+
+transaction_const_ptr as_ptr(transaction const& tx) {
+    return std::make_shared<domain::message::transaction>(tx);
+}
+
+mempool_entry entry_for(transaction_const_ptr const& tx, uint64_t tag) {
+    return mempool_entry{
+        .tx = tx,
+        .fee = 1000u + tag,
+        .size = static_cast<uint32_t>(tx->serialized_size(true)),
+        .sigchecks = 1u,
+        .time_seen = tag};
+}
+
+// A block carrying `txs` after a coinbase. Only its transactions matter here —
+// the mempool never looks at the header.
+block block_with(std::vector<transaction> txs) {
+    transaction::list all;
+    all.reserve(txs.size() + 1);
+    all.push_back(make_tx({output_point{null_hash, point::null_index}}, 1, 999));
+    for (auto& tx : txs) {
+        all.push_back(std::move(tx));
+    }
+    return block{header{}, std::move(all)};
+}
+
+data_chunk serialize(block const& blk) {
+    data_chunk raw(blk.serialized_size());
+    byte_writer writer(raw);
+    auto const written = blk.to_data(writer);
+    REQUIRE(written);
+    return raw;
+}
+
+} // namespace
+
+TEST_CASE("a connected block drops what it confirmed, and conflicts with it", "[mempool][connect]") {
+    test::chain_fixture fixture("mp_connect");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+    auto& pool = chain.mempool_ref();
+
+    auto const confirmed = as_ptr(make_tx({op(1, 0)}, 1, 1));   // in the block
+    auto const conflict = as_ptr(make_tx({op(2, 0)}, 1, 2));    // spends what the block spends
+    auto const child = as_ptr(make_tx({output_point{conflict->hash(), 0}}, 1, 3));
+    auto const bystander = as_ptr(make_tx({op(9, 0)}, 1, 4));   // unrelated
+
+    REQUIRE(pool.add(entry_for(confirmed, 1)));
+    REQUIRE(pool.add(entry_for(conflict, 2)));
+    REQUIRE(pool.add(entry_for(child, 3)));
+    REQUIRE(pool.add(entry_for(bystander, 4)));
+    REQUIRE(pool.size() == 4);
+
+    // The block confirms one pooled transaction and spends the outpoint another
+    // pooled one was spending.
+    auto const blk = block_with({*confirmed, make_tx({op(2, 0)}, 1, 5)});
+    chain.mempool_remove_for_block(blk);
+
+    CHECK_FALSE(pool.entry(confirmed->hash()));   // confirmed
+    CHECK_FALSE(pool.entry(conflict->hash()));    // double-spent by the block
+    CHECK_FALSE(pool.entry(child->hash()));       // its child goes with it
+    CHECK(pool.entry(bystander->hash()));         // untouched
+}
+
+TEST_CASE("the raw form does the same as the parsed one", "[mempool][connect]") {
+    test::chain_fixture fixture("mp_raw");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+    auto& pool = chain.mempool_ref();
+
+    auto const confirmed = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto const bystander = as_ptr(make_tx({op(9, 0)}, 1, 2));
+    REQUIRE(pool.add(entry_for(confirmed, 1)));
+    REQUIRE(pool.add(entry_for(bystander, 2)));
+
+    auto const raw = serialize(block_with({*confirmed}));
+    CHECK_FALSE(chain.mempool_remove_for_block(byte_span{raw.data(), raw.size()}));
+
+    CHECK_FALSE(pool.entry(confirmed->hash()));
+    CHECK(pool.entry(bystander->hash()));
+}
+
+TEST_CASE("with an empty pool the raw form never parses the block", "[mempool][connect]") {
+    // Which is the point of it: during initial sync there is nothing to remove,
+    // and parsing every block to discover that would be the only reason to parse
+    // it. Bytes that could not possibly parse still succeed, because they are
+    // never looked at.
+    test::chain_fixture fixture("mp_empty");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    REQUIRE(chain.mempool_ref().size() == 0);
+
+    data_chunk const garbage{0x00, 0x01, 0x02};
+    CHECK_FALSE(chain.mempool_remove_for_block(byte_span{garbage.data(), garbage.size()}));
+}
+
+TEST_CASE("with a pool to update the raw form reports bytes it cannot parse", "[mempool][connect]") {
+    // The same bytes, and now they matter: the caller has to hear that the pool
+    // was not updated rather than take silence for a block that confirmed
+    // nothing.
+    test::chain_fixture fixture("mp_bad");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+    auto& pool = chain.mempool_ref();
+
+    auto const pooled = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    REQUIRE(pool.add(entry_for(pooled, 1)));
+
+    data_chunk const garbage{0x00, 0x01, 0x02};
+    CHECK(chain.mempool_remove_for_block(byte_span{garbage.data(), garbage.size()}));
+
+    // And it left the pool alone.
+    CHECK(pool.size() == 1);
+    CHECK(pool.entry(pooled->hash()));
+}

--- a/src/blockchain/test/reorg_undo_roundtrip.cpp
+++ b/src/blockchain/test/reorg_undo_roundtrip.cpp
@@ -69,6 +69,27 @@ struct db_source {
     }
 };
 
+// A source that fails every read the way a broken storage layer would, to reach
+// the branch a working database cannot produce on demand.
+struct failing_source {
+    result_code error{result_code::other};
+    mutable size_t reads{0};
+    size_t sweeps{0};
+
+    std::expected<utxoz_database::raw_stored, result_code> find_utxo_raw(
+        utxoz::raw_outpoint const&, uint32_t) const {
+        ++reads;
+        return std::unexpected(error);
+    }
+
+    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxoz_database::raw_stored>,
+              std::vector<utxoz::raw_outpoint>>
+    utxo_process_pending_lookups_raw() {
+        ++sweeps;
+        return {};
+    }
+};
+
 } // namespace
 
 // =============================================================================
@@ -206,4 +227,67 @@ TEST_CASE("find_raw reports a miss for an unknown outpoint", "[reorg][undo]") {
     auto const missed = db.find_raw(make_outpoint(42, 3), 1);
     REQUIRE_FALSE(missed.has_value());
     CHECK(missed.error() == result_code::key_not_found);   // the documented contract
+}
+
+// =============================================================================
+// Telling a failed read apart from a missing output
+// =============================================================================
+//
+// find_utxo_raw answers key_not_found for "queued for the deferred sweep" and
+// other codes for a read that failed. Capture used to queue both, so a storage
+// failure came back out as a missing output — the caller told the set does not
+// hold what a block spends, when what happened is that it could not be asked.
+
+TEST_CASE("a failed read is reported as itself, not as a missing output", "[reorg][undo]") {
+    failing_source source{result_code::other, 0, 0};
+
+    utxo_raw_delta delta;
+    delta.deletes.emplace(make_outpoint(7, 0), 900u);
+    utxo_raw_delta const empty_batch;
+
+    auto const captured = capture_block_undo(delta, empty_batch, source, 900u);
+
+    REQUIRE_FALSE(captured.has_value());
+    CHECK(captured.error() == result_code::other);
+
+    // And it did not go through the deferred sweep: queueing a read that failed
+    // is what turned it into a missing output in the first place.
+    CHECK(source.sweeps == 0);
+}
+
+TEST_CASE("an output still missing after the sweep is reported as not found", "[reorg][undo]") {
+    // The other half of the split: key_not_found is what the sweep is for, so it
+    // is queued, swept, and only then reported — and it now means only this.
+    failing_source source{result_code::key_not_found, 0, 0};
+
+    utxo_raw_delta delta;
+    delta.deletes.emplace(make_outpoint(8, 0), 900u);
+    utxo_raw_delta const empty_batch;
+
+    auto const captured = capture_block_undo(delta, empty_batch, source, 900u);
+
+    REQUIRE_FALSE(captured.has_value());
+    CHECK(captured.error() == result_code::key_not_found);
+    CHECK(source.sweeps == 1);
+}
+
+TEST_CASE("an output the same batch created needs no read at all", "[reorg][undo]") {
+    // The in-flight parent case, pinned here because it is what keeps a failing
+    // source from being consulted: the batch delta answers first.
+    failing_source source{result_code::other, 0, 0};
+
+    auto const key = make_outpoint(9, 0);
+    utxo_raw_delta delta;
+    delta.deletes.emplace(key, 900u);
+
+    utxo_raw_delta batch;
+    batch.inserts.emplace(key, utxo_raw_value{data_chunk{0x01, 0x02}, 899u});
+
+    auto const captured = capture_block_undo(delta, batch, source, 900u);
+
+    REQUIRE(captured.has_value());
+    REQUIRE(captured->spent.size() == 1);
+    CHECK(captured->spent.front().height == 899u);
+    CHECK(source.reads == 0);
+    CHECK(source.sweeps == 0);
 }

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -296,6 +296,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/check_list.cpp
           test/chunk_coordinator.cpp
           test/fatal_shutdown.cpp
+          test/mempool_connect_wiring.cpp
           test/reorg_cycle.cpp
           test/reorg_stale_chunk_drop.cpp
           test/configuration.cpp

--- a/src/node/include/kth/node/sync/block_tasks.hpp
+++ b/src/node/include/kth/node/sync/block_tasks.hpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <string>
 #include <memory>
 #include <optional>
 
@@ -161,12 +162,17 @@ extern std::atomic<uint64_t> g_blocks_received_by_validation;
 //
 // =============================================================================
 
+// `on_fatal` reports a condition this task cannot go on from and that ending the
+// coroutine would not communicate: the task group only propagates exceptions, so
+// a co_return here reduces a counter and nothing else. Winding the node down is
+// the owner's (see full_node::notify_fatal).
 ::asio::awaitable<void> utxo_build_task(
     blockchain::block_chain& chain,
     std::atomic<uint32_t> const& contiguous_height,
     uint32_t start_height,
     domain::config::network network,
-    std::function<bool()> should_stop  // node-owned stop signal (e.g. network.stopped())
+    std::function<bool()> should_stop,  // node-owned stop signal (e.g. network.stopped())
+    std::function<void(std::string const&)> on_fatal
 );
 
 } // namespace kth::node::sync

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1785,7 +1785,8 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
     std::atomic<uint32_t> const& contiguous_height,
     uint32_t start_height,
     domain::config::network network,
-    std::function<bool()> should_stop
+    std::function<bool()> should_stop,
+    std::function<void(std::string const&)> on_fatal
 ) {
     spdlog::info("[utxo_build] Task started at height {}", start_height);
 
@@ -1953,12 +1954,22 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
         // every block in it is validated against a UTXO-Z that already holds every
         // below-checkpoint output. On failure we halt: the invalid block is never
         // applied.
+        // Kept past the validation step: the mempool update below needs parsed
+        // blocks, and above the checkpoint they are parsed here anyway. Below it
+        // this stays empty and the raw bytes are used instead.
+        std::vector<kth::block_const_ptr> validated_blocks;
+
         if (batch_start > checkpoint_height) {
             // Parse the blocks and validate them on the worker pool, off this
             // coroutine's executor.
+            // A parse failure here is not a consensus failure, and the branch below
+            // cannot tell them apart from the code alone. Kept separate so each is
+            // reported as what it is.
+            bool parse_failed = false;
+
             auto const vc = co_await ::asio::co_spawn(validation_pool.get_executor(),
                 [&]() -> ::asio::awaitable<code> {
-                    std::vector<kth::block_const_ptr> full_blocks;
+                    auto& full_blocks = validated_blocks;
                     full_blocks.reserve(raw_result->size());
                     for (uint32_t i = 0; i < raw_result->size(); ++i) {
                         uint32_t const h = batch_start + i;
@@ -1967,6 +1978,7 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
                         auto blk = domain::message::block::from_data(reader, 0u);
                         if ( ! blk) {
                             spdlog::critical("[utxo_build] Failed to parse block for validation at height {}", h);
+                            parse_failed = true;
                             co_return error::operation_failed;
                         }
                         full_blocks.push_back(
@@ -1980,7 +1992,23 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
                 }, ::asio::use_awaitable);
 
             if (vc) {
-                spdlog::critical("[utxo_build] POST-CHECKPOINT VALIDATION FAILED at {}-{}: {}",
+                if (parse_failed) {
+                    // Bytes this node wrote, and the compact parser accepted when it
+                    // stored them. Not being able to read them back is local damage,
+                    // not a peer's doing.
+                    on_fatal("a stored block could not be parsed for validation");
+                    co_return;
+                }
+
+                // A block that does not satisfy consensus: a peer sent something
+                // invalid. Recoverable in principle — the range wants re-fetching
+                // from someone else — but the block is already stored and marked
+                // have_data, its peer is not recorded here, and the contiguous
+                // height has moved past it, so there is nothing this task can do
+                // about it beyond stopping. Recovering properly needs a way back to
+                // the coordinator with the failed height, which does not exist yet.
+                spdlog::critical("[utxo_build] POST-CHECKPOINT VALIDATION FAILED at {}-{}: {}. "
+                    "The UTXO build stops here and nothing re-drives it",
                     batch_start, batch_end, vc.message());
                 co_return;
             }
@@ -2004,13 +2032,15 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             auto parsed = blockchain::parse_utxo_block(
                 byte_span{(*raw_result)[i].data(), (*raw_result)[i].size()});
             if ( ! parsed) {
-                spdlog::error("[utxo_build] Failed to parse block at height {}", h);
+                spdlog::critical("[utxo_build] Failed to parse block at height {}", h);
+                on_fatal("a stored block could not be parsed");
                 co_return;
             }
 
             auto const idx = chain.headers().active_at(static_cast<int32_t>(h));
             if (idx == blockchain::header_index::null_index) {
-                spdlog::error("[utxo_build] Height {} is not on the active chain", h);
+                spdlog::critical("[utxo_build] Height {} is not on the active chain", h);
+                on_fatal("a height being built is not on the active chain");
                 co_return;
             }
             // Prune with the bloom only up to the checkpoint; above it keep every
@@ -2030,7 +2060,28 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             if (h > checkpoint_height) {
                 auto undo = blockchain::capture_block_undo(block_delta, delta, chain, h);
                 if ( ! undo) {
-                    spdlog::error("[utxo_build] Failed to capture undo data at height {}", h);
+                    // Nothing is applied yet, so the state is clean — but neither
+                    // cause is one to retry into. A read that failed is storage
+                    // that is not answering; an output the set does not have,
+                    // after this batch has already validated, is the set and the
+                    // delta disagreeing. Both are local and both persist.
+                    if (undo.error() == database::result_code::key_not_found) {
+                        // Here — and not in capture_block_undo, which cannot know
+                        // this — the reading is unambiguous: undo data is captured
+                        // above the checkpoint, where this batch has already passed
+                        // full validation, and that resolves every prevout against
+                        // UTXO-Z or against a batch output created at or below the
+                        // height being validated. A block cannot spend one from a
+                        // later block. So the block is not the problem: the set and
+                        // the delta describing it disagree.
+                        spdlog::critical("[utxo_build] The UTXO set does not hold an output the "
+                            "block at height {} spends, which validation resolved", h);
+                        on_fatal("the UTXO set and the delta built from it disagree");
+                    } else {
+                        spdlog::critical("[utxo_build] Could not read the outputs the block at "
+                            "height {} spends", h);
+                        on_fatal("the UTXO set could not be read while capturing undo data");
+                    }
                     co_return;
                 }
                 pending_undo.emplace_back(idx, std::move(*undo),
@@ -2052,7 +2103,8 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
         if ( ! delta.empty()) {
             auto result = chain.apply_utxo_delta_raw(delta.inserts, delta.deletes);
             if (result != database::result_code::success) {
-                spdlog::error("[utxo_build] Failed to apply UTXO delta at batch {}", batch_start);
+                spdlog::critical("[utxo_build] Failed to apply UTXO delta at batch {}", batch_start);
+                on_fatal("a UTXO delta could not be applied");
                 co_return;
             }
         }
@@ -2062,15 +2114,55 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
         // already connected — never a connected block without undo data.
         for (auto& entry : pending_undo) {
             if ( ! chain.store_block_undo(entry.idx, entry.undo, entry.prev_hash)) {
-                spdlog::error("[utxo_build] Failed to store undo data for index {}", entry.idx);
+                // After the delta: these blocks are in the UTXO set and now cannot be
+                // disconnected, so a later reorganization would have nothing to
+                // reverse them with.
+                spdlog::critical("[utxo_build] Failed to store undo data for index {}", entry.idx);
+                on_fatal("a connected block has no undo data and cannot be disconnected");
                 co_return;
             }
         }
 
         utxo_built_height = batch_end;
 
-        // Save progress + process deferred deletions
-        std::ignore = chain.set_utxo_built_height(utxo_built_height);
+        // Save progress. Not ignorable: everything below treats these blocks as
+        // connected, and on the next start the built height is what says how far
+        // the UTXO set reaches. A set that moved without its marker would be
+        // rebuilt over on resume, applying deltas that are already in it.
+        if (auto const marked = chain.set_utxo_built_height(utxo_built_height);
+                marked != database::result_code::success) {
+            spdlog::critical("[utxo_build] Could not record the built height {}: the UTXO set is "
+                "ahead of what the next start will believe", utxo_built_height);
+            on_fatal("the UTXO set advanced past the height marker that describes it");
+            co_return;
+        }
+
+        // These blocks are connected now — the delta is applied, the undo records
+        // are written and the marker has moved — so what they confirmed leaves the
+        // mempool, along with anything pooled that conflicts with them.
+        //
+        // Through the chain rather than the mempool directly: the mempool's writes
+        // are serialized by the validation mutex, which is not this task's to take.
+        // Above the checkpoint the blocks are already parsed by validation; below
+        // it the raw form parses only if there is something in the pool to remove.
+        for (uint32_t i = 0; i < raw_result->size(); ++i) {
+            if (i < validated_blocks.size()) {
+                chain.mempool_remove_for_block(*validated_blocks[i]);
+                continue;
+            }
+            auto const& raw = (*raw_result)[i];
+            if (auto const ec = chain.mempool_remove_for_block(
+                    byte_span{raw.data(), raw.size()}); ec) {
+                // These bytes came off disk after the compact parser accepted
+                // them, so failing here should not be reachable. If it is, the
+                // pool now holds transactions this block confirmed and will keep
+                // offering them for a template — carrying on would mine them.
+                spdlog::critical("[utxo_build] Could not update the mempool for the block at "
+                    "height {}: {}", batch_start + i, ec.message());
+                on_fatal("the mempool still holds transactions a connected block confirmed");
+                co_return;
+            }
+        }
         auto deferred = chain.utxo_deferred_deletions_size();
         if (deferred > 0) {
             auto [deleted, failed] = chain.utxo_process_pending_deletions();

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -656,7 +656,8 @@ static
         *contiguous_height,
         initial_block_height + 1,
         network_type,
-        [&network]() { return network.stopped(); }
+        [&network]() { return network.stopped(); },
+        on_fatal
     ));
 
     // Bridge: validated_chunks -> coordinator_events (carries validation errors only)

--- a/src/node/test/mempool_connect_wiring.cpp
+++ b/src/node/test/mempool_connect_wiring.cpp
@@ -1,0 +1,153 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <vector>
+
+#include <kth/blockchain/pools/mempool.hpp>
+
+#include "sync_harness.hpp"
+
+using namespace kth;
+using namespace kth::test;
+using kth::blockchain::mempool_entry;
+
+// =============================================================================
+// When the connect path tells the mempool
+// =============================================================================
+//
+// block_chain::mempool_remove_for_block is what the mempool sees; that it does
+// the right thing is pinned in the blockchain suite. What matters here is when
+// the connect path calls it: only for a block that is actually connected — its
+// UTXO delta applied, its undo written, the built-height marker moved. Storing
+// bytes is not connecting, and a batch that fails to validate connects nothing.
+
+namespace {
+
+// A transaction the pool will hold, spending a made-up outpoint. Nothing
+// validates it here: it is placed in the pool directly, which is what a
+// previously admitted transaction looks like from the connect path's side.
+domain::chain::transaction pooled_tx(uint32_t tag) {
+    hash_digest prevout{};
+    prevout[0] = uint8_t(tag);
+    prevout[1] = 0xab;
+
+    domain::chain::input::list ins;
+    ins.emplace_back(domain::chain::output_point{prevout, 0}, domain::chain::script{}, 0xffffffffu);
+
+    domain::chain::output::list outs;
+    domain::chain::output o;
+    o.set_value(1000u + tag);
+    o.set_script(domain::chain::script{});
+    outs.push_back(std::move(o));
+
+    return domain::chain::transaction{1u, 0u, std::move(ins), std::move(outs)};
+}
+
+void put_in_pool(blockchain::block_chain& chain, domain::chain::transaction const& tx) {
+    auto const ptr = std::make_shared<domain::message::transaction>(tx);
+    REQUIRE(chain.mempool_ref().add(mempool_entry{
+        .tx = ptr,
+        .fee = 1000u,
+        .size = static_cast<uint32_t>(ptr->serialized_size(true)),
+        .sigchecks = 1u,
+        .time_seen = 1u}));
+}
+
+} // namespace
+
+TEST_CASE("connecting a block through the sync path updates the mempool", "[mempool][wiring]") {
+    // The transaction has to be one the block can really confirm, which means a
+    // spend of a matured coinbase: full validation resolves every prevout, so a
+    // block carrying an invented transaction would be rejected and connect
+    // nothing — and the test would pass for the wrong reason, having watched a
+    // block that never arrived.
+    chain_fixture fixture("mp_wire_ok");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    constexpr uint32_t trunk_len = 100;   // coinbase maturity
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+
+    std::vector<domain::chain::block> trunk;
+    auto prev = genesis.hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+    REQUIRE(fixture.organizer().add_headers(headers_of(trunk)).headers_added == trunk_len);
+    persist_headers(fixture, trunk, 1);
+    connect_bodies(fixture, trunk, 1);
+
+    // A spend of block 1's coinbase, which matures exactly at 101, sitting in
+    // the pool the way an admitted transaction would.
+    auto const& matured = trunk.front().transactions().front();
+    constexpr uint64_t fee = 1000;
+    auto const spend = spend_p2pkh(matured, 0, matured.outputs()[0].value() - fee,
+        chain.chain_settings().enabled_flags());
+    put_in_pool(chain, spend);
+
+    auto const bystander = pooled_tx(2);
+    put_in_pool(chain, bystander);
+    REQUIRE(chain.mempool_ref().size() == 2);
+
+    // The block at 101 carries that same spend.
+    auto const blk = mine_block(trunk.back().hash(), 101,
+        base_time + 101 * block_spacing, 1, {spend}, fee);
+    std::vector<domain::chain::block> const blocks{blk};
+
+    REQUIRE(fixture.organizer().add_headers(headers_of(blocks)).headers_added == 1);
+    persist_headers(fixture, blocks, 101);
+    connect_bodies(fixture, blocks, 101);
+
+    // Connected: the marker moved.
+    auto const built = chain.get_utxo_built_height();
+    REQUIRE(built);
+    REQUIRE(*built == 101);
+
+    // And what it confirmed is gone, while the rest of the pool is not.
+    CHECK_FALSE(chain.mempool_ref().entry(spend.hash()));
+    CHECK(chain.mempool_ref().entry(bystander.hash()));
+}
+
+TEST_CASE("a block that fails to connect leaves the mempool alone", "[mempool][wiring]") {
+    // The direction that shows the update follows connection rather than
+    // accompanying it: this block is stored and then rejected by validation, so
+    // the delta is never applied and the marker never moves. A cleanup that ran
+    // on storage, or before the marker, would evict a transaction that is still
+    // unconfirmed — and nothing would put it back.
+    chain_fixture fixture("mp_wire_fail");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - 40 * block_spacing;
+
+    auto const confirmed = pooled_tx(1);
+    put_in_pool(chain, confirmed);
+    REQUIRE(chain.mempool_ref().size() == 1);
+
+    // Claims more than the subsidy: rejected by full validation, which runs
+    // above the checkpoint — and regtest has none, so every height is above it.
+    auto const blk = mine_block(genesis.hash(), 1, base_time + block_spacing, 0,
+        {confirmed}, /*fees*/ 100'000'000);
+    std::vector<domain::chain::block> const blocks{blk};
+
+    REQUIRE(fixture.organizer().add_headers(headers_of(blocks)).headers_added == 1);
+    persist_headers(fixture, blocks, 1);
+    run_connect_tasks(fixture, blocks, 1);
+
+    // Nothing was connected. On a chain where nothing ever did, the marker has
+    // not been written at all — which is as much "nothing built" as a zero.
+    auto const built = chain.get_utxo_built_height();
+    CHECK(( ! built || *built == 0));
+
+    // ...so nothing left the pool.
+    CHECK(chain.mempool_ref().size() == 1);
+    CHECK(chain.mempool_ref().entry(confirmed.hash()));
+}

--- a/src/node/test/reorg_cycle.cpp
+++ b/src/node/test/reorg_cycle.cpp
@@ -15,11 +15,11 @@
 #include <kth/node/sync/messages.hpp>
 #include <kth/node/sync/reorg.hpp>
 
-#include "../../blockchain/test/regtest_miner.hpp"
-#include "../../blockchain/test/reorg_chain_fixture.hpp"
+#include "sync_harness.hpp"
 
 using namespace kth;
 using namespace kth::node::sync;
+using namespace kth::test;
 
 // =============================================================================
 // The reorganization, end to end
@@ -35,132 +35,7 @@ using namespace kth::node::sync;
 // real signature over a real prevout), so the connect path runs full validation
 // rather than the shortcuts a synthetic block would slip through.
 
-namespace {
 
-// Blocks are spaced two minutes apart and the chain ends near the present. The
-// node treats an old tip as "still in IBD" and then batches UTXO work a thousand
-// blocks at a time, so a chain stuck in 2011 would never build anything here.
-constexpr uint32_t block_spacing = 120;
-
-// Serialize a mined block the way a peer would send it and parse it back the way
-// the node does, so what reaches storage arrived through the same code path as a
-// block off the wire.
-std::shared_ptr<domain::chain::light_block const> to_light(domain::chain::block const& blk) {
-    data_chunk raw(blk.serialized_size());
-    byte_writer writer(raw);
-    auto const written = blk.to_data(writer);
-    REQUIRE(written);
-
-    byte_reader reader(raw);
-    auto light = domain::chain::light_block::from_data(reader, true);
-    REQUIRE(light);
-    return std::make_shared<domain::chain::light_block const>(std::move(*light));
-}
-
-// Write the headers into the internal database, standing in for the node's
-// header-persist task, which runs when a header sync completes. get_header(height)
-// reads that table, and the UTXO build needs it twice over: to rebuild its
-// median-time-past window, and to decide whether the chain is still far enough
-// behind to batch a thousand blocks at a time. Without it the build sits idle.
-//
-// Deliberately NOT called after the switch below: rewriting the heights a reorg
-// replaced is the reorg's own job, and doing it here would paper over whether it
-// actually happens.
-void persist_headers(test::chain_fixture& fixture, std::vector<domain::chain::block> const& blocks,
-                     uint32_t start_height) {
-    domain::chain::header::list batch;
-    batch.reserve(blocks.size());
-    for (auto const& blk : blocks) {
-        batch.push_back(blk.header());
-    }
-    REQUIRE( ! fixture.chain().organize_headers_batch(batch, start_height));
-}
-
-domain::message::header::list headers_of(std::vector<domain::chain::block> const& blocks) {
-    domain::message::header::list headers;
-    headers.reserve(blocks.size());
-    for (auto const& blk : blocks) {
-        headers.push_back(blk.header());
-    }
-    return headers;
-}
-
-// Run the real storage and UTXO-build tasks over `blocks`, a contiguous run
-// starting at `start_height` whose headers are already in the index and in the
-// by-height table. This is the node's connect path: bodies through
-// block_storage_task, then utxo_build_task reading them back off disk to
-// validate them, apply the UTXO delta and write the undo records.
-void connect_bodies(test::chain_fixture& fixture, std::vector<domain::chain::block> const& blocks,
-                    uint32_t start_height) {
-
-    auto& chain = fixture.chain();
-    auto const end_height = start_height + uint32_t(blocks.size()) - 1;
-
-    ::asio::io_context ctx;
-    block_storage_input_channel input(ctx.get_executor(), 16);
-    chunk_validated_channel output(ctx.get_executor(), 256);
-    std::atomic<uint32_t> contiguous{start_height};
-
-    std::vector<std::shared_ptr<domain::chain::light_block const>> light;
-    light.reserve(blocks.size());
-    for (auto const& blk : blocks) {
-        light.push_back(to_light(blk));
-    }
-
-    ::asio::co_spawn(ctx,
-        block_storage_task(chain, input, output, start_height, fixture.organizer(), &contiguous),
-        ::asio::detached);
-
-    ::asio::co_spawn(ctx,
-        utxo_build_task(chain, contiguous, start_height, domain::config::network::regtest,
-            [&chain, end_height] {
-                auto const built = chain.get_utxo_built_height();
-                return built && *built >= end_height;
-            }),
-        ::asio::detached);
-
-    REQUIRE(input.try_send(std::error_code{}, downloaded_chunk{
-        .start_height = start_height,
-        .chunk_id = 0,
-        .blocks = std::move(light),
-        .source_peer = nullptr,
-        .generation = chain.headers().generation()
-    }));
-    REQUIRE(input.try_send(std::error_code{}, stop_request{}));
-
-    ctx.run_for(std::chrono::seconds(120));
-
-    // Fail here if the tasks stalled, rather than at a height assertion further
-    // down that would point at the wrong thing.
-    auto const built = chain.get_utxo_built_height();
-    REQUIRE(built);
-    REQUIRE(*built >= end_height);
-
-    // Drain what the storage task reported, so nothing is left owning blocks.
-    while (output.try_receive([](std::error_code, chunk_validated) {})) {}
-}
-
-// What the coordinator passes: the real write, through the chain.
-header_persister real_persister(blockchain::block_chain& chain) {
-    return [&chain](domain::chain::header::list const& headers, size_t start_height) {
-        return chain.replace_headers_from(headers, start_height);
-    };
-}
-
-// UTXO-Z answers a miss with "queued", not "absent": the lookup is deferred to a
-// sweep. Concluding a UTXO is gone without draining that queue would report
-// whatever the sweep had not reached yet.
-bool utxo_present(blockchain::block_chain& chain, hash_digest const& txid, uint32_t index,
-                  uint32_t at_height) {
-    if (chain.get_utxo(domain::chain::output_point{txid, index}, at_height)) {
-        return true;
-    }
-    auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{txid.data(), 32}, index);
-    auto const [found, missing] = chain.utxo_process_pending_lookups();
-    return found.contains(key);
-}
-
-} // namespace
 
 // =============================================================================
 // The miner

--- a/src/node/test/sync_harness.hpp
+++ b/src/node/test/sync_harness.hpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_TEST_SYNC_HARNESS_HPP
+#define KTH_NODE_TEST_SYNC_HARNESS_HPP
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/io_context.hpp>
+
+#include <test_helpers.hpp>
+
+#include <kth/node/sync/block_tasks.hpp>
+#include <kth/node/sync/messages.hpp>
+#include <kth/node/sync/reorg.hpp>
+
+#include "../../blockchain/test/regtest_miner.hpp"
+#include "../../blockchain/test/reorg_chain_fixture.hpp"
+
+// Driving the node's own connect path from a test: headers into the index and
+// the by-height table, bodies through block_storage_task, and utxo_build_task
+// reading them back off disk to validate them, apply the UTXO delta and write
+// the undo records. Shared by the tests that need a chain that was built the way
+// the node builds one, rather than one assembled by hand.
+
+namespace kth::test {
+
+using namespace kth::node::sync;
+
+
+// Blocks are spaced two minutes apart and the chain ends near the present. The
+// node treats an old tip as "still in IBD" and then batches UTXO work a thousand
+// blocks at a time, so a chain stuck in 2011 would never build anything here.
+constexpr uint32_t block_spacing = 120;
+
+// Serialize a mined block the way a peer would send it and parse it back the way
+// the node does, so what reaches storage arrived through the same code path as a
+// block off the wire.
+inline std::shared_ptr<domain::chain::light_block const> to_light(domain::chain::block const& blk) {
+    data_chunk raw(blk.serialized_size());
+    byte_writer writer(raw);
+    auto const written = blk.to_data(writer);
+    REQUIRE(written);
+
+    byte_reader reader(raw);
+    auto light = domain::chain::light_block::from_data(reader, true);
+    REQUIRE(light);
+    return std::make_shared<domain::chain::light_block const>(std::move(*light));
+}
+
+// Write the headers into the internal database, standing in for the node's
+// header-persist task, which runs when a header sync completes. get_header(height)
+// reads that table, and the UTXO build needs it twice over: to rebuild its
+// median-time-past window, and to decide whether the chain is still far enough
+// behind to batch a thousand blocks at a time. Without it the build sits idle.
+//
+// Deliberately NOT called after the switch below: rewriting the heights a reorg
+// replaced is the reorg's own job, and doing it here would paper over whether it
+// actually happens.
+inline void persist_headers(test::chain_fixture& fixture, std::vector<domain::chain::block> const& blocks,
+                     uint32_t start_height) {
+    domain::chain::header::list batch;
+    batch.reserve(blocks.size());
+    for (auto const& blk : blocks) {
+        batch.push_back(blk.header());
+    }
+    REQUIRE( ! fixture.chain().organize_headers_batch(batch, start_height));
+}
+
+inline domain::message::header::list headers_of(std::vector<domain::chain::block> const& blocks) {
+    domain::message::header::list headers;
+    headers.reserve(blocks.size());
+    for (auto const& blk : blocks) {
+        headers.push_back(blk.header());
+    }
+    return headers;
+}
+
+// Run the real storage and UTXO-build tasks over `blocks`, a contiguous run
+// starting at `start_height` whose headers are already in the index and in the
+// by-height table. This is the node's connect path: bodies through
+// block_storage_task, then utxo_build_task reading them back off disk to
+// validate them, apply the UTXO delta and write the undo records.
+// Runs the connect tasks and returns when they are done, whatever the outcome:
+// a batch that fails validation ends the UTXO build, and this returns with
+// nothing connected. Callers that require progress use connect_bodies below.
+inline void run_connect_tasks(test::chain_fixture& fixture,
+                              std::vector<domain::chain::block> const& blocks,
+                              uint32_t start_height) {
+
+    auto& chain = fixture.chain();
+    auto const end_height = start_height + uint32_t(blocks.size()) - 1;
+
+    ::asio::io_context ctx;
+    block_storage_input_channel input(ctx.get_executor(), 16);
+    chunk_validated_channel output(ctx.get_executor(), 256);
+    std::atomic<uint32_t> contiguous{start_height};
+
+    std::vector<std::shared_ptr<domain::chain::light_block const>> light;
+    light.reserve(blocks.size());
+    for (auto const& blk : blocks) {
+        light.push_back(to_light(blk));
+    }
+
+    ::asio::co_spawn(ctx,
+        block_storage_task(chain, input, output, start_height, fixture.organizer(), &contiguous),
+        ::asio::detached);
+
+    ::asio::co_spawn(ctx,
+        utxo_build_task(chain, contiguous, start_height, domain::config::network::regtest,
+            [&chain, end_height] {
+                auto const built = chain.get_utxo_built_height();
+                return built && *built >= end_height;
+            },
+            // Nothing here can reach it: the two conditions that report through
+            // this are a failed height-marker write and a failed mempool update,
+            // neither of which a test can provoke against a working database.
+            [](std::string const& reason) {
+                FAIL("the UTXO build reported a fatal condition: " << reason);
+            }),
+        ::asio::detached);
+
+    REQUIRE(input.try_send(std::error_code{}, downloaded_chunk{
+        .start_height = start_height,
+        .chunk_id = 0,
+        .blocks = std::move(light),
+        .source_peer = nullptr,
+        .generation = chain.headers().generation()
+    }));
+    REQUIRE(input.try_send(std::error_code{}, stop_request{}));
+
+    ctx.run_for(std::chrono::seconds(120));
+
+    // Drain what the storage task reported, so nothing is left owning blocks.
+    while (output.try_receive([](std::error_code, chunk_validated) {})) {}
+}
+
+// The same, for a run that is expected to connect: fails here if the tasks
+// stalled, rather than at a height assertion further down that would point at
+// the wrong thing.
+inline void connect_bodies(test::chain_fixture& fixture,
+                           std::vector<domain::chain::block> const& blocks,
+                           uint32_t start_height) {
+    run_connect_tasks(fixture, blocks, start_height);
+
+    auto const built = fixture.chain().get_utxo_built_height();
+    REQUIRE(built);
+    REQUIRE(*built >= start_height + uint32_t(blocks.size()) - 1);
+}
+
+// What the coordinator passes: the real write, through the chain.
+inline header_persister real_persister(blockchain::block_chain& chain) {
+    return [&chain](domain::chain::header::list const& headers, size_t start_height) {
+        return chain.replace_headers_from(headers, start_height);
+    };
+}
+
+// UTXO-Z answers a miss with "queued", not "absent": the lookup is deferred to a
+// sweep. Concluding a UTXO is gone without draining that queue would report
+// whatever the sweep had not reached yet.
+inline bool utxo_present(blockchain::block_chain& chain, hash_digest const& txid, uint32_t index,
+                  uint32_t at_height) {
+    if (chain.get_utxo(domain::chain::output_point{txid, index}, at_height)) {
+        return true;
+    }
+    auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{txid.data(), 32}, index);
+    auto const [found, missing] = chain.utxo_process_pending_lookups();
+    return found.contains(key);
+}
+
+
+} // namespace kth::test
+
+#endif // KTH_NODE_TEST_SYNC_HARNESS_HPP


### PR DESCRIPTION
Two things about utxo_build_task, which is where a block actually becomes part
of the chain: it never told the mempool, and when it could not go on it said so
to nobody.


Telling the mempool

Nothing did. mempool::remove_for_block and update_for_reorg existed, and no
caller anywhere reached either — so a block could confirm a pooled transaction
and the pool would keep it, and keep offering it for a template, until a peer
or a restart happened to clear it. This wires the first half: every block that
actually connects.

Where, and why not elsewhere. Storing a block's bytes is not connecting it: the
delta is not applied, the undo is not written, and the block may still fail
validation. So the call sits in utxo_build_task, after the delta lands, the
undo records are persisted and the built-height marker moves — and that last one
is now checked rather than ignored, since "after the marker moved" is not a
premise a discarded result supports. A marker that fails to persist leaves the
UTXO set ahead of what the next start will believe; a failed pool update leaves
it offering transactions the block just confirmed.

How, and why not directly. The mempool's writes are serialized by the chain's
validation mutex, the one the transaction organizer holds while admitting;
calling remove_for_block from the block-connect path would race an admission in
flight. So the operation lives on block_chain, which takes that lock at high
priority — connecting takes precedence over admitting, which is what a
prioritized mutex is for — under an RAII guard, so the exclusion does not rest
on the body never throwing.

There are two forms. The connect path holds bytes, not parsed blocks, and
during initial sync the pool is empty, so parsing every block for this would be
the only reason to parse it at all. The raw form decides whether to parse under
the lock — an admission cannot land between finding nothing to remove and not
removing it — and reports bytes it cannot parse rather than passing for a block
that confirmed nothing. Above the checkpoint the blocks are already parsed by
full validation, so those are handed over directly.

The tests pin the operation (confirmed transactions, conflicts, descendants,
both forms, and the two directions of unparseable bytes) and when the connect
path calls it — a block that fails validation leaves the pool untouched, since a
cleanup hung on storage would evict transactions that are still unconfirmed,
with nothing to put them back.

What they do not pin is the locking, and nothing can yet. A test that runs the
real admission path against the real cleanup admits nothing at all: resolving a
prevout during admission takes utxoz_database::find's key_not_found for absence
when it only means "queued for the deferred sweep", so every admission fails
with a missing previous output (#584). Written as a stress it passed without a
single transaction ever entering the pool — which is evidence of nothing. It
belongs with that fix, and comes back there.

The connect helpers move to test/sync_harness.hpp now that a second test needs
them, split into one that requires progress and one that does not.


Ending loudly

The UTXO build gives up by co_return, and the task group only propagates
exceptions — so ending the coroutine reduces a counter and tells nobody. Sync
stops advancing with a line in the log and a node that looks alive. The two
exits added above report through on_fatal for that reason; so do these, which
were already there.

Which of them are fatal is not uniform, so they are not treated uniformly.
Fatal, and now reported — the node comes down rather than run on state that no
longer describes itself:

- a stored block that cannot be parsed, either for validation or for the delta:
  these are bytes this node wrote and the compact parser accepted when it stored
  them, so failing to read them back is local damage;
- a height being built that is not on the active chain;
- a UTXO delta that cannot be applied;
- undo data that cannot be stored after the delta was applied, which leaves
  those blocks connected and impossible to disconnect — a later reorganization
  would have nothing to reverse them with.

Left as it is, with why written where it happens: a block that fails consensus
validation is a peer's doing, not the node's, and should end in that range being
re-fetched from someone else. It cannot, here: the block is already stored and
marked have_data, the peer that sent it is not recorded at this point, and the
contiguous height has moved past it. Recovering needs a way back to the
coordinator carrying the failed height, and a decision about invalidating what
was stored — its own change.

One thing the split turned up: a parse failure inside the validation step was
being reported as a consensus failure. Both left the lambda as
error::operation_failed and the branch below could not tell them apart, so a
corrupt local block and a peer's invalid one produced the same message — and
now sit on opposite sides of this classification. They are separated.


Why undo capture is on the fatal side

It would have been the other one left alone. capture_block_undo had one way to
fail and three things it could mean, so the caller could only give up without
saying what happened. Two of the three turn out not to exist, and the third was
being hidden.

find_utxo_raw answers key_not_found for "not in the active version file, queued
for the deferred sweep" and other codes for a read that failed. The caller
discarded the code and queued both, so a storage failure came back out as a
missing output: the set was reported not to hold what a block spends, when what
happened is that it could not be asked. That case now propagates immediately.

What is left — an output still missing once the sweep has run — has only one
explanation at this point. Undo data is captured above the checkpoint, where the
same batch has already passed full validation, and that resolves every prevout
either against UTXO-Z or against a batch output created at or below the height
being validated. A block cannot spend one from a later block, so an output the
set does not have is not a block that should have been rejected: it is the set
and the delta describing it disagreeing. That reading belongs to the caller,
which knows the block validated; capture_block_undo reports the two causes and
interprets neither.

So neither is one to retry into — a read that fails is storage not answering,
and a set that disagrees with its own delta will disagree again — and both are
reported through on_fatal, told apart in the message. Nothing is applied when
this happens, so the state stays clean; what stops is building further on a set
that cannot describe itself.


Re-admitting the transactions of a disconnected branch (#498) needs the reorg
half of the mempool wiring, which comes next: at the end of a switch the new
blocks are not connected yet, so there is no new tip to re-validate against.