### PR TITLE
blockchain: let first-seen pick a winner however the inputs are ordered

### DIFF
--- a/src/blockchain/include/kth/blockchain/pools/mempool_hashers.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool_hashers.hpp
@@ -22,6 +22,12 @@ struct outpoint_key {
     hash_digest hash{};
     uint32_t index{};
     friend bool operator==(outpoint_key const&, outpoint_key const&) = default;
+
+    // Ordering
+    // Any total order does, and this one is only ever used to claim a
+    // transaction's outpoints in the same sequence every caller would — see
+    // mempool::add. It says nothing about the chain.
+    friend auto operator<=>(outpoint_key const&, outpoint_key const&) = default;
 };
 
 // SipHash-based, salted hashers for the mempool keys — the Bitcoin Core / BCHN

--- a/src/blockchain/include/kth/blockchain/pools/mempool_stats.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool_stats.hpp
@@ -20,6 +20,7 @@ struct mempool_stats {
     std::atomic<uint64_t> add_inserted{0};
     std::atomic<uint64_t> add_rejected_duplicate{0};
     std::atomic<uint64_t> add_rejected_conflict{0};
+    std::atomic<uint64_t> add_rejected_self_conflict{0};
     std::atomic<uint64_t> add_time_ns{0};
 
     // Block connect / reorg eviction.
@@ -52,7 +53,8 @@ struct mempool_stats {
 
     void reset_all() {
         add_calls = 0; add_inserted = 0; add_rejected_duplicate = 0;
-        add_rejected_conflict = 0; add_time_ns = 0;
+        add_rejected_conflict = 0; add_rejected_self_conflict = 0;
+        add_time_ns = 0;
         remove_for_block_calls = 0; removed_confirmed = 0; removed_conflict = 0;
         remove_time_ns = 0;
         resolve_calls = 0; resolve_hits = 0; resolve_time_ns = 0;

--- a/src/blockchain/src/pools/mempool.cpp
+++ b/src/blockchain/src/pools/mempool.cpp
@@ -47,27 +47,52 @@ bool mempool::add(mempool_entry entry) {
 
     // First-seen: atomically claim every spent outpoint. On any conflict, roll
     // back the claims already made and reject.
-    std::vector<outpoint_key> reserved;
-    reserved.reserve(tx.inputs().size());
+    //
+    // The claims go in a canonical order, not in input order, and that is what
+    // makes first-seen actually pick a winner. Two transactions spending the same
+    // outpoints listed differently — one {a,b}, the other {b,a} — would each take
+    // one, each fail on the other, and each roll back: both rejected, when exactly
+    // one should be admitted. Sorted, they contend on the same key first, so one
+    // wins outright and the other fails having claimed nothing.
+    std::vector<outpoint_key> keys;
+    keys.reserve(tx.inputs().size());
     for (auto const& in : tx.inputs()) {
         auto const& op = in.previous_output();
-        outpoint_key const key{op.hash(), op.index()};
+        keys.push_back({op.hash(), op.index()});
+    }
+    std::ranges::sort(keys);
+
+    // Sorting also puts a repeated outpoint next to itself. A transaction that
+    // spends one twice never reaches here through admission — check() rejects it
+    // as an internal double spend — so this guards the callers that did not come
+    // that way. Without it such a transaction would fail below and be reported as
+    // conflicting with another one, when what it conflicts with is itself.
+    if (std::ranges::adjacent_find(keys) != keys.end()) {
+        KTH_STATS_INCREMENT(stats_, add_rejected_self_conflict);
+        KTH_STATS_TIME_ADD(stats_, add, add_time_ns);
+        return false;
+    }
+
+    auto const release = [this, &keys](size_t claimed) {
+        for (size_t i = 0; i < claimed; ++i) {
+            spent_by_.erase(keys[i]);
+        }
+    };
+
+    size_t claimed = 0;
+    for (auto const& key : keys) {
         if ( ! spent_by_.try_insert(key, txid)) {
-            for (auto const& k : reserved) {
-                spent_by_.erase(k);
-            }
+            release(claimed);
             KTH_STATS_INCREMENT(stats_, add_rejected_conflict);
             KTH_STATS_TIME_ADD(stats_, add, add_time_ns);
             return false;
         }
-        reserved.push_back(key);
+        ++claimed;
     }
 
     // Commit the transaction; release the claims if it is a duplicate.
     if ( ! pool_.try_insert(txid, std::move(entry))) {
-        for (auto const& k : reserved) {
-            spent_by_.erase(k);
-        }
+        release(claimed);
         KTH_STATS_INCREMENT(stats_, add_rejected_duplicate);
         KTH_STATS_TIME_ADD(stats_, add, add_time_ns);
         return false;

--- a/src/blockchain/test/mempool_test.cpp
+++ b/src/blockchain/test/mempool_test.cpp
@@ -187,6 +187,86 @@ TEST_CASE("mempool first-seen conflict rolls back partial claims", "[mempool][se
     CHECK(mp.size() == 2u);
 }
 
+TEST_CASE("mempool rejects a transaction that spends an outpoint twice", "[mempool][serial]") {
+    // Admission never sends one of these — check() rejects an internal double
+    // spend first — so this is the guard for callers that did not come that way.
+    // What matters is that it is turned away without leaving a claim behind: the
+    // outpoint has to stay free for the transaction that legitimately spends it.
+    mempool mp{0x1111u, 0x2222u};
+
+    auto const P = op(1, 0);
+    auto const self = make_tx({P, P}, 1, 1);
+    auto const other = make_tx({P}, 1, 2);
+
+    REQUIRE_FALSE(mp.add(entry_for(self, 1)));
+    CHECK(mp.size() == 0u);
+
+    REQUIRE(mp.add(entry_for(other, 2)));
+    CHECK(mp.contains(other.hash()));
+}
+
+TEST_CASE("mempool first-seen picks a winner however inputs are ordered", "[mempool][concurrent]") {
+    // The reason claims are made in a canonical order rather than in input
+    // order. Two transactions spending the same pair of outpoints, one listing
+    // them {P,Q} and the other {Q,P}, race: claiming in input order lets each
+    // take one, fail on the other, and roll back — both rejected, when exactly
+    // one should win. Sorted, they contend on the same key first.
+    //
+    // Serially this is invisible: whoever runs first takes both. Only the race
+    // shows it. The assertion is absolute — exactly one of each pair, always —
+    // but noticing a regression depends on the race landing, and the window is
+    // two atomic inserts wide. Hence the rounds: each pair is an independent
+    // chance, and rounds buy chances without buying threads. Removing the sort
+    // fails this within a couple of rounds; it has never failed with it.
+    constexpr size_t rounds = 24;
+    constexpr size_t pairs = 64;
+
+    for (size_t round = 0; round < rounds; ++round) {
+        mempool mp{0x1111u, 0x2222u};
+
+        std::vector<transaction> first;
+        std::vector<transaction> second;
+        first.reserve(pairs);
+        second.reserve(pairs);
+        for (size_t i = 0; i < pairs; ++i) {
+            auto const P = op(1000 + i * 2, 0);
+            auto const Q = op(1000 + i * 2 + 1, 0);
+            first.push_back(make_tx({P, Q}, 1, 2 * i));
+            second.push_back(make_tx({Q, P}, 1, 2 * i + 1));
+        }
+
+        // Released together, so the two halves of a pair are actually inside
+        // add() at the same time. Spawning them in order lets the first finish
+        // before the second starts, and then there is no race to observe.
+        std::atomic<bool> go{false};
+        auto const run = [&go](mempool& pool, transaction const& tx, uint64_t tag) {
+            while ( ! go.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            pool.add(entry_for(tx, tag));
+        };
+
+        std::vector<std::thread> threads;
+        threads.reserve(pairs * 2);
+        for (size_t i = 0; i < pairs; ++i) {
+            threads.emplace_back(run, std::ref(mp), std::cref(first[i]), 2 * i);
+            threads.emplace_back(run, std::ref(mp), std::cref(second[i]), 2 * i + 1);
+        }
+        go.store(true, std::memory_order_release);
+        for (auto& t : threads) {
+            t.join();
+        }
+
+        for (size_t i = 0; i < pairs; ++i) {
+            auto const a = mp.contains(first[i].hash());
+            auto const b = mp.contains(second[i].hash());
+            INFO("round " << round << " pair " << i << ": first=" << a << " second=" << b);
+            REQUIRE(a != b);
+        }
+        REQUIRE(mp.size() == pairs);
+    }
+}
+
 TEST_CASE("mempool rejects duplicate txid", "[mempool][serial]") {
     mempool mp{0x1111u, 0x2222u};
 


### PR DESCRIPTION
The mempool claims a transaction's spent outpoints one at a time, and rolls back
what it claimed if any is already taken. Claiming them in input order means two
transactions spending the same outpoints can reject each other: one lists them
{a,b} and the other {b,a}, each takes one, each fails on the other, and each
rolls back. Neither is admitted, when first-seen says exactly one should be.

No corruption and no double spend — a valid transaction is simply dropped, and
the peer that sent it has no way to tell. Claiming in a canonical order fixes it
outright: sorted, the two contend on the same key first, so one wins and the
other fails having claimed nothing.

Sorting also puts a repeated outpoint next to itself, which makes the other case
free to catch. A transaction that spends one twice never reaches admission —
check() rejects it as an internal double spend — so this guards whoever did not
come that way; without it such a transaction fails on its second claim and is
reported as conflicting with another one, when what it conflicts with is itself.
It gets its own counter for the same reason.

The rollback no longer needs a second vector: the claims are made from the
sorted list itself, tracking how many went in, so this removes an allocation
rather than adding one.

Testing the pair case needs the race — serially, whoever runs first takes both
and there is nothing to see. The test releases its threads together and repeats
over rounds, because the window is two atomic inserts wide: with one round it
caught the regression about a third of the time, which would have let it through.
As written it fails every run without the sort and has never failed with it. Its
assertion is absolute either way: exactly one of each pair.

First of the code changes planned in #585 (step 2), and independent of the rest: it touches neither the barrier nor the UTXO set.

Local: blockchain 3593 assertions / 187 cases, node 1011 / 116, both green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mempool conflict handling for transactions with duplicate or competing inputs.
  * Ensured conflict resolution is deterministic, including under concurrent submission.
  * Prevented rejected transactions from leaving inputs incorrectly reserved.
  * Added statistics tracking for transactions rejected due to self-conflicts.

* **Tests**
  * Added coverage for serial and concurrent mempool conflict scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->