### PR TITLE
docs: express stage 1 as windows, because a mutex cannot cross a suspension

### DIFF
--- a/docs/utxo-set-synchronization.md
+++ b/docs/utxo-set-synchronization.md
@@ -144,6 +144,21 @@ until after publishing to the mempool. Inside that window sit prevout
 resolution, the contextual checks and — the expensive part — script
 verification. **Two transactions never validate in parallel.**
 
+**[TODAY] The exclusion is held across coroutine suspension points, which is
+undefined behaviour.** `transaction_organizer::organize` takes the mutex, then
+awaits the context-free checks, the contextual ones and script verification, then
+releases it. Two of those awaits post work to the priority pool — up to eight
+threads — and wait on a channel, so they genuinely suspend. A `shared_mutex` may
+only be released by the thread that took it, and a coroutine may resume on
+another. Whether it currently misbehaves depends on how the awaiting coroutine's
+executor happens to be configured, which is not a property to rely on.
+
+It is live, not latent, and not only on the path that publishes: every exit after
+those awaits releases the mutex, so a rejected admission runs it too. Admission
+is reachable today over JSON-RPC and through the C API. The block-connect path
+has the same shape — its batch validation is awaited across the pool — so both
+sides need the same treatment.
+
 **[TODAY] The exclusion primitive has no shared mode.** The node's priority mutex
 takes the same exclusive lock on both of its paths; priority only decides who
 enters next when there is a queue. It gives one-at-a-time, not
@@ -155,62 +170,184 @@ implement the turn rather than protecting data.
 
 ## 3. Stage 1 — correctness with the exclusion that already exists
 
-**[TARGET, immediate]** Transitory and deliberately so: it uses the current
-exclusive mutex, adds no new protocol, and depends on no change to the store.
+**[TARGET, immediate]** Transitory and deliberately so: it reuses the existing
+exclusive mutex, introduces none of stage 2's atomic gate, and depends on no
+change to the store.
 
-### What it does
+It does add coordination — the four windows, the generation, readiness and the
+dependency re-check — and that is the point of writing the contract down before
+implementing it.
 
-The block-connect path takes the same lock admission already takes, and holds it
-across **its whole sequence**: prevout resolution, validation, undo capture,
-delta application, markers and mempool cleanup.
+### The constraint that shapes it
 
-With that:
+**No mutex may be held across a suspension point.** Both paths are coroutines and
+both suspend in the middle of the work that has to be exclusive, so "take the
+lock and hold it across the sequence" is not available: the thread that releases
+would not always be the thread that took it.
+
+So the exclusion is expressed as **windows**, each one entirely synchronous, with
+the suspending work outside them. The windows are chosen so that nothing partial
+is ever observable between them.
+
+It helps that the phases do not all need the same thing. The store admits N
+readers *or* one writer, and validation only reads. What must not overlap is a
+reader with a writer, and one historical resolution with another.
+
+### The block-connect path: two windows
+
+**W1 — prevout resolution.** Emit the active-map probes for every input of the
+batch and run the one historical resolution. Both are synchronous and on the same
+thread, so the window closes before anything suspends.
+
+Released before script verification, which touches nothing shared: it works on
+prevouts already copied into memory.
+
+**W2 — connection.** Undo capture, the delta, deferred deletions, markers, the
+generation bump and the mempool cleanup. All synchronous; verified that the batch
+sequence suspends only at validation, which is over by now.
+
+Between W1 and W2 nothing has been applied, so an admission that runs there sees
+the pre-block state — coherent, if about to be superseded. The half-applied
+states worth worrying about — an output the block spends still present because
+its deletion has not run — are all inside W2.
+
+### The admission path: two windows and a generation
+
+**A1 — resolution.** Take the exclusion, probe the active map for every prevout,
+run the one historical resolution, resolve unconfirmed parents from the mempool
+overlay, and **copy every prevout out**. Record which of them came from the
+mempool and the parent transaction each came from. Capture the validation-state
+generation. Release before anything suspends.
+
+**Verification, unlocked.** Scripts and signatures, against the copies. A block
+may connect while this runs.
+
+**A2 — publication.** Retake the exclusion and check, before publishing:
+
+- the **validation-state generation** is the one A1 captured;
+- every dependency taken from the mempool is still present and still the same
+  output.
+
+Only then publish. Two distinct reasons to fail, both ending in the result being
+discarded rather than published — whether to retry against the new state is
+policy, subject to the same limits any retry is:
+
+- the chain or UTXO state moved;
+- an unconfirmed dependency vanished or changed.
+
+### The validation-state generation
+
+A counter representing the state transactions are validated against. It is not
+the mempool's generation and not the active chain's: it must advance on **every**
+change to that state, and only under the exclusion that publishes the change —
+
+- a normal block connection;
+- a disconnect or a reorg;
+- adopting the state a reorg leaves behind;
+- any rebuild or equivalent replacement of the active UTXO set.
+
+It is deliberately named for validation state rather than for the UTXO set,
+because it also invalidates the height and the consensus context a transaction
+was checked under.
+
+**Why the mempool's own generation is not the test for unconfirmed parents.** It
+moves on every admission, so an unrelated one would invalidate work that is still
+perfectly good. Checking the specific dependencies costs a lookup each and
+invalidates only what actually broke. A global counter would be a correct first
+implementation, just a needlessly conservative one.
+
+### Readiness: the generation proves movement, not coherence
+
+A generation that has not changed says nothing moved between A1 and A2. It does
+not say the state A1 read was coherent to begin with, and there is a window where
+it is not.
+
+After a reorg the UTXO set can sit rewound near the fork while the active chain
+already names the winning branch and the build has not caught up. Staleness is
+judged from the top block's timestamp, so a recent tip after a reorg reads as not
+stale and admission stays open. A1 could then resolve prevouts against the older
+UTXO state while taking height and consensus flags from the newer tip — a
+combination that never existed as a connectable tip. Nothing moves between A1 and
+A2, the generation matches, and the transaction is published.
+
+So A1 needs a **readiness** condition on entry, re-checked in A2 alongside the
+generation. It has two halves, and both are needed:
+
+**A coherent local view** —
+
+- no reorg in progress;
+- the UTXO set is built to exactly the height being used as context;
+- that height, its hash and its consensus context come from the same view.
+
+**And a synchronized node.** Coherence is not enough on its own: while catching
+up, the set can momentarily reach the newest tip the node happens to know, and
+all three conditions above hold while that tip is still old and headers are
+still coming. The state is internally consistent and months behind. Admitting
+against it produces decisions no peer would agree with, which is why blocking
+during IBD was about relay stability and not only about internal coherence.
+
+    ready = coherent_local_view && synchronized
+
+with the reorg condition already inside the first, not a third term beside it.
+
+Absent a formal signal that IBD has finished, `synchronized` starts as the
+existing staleness heuristic. It proves nothing about coherence — that is what
+the first half is for — but it remains the answer to a different question, and
+readiness needs both answers.
+
+**One consequence for the generation:** it advances once per coherent state
+published, not once per internal step. A reorg's disconnect, adoption and rebuild
+are steps of a single transition, and any of them can leave a state that is not
+valid to admit against. During such a transition admission stays closed on
+readiness — treating each step as a publishable state would be exactly the bug
+above, with extra steps.
+
+### Why this covers the interleavings
+
+- **A2 before W2:** the transaction is published against the older state, and W2's
+  mempool cleanup removes it if the block confirmed it or conflicts with it.
+- **W2 before A2:** the generation moved, so A2 does not publish a stale result.
+- **Admission starting between W1 and W2:** it validates coherently against the
+  pre-block state, and the generation decides afterwards whether it may still
+  publish.
+
+### What it buys
 
 - No reader is inside the store while it is mutated or rotated.
-- The window between validating a transaction and publishing it closes: if a
-  block connects in between, a transaction the block already confirmed — or whose
-  inputs it already spent — cannot end up in the mempool.
+- The window between validating a transaction and publishing it closes.
 - **The global pending-lookup queue gets a single owner at a time**, which is what
   makes it safe for admission to sweep. That closes #584 without waiting for any
   change to the store.
 
 ### Why the queue's ownership holds
 
-Only one thing can run at a time, so nobody can consume anyone else's results. It
-rests on two conditions, **both necessary**:
+Only one thing can be inside a window at a time, so nobody can consume anyone
+else's results. It rests on two conditions, **both necessary**:
 
-1. **Every** user of the store participates in the barrier. A single one outside
-   invalidates the property.
-2. **An unconditional epilogue** leaves the queue empty before releasing the
-   lock, even on errors and cancellations — by RAII or a single exit path, never
-   by returns that remember to sweep.
+1. **Every** user of the store participates. A single one outside invalidates the
+   property.
+2. **An unconditional epilogue** leaves the queue empty before releasing, even on
+   errors and cancellations — by RAII or a single exit path, never by returns
+   that remember to sweep.
 
-The coarse lock tolerates the queue getting dirty *within* a sequence, because
-the same owner drains it later. It does not tolerate it getting dirty on the way
-out.
+A window tolerates the queue getting dirty inside it, because the same owner
+drains before closing. It does not tolerate it getting dirty on the way out.
 
-### Granularity
+### Cost
 
-Ownership is **per sequence**, not per operation.
+Admission is stalled during W1 and W2, not during script verification — its own
+or the block's. Outside IBD that is one block every ten minutes. During IBD it
+would still matter, because W1 covers a batch of up to a hundred blocks — but
+readiness is false throughout IBD, through its synchronization half, so admission
+is closed rather than queued behind batches. That gate is part of stage 1's scope
+rather than a later target: without it, RPC can still admit during IBD today.
 
-Per-operation locking is not merely unproven, it is unsafe as things stand: delta
-application, deferred deletions, the height marker and the mempool cleanup are
-not one atomic visible transaction, so an admission slipping between them can
-observe a half-applied connection. Between the delta and its deletions, an output
-the block spends is still present, and a conflicting transaction could be
-admitted against it.
-
-Fine granularity would need either a snapshot with atomic publication, or a
-generation protocol guaranteeing a coherent view. Neither exists, so it is not on
-the table — and it would additionally require that no exit ever leaves the queue
-dirty, which does not hold today either.
-
-Cost: admission is stalled while a block connects. Outside IBD that is one block
-every ten minutes. During IBD it would matter a great deal — batches are up to a
-hundred blocks including full script verification — so the stale-admission gate
-of section 8 is part of stage 1's scope, not a later target. Without it, RPC can
-still admit during IBD today, and those admissions would wait behind entire
-batches.
+One cost is accepted deliberately: the generation is coarse, so **any** block
+connecting between A1 and A2 discards the transaction, even one that touched none
+of its prevouts. That is signature work thrown away. Outside IBD it is a block
+every ten minutes and during IBD admission is closed, so it is not worth
+refining now — but it is a decision, not an oversight. Narrowing it to "did the
+block touch *our* prevouts" is a later optimization.
 
 ### `unresolved` is not absence
 
@@ -225,12 +362,37 @@ from "queued for the sweep" — but after the sweep has run, a key that did not
 come back is still indistinguishable from one whose version could not be read.
 Closing that needs the store's third result.
 
+### Admissions do overlap, and that has to be chosen
+
+A1 and A2 are exclusive, but the verification between them is not. A second
+admission can run its own A1 and both can verify signatures at the same time.
+This is worth having — it is most of what stage 2 was for — but it is a choice,
+not a side effect, and it has a prerequisite.
+
+**The per-transaction validation scratch is not safe for it today.** It lives in a
+plain `boost::unordered_flat_map`, and the header says why that was fine:
+
+> mutex held across their co_awaits, so they are mutually exclusive
+
+That is precisely the property being removed. Once two admissions overlap, they
+touch that map concurrently — the contextual checks write an entry and script
+verification reads it back. Either it becomes concurrent, or the scratch stops
+living in a shared store at all, which is the better shape: nothing reads an
+entry once its admission returns, so it is private to the admission and only
+happens to be kept somewhere shared.
+
+The audit is the rest of the admission path under overlap: the context-free
+checks, the contextual ones, script verification, and anything else reading that
+scratch — block validation uses the same class of store.
+
+The alternative is to forbid the overlap, and that needs serialization that is
+not bound to a thread — a strand, an async semaphore, a queue. The existing mutex
+cannot express it, which is the whole reason for the windows.
+
 ### What stage 1 does NOT do
 
-- It does not let two transactions validate in parallel. They stay serialized, as
-  today.
 - It does not remove the mutex.
-- It does not parallelize the probes.
+- It does not parallelize the block path's probes.
 
 It is the correctness floor to measure from.
 
@@ -457,8 +619,14 @@ the conflicting transaction and its descendants.
 
 ## 8. Admission during IBD
 
-**[TARGET]** Do not accept new admissions while the node is stale. A mempool
-restored at startup stays pending and is revalidated when IBD ends.
+**[TARGET]** Do not accept new admissions unless the validation state is ready
+(section 3). A mempool restored at startup stays pending and is revalidated once
+it is.
+
+Readiness rather than staleness alone, and neither replaces the other. Staleness
+misses the reorg window — a recent tip reads as not stale while the set is still
+rewound — and coherence misses IBD, since the set can momentarily catch up to an
+old tip while headers are still arriving. Readiness is the conjunction.
 
 It should not be informally assumed that the mempool is empty during IBD: there
 may be admission over RPC, or a restored pool.
@@ -484,6 +652,9 @@ continuously, and is no use for stable relay.
 | 9 | The mempool is updated only after a block actually connects | **implemented, tested** |
 | 10 | Mempool membership does not replace a block's contextual validation | **holds** — no reuse path exists yet; a requirement on any future one |
 | 11 | No exit leaves the pending-lookup queue dirty | pending — stage 1 |
+| 12 | No mutex is held across a coroutine suspension point | **violated today** — stage 1 |
+| 13 | The validation-state generation advances once per coherent state published, under the exclusion that publishes it | pending — stage 1 |
+| 14 | A transaction is only validated against a state that existed as a connectable tip | pending — stage 1 |
 
 ---
 
@@ -492,12 +663,13 @@ continuously, and is no use for stable relay.
 1. This document.
 2. Canonical outpoint ordering and duplicate-input detection in mempool
    admission. Independent of everything else.
-3. **One PR**: coarse barrier, #584, and queue sanitation. Take the exclusion
-   before any possible probe, check the queue is empty on entry, hold ownership
-   across the whole sequence, drain unconditionally on every early exit, check the
-   queue is empty before releasing, keep the primary error distinct from the
-   drain's result, treat `unresolved` as a resolution failure, and gate admission
-   off while the node is stale.
+3. **One PR**: the four windows, #584, and queue sanitation. W1/W2 on the
+   block-connect path and A1/A2 on the admission path, each synchronous and none
+   crossing a suspension; the validation-state generation and the mempool
+   dependency check; the queue empty on entry and before release, drained
+   unconditionally on every early exit, with the primary error kept distinct from
+   the drain's result; `unresolved` treated as a resolution failure; and admission
+   gated on readiness — a coherent local view and a synchronized node.
 4. Measure.
 5. Explicit store API and Bloom filters.
 6. Stage 2, only if the data justifies it.
@@ -509,20 +681,43 @@ It would fix the leak without establishing ownership.
 
 ### Tests PR 3 must bring
 
+The queue's discipline:
+
 - Undo capture queues a key and fails on a later iteration: on the way out, the
   queue is empty.
 - Batch validation, the same, failing on a double spend.
 - A later operation does not receive results belonging to the previous one.
 - The same cases on normal returns, not only on errors.
+
+That admission can resolve at all:
+
 - A prevout living outside the active map ends up admitted — the direct
   regression for #584.
 - A historical read failure does not turn into *previous output not found*.
-- The concurrency test removed when the mempool notification landed comes back.
-  It used to pass with zero admissions, because admission did not work; with #584
-  closed it exercises something for the first time.
 
-What **cannot** be tested deterministically is the validate → block → publish
-race: there is no way without putting a stopping point into production code. The
-barrier makes it structurally impossible, and the concurrency test covers it
-probabilistically under a thread sanitizer. Writing that down keeps a test name
-from suggesting it was pinned.
+**The state machine, and none of it probabilistic.** If A1, A2 and the readiness
+evaluation are separable operations with contracts of their own, every decision
+below is a direct test — no artificial pause in production code, no waiting on a
+scheduler:
+
+- A1 captures a generation; it is bumped before A2; A2 does not publish.
+- A1 captures a mempool dependency; that parent is removed before A2; A2 does not
+  publish.
+- A1 and A2 see the same generation and the same dependencies; A2 publishes.
+- A1 refused: a reorg is in flight.
+- A1 refused: the set's built height and the context height disagree.
+- A1 refused: the local view is coherent but the node is still stale — the case
+  coherence alone would let through.
+- Two admissions pass through the unlocked phase at once and share no scratch.
+- A2 before W2: the transaction is published, and W2 removes it when it should.
+- W2 before A2: the generation moved, so A2 does not publish.
+
+And one against the defect that started this: run an admission with its
+continuations landing on different threads. It does not prove the absence of
+undefined behaviour on its own, but it is what stops the mutex being held across
+the awaits again.
+
+What stays probabilistic is only the scheduling — whether a particular real
+interleaving occurs under load, which the concurrency test covers under a thread
+sanitizer. The state machine itself should not be, and writing it as separable
+operations is what buys that.


### PR DESCRIPTION
The stage-1 barrier was written as "the block path holds the lock across its
whole sequence". That is not implementable. Both paths are coroutines and both
suspend in the middle of the work that has to be exclusive — the block path
awaits its batch validation on the priority pool, admission awaits the
context-free checks, the contextual ones and script verification — and a
shared_mutex may only be released by the thread that took it. A coroutine may
resume on another.

Admission does this today, which makes it a defect rather than a design
question, and it is recorded as one. It is live rather than latent: every exit
after those awaits releases the mutex, so a rejected admission runs it too, and
the path is reachable over JSON-RPC and through the C API. It has gone unnoticed
because whether it misbehaves depends on how the awaiting coroutine's executor
happens to be configured.

So the exclusion becomes four windows, each entirely synchronous, with the
suspending work outside them. It helps that the phases do not all need the same
thing: the store admits N readers or one writer, and validation only reads.

W1 resolves the batch's prevouts and closes before script verification. W2 does
undo capture, the delta, deletions, markers and the mempool cleanup — every
half-applied state worth worrying about is inside it, and between the two
nothing has been applied at all. A1 resolves a transaction's prevouts, copies
them out and captures a generation. A2 retakes the exclusion, checks the state
has not moved, and only then publishes.

That leaves admissions overlapping between A1 and A2, which is worth having and
so is written down as a choice rather than left as a side effect. It has a
prerequisite: the per-transaction validation scratch lives in a plain hash map
whose header justifies itself with "mutex held across their co_awaits, so they
are mutually exclusive" — the very property being removed. It has to become
concurrent, or stop living in a shared store, which is the better shape since
nothing reads an entry once its admission returns.

Two things make A2's check trustworthy. The generation is a validation-state
generation, not a UTXO one: it advances on connection, on disconnect, on
adopting what a reorg leaves, on any replacement of the active set, and only
under the exclusion that publishes the change — it invalidates the height and
the consensus context too, not just the outputs. And because A1 may also resolve
unconfirmed parents out of the mempool overlay, which no chain generation would
notice, A2 checks those specific dependencies rather than the mempool's own
counter, which would move on every unrelated admission and throw away work that
is still good.

But a generation only proves nothing moved, not that what A1 read was coherent.
After a reorg the UTXO set can sit rewound near the fork while the active chain
already names the winning branch; the tip is recent, so staleness reads false and
admission stays open, and A1 can take prevouts from the older state and height
and flags from the newer one — a combination that was never a connectable tip.
Nothing moves, the generation matches, and it publishes. So A1 also needs a
readiness condition, re-checked in A2: no reorg in flight, the set built to
exactly the height used as context, and that height, hash and context from one
view. That is coherence, and it is not sufficient by itself — while catching up
the set can momentarily reach the newest tip the node knows while that tip is
still old, so all three hold on a state that is internally consistent and months
behind. Readiness is coherence and synchronization together, the second starting
as the existing staleness heuristic, and neither half subsumes the other: one
misses the reorg window, the other misses IBD. The generation then advances once per coherent state published rather than once per
internal step, since a reorg's disconnect, adoption and rebuild are steps of one
transition and any of them can leave a state nothing should be admitted against.

One cost is accepted rather than hidden: the generation is coarse, so any block
landing between A1 and A2 discards the transaction even if it touched none of
its prevouts. Outside IBD that is a block every ten minutes, and during IBD
admission is closed, so narrowing it is a later optimization.

The test list is rewritten against this contract rather than left describing the
old one. The point of separable A1, A2 and readiness operations is that the state
machine stops being something only a race can exercise: each decision — a bumped
generation, a vanished dependency, each reason readiness refuses, either order of
A2 against W2 — becomes a direct test, with no pause built into production code
to make it observable. What stays probabilistic is the scheduling, not the
decisions. And one test runs an admission with its continuations landing on
different threads, which is what keeps the mutex from creeping back across the
awaits.

Rewrites section 3 of the synchronization document, adjusts section 8, rewrites the test list in section 10, and adds invariants 12 to 14. Documentation only — the implementation follows against this contract.

Adds one **[TODAY]** defect to section 2: the mutex held across suspension points in the admission path, which is a pre-existing bug rather than something this work introduces.