### PR TITLE
blockchain: tell apart why undo capture failed, and stop on either

### DIFF
--- a/src/blockchain/include/kth/blockchain/utxo_builder.hpp
+++ b/src/blockchain/include/kth/blockchain/utxo_builder.hpp
@@ -174,13 +174,22 @@ KB_API utxo_raw_delta process_compact_block_utxos(
 //   - UTXO-Z — everything older, read verbatim (no resolution) via find_raw,
 //     honouring its two-phase contract (a miss is queued, not absent).
 //
-// Returns an error if any spent output cannot be located, since undo data that
-// silently drops entries would corrupt the UTXO set on disconnect.
+// Fails rather than drop an entry, since undo data missing one would corrupt the
+// UTXO set on disconnect. The two ways to fail are kept apart, because they mean
+// different things:
+//   key_not_found — the delta says an output is spent that the set does not
+//                   have, once the deferred sweep has run;
+//   anything else — the source could not be read at all.
+// Neither is interpreted here: this function does not know what the caller knows
+// about the block. One that knows it passed validation can conclude more from
+// the first than one that does not (see utxo_build_task).
+//
 // `source` is anything exposing the two raw lookups this needs:
 //     std::expected<utxoz_database::raw_stored, result_code> find_utxo_raw(key, height)
 //     pair<map<key, raw_stored>, vector<key>>              utxo_process_pending_lookups_raw()
 // block_chain satisfies it in production; a test can substitute a thin adapter
-// over a utxoz_database, which is what keeps this function directly testable.
+// over a utxoz_database — or one that fails on purpose, which is how the two
+// branches above are covered.
 template <typename UtxoSource>
 [[nodiscard]]
 std::expected<database::block_undo, database::result_code> capture_block_undo(
@@ -207,9 +216,20 @@ std::expected<database::block_undo, database::result_code> capture_block_undo(
         auto stored = source.find_utxo_raw(key, height);
         if (stored) {
             undo.spent.push_back({key, std::move(stored->value), stored->height});
-        } else {
-            deferred.push_back(key);
+            continue;
         }
+
+        // Only key_not_found means "queued for the deferred sweep". Anything else
+        // is a read that failed, and queueing it would turn a storage error into a
+        // missing output — the caller would be told the set does not have what the
+        // block spends, when what happened is that it could not be asked.
+        if (stored.error() != database::result_code::key_not_found) {
+            spdlog::error("[utxo_builder] capture_block_undo: reading a spent output failed at "
+                "height {}", height);
+            return std::unexpected(stored.error());
+        }
+
+        deferred.push_back(key);
     }
 
     if ( ! deferred.empty()) {
@@ -218,13 +238,17 @@ std::expected<database::block_undo, database::result_code> capture_block_undo(
         for (auto const& key : deferred) {
             auto it = resolved.find(key);
             if (it == resolved.end()) {
-                // The block spends an output the UTXO set does not have. Either
-                // the block should not have validated, or the set is corrupt —
-                // either way, undo data that silently dropped it would corrupt
-                // the set further on disconnect.
+                // The delta says this output is spent and the set does not have
+                // it. What that means depends on what the caller already knows
+                // about the block — this function does not know, and does not
+                // guess; it reports the fact and leaves the reading to whoever
+                // called (see the UTXO build, which knows the block validated).
+                //
+                // key_not_found means exactly this and nothing else now: a read
+                // that failed took the branch above.
                 spdlog::error("[utxo_builder] capture_block_undo: spent output not found at height {} "
-                    "({} of {} deferred lookups unresolved) — cannot build undo data",
-                    height, missing.size(), deferred.size());
+                    "({} of {} deferred lookups unresolved) — the delta and the UTXO set disagree "
+                    "about it", height, missing.size(), deferred.size());
                 return std::unexpected(database::result_code::key_not_found);
             }
             undo.spent.push_back({key, it->second.value, it->second.height});

--- a/src/blockchain/test/reorg_undo_roundtrip.cpp
+++ b/src/blockchain/test/reorg_undo_roundtrip.cpp
@@ -69,6 +69,27 @@ struct db_source {
     }
 };
 
+// A source that fails every read the way a broken storage layer would, to reach
+// the branch a working database cannot produce on demand.
+struct failing_source {
+    result_code error{result_code::other};
+    mutable size_t reads{0};
+    size_t sweeps{0};
+
+    std::expected<utxoz_database::raw_stored, result_code> find_utxo_raw(
+        utxoz::raw_outpoint const&, uint32_t) const {
+        ++reads;
+        return std::unexpected(error);
+    }
+
+    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxoz_database::raw_stored>,
+              std::vector<utxoz::raw_outpoint>>
+    utxo_process_pending_lookups_raw() {
+        ++sweeps;
+        return {};
+    }
+};
+
 } // namespace
 
 // =============================================================================
@@ -206,4 +227,67 @@ TEST_CASE("find_raw reports a miss for an unknown outpoint", "[reorg][undo]") {
     auto const missed = db.find_raw(make_outpoint(42, 3), 1);
     REQUIRE_FALSE(missed.has_value());
     CHECK(missed.error() == result_code::key_not_found);   // the documented contract
+}
+
+// =============================================================================
+// Telling a failed read apart from a missing output
+// =============================================================================
+//
+// find_utxo_raw answers key_not_found for "queued for the deferred sweep" and
+// other codes for a read that failed. Capture used to queue both, so a storage
+// failure came back out as a missing output — the caller told the set does not
+// hold what a block spends, when what happened is that it could not be asked.
+
+TEST_CASE("a failed read is reported as itself, not as a missing output", "[reorg][undo]") {
+    failing_source source{result_code::other, 0, 0};
+
+    utxo_raw_delta delta;
+    delta.deletes.emplace(make_outpoint(7, 0), 900u);
+    utxo_raw_delta const empty_batch;
+
+    auto const captured = capture_block_undo(delta, empty_batch, source, 900u);
+
+    REQUIRE_FALSE(captured.has_value());
+    CHECK(captured.error() == result_code::other);
+
+    // And it did not go through the deferred sweep: queueing a read that failed
+    // is what turned it into a missing output in the first place.
+    CHECK(source.sweeps == 0);
+}
+
+TEST_CASE("an output still missing after the sweep is reported as not found", "[reorg][undo]") {
+    // The other half of the split: key_not_found is what the sweep is for, so it
+    // is queued, swept, and only then reported — and it now means only this.
+    failing_source source{result_code::key_not_found, 0, 0};
+
+    utxo_raw_delta delta;
+    delta.deletes.emplace(make_outpoint(8, 0), 900u);
+    utxo_raw_delta const empty_batch;
+
+    auto const captured = capture_block_undo(delta, empty_batch, source, 900u);
+
+    REQUIRE_FALSE(captured.has_value());
+    CHECK(captured.error() == result_code::key_not_found);
+    CHECK(source.sweeps == 1);
+}
+
+TEST_CASE("an output the same batch created needs no read at all", "[reorg][undo]") {
+    // The in-flight parent case, pinned here because it is what keeps a failing
+    // source from being consulted: the batch delta answers first.
+    failing_source source{result_code::other, 0, 0};
+
+    auto const key = make_outpoint(9, 0);
+    utxo_raw_delta delta;
+    delta.deletes.emplace(key, 900u);
+
+    utxo_raw_delta batch;
+    batch.inserts.emplace(key, utxo_raw_value{data_chunk{0x01, 0x02}, 899u});
+
+    auto const captured = capture_block_undo(delta, batch, source, 900u);
+
+    REQUIRE(captured.has_value());
+    REQUIRE(captured->spent.size() == 1);
+    CHECK(captured->spent.front().height == 899u);
+    CHECK(source.reads == 0);
+    CHECK(source.sweeps == 0);
 }

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -2060,14 +2060,28 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             if (h > checkpoint_height) {
                 auto undo = blockchain::capture_block_undo(block_delta, delta, chain, h);
                 if ( ! undo) {
-                    // Before the delta is applied, so nothing is half-done and this
-                    // could in principle be retried. It is not, because the failure
-                    // is not distinguishable here: a prevout missing because the
-                    // block is invalid, a read that failed, and a delta that does
-                    // not match the set all arrive as the same absence, and
-                    // retrying the last two forever would be worse than stopping.
-                    spdlog::error("[utxo_build] Failed to capture undo data at height {}; the UTXO "
-                        "build stops with nothing applied for this batch", h);
+                    // Nothing is applied yet, so the state is clean — but neither
+                    // cause is one to retry into. A read that failed is storage
+                    // that is not answering; an output the set does not have,
+                    // after this batch has already validated, is the set and the
+                    // delta disagreeing. Both are local and both persist.
+                    if (undo.error() == database::result_code::key_not_found) {
+                        // Here — and not in capture_block_undo, which cannot know
+                        // this — the reading is unambiguous: undo data is captured
+                        // above the checkpoint, where this batch has already passed
+                        // full validation, and that resolves every prevout against
+                        // UTXO-Z or against a batch output created at or below the
+                        // height being validated. A block cannot spend one from a
+                        // later block. So the block is not the problem: the set and
+                        // the delta describing it disagree.
+                        spdlog::critical("[utxo_build] The UTXO set does not hold an output the "
+                            "block at height {} spends, which validation resolved", h);
+                        on_fatal("the UTXO set and the delta built from it disagree");
+                    } else {
+                        spdlog::critical("[utxo_build] Could not read the outputs the block at "
+                            "height {} spends", h);
+                        on_fatal("the UTXO set could not be read while capturing undo data");
+                    }
                     co_return;
                 }
                 pending_undo.emplace_back(idx, std::move(*undo),


### PR DESCRIPTION
Stacked on #582, which is stacked on #581. Merge in that order; each rebases onto master after the one below it.

Third step of the sequence agreed in #582's thread: the exits that were classified there left `capture_block_undo` open, because its failure could mean three different things and the caller could not tell which. Two of them turn out not to exist, and the third was being hidden.

## The one that was hidden

`find_utxo_raw` answers `key_not_found` for *"not in the active version file, queued for the deferred sweep"* and other codes for a read that failed. The caller discarded the code and queued both:

```cpp
auto stored = source.find_utxo_raw(key, height);
if (stored) { ... } else { deferred.push_back(key); }   // every error becomes "queued"
```

So a storage failure came back out as a missing output — the set reported not to hold what a block spends, when what happened is that it could not be asked. That now propagates immediately.

## The one that is left

An output still missing once the sweep has run has a single explanation here. Undo data is captured **above the checkpoint**, where the same batch has already passed full validation, and that resolves every prevout against UTXO-Z or against a batch output created at or below the height being validated — a block cannot spend one from a later block. So a missing output is not a block that should have been rejected; it is the set and the delta describing it disagreeing.

## The one that does not exist

"The block is invalid" — excluded by the ordering above.

## Why neither is retried

A read that fails is storage not answering; a set that disagrees with its own delta will disagree again. Both are local and both persist, so the UTXO build reports them through `on_fatal` with the two told apart in the message. Nothing is applied when this happens, so the state stays clean — what stops is building further on a set that cannot describe itself.

Local: `kth_blockchain_test` 2019 assertions / 182 cases, `kth_node_test` 1245 / 117.
