### PR TITLE
docs: say what the height on a delete means, and make it agree with a read

### DIFF
--- a/docs/utxo-store-api-requirements.md
+++ b/docs/utxo-store-api-requirements.md
@@ -647,9 +647,47 @@ after being made optional.
 The same shape, for the same reasons.
 
 ```
-erase(key, height)                        -> erased | not_in_active_map | error
+erase(request)                            -> erased | needs_resolution | error
 resolve_deletions(span<request const>)    -> { erased_count, absent, unresolved, cancelled }
 ```
+
+### The creation-height bound applies here too, identically
+
+Section 2 settles what the height on a lookup means — `max_creation_height`, a
+bound on which entries are eligible — and section 3 restates the rule the
+resolver needs. **Deletion was left silent on both, and it is the side that
+mutates.** A lookup that applies the bound wrongly returns a wrong answer; a
+delete that applies it wrongly **removes the wrong entry**, and that does not
+undo.
+
+So, in full and with nothing left to infer:
+
+- `erase(request)` removes from the active map **only if the entry it finds is
+  eligible** under the request's bound;
+- an active entry that is **too new is not erased**, and the answer is
+  **`needs_resolution`**, exactly as the probe's is. Not "not in the active map":
+  the entry *is* there, it is simply not eligible, and a name that says otherwise
+  would be false and would leave the caller translating it with knowledge the
+  answer failed to carry. One outcome covers both reasons a delete cannot settle
+  from the active map — the key is absent from it, or present and ineligible —
+  and in both the caller carries the request on to `resolve_deletions`;
+- `resolve_deletions` walks versions in the **same order** `resolve_lookups`
+  does;
+- a too-new entry found in some version **does not count as erased and does not
+  authorize `absent`.** The walk continues into older versions;
+- `absent` is authoritative only after every relevant location has been exhausted
+  without an eligible entry.
+
+**And the rule that makes the two agree.** If reinsertions leave more than one
+eligible copy, the delete removes **exactly the entry a read would have returned
+for the same `{key, max_creation_height}`** — same traversal order, first
+eligible one wins.
+
+That is not a tidiness requirement. Validation resolves a prevout through a read
+and the delta then erases it through a delete; if the two resolve to different
+entries, the block is validated against one UTXO and spends another. Read and
+delete must identify the same one, and the only way to guarantee that is for them
+to search the same way.
 
 `erase` must touch only the active map. Today it also searches cached files
 inline, which puts a writer into the file cache from wherever it is called; that


### PR DESCRIPTION
The creation-height bound was settled for lookups and left silent for deletes.
Section 2 defines it, section 3 restates the part the resolver needs, and section
4 says nothing — so `erase` took a height with three incompatible readings
available and no way to choose between them from the text.

That silence is worse on this side than it would be on the other. A lookup that
applies the bound wrongly returns a wrong answer; a delete that applies it
wrongly removes the wrong entry, and there is no undoing that.

So the bound is spelled out for deletion in the same terms: an active entry too
new for the request is not erased, and the answer is needs_resolution — the same
one the probe gives, and for the same reason. Not "not in the active map", which
would be false: the entry is there, it is simply not eligible, and a name that
denied its presence would leave the caller translating the answer with knowledge
the answer failed to carry. One outcome covers both reasons a delete cannot
settle from the active map, and in both the caller carries the request on to
history; the historical walk visits versions in the
same order a lookup does; a too-new entry neither counts as erased nor authorizes
absence; and absence is authoritative only once every relevant location has been
exhausted.

And one rule that neither section had, because it only becomes visible when the
two are read together: if reinsertions leave more than one eligible copy, the
delete must remove exactly the entry a read would have returned for the same key
and bound — same order, first eligible wins. Validation resolves a prevout
through a read and the delta erases it through a delete, so if the two resolve
differently the block is validated against one UTXO and spends another. Searching
the same way is the only thing that guarantees they mean the same entry.

`erase` also takes a request now rather than a loose key and height, so the thing
carrying the bound is the same type on both paths.

Follows #595 and #597. Documentation only, one commit — worth closing before the store implements the API, since it is part of the contract that was just agreed as final.