### PR TITLE
node: report the UTXO build's fatal exits instead of ending quietly

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -302,6 +302,7 @@ if (ENABLE_TEST)
         test/block_pool.cpp
         test/branch.cpp
         test/validate_transaction.cpp
+        test/mempool_block_connect.cpp
         test/mempool_test.cpp
         test/mempool_persistence_test.cpp
         test/block_template_test.cpp

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -393,6 +393,26 @@ struct KB_API block_chain {
 
     /// The unconfirmed-transaction mempool. Owned here; the organizers admit to
     /// it (tx accept) and evict from it (block connect / reorg).
+    // A block was connected: drop the transactions it confirmed and any pooled
+    // transaction that conflicts with them (recursively, with descendants).
+    //
+    // This lives here, and not in the caller, because the mempool's writes are
+    // serialized by the validation mutex — the one the transaction organizer
+    // holds while admitting. Calling mempool::remove_for_block directly from the
+    // block-connect path would race an admission in flight. The lock is taken at
+    // high priority: connecting a block takes precedence over admitting, which is
+    // what a prioritized mutex is for.
+    //
+    // The raw form exists for the block-connect path, which holds bytes rather
+    // than parsed blocks: it parses only when there is something to remove, and
+    // decides that under the lock, so an admission cannot slip in between the
+    // decision and the removal. Returns an error if the bytes do not parse,
+    // rather than passing for a block with nothing to confirm.
+    code mempool_remove_for_block(byte_span raw);
+
+    // The same, for a caller that has already parsed the block.
+    void mempool_remove_for_block(domain::chain::block const& block);
+
     blockchain::mempool& mempool_ref();
     blockchain::mempool const& mempool_ref() const;
 

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1016,6 +1016,48 @@ transaction_validation_store& block_chain::transaction_validations() const {
     return transaction_validations_;
 }
 
+namespace {
+
+// Holds the validation mutex at high priority for a scope. The exclusion the
+// mempool depends on must not rest on the body never throwing.
+struct validation_high_priority_lock {
+    explicit validation_high_priority_lock(prioritized_mutex& mutex) : mutex_(mutex) {
+        mutex_.lock_high_priority();
+    }
+    ~validation_high_priority_lock() { mutex_.unlock_high_priority(); }
+    validation_high_priority_lock(validation_high_priority_lock const&) = delete;
+    validation_high_priority_lock& operator=(validation_high_priority_lock const&) = delete;
+private:
+    prioritized_mutex& mutex_;
+};
+
+} // namespace
+
+code block_chain::mempool_remove_for_block(byte_span raw) {
+    validation_high_priority_lock const lock(validation_mutex_);
+
+    // Under the lock, so an admission cannot land between finding the pool empty
+    // and deciding there is nothing to do. Empty is the whole of initial sync,
+    // where parsing every block for this would be the only reason to parse it.
+    if (mempool_.size() == 0) {
+        return error::success;
+    }
+
+    byte_reader reader(raw);
+    auto block = domain::message::block::from_data(reader, 0u);
+    if ( ! block) {
+        return error::operation_failed;
+    }
+
+    mempool_.remove_for_block(*block);
+    return error::success;
+}
+
+void block_chain::mempool_remove_for_block(domain::chain::block const& block) {
+    validation_high_priority_lock const lock(validation_mutex_);
+    mempool_.remove_for_block(block);
+}
+
 blockchain::mempool& block_chain::mempool_ref() {
     return mempool_;
 }

--- a/src/blockchain/test/mempool_block_connect.cpp
+++ b/src/blockchain/test/mempool_block_connect.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <vector>
+
+#include <kth/blockchain/pools/mempool.hpp>
+#include <kth/domain.hpp>
+
+#include "reorg_chain_fixture.hpp"
+
+using namespace kth;
+using namespace kth::domain::chain;
+using kth::blockchain::mempool_entry;
+
+// =============================================================================
+// Telling the mempool a block was connected
+// =============================================================================
+//
+// The mempool's writes are serialized by the chain's validation mutex — the one
+// the transaction organizer holds while admitting. So the block-connect path
+// does not call mempool::remove_for_block itself; it asks the chain, which takes
+// that lock at high priority. These pin what the chain's operation does.
+//
+// The raw form exists because the connect path holds bytes, not parsed blocks,
+// and parsing every block during initial sync purely for a mempool that is empty
+// would be the only reason to parse it at all. It decides whether to parse under
+// the lock, so an admission cannot land between "nothing to remove" and the
+// removal.
+
+namespace {
+
+hash_digest make_hash(uint64_t seed) {
+    hash_digest h{};
+    for (int i = 0; i < 8; ++i) {
+        h[i] = static_cast<uint8_t>(seed >> (8 * i));
+    }
+    h[16] = static_cast<uint8_t>(seed >> 5);
+    h[31] = static_cast<uint8_t>(seed >> 11);
+    return h;
+}
+
+output_point op(uint64_t seed, uint32_t index) {
+    return output_point{make_hash(seed), index};
+}
+
+transaction make_tx(std::vector<output_point> const& prevouts, uint32_t num_outputs, uint64_t tag) {
+    input::list ins;
+    ins.reserve(prevouts.size());
+    for (auto const& po : prevouts) {
+        ins.emplace_back(po, script{}, 0xffffffffu);
+    }
+
+    output::list outs;
+    outs.reserve(num_outputs);
+    for (uint32_t i = 0; i < num_outputs; ++i) {
+        output o;
+        o.set_value(1000u + tag * 100u + i);
+        o.set_script(script{});
+        outs.push_back(std::move(o));
+    }
+
+    return transaction{1u, 0u, std::move(ins), std::move(outs)};
+}
+
+transaction_const_ptr as_ptr(transaction const& tx) {
+    return std::make_shared<domain::message::transaction>(tx);
+}
+
+mempool_entry entry_for(transaction_const_ptr const& tx, uint64_t tag) {
+    return mempool_entry{tx, 1000u + tag,
+        static_cast<uint32_t>(tx->serialized_size(true)), 1u, tag};
+}
+
+// A block carrying `txs` after a coinbase. Only its transactions matter here —
+// the mempool never looks at the header.
+block block_with(std::vector<transaction> txs) {
+    transaction::list all;
+    all.reserve(txs.size() + 1);
+    all.push_back(make_tx({output_point{null_hash, point::null_index}}, 1, 999));
+    for (auto& tx : txs) {
+        all.push_back(std::move(tx));
+    }
+    return block{header{}, std::move(all)};
+}
+
+data_chunk serialize(block const& blk) {
+    data_chunk raw(blk.serialized_size());
+    byte_writer writer(raw);
+    auto const written = blk.to_data(writer);
+    REQUIRE(written);
+    return raw;
+}
+
+} // namespace
+
+TEST_CASE("a connected block drops what it confirmed, and conflicts with it", "[mempool][connect]") {
+    test::chain_fixture fixture("mp_connect");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+    auto& pool = chain.mempool_ref();
+
+    auto const confirmed = as_ptr(make_tx({op(1, 0)}, 1, 1));   // in the block
+    auto const conflict = as_ptr(make_tx({op(2, 0)}, 1, 2));    // spends what the block spends
+    auto const child = as_ptr(make_tx({output_point{conflict->hash(), 0}}, 1, 3));
+    auto const bystander = as_ptr(make_tx({op(9, 0)}, 1, 4));   // unrelated
+
+    REQUIRE(pool.add(entry_for(confirmed, 1)));
+    REQUIRE(pool.add(entry_for(conflict, 2)));
+    REQUIRE(pool.add(entry_for(child, 3)));
+    REQUIRE(pool.add(entry_for(bystander, 4)));
+    REQUIRE(pool.size() == 4);
+
+    // The block confirms one pooled transaction and spends the outpoint another
+    // pooled one was spending.
+    auto const blk = block_with({*confirmed, make_tx({op(2, 0)}, 1, 5)});
+    chain.mempool_remove_for_block(blk);
+
+    CHECK_FALSE(pool.entry(confirmed->hash()));   // confirmed
+    CHECK_FALSE(pool.entry(conflict->hash()));    // double-spent by the block
+    CHECK_FALSE(pool.entry(child->hash()));       // its child goes with it
+    CHECK(pool.entry(bystander->hash()));         // untouched
+}
+
+TEST_CASE("the raw form does the same as the parsed one", "[mempool][connect]") {
+    test::chain_fixture fixture("mp_raw");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+    auto& pool = chain.mempool_ref();
+
+    auto const confirmed = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto const bystander = as_ptr(make_tx({op(9, 0)}, 1, 2));
+    REQUIRE(pool.add(entry_for(confirmed, 1)));
+    REQUIRE(pool.add(entry_for(bystander, 2)));
+
+    auto const raw = serialize(block_with({*confirmed}));
+    CHECK_FALSE(chain.mempool_remove_for_block(byte_span{raw.data(), raw.size()}));
+
+    CHECK_FALSE(pool.entry(confirmed->hash()));
+    CHECK(pool.entry(bystander->hash()));
+}
+
+TEST_CASE("with an empty pool the raw form never parses the block", "[mempool][connect]") {
+    // Which is the point of it: during initial sync there is nothing to remove,
+    // and parsing every block to discover that would be the only reason to parse
+    // it. Bytes that could not possibly parse still succeed, because they are
+    // never looked at.
+    test::chain_fixture fixture("mp_empty");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    REQUIRE(chain.mempool_ref().size() == 0);
+
+    data_chunk const garbage{0x00, 0x01, 0x02};
+    CHECK_FALSE(chain.mempool_remove_for_block(byte_span{garbage.data(), garbage.size()}));
+}
+
+TEST_CASE("with a pool to update the raw form reports bytes it cannot parse", "[mempool][connect]") {
+    // The same bytes, and now they matter: the caller has to hear that the pool
+    // was not updated rather than take silence for a block that confirmed
+    // nothing.
+    test::chain_fixture fixture("mp_bad");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+    auto& pool = chain.mempool_ref();
+
+    auto const pooled = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    REQUIRE(pool.add(entry_for(pooled, 1)));
+
+    data_chunk const garbage{0x00, 0x01, 0x02};
+    CHECK(chain.mempool_remove_for_block(byte_span{garbage.data(), garbage.size()}));
+
+    // And it left the pool alone.
+    CHECK(pool.size() == 1);
+    CHECK(pool.entry(pooled->hash()));
+}

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -296,6 +296,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/check_list.cpp
           test/chunk_coordinator.cpp
           test/fatal_shutdown.cpp
+          test/mempool_connect_wiring.cpp
           test/reorg_cycle.cpp
           test/reorg_stale_chunk_drop.cpp
           test/configuration.cpp

--- a/src/node/include/kth/node/sync/block_tasks.hpp
+++ b/src/node/include/kth/node/sync/block_tasks.hpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <string>
 #include <memory>
 #include <optional>
 
@@ -161,12 +162,17 @@ extern std::atomic<uint64_t> g_blocks_received_by_validation;
 //
 // =============================================================================
 
+// `on_fatal` reports a condition this task cannot go on from and that ending the
+// coroutine would not communicate: the task group only propagates exceptions, so
+// a co_return here reduces a counter and nothing else. Winding the node down is
+// the owner's (see full_node::notify_fatal).
 ::asio::awaitable<void> utxo_build_task(
     blockchain::block_chain& chain,
     std::atomic<uint32_t> const& contiguous_height,
     uint32_t start_height,
     domain::config::network network,
-    std::function<bool()> should_stop  // node-owned stop signal (e.g. network.stopped())
+    std::function<bool()> should_stop,  // node-owned stop signal (e.g. network.stopped())
+    std::function<void(std::string const&)> on_fatal
 );
 
 } // namespace kth::node::sync

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1785,7 +1785,8 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
     std::atomic<uint32_t> const& contiguous_height,
     uint32_t start_height,
     domain::config::network network,
-    std::function<bool()> should_stop
+    std::function<bool()> should_stop,
+    std::function<void(std::string const&)> on_fatal
 ) {
     spdlog::info("[utxo_build] Task started at height {}", start_height);
 
@@ -1953,12 +1954,17 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
         // every block in it is validated against a UTXO-Z that already holds every
         // below-checkpoint output. On failure we halt: the invalid block is never
         // applied.
+        // Kept past the validation step: the mempool update below needs parsed
+        // blocks, and above the checkpoint they are parsed here anyway. Below it
+        // this stays empty and the raw bytes are used instead.
+        std::vector<kth::block_const_ptr> validated_blocks;
+
         if (batch_start > checkpoint_height) {
             // Parse the blocks and validate them on the worker pool, off this
             // coroutine's executor.
             auto const vc = co_await ::asio::co_spawn(validation_pool.get_executor(),
                 [&]() -> ::asio::awaitable<code> {
-                    std::vector<kth::block_const_ptr> full_blocks;
+                    auto& full_blocks = validated_blocks;
                     full_blocks.reserve(raw_result->size());
                     for (uint32_t i = 0; i < raw_result->size(); ++i) {
                         uint32_t const h = batch_start + i;
@@ -2069,8 +2075,44 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
 
         utxo_built_height = batch_end;
 
-        // Save progress + process deferred deletions
-        std::ignore = chain.set_utxo_built_height(utxo_built_height);
+        // Save progress. Not ignorable: everything below treats these blocks as
+        // connected, and on the next start the built height is what says how far
+        // the UTXO set reaches. A set that moved without its marker would be
+        // rebuilt over on resume, applying deltas that are already in it.
+        if (auto const marked = chain.set_utxo_built_height(utxo_built_height);
+                marked != database::result_code::success) {
+            spdlog::critical("[utxo_build] Could not record the built height {}: the UTXO set is "
+                "ahead of what the next start will believe", utxo_built_height);
+            on_fatal("the UTXO set advanced past the height marker that describes it");
+            co_return;
+        }
+
+        // These blocks are connected now — the delta is applied, the undo records
+        // are written and the marker has moved — so what they confirmed leaves the
+        // mempool, along with anything pooled that conflicts with them.
+        //
+        // Through the chain rather than the mempool directly: the mempool's writes
+        // are serialized by the validation mutex, which is not this task's to take.
+        // Above the checkpoint the blocks are already parsed by validation; below
+        // it the raw form parses only if there is something in the pool to remove.
+        for (uint32_t i = 0; i < raw_result->size(); ++i) {
+            if (i < validated_blocks.size()) {
+                chain.mempool_remove_for_block(*validated_blocks[i]);
+                continue;
+            }
+            auto const& raw = (*raw_result)[i];
+            if (auto const ec = chain.mempool_remove_for_block(
+                    byte_span{raw.data(), raw.size()}); ec) {
+                // These bytes came off disk after the compact parser accepted
+                // them, so failing here should not be reachable. If it is, the
+                // pool now holds transactions this block confirmed and will keep
+                // offering them for a template — carrying on would mine them.
+                spdlog::critical("[utxo_build] Could not update the mempool for the block at "
+                    "height {}: {}", batch_start + i, ec.message());
+                on_fatal("the mempool still holds transactions a connected block confirmed");
+                co_return;
+            }
+        }
         auto deferred = chain.utxo_deferred_deletions_size();
         if (deferred > 0) {
             auto [deleted, failed] = chain.utxo_process_pending_deletions();

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -1962,6 +1962,11 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
         if (batch_start > checkpoint_height) {
             // Parse the blocks and validate them on the worker pool, off this
             // coroutine's executor.
+            // A parse failure here is not a consensus failure, and the branch below
+            // cannot tell them apart from the code alone. Kept separate so each is
+            // reported as what it is.
+            bool parse_failed = false;
+
             auto const vc = co_await ::asio::co_spawn(validation_pool.get_executor(),
                 [&]() -> ::asio::awaitable<code> {
                     auto& full_blocks = validated_blocks;
@@ -1973,6 +1978,7 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
                         auto blk = domain::message::block::from_data(reader, 0u);
                         if ( ! blk) {
                             spdlog::critical("[utxo_build] Failed to parse block for validation at height {}", h);
+                            parse_failed = true;
                             co_return error::operation_failed;
                         }
                         full_blocks.push_back(
@@ -1986,7 +1992,23 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
                 }, ::asio::use_awaitable);
 
             if (vc) {
-                spdlog::critical("[utxo_build] POST-CHECKPOINT VALIDATION FAILED at {}-{}: {}",
+                if (parse_failed) {
+                    // Bytes this node wrote, and the compact parser accepted when it
+                    // stored them. Not being able to read them back is local damage,
+                    // not a peer's doing.
+                    on_fatal("a stored block could not be parsed for validation");
+                    co_return;
+                }
+
+                // A block that does not satisfy consensus: a peer sent something
+                // invalid. Recoverable in principle — the range wants re-fetching
+                // from someone else — but the block is already stored and marked
+                // have_data, its peer is not recorded here, and the contiguous
+                // height has moved past it, so there is nothing this task can do
+                // about it beyond stopping. Recovering properly needs a way back to
+                // the coordinator with the failed height, which does not exist yet.
+                spdlog::critical("[utxo_build] POST-CHECKPOINT VALIDATION FAILED at {}-{}: {}. "
+                    "The UTXO build stops here and nothing re-drives it",
                     batch_start, batch_end, vc.message());
                 co_return;
             }
@@ -2010,13 +2032,15 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             auto parsed = blockchain::parse_utxo_block(
                 byte_span{(*raw_result)[i].data(), (*raw_result)[i].size()});
             if ( ! parsed) {
-                spdlog::error("[utxo_build] Failed to parse block at height {}", h);
+                spdlog::critical("[utxo_build] Failed to parse block at height {}", h);
+                on_fatal("a stored block could not be parsed");
                 co_return;
             }
 
             auto const idx = chain.headers().active_at(static_cast<int32_t>(h));
             if (idx == blockchain::header_index::null_index) {
-                spdlog::error("[utxo_build] Height {} is not on the active chain", h);
+                spdlog::critical("[utxo_build] Height {} is not on the active chain", h);
+                on_fatal("a height being built is not on the active chain");
                 co_return;
             }
             // Prune with the bloom only up to the checkpoint; above it keep every
@@ -2036,7 +2060,14 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             if (h > checkpoint_height) {
                 auto undo = blockchain::capture_block_undo(block_delta, delta, chain, h);
                 if ( ! undo) {
-                    spdlog::error("[utxo_build] Failed to capture undo data at height {}", h);
+                    // Before the delta is applied, so nothing is half-done and this
+                    // could in principle be retried. It is not, because the failure
+                    // is not distinguishable here: a prevout missing because the
+                    // block is invalid, a read that failed, and a delta that does
+                    // not match the set all arrive as the same absence, and
+                    // retrying the last two forever would be worse than stopping.
+                    spdlog::error("[utxo_build] Failed to capture undo data at height {}; the UTXO "
+                        "build stops with nothing applied for this batch", h);
                     co_return;
                 }
                 pending_undo.emplace_back(idx, std::move(*undo),
@@ -2058,7 +2089,8 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
         if ( ! delta.empty()) {
             auto result = chain.apply_utxo_delta_raw(delta.inserts, delta.deletes);
             if (result != database::result_code::success) {
-                spdlog::error("[utxo_build] Failed to apply UTXO delta at batch {}", batch_start);
+                spdlog::critical("[utxo_build] Failed to apply UTXO delta at batch {}", batch_start);
+                on_fatal("a UTXO delta could not be applied");
                 co_return;
             }
         }
@@ -2068,7 +2100,11 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
         // already connected — never a connected block without undo data.
         for (auto& entry : pending_undo) {
             if ( ! chain.store_block_undo(entry.idx, entry.undo, entry.prev_hash)) {
-                spdlog::error("[utxo_build] Failed to store undo data for index {}", entry.idx);
+                // After the delta: these blocks are in the UTXO set and now cannot be
+                // disconnected, so a later reorganization would have nothing to
+                // reverse them with.
+                spdlog::critical("[utxo_build] Failed to store undo data for index {}", entry.idx);
+                on_fatal("a connected block has no undo data and cannot be disconnected");
                 co_return;
             }
         }

--- a/src/node/src/sync/orchestrator.cpp
+++ b/src/node/src/sync/orchestrator.cpp
@@ -656,7 +656,8 @@ static
         *contiguous_height,
         initial_block_height + 1,
         network_type,
-        [&network]() { return network.stopped(); }
+        [&network]() { return network.stopped(); },
+        on_fatal
     ));
 
     // Bridge: validated_chunks -> coordinator_events (carries validation errors only)

--- a/src/node/test/mempool_connect_wiring.cpp
+++ b/src/node/test/mempool_connect_wiring.cpp
@@ -1,0 +1,254 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <kth/blockchain/pools/mempool.hpp>
+
+#include "sync_harness.hpp"
+
+using namespace kth;
+using namespace kth::test;
+using kth::blockchain::mempool_entry;
+
+// =============================================================================
+// When the connect path tells the mempool
+// =============================================================================
+//
+// block_chain::mempool_remove_for_block is what the mempool sees; that it does
+// the right thing is pinned in the blockchain suite. What matters here is when
+// the connect path calls it: only for a block that is actually connected — its
+// UTXO delta applied, its undo written, the built-height marker moved. Storing
+// bytes is not connecting, and a batch that fails to validate connects nothing.
+
+namespace {
+
+// A transaction the pool will hold, spending a made-up outpoint. Nothing
+// validates it here: it is placed in the pool directly, which is what a
+// previously admitted transaction looks like from the connect path's side.
+domain::chain::transaction pooled_tx(uint32_t tag) {
+    hash_digest prevout{};
+    prevout[0] = uint8_t(tag);
+    prevout[1] = 0xab;
+
+    domain::chain::input::list ins;
+    ins.emplace_back(domain::chain::output_point{prevout, 0}, domain::chain::script{}, 0xffffffffu);
+
+    domain::chain::output::list outs;
+    domain::chain::output o;
+    o.set_value(1000u + tag);
+    o.set_script(domain::chain::script{});
+    outs.push_back(std::move(o));
+
+    return domain::chain::transaction{1u, 0u, std::move(ins), std::move(outs)};
+}
+
+void put_in_pool(blockchain::block_chain& chain, domain::chain::transaction const& tx) {
+    auto const ptr = std::make_shared<domain::message::transaction>(tx);
+    REQUIRE(chain.mempool_ref().add(mempool_entry{
+        ptr, 1000u, static_cast<uint32_t>(ptr->serialized_size(true)), 1u, 1u}));
+}
+
+} // namespace
+
+TEST_CASE("connecting a block through the sync path updates the mempool", "[mempool][wiring]") {
+    // The transaction has to be one the block can really confirm, which means a
+    // spend of a matured coinbase: full validation resolves every prevout, so a
+    // block carrying an invented transaction would be rejected and connect
+    // nothing — and the test would pass for the wrong reason, having watched a
+    // block that never arrived.
+    chain_fixture fixture("mp_wire_ok");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    constexpr uint32_t trunk_len = 100;   // coinbase maturity
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+
+    std::vector<domain::chain::block> trunk;
+    auto prev = genesis.hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+    REQUIRE(fixture.organizer().add_headers(headers_of(trunk)).headers_added == trunk_len);
+    persist_headers(fixture, trunk, 1);
+    connect_bodies(fixture, trunk, 1);
+
+    // A spend of block 1's coinbase, which matures exactly at 101, sitting in
+    // the pool the way an admitted transaction would.
+    auto const& matured = trunk.front().transactions().front();
+    constexpr uint64_t fee = 1000;
+    auto const spend = spend_p2pkh(matured, 0, matured.outputs()[0].value() - fee,
+        chain.chain_settings().enabled_flags());
+    put_in_pool(chain, spend);
+
+    auto const bystander = pooled_tx(2);
+    put_in_pool(chain, bystander);
+    REQUIRE(chain.mempool_ref().size() == 2);
+
+    // The block at 101 carries that same spend.
+    auto const blk = mine_block(trunk.back().hash(), 101,
+        base_time + 101 * block_spacing, 1, {spend}, fee);
+    std::vector<domain::chain::block> const blocks{blk};
+
+    REQUIRE(fixture.organizer().add_headers(headers_of(blocks)).headers_added == 1);
+    persist_headers(fixture, blocks, 101);
+    connect_bodies(fixture, blocks, 101);
+
+    // Connected: the marker moved.
+    auto const built = chain.get_utxo_built_height();
+    REQUIRE(built);
+    REQUIRE(*built == 101);
+
+    // And what it confirmed is gone, while the rest of the pool is not.
+    CHECK_FALSE(chain.mempool_ref().entry(spend.hash()));
+    CHECK(chain.mempool_ref().entry(bystander.hash()));
+}
+
+TEST_CASE("a block that fails to connect leaves the mempool alone", "[mempool][wiring]") {
+    // The direction that shows the update follows connection rather than
+    // accompanying it: this block is stored and then rejected by validation, so
+    // the delta is never applied and the marker never moves. A cleanup that ran
+    // on storage, or before the marker, would evict a transaction that is still
+    // unconfirmed — and nothing would put it back.
+    chain_fixture fixture("mp_wire_fail");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - 40 * block_spacing;
+
+    auto const confirmed = pooled_tx(1);
+    put_in_pool(chain, confirmed);
+    REQUIRE(chain.mempool_ref().size() == 1);
+
+    // Claims more than the subsidy: rejected by full validation, which runs
+    // above the checkpoint — and regtest has none, so every height is above it.
+    auto const blk = mine_block(genesis.hash(), 1, base_time + block_spacing, 0,
+        {confirmed}, /*fees*/ 100'000'000);
+    std::vector<domain::chain::block> const blocks{blk};
+
+    REQUIRE(fixture.organizer().add_headers(headers_of(blocks)).headers_added == 1);
+    persist_headers(fixture, blocks, 1);
+    run_connect_tasks(fixture, blocks, 1);
+
+    // Nothing was connected. On a chain where nothing ever did, the marker has
+    // not been written at all — which is as much "nothing built" as a zero.
+    auto const built = chain.get_utxo_built_height();
+    CHECK(( ! built || *built == 0));
+
+    // ...so nothing left the pool.
+    CHECK(chain.mempool_ref().size() == 1);
+    CHECK(chain.mempool_ref().entry(confirmed.hash()));
+}
+
+TEST_CASE("admission and block-connect cleanup run against each other", "[mempool][wiring][stress]") {
+    // Scope, so this is not read as more than it is. It exercises the real
+    // admission path (transaction_organizer, which takes the validation mutex at
+    // low priority) against the real cleanup (which takes it at high priority),
+    // and under a thread sanitizer it is where a missing lock would show. It does
+    // NOT demonstrate a particular interleaving, and it cannot demonstrate the
+    // priority at all: the fixture builds its chain with relay off, which leaves
+    // the mutex unprioritized — exclusion holds, ordering between the two sides
+    // does not.
+    //
+    // Nothing is asserted about who won a given race while the threads run. The
+    // strong assertions come after the join, past a final cleanup whose outcome
+    // does not depend on the scheduler.
+    chain_fixture fixture("mp_stress");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    // Long enough that the first ten coinbases have matured at the tip.
+    constexpr uint32_t trunk_len = 110;
+    constexpr size_t spend_count = 10;
+    constexpr size_t confirmed_count = 5;
+
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+
+    std::vector<domain::chain::block> trunk;
+    auto prev = genesis.hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+    REQUIRE(fixture.organizer().add_headers(headers_of(trunk)).headers_added == trunk_len);
+    persist_headers(fixture, trunk, 1);
+    connect_bodies(fixture, trunk, 1);
+
+    std::vector<domain::chain::transaction> spends;
+    spends.reserve(spend_count);
+    for (size_t i = 0; i < spend_count; ++i) {
+        auto const& coinbase = trunk[i].transactions().front();
+        spends.push_back(spend_p2pkh(coinbase, 0, coinbase.outputs()[0].value() - 1000,
+            chain.chain_settings().enabled_flags()));
+    }
+
+    // The block the cleanup keeps announcing. It is never connected — only read
+    // for its transactions — so it does not have to be a block anyone would mine.
+    domain::chain::transaction::list block_txs;
+    block_txs.push_back(trunk.front().transactions().front());   // stands in for a coinbase
+    for (size_t i = 0; i < confirmed_count; ++i) {
+        block_txs.push_back(spends[i]);
+    }
+    domain::chain::block const confirming{domain::chain::header{}, std::move(block_txs)};
+
+    std::atomic<size_t> admitted{0};
+    std::vector<std::thread> threads;
+
+    for (size_t i = 0; i < spend_count; ++i) {
+        threads.emplace_back([&chain, &spends, &admitted, i] {
+            ::asio::io_context ctx;
+            auto const tx = std::make_shared<domain::message::transaction>(spends[i]);
+            code result = error::operation_failed;
+            ::asio::co_spawn(ctx, chain.organize(tx),
+                [&result](std::exception_ptr, code ec) { result = ec; });
+            ctx.run();
+            if ( ! result) {
+                admitted.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    std::atomic<bool> done{false};
+    std::thread cleaner([&chain, &confirming, &done] {
+        while ( ! done.load(std::memory_order_acquire)) {
+            chain.mempool_remove_for_block(confirming);
+        }
+    });
+
+    for (auto& t : threads) {
+        t.join();
+    }
+    done.store(true, std::memory_order_release);
+    cleaner.join();
+
+    // A last cleanup with the threads stopped: from here the state is settled.
+    chain.mempool_remove_for_block(confirming);
+
+    // Whatever order the races took, the block's transactions are not in the pool.
+    for (size_t i = 0; i < confirmed_count; ++i) {
+        CHECK_FALSE(chain.mempool_ref().entry(spends[i].hash()));
+    }
+
+    // And the ones it never confirmed are still there, if they were admitted at
+    // all — they spend different coinbases, so no cleanup could have touched them.
+    size_t survivors = 0;
+    for (size_t i = confirmed_count; i < spend_count; ++i) {
+        if (chain.mempool_ref().entry(spends[i].hash())) {
+            ++survivors;
+        }
+    }
+    CHECK(survivors == chain.mempool_ref().size());
+    INFO("admitted " << admitted.load() << " of " << spend_count);
+}

--- a/src/node/test/reorg_cycle.cpp
+++ b/src/node/test/reorg_cycle.cpp
@@ -15,11 +15,11 @@
 #include <kth/node/sync/messages.hpp>
 #include <kth/node/sync/reorg.hpp>
 
-#include "../../blockchain/test/regtest_miner.hpp"
-#include "../../blockchain/test/reorg_chain_fixture.hpp"
+#include "sync_harness.hpp"
 
 using namespace kth;
 using namespace kth::node::sync;
+using namespace kth::test;
 
 // =============================================================================
 // The reorganization, end to end
@@ -35,132 +35,7 @@ using namespace kth::node::sync;
 // real signature over a real prevout), so the connect path runs full validation
 // rather than the shortcuts a synthetic block would slip through.
 
-namespace {
 
-// Blocks are spaced two minutes apart and the chain ends near the present. The
-// node treats an old tip as "still in IBD" and then batches UTXO work a thousand
-// blocks at a time, so a chain stuck in 2011 would never build anything here.
-constexpr uint32_t block_spacing = 120;
-
-// Serialize a mined block the way a peer would send it and parse it back the way
-// the node does, so what reaches storage arrived through the same code path as a
-// block off the wire.
-std::shared_ptr<domain::chain::light_block const> to_light(domain::chain::block const& blk) {
-    data_chunk raw(blk.serialized_size());
-    byte_writer writer(raw);
-    auto const written = blk.to_data(writer);
-    REQUIRE(written);
-
-    byte_reader reader(raw);
-    auto light = domain::chain::light_block::from_data(reader, true);
-    REQUIRE(light);
-    return std::make_shared<domain::chain::light_block const>(std::move(*light));
-}
-
-// Write the headers into the internal database, standing in for the node's
-// header-persist task, which runs when a header sync completes. get_header(height)
-// reads that table, and the UTXO build needs it twice over: to rebuild its
-// median-time-past window, and to decide whether the chain is still far enough
-// behind to batch a thousand blocks at a time. Without it the build sits idle.
-//
-// Deliberately NOT called after the switch below: rewriting the heights a reorg
-// replaced is the reorg's own job, and doing it here would paper over whether it
-// actually happens.
-void persist_headers(test::chain_fixture& fixture, std::vector<domain::chain::block> const& blocks,
-                     uint32_t start_height) {
-    domain::chain::header::list batch;
-    batch.reserve(blocks.size());
-    for (auto const& blk : blocks) {
-        batch.push_back(blk.header());
-    }
-    REQUIRE( ! fixture.chain().organize_headers_batch(batch, start_height));
-}
-
-domain::message::header::list headers_of(std::vector<domain::chain::block> const& blocks) {
-    domain::message::header::list headers;
-    headers.reserve(blocks.size());
-    for (auto const& blk : blocks) {
-        headers.push_back(blk.header());
-    }
-    return headers;
-}
-
-// Run the real storage and UTXO-build tasks over `blocks`, a contiguous run
-// starting at `start_height` whose headers are already in the index and in the
-// by-height table. This is the node's connect path: bodies through
-// block_storage_task, then utxo_build_task reading them back off disk to
-// validate them, apply the UTXO delta and write the undo records.
-void connect_bodies(test::chain_fixture& fixture, std::vector<domain::chain::block> const& blocks,
-                    uint32_t start_height) {
-
-    auto& chain = fixture.chain();
-    auto const end_height = start_height + uint32_t(blocks.size()) - 1;
-
-    ::asio::io_context ctx;
-    block_storage_input_channel input(ctx.get_executor(), 16);
-    chunk_validated_channel output(ctx.get_executor(), 256);
-    std::atomic<uint32_t> contiguous{start_height};
-
-    std::vector<std::shared_ptr<domain::chain::light_block const>> light;
-    light.reserve(blocks.size());
-    for (auto const& blk : blocks) {
-        light.push_back(to_light(blk));
-    }
-
-    ::asio::co_spawn(ctx,
-        block_storage_task(chain, input, output, start_height, fixture.organizer(), &contiguous),
-        ::asio::detached);
-
-    ::asio::co_spawn(ctx,
-        utxo_build_task(chain, contiguous, start_height, domain::config::network::regtest,
-            [&chain, end_height] {
-                auto const built = chain.get_utxo_built_height();
-                return built && *built >= end_height;
-            }),
-        ::asio::detached);
-
-    REQUIRE(input.try_send(std::error_code{}, downloaded_chunk{
-        .start_height = start_height,
-        .chunk_id = 0,
-        .blocks = std::move(light),
-        .source_peer = nullptr,
-        .generation = chain.headers().generation()
-    }));
-    REQUIRE(input.try_send(std::error_code{}, stop_request{}));
-
-    ctx.run_for(std::chrono::seconds(120));
-
-    // Fail here if the tasks stalled, rather than at a height assertion further
-    // down that would point at the wrong thing.
-    auto const built = chain.get_utxo_built_height();
-    REQUIRE(built);
-    REQUIRE(*built >= end_height);
-
-    // Drain what the storage task reported, so nothing is left owning blocks.
-    while (output.try_receive([](std::error_code, chunk_validated) {})) {}
-}
-
-// What the coordinator passes: the real write, through the chain.
-header_persister real_persister(blockchain::block_chain& chain) {
-    return [&chain](domain::chain::header::list const& headers, size_t start_height) {
-        return chain.replace_headers_from(headers, start_height);
-    };
-}
-
-// UTXO-Z answers a miss with "queued", not "absent": the lookup is deferred to a
-// sweep. Concluding a UTXO is gone without draining that queue would report
-// whatever the sweep had not reached yet.
-bool utxo_present(blockchain::block_chain& chain, hash_digest const& txid, uint32_t index,
-                  uint32_t at_height) {
-    if (chain.get_utxo(domain::chain::output_point{txid, index}, at_height)) {
-        return true;
-    }
-    auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{txid.data(), 32}, index);
-    auto const [found, missing] = chain.utxo_process_pending_lookups();
-    return found.contains(key);
-}
-
-} // namespace
 
 // =============================================================================
 // The miner

--- a/src/node/test/sync_harness.hpp
+++ b/src/node/test/sync_harness.hpp
@@ -1,0 +1,177 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_NODE_TEST_SYNC_HARNESS_HPP
+#define KTH_NODE_TEST_SYNC_HARNESS_HPP
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/io_context.hpp>
+
+#include <kth/node/sync/block_tasks.hpp>
+#include <kth/node/sync/messages.hpp>
+#include <kth/node/sync/reorg.hpp>
+
+#include "../../blockchain/test/regtest_miner.hpp"
+#include "../../blockchain/test/reorg_chain_fixture.hpp"
+
+// Driving the node's own connect path from a test: headers into the index and
+// the by-height table, bodies through block_storage_task, and utxo_build_task
+// reading them back off disk to validate them, apply the UTXO delta and write
+// the undo records. Shared by the tests that need a chain that was built the way
+// the node builds one, rather than one assembled by hand.
+
+namespace kth::test {
+
+using namespace kth::node::sync;
+
+
+// Blocks are spaced two minutes apart and the chain ends near the present. The
+// node treats an old tip as "still in IBD" and then batches UTXO work a thousand
+// blocks at a time, so a chain stuck in 2011 would never build anything here.
+constexpr uint32_t block_spacing = 120;
+
+// Serialize a mined block the way a peer would send it and parse it back the way
+// the node does, so what reaches storage arrived through the same code path as a
+// block off the wire.
+inline std::shared_ptr<domain::chain::light_block const> to_light(domain::chain::block const& blk) {
+    data_chunk raw(blk.serialized_size());
+    byte_writer writer(raw);
+    auto const written = blk.to_data(writer);
+    REQUIRE(written);
+
+    byte_reader reader(raw);
+    auto light = domain::chain::light_block::from_data(reader, true);
+    REQUIRE(light);
+    return std::make_shared<domain::chain::light_block const>(std::move(*light));
+}
+
+// Write the headers into the internal database, standing in for the node's
+// header-persist task, which runs when a header sync completes. get_header(height)
+// reads that table, and the UTXO build needs it twice over: to rebuild its
+// median-time-past window, and to decide whether the chain is still far enough
+// behind to batch a thousand blocks at a time. Without it the build sits idle.
+//
+// Deliberately NOT called after the switch below: rewriting the heights a reorg
+// replaced is the reorg's own job, and doing it here would paper over whether it
+// actually happens.
+inline void persist_headers(test::chain_fixture& fixture, std::vector<domain::chain::block> const& blocks,
+                     uint32_t start_height) {
+    domain::chain::header::list batch;
+    batch.reserve(blocks.size());
+    for (auto const& blk : blocks) {
+        batch.push_back(blk.header());
+    }
+    REQUIRE( ! fixture.chain().organize_headers_batch(batch, start_height));
+}
+
+inline domain::message::header::list headers_of(std::vector<domain::chain::block> const& blocks) {
+    domain::message::header::list headers;
+    headers.reserve(blocks.size());
+    for (auto const& blk : blocks) {
+        headers.push_back(blk.header());
+    }
+    return headers;
+}
+
+// Run the real storage and UTXO-build tasks over `blocks`, a contiguous run
+// starting at `start_height` whose headers are already in the index and in the
+// by-height table. This is the node's connect path: bodies through
+// block_storage_task, then utxo_build_task reading them back off disk to
+// validate them, apply the UTXO delta and write the undo records.
+// Runs the connect tasks and returns when they are done, whatever the outcome:
+// a batch that fails validation ends the UTXO build, and this returns with
+// nothing connected. Callers that require progress use connect_bodies below.
+inline void run_connect_tasks(test::chain_fixture& fixture,
+                              std::vector<domain::chain::block> const& blocks,
+                              uint32_t start_height) {
+
+    auto& chain = fixture.chain();
+    auto const end_height = start_height + uint32_t(blocks.size()) - 1;
+
+    ::asio::io_context ctx;
+    block_storage_input_channel input(ctx.get_executor(), 16);
+    chunk_validated_channel output(ctx.get_executor(), 256);
+    std::atomic<uint32_t> contiguous{start_height};
+
+    std::vector<std::shared_ptr<domain::chain::light_block const>> light;
+    light.reserve(blocks.size());
+    for (auto const& blk : blocks) {
+        light.push_back(to_light(blk));
+    }
+
+    ::asio::co_spawn(ctx,
+        block_storage_task(chain, input, output, start_height, fixture.organizer(), &contiguous),
+        ::asio::detached);
+
+    ::asio::co_spawn(ctx,
+        utxo_build_task(chain, contiguous, start_height, domain::config::network::regtest,
+            [&chain, end_height] {
+                auto const built = chain.get_utxo_built_height();
+                return built && *built >= end_height;
+            },
+            // Nothing here can reach it: the two conditions that report through
+            // this are a failed height-marker write and a failed mempool update,
+            // neither of which a test can provoke against a working database.
+            [](std::string const& reason) {
+                FAIL("the UTXO build reported a fatal condition: " << reason);
+            }),
+        ::asio::detached);
+
+    REQUIRE(input.try_send(std::error_code{}, downloaded_chunk{
+        .start_height = start_height,
+        .chunk_id = 0,
+        .blocks = std::move(light),
+        .source_peer = nullptr,
+        .generation = chain.headers().generation()
+    }));
+    REQUIRE(input.try_send(std::error_code{}, stop_request{}));
+
+    ctx.run_for(std::chrono::seconds(120));
+
+    // Drain what the storage task reported, so nothing is left owning blocks.
+    while (output.try_receive([](std::error_code, chunk_validated) {})) {}
+}
+
+// The same, for a run that is expected to connect: fails here if the tasks
+// stalled, rather than at a height assertion further down that would point at
+// the wrong thing.
+inline void connect_bodies(test::chain_fixture& fixture,
+                           std::vector<domain::chain::block> const& blocks,
+                           uint32_t start_height) {
+    run_connect_tasks(fixture, blocks, start_height);
+
+    auto const built = fixture.chain().get_utxo_built_height();
+    REQUIRE(built);
+    REQUIRE(*built >= start_height + uint32_t(blocks.size()) - 1);
+}
+
+// What the coordinator passes: the real write, through the chain.
+inline header_persister real_persister(blockchain::block_chain& chain) {
+    return [&chain](domain::chain::header::list const& headers, size_t start_height) {
+        return chain.replace_headers_from(headers, start_height);
+    };
+}
+
+// UTXO-Z answers a miss with "queued", not "absent": the lookup is deferred to a
+// sweep. Concluding a UTXO is gone without draining that queue would report
+// whatever the sweep had not reached yet.
+inline bool utxo_present(blockchain::block_chain& chain, hash_digest const& txid, uint32_t index,
+                  uint32_t at_height) {
+    if (chain.get_utxo(domain::chain::output_point{txid, index}, at_height)) {
+        return true;
+    }
+    auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{txid.data(), 32}, index);
+    auto const [found, missing] = chain.utxo_process_pending_lookups();
+    return found.contains(key);
+}
+
+
+} // namespace kth::test
+
+#endif // KTH_NODE_TEST_SYNC_HARNESS_HPP


### PR DESCRIPTION
Stacked on #581 — same function. Merge #581 first; this rebases onto master after.

The UTXO build gives up by `co_return`, and the task group only propagates exceptions — so ending the coroutine reduces a counter and tells nobody. Sync stops advancing with a line in the log and a node that looks alive. #581 fixed that for the two exits it added; these are the ones that were already there.

**Fatal exits only.** Which exits are fatal is not uniform, so they are not treated uniformly.

## Fatal — reported through `on_fatal`, the node comes down

| Exit | Why fatal |
|---|---|
| a stored block cannot be parsed (for validation, or for the delta) | these are bytes this node wrote and the compact parser accepted when it stored them; failing to read them back is local damage |
| a height being built is not on the active chain | the index and the range being built disagree |
| a UTXO delta cannot be applied | the set is not what the build believes |
| undo data cannot be stored **after** the delta was applied | those blocks are connected and cannot be disconnected; a later reorganization would have nothing to reverse them with |

## Left as they are, with the reason written where they happen

**A block that fails consensus validation** is a peer's doing and should end in that range being re-fetched from someone else. It cannot, here: the block is already stored and marked `have_data`, the peer that sent it is not recorded at this point, and the contiguous height has moved past it. Recovering needs a way back to the coordinator carrying the failed height, plus a decision about invalidating what was stored — its own change.

**A failure to capture undo data** happens before the delta is applied, so nothing is half-done and a retry would be legitimate. But a prevout missing because the block is invalid, a read that failed, and a delta that disagrees with the set all arrive as the same absence, and retrying the last two forever would be worse than stopping. Distinguishing them comes first.

## What the split turned up

A parse failure inside the validation step was being **reported as a consensus failure**. Both left the lambda as `error::operation_failed` and the branch below could not tell them apart — so a corrupt local block and a peer's invalid one produced the same message, and they sit on opposite sides of this classification. They are separated now.

## Tests

None added: every exit here needs a database that fails on demand, which is the same seam question #580 dealt with for the reorg persister. The one path a test can reach — a block failing consensus validation — is the one deliberately left alone, and it is already covered in `mempool_connect_wiring.cpp`.

Local: `kth_node_test` 1245 assertions / 117 cases, `node-exe` builds.
