### PR TITLE
docs: note that the mempool's conflict branch is a double-spend-proof seam

### DIFF
--- a/docs/utxo-set-synchronization.md
+++ b/docs/utxo-set-synchronization.md
@@ -411,6 +411,30 @@ within the transaction itself. With the keys sorted, two conflicting transaction
 try the same key first: one wins cleanly and the other fails having claimed
 nothing.
 
+### The conflict branch is where a double-spend proof is born
+
+Worth knowing before that code is touched again. Detecting a conflict is exactly
+the moment the node learns of a double spend, which is what a proof attests to —
+and admission today answers a conflict with a bare `false`. It reports neither
+the outpoint that conflicted nor the pooled transaction holding it, and a proof
+needs both.
+
+Nothing asks for that yet: no path creates a proof, none ingests one, and none
+validates one (#587). So this is a constraint on that work rather than something
+to build ahead of it — when proofs are implemented, the conflict result grows
+along with the code that consumes it.
+
+Canonical claim order helps here too, beyond picking a winner: it makes *which*
+outpoint this node reports as the conflict deterministic, so the same pair of
+transactions always yields the same proof candidate locally.
+
+It does not give a proof its identity, and it should not be read that way. That
+comes from the specification's ordering of the two spenders — by hash-outputs,
+and by hash-prevoutputs where those tie — which is a separate thing this code
+does not touch. Nor does it bind anyone else: when two transactions conflict on
+several outpoints, another implementation may pick a different one and build a
+different, equally valid proof.
+
 ### A block is not valid because its transactions are in the mempool
 
 That a transaction is pooled means it was validated against some chain state. A


### PR DESCRIPTION
Detecting a conflict is the moment a node learns of a double spend, which is
what a proof attests to — so the branch that rejects a conflicting transaction
is where one would be built. Admission answers a conflict with a bare false
today: it reports neither the outpoint that conflicted nor the pooled
transaction holding it, and a proof needs both.

Nothing asks for that yet — nothing creates, ingests or validates a proof
(#587) — so this is written as a constraint on that work rather than a reason
to widen the result now, with no consumer.

It also bounds what canonical claim order buys, since the temptation is to claim
more: the outpoint this node reports as the conflict becomes deterministic, so
the same pair of transactions always yields the same proof candidate here. It
does not give a proof its identity — that is the specification's ordering of the
two spenders, which this code does not touch — and it binds no one else, since
two transactions conflicting on several outpoints leave another implementation
free to pick a different one.

Follows #586 and the state recorded in #587. Documentation only.