### PR TITLE
database: give an undo record the identity that lets a restart find it again

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -313,6 +313,7 @@ if (ENABLE_TEST)
         test/parking.cpp
         test/block_undo.cpp
         test/reorg_undo_roundtrip.cpp
+        test/undo_scan.cpp
         test/reorg_e2e.cpp
     )
 

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -187,6 +187,11 @@ bool block_chain::start(uint32_t disk_magic) {
 
     // Load all headers from database into header_index
     // This allows resuming sync from where we left off
+    // The chain by height as the database holds it, filled while headers load and
+    // used below to check undo coverage. Declared out here because the check and
+    // the load are in different scopes.
+    std::vector<header_index::index_t> persisted_chain_indices;
+
     auto const heights = get_last_heights();
     if ( ! heights) {
         spdlog::error("[blockchain] Failed to get last heights from database.");
@@ -217,6 +222,16 @@ bool block_chain::start(uint32_t disk_magic) {
         constexpr size_t batch_size = 10000;
         size_t loaded = 0;
 
+        // The chain by height as LMDB holds it, recorded as it is loaded.
+        //
+        // Deliberately not called the active chain: the organizer publishes that
+        // view after startup, so active_at() answers nothing here — a fact this
+        // code learned by asking it and being told height one does not exist.
+        // The persisted by-height table is the authoritative source available
+        // during startup, and it is the one the UTXO set was built against, so
+        // it is what undo coverage is checked against below.
+        persisted_chain_indices.assign(heights->header + 1, header_index::null_index);
+
         for (size_t from = 0; from <= heights->header; from += batch_size) {
             auto const to = std::min(from + batch_size - 1, size_t(heights->header));
             auto const headers_result = get_headers(from, to);
@@ -234,6 +249,18 @@ bool block_chain::start(uint32_t disk_magic) {
                     // Genesis might already be added, ignore that case
                     spdlog::warn("[blockchain] Failed to add header at height {} to index", height);
                 }
+                if (idx == header_index::null_index) {
+                    spdlog::critical("[blockchain] The header at height {} has no index after "
+                        "loading; the persisted chain cannot be reconstructed", height);
+                    return false;
+                }
+                if (height >= persisted_chain_indices.size()) {
+                    spdlog::critical("[blockchain] Loaded a header at height {}, past the {} the "
+                        "database reports; the by-height table is inconsistent",
+                        height, heights->header);
+                    return false;
+                }
+                persisted_chain_indices[height] = idx;
                 ++height;
                 ++loaded;
             }
@@ -265,6 +292,104 @@ bool block_chain::start(uint32_t disk_magic) {
                 }
             }
         );
+
+        // And the undo records, the same way and for the same reason: their
+        // positions live only in this in-memory index, so without this pass a
+        // restart leaves every block without undo and no reorganization can
+        // disconnect anything (#603).
+        //
+        // Nothing is applied until the whole scan succeeds. A half-restored index
+        // is worse than an empty one, because it looks complete: the blocks it
+        // reached would report undo data and the rest would not, with no way to
+        // tell which case a missing record is.
+        auto const undo_scan = block_store_->scan_undo_positions(
+            [this](hash_digest const& block_hash) -> std::optional<hash_digest> {
+                auto const idx = header_index_.find(block_hash);
+                if (idx == header_index::null_index) {
+                    return std::nullopt;
+                }
+                auto const parent = header_index_.get_parent_index(idx);
+                if (parent == header_index::null_index) {
+                    return std::nullopt;
+                }
+                return header_index_.get_hash(parent);
+            });
+
+        if (undo_scan.status != block_store::undo_scan_status::clean_eof) {
+            if (undo_scan.status == block_store::undo_scan_status::legacy_format) {
+                spdlog::critical("[blockchain] This database's undo records predate the format "
+                    "that records which block each one belongs to, and the association cannot be "
+                    "recovered from what is on disk. Without it no reorganization can disconnect "
+                    "a block connected before this start. The UTXO set and undo data have to be "
+                    "rebuilt.");
+            } else {
+                spdlog::critical("[blockchain] The undo records could not be read back "
+                    "(status {}, file {}, offset {}). Refusing to start on a chain whose undo "
+                    "data is unaccounted for.",
+                    static_cast<int>(undo_scan.status), undo_scan.file_number, undo_scan.position);
+            }
+            return false;
+        }
+
+        for (auto const& location : undo_scan.found) {
+            auto const idx = header_index_.find(location.block_hash);
+            if (idx == header_index::null_index) {
+                // The scan already refused an unknown block, so this cannot
+                // happen; if it somehow does, the index and the files disagree.
+                spdlog::critical("[blockchain] An undo record survived the scan for a block the "
+                    "index does not hold");
+                return false;
+            }
+            header_index_.set_undo_pos(idx, location.position);
+            header_index_.add_status(idx, header_status::have_undo);
+        }
+        spdlog::info("[blockchain] Restored {} undo positions ({} records belong to blocks this "
+            "index no longer holds, which is ordinary after a reorganization)",
+            undo_scan.found.size(), undo_scan.unattributed);
+
+        // Skipping a record whose block is unknown is right for an abandoned
+        // branch and would be wrong for a live one — and locally the two look the
+        // same, since a single flipped bit in a stored hash makes an active
+        // record unattributable. What separates them is coverage: every block on
+        // the active chain that was connected with undo must have it now. Below
+        // the checkpoint none is captured, and above the built height nothing is
+        // connected, so the range between is exactly what has to be complete.
+        auto const built = get_utxo_built_height();
+        if ( ! built) {
+            if (built.error() != database::result_code::key_not_found) {
+                // Not knowing how far the set was built is not the same as
+                // nothing having been built, and taking it for that would skip
+                // the coverage check entirely — the failure this check exists to
+                // catch, arriving through the check itself.
+                spdlog::critical("[blockchain] The built height could not be read, so whether the "
+                    "chain's undo data is complete cannot be established. Refusing to start.");
+                return false;
+            }
+        } else {
+            auto const first = static_cast<int32_t>(settings_.max_checkpoint_height) + 1;
+            for (int32_t height = first; height <= static_cast<int32_t>(*built); ++height) {
+                auto const at = static_cast<size_t>(height);
+                if (at >= persisted_chain_indices.size() ||
+                        persisted_chain_indices[at] == header_index::null_index) {
+                    // The range is the part of the persisted chain that was
+                    // connected. A height in it with no block means the coverage
+                    // cannot be established rather than that there is nothing to
+                    // cover.
+                    spdlog::critical("[blockchain] No block at height {}, which the built height "
+                        "says was connected. Refusing to start on a chain whose undo coverage "
+                        "cannot be established.", height);
+                    return false;
+                }
+                auto const idx = persisted_chain_indices[at];
+                if (header_index_.has_undo_data(idx)) continue;
+
+                spdlog::critical("[blockchain] The block at height {} is connected but has no undo "
+                    "data. Its record is missing or names a block this index does not hold, which "
+                    "means it cannot be disconnected and no reorganization below this height can "
+                    "run. The UTXO set and undo data have to be rebuilt.", height);
+                return false;
+            }
+        }
 
         auto const scan_elapsed = std::chrono::steady_clock::now() - scan_start;
         auto const scan_ms = std::chrono::duration_cast<std::chrono::milliseconds>(scan_elapsed).count();
@@ -723,7 +848,11 @@ bool block_chain::store_block_undo(database::header_index::index_t idx,
         return false;
     }
 
-    auto const pos = block_store_->write_undo(undo, file_number, prev_hash);
+    // The record carries the owning block's hash so a restart can attribute it.
+    // Nothing else can: the checksum is seeded with the parent hash, so every
+    // sibling validates the same record (#603).
+    auto const pos = block_store_->write_undo(undo, file_number,
+        header_index_.get_hash(idx), prev_hash);
     if (pos.is_null()) {
         spdlog::error("[blockchain] store_block_undo: failed to write undo for index {}", idx);
         return false;
@@ -745,7 +874,7 @@ block_chain::read_block_undo(database::header_index::index_t idx, hash_digest co
         header_index_.get_file_number(idx),
         header_index_.get_undo_pos(idx)
     };
-    return block_store_->read_undo(pos, prev_hash);
+    return block_store_->read_undo(pos, header_index_.get_hash(idx), prev_hash);
 }
 
 #if ! defined(KTH_DB_READONLY)

--- a/src/blockchain/src/utxo_builder.cpp
+++ b/src/blockchain/src/utxo_builder.cpp
@@ -26,6 +26,7 @@
 
 #include <kth/blockchain/interface/block_chain.hpp>
 #include <kth/database/databases/utxoz_database.hpp>
+#include <kth/database/native_file.hpp>
 #include <kth/domain/chain/block.hpp>
 #include <kth/domain/machine/opcode.hpp>
 namespace kth::blockchain {
@@ -605,7 +606,7 @@ bool save_utxo_bloom(
     auto const path = data_dir / fmt::format("utxo_bloom_{}.dat", checkpoint_height);
     std::filesystem::create_directories(data_dir);
 
-    auto* fp = std::fopen(path.c_str(), "wb");
+    auto* fp = database::open_native(path, "wb");
     if ( ! fp) {
         spdlog::error("[bloom] Failed to open {} for writing", path.string());
         return false;

--- a/src/blockchain/test/undo_scan.cpp
+++ b/src/blockchain/test/undo_scan.cpp
@@ -1,0 +1,635 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <array>
+#include <cstdio>
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include <kth/database/block_store.hpp>
+#include <kth/database/block_undo.hpp>
+#include <kth/database/databases/utxoz_database.hpp>
+#include <kth/database/native_file.hpp>
+
+using namespace kth;
+using namespace kth::database;
+
+// =============================================================================
+// Recovering undo records at startup
+// =============================================================================
+//
+// Undo positions live only in the header index, which is rebuilt from disk at
+// startup, so they have to be recoverable from the rev files alone. Nothing
+// already there could do it — order cannot, because a rev file holds records
+// for a subset of its blk file's blocks with no gap marking the rest, and the
+// checksum cannot, because it is seeded with the parent hash: every sibling
+// validates the same record. So the record carries its owner's hash.
+//
+// These drive block_store directly, against real files, because what is being
+// pinned is how bytes on disk are read back — including bytes no correct writer
+// would produce.
+
+namespace {
+
+hash_digest make_hash(uint8_t seed) {
+    hash_digest h{};
+    h[0] = seed;
+    h[31] = uint8_t(0xF0 ^ seed);
+    return h;
+}
+
+utxoz::raw_outpoint make_outpoint(uint8_t seed, uint32_t index) {
+    auto const txid = make_hash(seed);
+    return utxoz::make_outpoint(std::span<uint8_t const, 32>(txid.data(), 32), index);
+}
+
+block_undo make_undo(uint8_t seed, uint32_t height) {
+    block_undo undo;
+    undo.spent.push_back({make_outpoint(seed, 0), data_chunk{0x51, 0x52, 0x53}, height});
+    return undo;
+}
+
+// A directory of its own per test, so one leaving files behind cannot make
+// another pass or fail for the wrong reason.
+struct store_fixture {
+    std::filesystem::path dir;
+    block_store store;
+
+    explicit store_fixture(std::string const& name)
+        : dir(std::filesystem::temp_directory_path() / ("kth_undo_scan_" + name))
+        , store(dir, block_store::magic_t{{0xe3, 0xe1, 0xf3, 0xe8}})
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(dir, ec);
+        REQUIRE(store.initialize());
+        // initialize() reads a rev file's size only when the matching blk file
+        // exists — the two are discovered together, since a rev file only ever
+        // holds undo for blocks in its blk file. Production always has one; a
+        // test writing undo by hand has to say so.
+        make_block_file();
+    }
+
+    // Give a file number its blk file, so a later initialize() picks up the
+    // matching rev size — the two are only ever discovered together.
+    void make_block_file(int32_t file_num = 0) const {
+        std::filesystem::create_directories(dir);
+        auto const path = dir / fmt::format("blk{:05d}.dat", file_num);
+        if (std::filesystem::exists(path)) return;
+        FILE* file = std::fopen(path.string().c_str(), "wb");
+        REQUIRE(file != nullptr);
+        std::fclose(file);
+    }
+
+    ~store_fixture() {
+        std::error_code ec;
+        std::filesystem::remove_all(dir, ec);
+    }
+
+    std::filesystem::path rev_path(int32_t file_num) const {
+        return dir / fmt::format("rev{:05d}.dat", file_num);
+    }
+};
+
+// Every block resolves to a parent, which is what the checksum is seeded with.
+// A test that wants an unknown block returns nullopt for it.
+block_store::undo_parent_lookup parents_of(
+    std::vector<std::pair<hash_digest, hash_digest>> const& pairs) {
+    return [pairs](hash_digest const& block_hash) -> std::optional<hash_digest> {
+        for (auto const& [block, parent] : pairs) {
+            if (block == block_hash) return parent;
+        }
+        return std::nullopt;
+    };
+}
+
+// Cut a file short, the way an interrupted write leaves it.
+void truncate_to(std::filesystem::path const& path, uintmax_t bytes) {
+    std::error_code ec;
+    std::filesystem::resize_file(path, bytes, ec);
+    REQUIRE_FALSE(ec);
+}
+
+// Flip a byte in place.
+void corrupt_byte(std::filesystem::path const& path, uintmax_t offset) {
+    FILE* file = std::fopen(path.string().c_str(), "r+b");
+    REQUIRE(file != nullptr);
+    REQUIRE(std::fseek(file, static_cast<long>(offset), SEEK_SET) == 0);
+    int const original = std::fgetc(file);
+    REQUIRE(original != EOF);
+    REQUIRE(std::fseek(file, static_cast<long>(offset), SEEK_SET) == 0);
+    REQUIRE(std::fputc(original ^ 0xFF, file) != EOF);
+    std::fclose(file);
+}
+
+} // namespace
+
+TEST_CASE("a scan recovers every record it wrote", "[undo][scan]") {
+    store_fixture fixture("roundtrip");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    auto const block_b = make_hash(2);
+    auto const parent_b = block_a;
+
+    auto const pos_a = fixture.store.write_undo(make_undo(10, 100), 0, block_a, parent_a);
+    REQUIRE_FALSE(pos_a.is_null());
+    auto const pos_b = fixture.store.write_undo(make_undo(11, 101), 0, block_b, parent_b);
+    REQUIRE_FALSE(pos_b.is_null());
+
+    auto const result = fixture.store.scan_undo_positions(
+        parents_of({{block_a, parent_a}, {block_b, parent_b}}));
+
+    REQUIRE(result.status == block_store::undo_scan_status::clean_eof);
+    REQUIRE(result.found.size() == 2);
+    CHECK(result.found[0].block_hash == block_a);
+    CHECK(result.found[0].position == pos_a.pos);
+    CHECK(result.found[1].block_hash == block_b);
+    CHECK(result.found[1].position == pos_b.pos);
+}
+
+TEST_CASE("a record identifies its own block, not merely its parent", "[undo][scan]") {
+    // The reason the hash is in the record. Two siblings share a parent, so they
+    // share the checksum seed — and two siblings built from the same
+    // transactions with different coinbases spend the same outputs, so their
+    // undo data is byte-identical too. Nothing about the payload or its checksum
+    // can tell them apart; only the stored hash can.
+    store_fixture fixture("siblings");
+
+    auto const parent = make_hash(0);
+    auto const sibling_x = make_hash(1);
+    auto const sibling_y = make_hash(2);
+
+    auto const undo = make_undo(10, 100);   // identical for both, deliberately
+    auto const pos = fixture.store.write_undo(undo, 0, sibling_x, parent);
+    REQUIRE_FALSE(pos.is_null());
+
+    // Both siblings are known and share the parent, so the checksum validates
+    // for either. Only the recorded hash decides.
+    auto const result = fixture.store.scan_undo_positions(
+        parents_of({{sibling_x, parent}, {sibling_y, parent}}));
+    REQUIRE(result.status == block_store::undo_scan_status::clean_eof);
+    REQUIRE(result.found.size() == 1);
+    CHECK(result.found.front().block_hash == sibling_x);
+
+    // And reading it as the other sibling is refused, which the checksum alone
+    // could never do: it satisfies both.
+    auto const as_x = fixture.store.read_undo(pos, sibling_x, parent);
+    CHECK(as_x.has_value());
+
+    auto const as_y = fixture.store.read_undo(pos, sibling_y, parent);
+    REQUIRE_FALSE(as_y.has_value());
+    // Corruption, not absence: something pointed at another block's record, and
+    // reporting that as "no undo here" would dress a damaged database as an
+    // ordinary missing one.
+    CHECK(as_y.error() == result_code::db_corrupt);
+}
+
+TEST_CASE("a record from before the format carried a hash is named as such", "[undo][scan]") {
+    // The old layout was magic | size | payload, using the network magic — the
+    // same four bytes blocks use. A reader expecting the current layout would
+    // take those size bytes for the start of a hash and misread everything
+    // after, which is why the record has a marker of its own. Finding the
+    // network magic here is a database from an older build, and saying that is
+    // what lets a caller ask for a rebuild instead of guessing.
+    store_fixture fixture("legacy");
+
+    // Hand-write a legacy record: network magic, then a size.
+    auto const path = fixture.rev_path(0);
+    std::filesystem::create_directories(fixture.dir);
+    FILE* file = std::fopen(path.string().c_str(), "wb");
+    REQUIRE(file != nullptr);
+    std::array<uint8_t, 4> const network_magic{{0xe3, 0xe1, 0xf3, 0xe8}};
+    REQUIRE(std::fwrite(network_magic.data(), 1, 4, file) == 4);
+    uint32_t const payload_size = 64;
+    REQUIRE(std::fwrite(&payload_size, sizeof(payload_size), 1, file) == 1);
+    std::vector<uint8_t> const filler(payload_size + 32, 0xAB);
+    REQUIRE(std::fwrite(filler.data(), 1, filler.size(), file) == filler.size());
+    std::fclose(file);
+
+    fixture.make_block_file();
+    REQUIRE(fixture.store.initialize());
+
+    auto const result = fixture.store.scan_undo_positions(parents_of({}));
+    CHECK(result.status == block_store::undo_scan_status::legacy_format);
+    CHECK(result.found.empty());
+}
+
+TEST_CASE("a truncated record stops the scan and yields nothing", "[undo][scan]") {
+    store_fixture fixture("truncated");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    auto const block_b = make_hash(2);
+
+    REQUIRE_FALSE(fixture.store.write_undo(make_undo(10, 100), 0, block_a, parent_a).is_null());
+    auto const pos_b = fixture.store.write_undo(make_undo(11, 101), 0, block_b, block_a);
+    REQUIRE_FALSE(pos_b.is_null());
+
+    // Cut into the second record's payload, so its header still fits and its
+    // body does not — what an interrupted write leaves behind. Measured from the
+    // write position, not from the file size: rev files are preallocated, so the
+    // file is far larger than what has been written into it.
+    truncate_to(fixture.rev_path(0), pos_b.pos + 2);
+    fixture.make_block_file();
+    REQUIRE(fixture.store.initialize());
+
+    auto const result = fixture.store.scan_undo_positions(
+        parents_of({{block_a, parent_a}, {block_b, block_a}}));
+
+    CHECK(result.status == block_store::undo_scan_status::truncated_record);
+
+    // And nothing is handed back, including the first record, which was intact.
+    // A half-restored index is worse than an empty one: it looks complete, so a
+    // block with no undo cannot be told from a block whose undo was not reached.
+    CHECK(result.found.empty());
+}
+
+TEST_CASE("a record whose contents were altered fails its checksum", "[undo][scan]") {
+    store_fixture fixture("corrupt");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    auto const pos = fixture.store.write_undo(make_undo(10, 100), 0, block_a, parent_a);
+    REQUIRE_FALSE(pos.is_null());
+
+    // Flip a byte of the payload, past the 40-byte header.
+    corrupt_byte(fixture.rev_path(0), 45);
+    fixture.make_block_file();
+    REQUIRE(fixture.store.initialize());
+
+    auto const result = fixture.store.scan_undo_positions(parents_of({{block_a, parent_a}}));
+    CHECK(result.status == block_store::undo_scan_status::invalid_checksum);
+    CHECK(result.block_hash == block_a);
+    CHECK(result.found.empty());
+}
+
+TEST_CASE("a record for a block the index no longer holds is counted, not refused",
+          "[undo][scan]") {
+    // Refusing looked right and is wrong: a restart rebuilds the index from the
+    // active chain only, so a branch that lost a reorganization is forgotten
+    // while its undo records stay in the files. Treating that as a disagreement
+    // would stop any node that ever reorganized from starting again — which is
+    // how this was found, by the restart-after-reorganization test failing.
+    //
+    // Nothing on disk separates that from a real disagreement, and the ordinary
+    // case is the first, so the record is skipped and counted.
+    store_fixture fixture("unattributed");
+
+    auto const kept = make_hash(1);
+    auto const parent = make_hash(0);
+    auto const forgotten = make_hash(9);
+
+    REQUIRE_FALSE(fixture.store.write_undo(make_undo(10, 100), 0, forgotten, make_hash(8)).is_null());
+    REQUIRE_FALSE(fixture.store.write_undo(make_undo(11, 101), 0, kept, parent).is_null());
+
+    auto const result = fixture.store.scan_undo_positions(parents_of({{kept, parent}}));
+
+    REQUIRE(result.status == block_store::undo_scan_status::clean_eof);
+    CHECK(result.unattributed == 1);
+
+    // And the walk continued past it: the record after the forgotten one is
+    // still recovered, which it would not be if an unknown block stopped the scan.
+    REQUIRE(result.found.size() == 1);
+    CHECK(result.found.front().block_hash == kept);
+}
+
+TEST_CASE("two records claiming the same block are refused", "[undo][scan]") {
+    store_fixture fixture("duplicate");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+
+    REQUIRE_FALSE(fixture.store.write_undo(make_undo(10, 100), 0, block_a, parent_a).is_null());
+    REQUIRE_FALSE(fixture.store.write_undo(make_undo(10, 100), 0, block_a, parent_a).is_null());
+
+    auto const result = fixture.store.scan_undo_positions(parents_of({{block_a, parent_a}}));
+    CHECK(result.status == block_store::undo_scan_status::duplicate_record);
+    CHECK(result.block_hash == block_a);
+    CHECK(result.found.empty());
+}
+
+TEST_CASE("a block with no undo record simply has none", "[undo][scan]") {
+    // Side branches, blocks stored but never connected, and blocks below the
+    // checkpoint never receive undo. They leave no gap and no marker — which is
+    // half of why order cannot attribute records, and why the scan must not
+    // infer anything from how many it finds.
+    store_fixture fixture("absent");
+
+    auto const connected = make_hash(1);
+    auto const parent = make_hash(0);
+    auto const side_branch = make_hash(7);
+
+    REQUIRE_FALSE(fixture.store.write_undo(make_undo(10, 100), 0, connected, parent).is_null());
+
+    auto const result = fixture.store.scan_undo_positions(
+        parents_of({{connected, parent}, {side_branch, parent}}));
+
+    REQUIRE(result.status == block_store::undo_scan_status::clean_eof);
+    REQUIRE(result.found.size() == 1);
+    CHECK(result.found.front().block_hash == connected);
+}
+
+TEST_CASE("a rev file that exists and will not open is a failure, not an absence",
+          "[undo][scan]") {
+    // Skipping it would start the node without undo it actually has. A file that
+    // is not there was never written; one that is there and will not open is a
+    // different thing and has to be said so.
+    store_fixture fixture("unreadable");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    REQUIRE_FALSE(fixture.store.write_undo(make_undo(10, 100), 0, block_a, parent_a).is_null());
+
+    // A directory where the file should be: it exists, and it will not open.
+    // Dropping permissions would be the obvious way and is not portable —
+    // Windows ignores it, and root ignores it everywhere.
+    auto const path = fixture.rev_path(0);
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+    REQUIRE_FALSE(ec);
+    REQUIRE(std::filesystem::create_directory(path, ec));
+
+    auto const result = fixture.store.scan_undo_positions(parents_of({{block_a, parent_a}}));
+
+    std::filesystem::remove_all(path, ec);
+
+    CHECK(result.status == block_store::undo_scan_status::io_error);
+    CHECK(result.found.empty());
+}
+
+TEST_CASE("a partial header is truncation, not the end of the file", "[undo][scan]") {
+    // Between one and thirty-nine bytes of a header is an interrupted write. The
+    // earlier truncation case cuts a payload, which leaves a whole header behind
+    // and takes a different path.
+    store_fixture fixture("partial_header");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    auto const undo_a = make_undo(10, 100);
+    auto const pos_a = fixture.store.write_undo(undo_a, 0, block_a, parent_a);
+    REQUIRE_FALSE(pos_a.is_null());
+
+    // Where the first record actually ends: its payload is the serialized undo,
+    // not just the value inside it, and the checksum follows. Guessing that had
+    // this test cutting into the first record instead, which takes the
+    // payload-does-not-fit path the truncation case already covers.
+    auto const first_record_end =
+        pos_a.pos + static_cast<uint32_t>(undo_a.serialized_size()) + 32;
+
+    // Six bytes of a second header, and nothing more.
+    constexpr size_t partial_bytes = 6;
+    {
+        FILE* file = std::fopen(fixture.rev_path(0).string().c_str(), "r+b");
+        REQUIRE(file != nullptr);
+        REQUIRE(std::fseek(file, static_cast<long>(first_record_end), SEEK_SET) == 0);
+        std::array<uint8_t, partial_bytes> const partial{{'K', 'U', 'N', '2', 0x11, 0x22}};
+        REQUIRE(std::fwrite(partial.data(), 1, partial.size(), file) == partial.size());
+        std::fclose(file);
+    }
+    truncate_to(fixture.rev_path(0), first_record_end + partial_bytes);
+    fixture.make_block_file();
+    REQUIRE(fixture.store.initialize());
+
+    auto const result = fixture.store.scan_undo_positions(parents_of({{block_a, parent_a}}));
+    CHECK(result.status == block_store::undo_scan_status::truncated_record);
+    CHECK(result.found.empty());
+}
+
+TEST_CASE("four zero bytes end the file only if the rest is zero too", "[undo][scan]") {
+    // Reserved space a preallocated file never used begins with zeroes and stays
+    // that way. Four zeroes with content after them is damage, and stopping there
+    // would report a clean read while hiding every record beyond.
+    store_fixture fixture("zeroes_then_content");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    auto const pos_a = fixture.store.write_undo(make_undo(10, 100), 0, block_a, parent_a);
+    REQUIRE_FALSE(pos_a.is_null());
+
+    auto const block_b = make_hash(2);
+    auto const pos_b = fixture.store.write_undo(make_undo(11, 101), 0, block_b, block_a);
+    REQUIRE_FALSE(pos_b.is_null());
+
+    // Zero the second record's marker, leaving its body in place.
+    {
+        FILE* file = std::fopen(fixture.rev_path(0).string().c_str(), "r+b");
+        REQUIRE(file != nullptr);
+        auto const header_start = pos_b.pos - 40;
+        REQUIRE(std::fseek(file, static_cast<long>(header_start), SEEK_SET) == 0);
+        std::array<uint8_t, 4> const zeroes{};
+        REQUIRE(std::fwrite(zeroes.data(), 1, zeroes.size(), file) == zeroes.size());
+        std::fclose(file);
+    }
+
+    auto const result = fixture.store.scan_undo_positions(
+        parents_of({{block_a, parent_a}, {block_b, block_a}}));
+
+    CHECK(result.status == block_store::undo_scan_status::truncated_record);
+    CHECK(result.found.empty());
+}
+
+TEST_CASE("records are recovered from more than one rev file", "[undo][scan]") {
+    // The scan walks file numbers, and initialize() only learns a rev file's size
+    // alongside its blk file, so more than one of each has to work.
+    store_fixture fixture("multi_file");
+    // file_info_ only learns about file 1 through initialize(), which discovers
+    // it from the blk file — so that has to exist before anything is written to
+    // rev00001.dat.
+    fixture.make_block_file(1);
+    REQUIRE(fixture.store.initialize());
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    auto const block_b = make_hash(2);
+
+    auto const pos_a = fixture.store.write_undo(make_undo(10, 100), 0, block_a, parent_a);
+    REQUIRE_FALSE(pos_a.is_null());
+    auto const pos_b = fixture.store.write_undo(make_undo(11, 101), 1, block_b, block_a);
+    REQUIRE_FALSE(pos_b.is_null());
+
+    auto const result = fixture.store.scan_undo_positions(
+        parents_of({{block_a, parent_a}, {block_b, block_a}}));
+
+    REQUIRE(result.status == block_store::undo_scan_status::clean_eof);
+    REQUIRE(result.found.size() == 2);
+    CHECK(result.found[0].file_number == 0);
+    CHECK(result.found[0].block_hash == block_a);
+    CHECK(result.found[1].file_number == 1);
+    CHECK(result.found[1].block_hash == block_b);
+}
+
+TEST_CASE("an unknown marker is not a truncated record", "[undo][scan]") {
+    // Three different things at the same place, and they read as three: the old
+    // magic is a database from before the format, four zeroes are unused space,
+    // and anything else is a marker that should not be there. Calling the last
+    // one truncation would send whoever reads the log looking for an interrupted
+    // write instead of for what actually happened.
+    store_fixture fixture("bad_marker");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    auto const undo_a = make_undo(10, 100);
+    auto const pos_a = fixture.store.write_undo(undo_a, 0, block_a, parent_a);
+    REQUIRE_FALSE(pos_a.is_null());
+
+    // A whole record's worth of bytes after the first, so nothing is short —
+    // only the marker is wrong.
+    auto const second_start =
+        pos_a.pos + static_cast<uint32_t>(undo_a.serialized_size()) + 32;
+    {
+        FILE* file = std::fopen(fixture.rev_path(0).string().c_str(), "r+b");
+        REQUIRE(file != nullptr);
+        REQUIRE(std::fseek(file, static_cast<long>(second_start), SEEK_SET) == 0);
+        std::array<uint8_t, 4> const nonsense{{'X', 'Y', 'Z', 'W'}};
+        REQUIRE(std::fwrite(nonsense.data(), 1, nonsense.size(), file) == nonsense.size());
+        std::array<uint8_t, 200> body;
+        body.fill(0x7E);
+        REQUIRE(std::fwrite(body.data(), 1, body.size(), file) == body.size());
+        std::fclose(file);
+    }
+    // Re-read the file size: what was written by hand is past where the store
+    // thinks it left off, and the scan honours the recorded size.
+    fixture.make_block_file();
+    REQUIRE(fixture.store.initialize());
+
+    auto const result = fixture.store.scan_undo_positions(parents_of({{block_a, parent_a}}));
+    CHECK(result.status == block_store::undo_scan_status::invalid_marker);
+    CHECK(result.found.empty());
+}
+
+TEST_CASE("reading a legacy record says so, rather than blaming another block",
+          "[undo][scan]") {
+    // The marker has to be checked before anything after it is read. In the old
+    // layout the next thirty-two bytes are a size and the start of a payload, not
+    // a hash, so comparing them first would report a record belonging to another
+    // block — the wrong diagnosis, under an error code that means corruption.
+    store_fixture fixture("legacy_read");
+
+    auto const path = fixture.rev_path(0);
+    std::filesystem::create_directories(fixture.dir);
+    {
+        FILE* file = std::fopen(path.string().c_str(), "wb");
+        REQUIRE(file != nullptr);
+        std::array<uint8_t, 4> const network_magic{{0xe3, 0xe1, 0xf3, 0xe8}};
+        REQUIRE(std::fwrite(network_magic.data(), 1, 4, file) == 4);
+        uint32_t const payload_size = 8;
+        REQUIRE(std::fwrite(&payload_size, sizeof(payload_size), 1, file) == 1);
+        std::vector<uint8_t> const rest(payload_size + 32, 0xAB);
+        REQUIRE(std::fwrite(rest.data(), 1, rest.size(), file) == rest.size());
+        std::fclose(file);
+    }
+    fixture.make_block_file();
+    REQUIRE(fixture.store.initialize());
+
+    // The position a legacy header would have handed back: just past its 8-byte
+    // header, which is where read_undo seeks backwards from.
+    auto const result = fixture.store.read_undo(flat_file_pos{0, 40}, make_hash(1), make_hash(0));
+
+    REQUIRE_FALSE(result.has_value());
+    // Not db_corrupt: the record does not belong to another block, it belongs to
+    // another format.
+    CHECK(result.error() == result_code::other);
+}
+
+TEST_CASE("an implausible payload size is refused before anything is reserved",
+          "[undo][scan]") {
+    // The scanner bounds the size on the way in, but a record can be damaged
+    // after that. Without the same bound here the value goes straight to an
+    // allocation — gigabytes of it — and the addition of the checksum length
+    // overflows first.
+    store_fixture fixture("huge_size");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    auto const pos_a = fixture.store.write_undo(make_undo(10, 100), 0, block_a, parent_a);
+    REQUIRE_FALSE(pos_a.is_null());
+
+    // The size field sits four bytes past the marker and hash.
+    {
+        FILE* file = std::fopen(fixture.rev_path(0).string().c_str(), "r+b");
+        REQUIRE(file != nullptr);
+        REQUIRE(std::fseek(file, static_cast<long>(pos_a.pos) - 4, SEEK_SET) == 0);
+        uint32_t const absurd = 0xFFFFFFFFu;
+        REQUIRE(std::fwrite(&absurd, sizeof(absurd), 1, file) == 1);
+        std::fclose(file);
+    }
+
+    auto const result = fixture.store.read_undo(pos_a, block_a, parent_a);
+    REQUIRE_FALSE(result.has_value());
+    CHECK(result.error() == result_code::db_corrupt);
+}
+
+TEST_CASE("two records claiming one forgotten block are still refused", "[undo][scan]") {
+    // Uniqueness does not depend on knowing the block. Checking it only after
+    // the owner is resolved would let a duplicate pair from a branch the index
+    // has forgotten pass as two ordinary unattributed records — the promise that
+    // duplicates are refused holding only while the block is still known.
+    store_fixture fixture("duplicate_forgotten");
+
+    auto const forgotten = make_hash(9);
+    REQUIRE_FALSE(fixture.store.write_undo(make_undo(10, 100), 0, forgotten, make_hash(8)).is_null());
+    REQUIRE_FALSE(fixture.store.write_undo(make_undo(10, 100), 0, forgotten, make_hash(8)).is_null());
+
+    // Nothing resolves, so both records are unattributable.
+    auto const result = fixture.store.scan_undo_positions(parents_of({}));
+
+    CHECK(result.status == block_store::undo_scan_status::duplicate_record);
+    CHECK(result.block_hash == forgotten);
+    CHECK(result.found.empty());
+}
+
+TEST_CASE("a path the platform can hold is a path the store can open", "[undo][scan]") {
+    // std::fopen takes char const*, but a path is wchar_t on Windows. Narrowing
+    // one with .string() compiles and then converts through the active code
+    // page, so a data directory holding a character that page cannot represent
+    // simply stops opening — and a user's own name is enough to put one there.
+    // open_native hands each platform the call that takes its own path type, so
+    // what the filesystem accepts is what the store can read back.
+    auto const path = std::filesystem::temp_directory_path() / "kth_náïve_ñ_日本.dat";
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+
+    {
+        FILE* file = open_native(path, "wb");
+        REQUIRE(file != nullptr);
+        uint8_t const payload[] = {0x4B, 0x54, 0x48};
+        REQUIRE(std::fwrite(payload, 1, sizeof(payload), file) == sizeof(payload));
+        std::fclose(file);
+    }
+
+    FILE* file = open_native(path, "rb");
+    REQUIRE(file != nullptr);
+    std::array<uint8_t, 3> read_back{};
+    CHECK(std::fread(read_back.data(), 1, read_back.size(), file) == read_back.size());
+    std::fclose(file);
+    CHECK(read_back == std::array<uint8_t, 3>{{0x4B, 0x54, 0x48}});
+
+    std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("a block that spent nothing still has an undo record", "[undo][scan]") {
+    // A block with nothing to restore does not produce an empty payload: the
+    // count is written whatever it is, so the record is a single zero byte. A
+    // payload of no bytes at all is something no writer can produce, which is
+    // why both readers refuse one — the block that spends nothing is an
+    // ordinary block, and it round-trips.
+    store_fixture fixture("empty_undo");
+
+    auto const block_a = make_hash(1);
+    auto const parent_a = make_hash(0);
+    auto const pos_a = fixture.store.write_undo(block_undo{}, 0, block_a, parent_a);
+    REQUIRE_FALSE(pos_a.is_null());
+
+    auto const record = fixture.store.read_undo(pos_a, block_a, parent_a);
+    REQUIRE(record.has_value());
+    CHECK(record->spent.empty());
+
+    auto const result = fixture.store.scan_undo_positions(parents_of({{block_a, parent_a}}));
+    CHECK(result.status == block_store::undo_scan_status::clean_eof);
+    REQUIRE(result.found.size() == 1);
+    CHECK(result.found[0].block_hash == block_a);
+}

--- a/src/database/include/kth/database/block_store.hpp
+++ b/src/database/include/kth/database/block_store.hpp
@@ -10,6 +10,7 @@
 #include <expected>
 #include <filesystem>
 #include <functional>
+#include <optional>
 #include <vector>
 
 #include <kth/database/define.hpp>
@@ -85,13 +86,14 @@ struct KD_API block_store {
     [[nodiscard]]
     flat_file_pos write_block_at(data_chunk const& raw_block, flat_file_pos header_pos);
 
-    /// Write undo data for a block.
-    /// @param undo The undo data.
-    /// @param file_num File number where the block is stored.
-    /// @param prev_hash Hash of the previous block (for checksum).
-    /// @return Position where undo was saved, or null position on error.
+    /// Write a block's undo record into the rev file matching `file_num`.
+    /// `block_hash` identifies the owning block and is stored in the record —
+    /// nothing else on disk can attribute it (#603). `prev_hash` seeds the
+    /// checksum and is not stored.
+    /// @return Position of the payload (just past the header), or null on error.
     [[nodiscard]]
-    flat_file_pos write_undo(block_undo const& undo, int32_t file_num, hash_digest const& prev_hash);
+    flat_file_pos write_undo(block_undo const& undo, int32_t file_num,
+                             hash_digest const& block_hash, hash_digest const& prev_hash);
 
     // =========================================================================
     // Read Operations
@@ -135,13 +137,14 @@ struct KD_API block_store {
     std::expected<std::vector<data_chunk>, result_code>
     read_blocks_raw(std::vector<flat_file_pos> const& positions) const;
 
-    /// Read undo data from disk.
-    /// @param pos Position of the undo data.
-    /// @param prev_hash Hash of the previous block (for checksum verification).
-    /// @return Undo data or error.
-    [[nodiscard]]
-    std::expected<block_undo, result_code>
-    read_undo(flat_file_pos const& pos, hash_digest const& prev_hash) const;
+    /// Read a block's undo record. `block_hash` is the block the caller believes
+    /// owns the record, and the record must agree — a wrong position would
+    /// otherwise return some other block's undo, and the checksum cannot catch
+    /// the sibling case, since siblings share its seed. `prev_hash` seeds the
+    /// checksum, as at write time.
+    [[nodiscard]] std::expected<block_undo, result_code>
+    read_undo(flat_file_pos const& pos, hash_digest const& block_hash,
+              hash_digest const& prev_hash) const;
 
     /// Scan all block files and invoke callback for each block found.
     /// Used on startup to rebuild in-memory block position index.
@@ -149,8 +152,66 @@ struct KD_API block_store {
     /// @return Number of blocks scanned.
     using block_position_callback = std::function<void(int32_t, uint32_t, hash_digest const&)>;
 
+    /// One recovered undo record: where it is, and which block owns it.
+    struct undo_location {
+        int32_t file_number;
+        uint32_t position;
+        hash_digest block_hash;
+    };
+
+    /// Why a scan stopped. Only `clean_eof` means the files were whole; every
+    /// other value has to keep the database from looking healthy, which is why
+    /// they are named apart rather than folded into one failure.
+    enum class undo_scan_status {
+        clean_eof,          ///< Every record read; nothing left but empty space.
+        legacy_format,      ///< A record written before it carried its block's hash.
+        invalid_marker,     ///< A marker that is neither this format's nor the old one's.
+        truncated_record,   ///< A header or payload that does not fit the file.
+        invalid_size,       ///< A payload size that cannot be right.
+        io_error,           ///< A seek or read failed.
+
+        invalid_checksum,   ///< A record whose contents do not match its checksum.
+        duplicate_record,   ///< Two records claiming the same block.
+    };
+
+    struct undo_scan_result {
+        undo_scan_status status;
+        std::vector<undo_location> found;   ///< Only meaningful when clean_eof.
+
+        /// Records naming a block the index does not hold. Not an error: a
+        /// restart rebuilds the index from the active chain only, so a branch
+        /// that lost a reorganization is forgotten while its undo records stay
+        /// in the files. They are counted rather than refused, because nothing
+        /// on disk distinguishes that from a genuine disagreement — and the
+        /// first is ordinary.
+        size_t unattributed{0};
+        int32_t file_number{-1};            ///< Where it stopped, for diagnosis.
+        uint32_t position{0};
+        hash_digest block_hash{};
+    };
+
+    /// Resolves a record's owning block to the hash its checksum is seeded with,
+    /// so the scan can verify a record rather than trust its header. Returns
+    /// nullopt when the block is not in the index, which is ordinary after a
+    /// reorganization: see undo_scan_result::unattributed.
+    using undo_parent_lookup = std::function<std::optional<hash_digest>(hash_digest const&)>;
+
     [[nodiscard]]
     size_t scan_block_positions(block_position_callback const& callback) const;
+
+    /// Walk the rev files and recover every undo record, so the header index can
+    /// be rebuilt at startup the way block positions already are.
+    ///
+    /// Each record is validated structurally — marker, size, bounds — and each
+    /// one whose block the index still holds is validated fully, against that
+    /// block's parent. Records naming a forgotten block cannot be checked further
+    /// and are counted rather than trusted; the coverage of the connected chain
+    /// is what protects against one of those being an active record in disguise. Nothing is
+    /// reported until every file has been read, so a failure late in the last
+    /// file cannot leave earlier records already applied — a half-restored index
+    /// is worse than none, because it looks complete.
+    [[nodiscard]]
+    undo_scan_result scan_undo_positions(undo_parent_lookup const& parent_of) const;
 
     // =========================================================================
     // Maintenance
@@ -192,7 +253,8 @@ private:
 
     /// Write undo to disk at position.
     [[nodiscard]]
-    bool write_undo_to_disk(block_undo const& undo, flat_file_pos& pos, hash_digest const& prev_hash);
+    bool write_undo_to_disk(block_undo const& undo, flat_file_pos& pos,
+                            hash_digest const& block_hash, hash_digest const& prev_hash);
 
     std::filesystem::path blocks_dir_;
     magic_t magic_;

--- a/src/database/include/kth/database/native_file.hpp
+++ b/src/database/include/kth/database/native_file.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_DATABASE_NATIVE_FILE_HPP
+#define KTH_DATABASE_NATIVE_FILE_HPP
+
+#include <cstdio>
+#include <filesystem>
+
+#ifdef _WIN32
+#include <cstring>
+#include <string>
+#endif
+
+namespace kth::database {
+
+/// Open a path with the C stdio API, in the character type the platform stores
+/// paths in.
+///
+/// A std::filesystem::path holds wchar_t on Windows and char elsewhere, while
+/// std::fopen only ever takes char const*. Narrowing the path with .string()
+/// would compile, but it converts through the active code page, so a path
+/// holding any character that page cannot represent would stop opening at all —
+/// a data directory under a user's name is enough. Each platform is therefore
+/// handed the call that takes its own path verbatim. The mode is always an
+/// ASCII literal, so widening it is a copy.
+inline
+FILE* open_native(std::filesystem::path const& path, char const* mode) {
+#ifdef _WIN32
+    std::wstring const wide_mode(mode, mode + std::strlen(mode));
+    return _wfopen(path.c_str(), wide_mode.c_str());
+#else
+    return std::fopen(path.c_str(), mode);
+#endif
+}
+
+} // namespace kth::database
+
+#endif // KTH_DATABASE_NATIVE_FILE_HPP

--- a/src/database/src/block_store.cpp
+++ b/src/database/src/block_store.cpp
@@ -7,10 +7,14 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <optional>
 #include <print>
 #include <thread>
 
+#include <boost/unordered/unordered_flat_set.hpp>
+
 #include <spdlog/spdlog.h>
+#include <kth/database/native_file.hpp>
 #include <kth/infrastructure/utility/stats.hpp>
 
 namespace kth::database {
@@ -20,11 +24,65 @@ namespace {
 // Size of block file header: magic (4) + size (4)
 constexpr size_t block_header_size = 8;
 
-// Size of undo file header: magic (4) + size (4)
-constexpr size_t undo_header_size = 8;
+// The undo record's own marker, and it has to be its own rather than the network
+// magic the blocks use. Records written before issue #603 begin with that same
+// network magic followed by a size, so a reader expecting the current layout
+// would take those four size bytes for the first of a hash and misread
+// everything after. Two formats sharing a marker are two formats that cannot be
+// told apart. Finding the network magic where this is expected is therefore not
+// a corrupt record: it is a database written by an older build, and it is
+// reported as such.
+constexpr std::array<uint8_t, 4> undo_magic_v2{{'K', 'U', 'N', '2'}};
+
+// undo marker (4) + owning block hash (32) + payload size (4). The hash is what
+// makes a record self-identifying. Nothing already on disk could stand in for
+// it: order cannot, because a rev file holds undo for a subset of its blk file's
+// blocks in build order with no gap to mark the ones that never got any; and the
+// checksum cannot, because it is seeded with the parent hash, so every sibling
+// validates the same record — and two siblings built from the same transactions
+// with different coinbases produce byte-identical undo data.
+constexpr size_t undo_header_size = 40;
 
 // Size of undo checksum (SHA256)
 constexpr size_t undo_checksum_size = 32;
+
+// A payload larger than this is not a record, it is a misread header. Undo data
+// holds one entry per output a block spends, so this is far above anything a
+// block could produce and only rules out nonsense.
+constexpr uint32_t max_undo_size = 256u * 1024u * 1024u;
+
+// The record's checksum: the owning block's parent hash, then the payload. The
+// parent seeds it and is not stored, which is why it cannot serve as identity —
+// every sibling produces the same value.
+// Whether everything from `offset` to `file_size` is zero. Reserved space a
+// preallocated file never used looks exactly like that, and it is the only tail
+// that may be taken for a clean end: anything non-zero after the records is
+// either an interrupted write or damage, and treating it as the end would let it
+// hide whatever follows.
+bool tail_is_all_zero(FILE* file, uint32_t offset, uint32_t file_size) {
+    if (std::fseek(file, static_cast<long>(offset), SEEK_SET) != 0) return false;
+
+    std::array<uint8_t, 4096> buffer{};
+    uint32_t remaining = file_size - offset;
+    while (remaining > 0) {
+        auto const want = std::min<size_t>(remaining, buffer.size());
+        if (std::fread(buffer.data(), 1, want, file) != want) return false;
+        if (std::any_of(buffer.begin(), buffer.begin() + want,
+                        [](uint8_t byte) { return byte != 0; })) {
+            return false;
+        }
+        remaining -= static_cast<uint32_t>(want);
+    }
+    return true;
+}
+
+hash_digest undo_checksum(hash_digest const& prev_hash, data_chunk const& undo_data) {
+    data_chunk input;
+    input.reserve(prev_hash.size() + undo_data.size());
+    input.insert(input.end(), prev_hash.begin(), prev_hash.end());
+    input.insert(input.end(), undo_data.begin(), undo_data.end());
+    return bitcoin_hash(input);
+}
 
 } // anonymous namespace
 
@@ -135,7 +193,8 @@ flat_file_pos block_store::write_block_at(data_chunk const& raw_block, flat_file
     return header_pos;
 }
 
-flat_file_pos block_store::write_undo(block_undo const& undo, int32_t file_num, hash_digest const& prev_hash) {
+flat_file_pos block_store::write_undo(block_undo const& undo, int32_t file_num,
+                                     hash_digest const& block_hash, hash_digest const& prev_hash) {
     std::println("[block_store::write_undo] thread_id: {}", std::this_thread::get_id());
 
     auto const undo_size = static_cast<uint32_t>(undo.serialized_size());
@@ -146,7 +205,7 @@ flat_file_pos block_store::write_undo(block_undo const& undo, int32_t file_num, 
         return {};
     }
 
-    if (!write_undo_to_disk(undo, pos, prev_hash)) {
+    if (!write_undo_to_disk(undo, pos, block_hash, prev_hash)) {
         return {};
     }
 
@@ -448,6 +507,178 @@ block_store::read_blocks_raw(std::vector<flat_file_pos> const& positions) const 
     return results;
 }
 
+block_store::undo_scan_result
+block_store::scan_undo_positions(undo_parent_lookup const& parent_of) const {
+    undo_scan_result result;
+    result.status = undo_scan_status::clean_eof;
+
+    // Collected, not published. A caller applies these only once every file has
+    // been read without incident; a record rejected in the last file must not
+    // leave the ones before it already in the index.
+    boost::unordered_flat_set<hash_digest> seen;
+
+    auto fail = [&result](undo_scan_status status, int32_t file_num, uint32_t offset,
+                          hash_digest const& hash) {
+        result.status = status;
+        result.file_number = file_num;
+        result.position = offset;
+        result.block_hash = hash;
+        result.found.clear();
+        return result;
+    };
+
+    for (int32_t file_num = 0; file_num <= last_block_file_; ++file_num) {
+        auto path = undo_files_.file_name(flat_file_pos{file_num, 0});
+
+        FILE* file = open_native(path, "rb");
+        if (file == nullptr) {
+            // A file that is not there is a file that was never written. One that
+            // is there and will not open is a failure, and skipping it would
+            // start the node without undo it actually has.
+            std::error_code ec;
+            auto const present = std::filesystem::exists(path, ec);
+            // Not being able to ask whether it exists is its own failure, and
+            // taking it for "not there" would be the same mistake once more.
+            if (ec) return fail(undo_scan_status::io_error, file_num, 0, {});
+            if ( ! present) continue;
+            return fail(undo_scan_status::io_error, file_num, 0, {});
+        }
+
+        auto const file_size = file_info_[file_num].undo_size;
+        uint32_t offset = 0;
+
+        while (true) {
+            // No room for another header. That is the end only if what remains
+            // is the zeroes of unused reserved space; between one and thirty-nine
+            // non-zero bytes are an interrupted write, not an ending.
+            if (offset + undo_header_size > file_size) {
+                if ( ! tail_is_all_zero(file, offset, file_size)) {
+                    std::fclose(file);
+                    return fail(undo_scan_status::truncated_record, file_num, offset, {});
+                }
+                break;
+            }
+
+            if (std::fseek(file, static_cast<long>(offset), SEEK_SET) != 0) {
+                std::fclose(file);
+                return fail(undo_scan_status::io_error, file_num, offset, {});
+            }
+
+            std::array<uint8_t, 4> marker;
+            if (std::fread(marker.data(), 1, marker.size(), file) != marker.size()) {
+                std::fclose(file);
+                return fail(undo_scan_status::io_error, file_num, offset, {});
+            }
+
+            if (marker != undo_magic_v2) {
+                // All zeroes is space the file reserved and never used: rev files
+                // are preallocated, and a restart takes their size from the file
+                // system rather than from how far writing got. That is the normal
+                // end of the records, not damage.
+                if (marker == std::array<uint8_t, 4>{}) {
+                    // Four zero bytes are the start of unused space — but only if
+                    // everything after them is unused too. Four zeroes in the
+                    // middle of a file would otherwise end the scan and hide every
+                    // record beyond, reporting a clean read of a damaged file.
+                    if ( ! tail_is_all_zero(file, offset, file_size)) {
+                        std::fclose(file);
+                        return fail(undo_scan_status::truncated_record, file_num, offset, {});
+                    }
+                    break;
+                }
+
+                std::fclose(file);
+                // Three different things, and they read as three. The network
+                // magic is a record from before undo records carried their
+                // block's hash, which is what lets a caller ask for a rebuild
+                // rather than guess. Anything else is a marker that should not be
+                // here at all — not a record cut short, which is what
+                // truncated_record means and is a different diagnosis.
+                auto const status = (marker == magic_)
+                    ? undo_scan_status::legacy_format
+                    : undo_scan_status::invalid_marker;
+                return fail(status, file_num, offset, {});
+            }
+
+            hash_digest block_hash;
+            if (std::fread(block_hash.data(), 1, block_hash.size(), file) != block_hash.size()) {
+                std::fclose(file);
+                return fail(undo_scan_status::io_error, file_num, offset, {});
+            }
+
+            uint32_t undo_size = 0;
+            if (std::fread(&undo_size, sizeof(undo_size), 1, file) != 1) {
+                std::fclose(file);
+                return fail(undo_scan_status::io_error, file_num, offset, block_hash);
+            }
+
+            if (undo_size == 0 || undo_size > max_undo_size) {
+                std::fclose(file);
+                return fail(undo_scan_status::invalid_size, file_num, offset, block_hash);
+            }
+
+            auto const record_size = undo_header_size + undo_size + undo_checksum_size;
+            if (offset + record_size > file_size) {
+                std::fclose(file);
+                return fail(undo_scan_status::truncated_record, file_num, offset, block_hash);
+            }
+
+            // Uniqueness first, because it does not depend on knowing the
+            // block: two records claiming one block are wrong whether or not the
+            // index still holds it, and checking after the owner is resolved
+            // would let a duplicate pair from a forgotten branch pass as two
+            // ordinary unattributed records.
+            if ( ! seen.insert(block_hash).second) {
+                std::fclose(file);
+                return fail(undo_scan_status::duplicate_record, file_num, offset, block_hash);
+            }
+
+            // The block this claims to belong to gives the parent hash the
+            // checksum was seeded with. Not having it is not a failure: a
+            // restart rebuilds the index from the active chain, so a branch that
+            // lost a reorganization is gone while its undo records remain. Skip
+            // the record — its size is known, so the walk continues — and count
+            // it, rather than refuse a database that is merely older than its
+            // last reorganization.
+            auto const prev_hash = parent_of(block_hash);
+            if ( ! prev_hash) {
+                ++result.unattributed;
+                offset += static_cast<uint32_t>(record_size);
+                continue;
+            }
+
+            data_chunk undo_data(undo_size);
+            if (std::fread(undo_data.data(), 1, undo_size, file) != undo_size) {
+                std::fclose(file);
+                return fail(undo_scan_status::io_error, file_num, offset, block_hash);
+            }
+
+            hash_digest stored_checksum;
+            if (std::fread(stored_checksum.data(), 1, stored_checksum.size(), file)
+                    != stored_checksum.size()) {
+                std::fclose(file);
+                return fail(undo_scan_status::io_error, file_num, offset, block_hash);
+            }
+
+            if (undo_checksum(*prev_hash, undo_data) != stored_checksum) {
+                std::fclose(file);
+                return fail(undo_scan_status::invalid_checksum, file_num, offset, block_hash);
+            }
+
+            // The position handed back is what read_undo expects: just past the
+            // header, since it seeks backwards from there.
+            result.found.push_back({file_num, offset + static_cast<uint32_t>(undo_header_size),
+                block_hash});
+
+            offset += static_cast<uint32_t>(record_size);
+        }
+
+        std::fclose(file);
+    }
+
+    return result;
+}
+
 size_t block_store::scan_block_positions(block_position_callback const& callback) const {
     size_t count = 0;
     constexpr size_t header_bytes = 80;  // Bitcoin block header size
@@ -455,7 +686,7 @@ size_t block_store::scan_block_positions(block_position_callback const& callback
     for (int32_t file_num = 0; file_num <= last_block_file_; ++file_num) {
         auto path = block_files_.file_name(flat_file_pos{file_num, 0});
 
-        FILE* file = std::fopen(path.c_str(), "rb");
+        FILE* file = open_native(path, "rb");
         if (!file) continue;
 
         auto const file_size = file_info_[file_num].size;
@@ -498,7 +729,8 @@ size_t block_store::scan_block_positions(block_position_callback const& callback
 }
 
 std::expected<block_undo, result_code>
-block_store::read_undo(flat_file_pos const& pos, hash_digest const& prev_hash) const {
+block_store::read_undo(flat_file_pos const& pos, hash_digest const& block_hash,
+                       hash_digest const& prev_hash) const {
     if (pos.is_null()) {
         return std::unexpected(result_code::key_not_found);
     }
@@ -510,8 +742,9 @@ block_store::read_undo(flat_file_pos const& pos, hash_digest const& prev_hash) c
         return std::unexpected(result_code::other);
     }
 
-    // Read header: magic + size
+    // Read header: magic + owning block hash + size
     std::array<uint8_t, 4> file_magic;
+    hash_digest record_block_hash;
     uint32_t undo_size;
 
     // Seek back to header position
@@ -525,20 +758,59 @@ block_store::read_undo(flat_file_pos const& pos, hash_digest const& prev_hash) c
         return std::unexpected(result_code::other);
     }
 
+    // Before anything after it is read, let alone compared. In the old layout
+    // the next thirty-two bytes are a size and the start of a payload, not a
+    // hash — comparing them would report a record belonging to another block,
+    // which is both the wrong diagnosis and the wrong error.
+    if (file_magic != undo_magic_v2) {
+        if (file_magic == magic_) {
+            spdlog::error("block_store::read_undo: undo record at {} predates the format that "
+                "identifies its block; this database cannot serve undo data", pos.to_string());
+        } else {
+            spdlog::error("block_store::read_undo: marker mismatch at {}", pos.to_string());
+        }
+        std::fclose(file);
+        return std::unexpected(result_code::other);
+    }
+
+    if (std::fread(record_block_hash.data(), 1, record_block_hash.size(), file)
+            != record_block_hash.size()) {
+        std::fclose(file);
+        return std::unexpected(result_code::other);
+    }
+
+    // The record names its owner, so a position that points at some other
+    // block's record is caught here rather than by the checksum — which cannot
+    // catch it for a sibling, whose checksum this record also satisfies.
+    if (record_block_hash != block_hash) {
+        // Corruption, not absence: something pointed at a record belonging to
+        // another block. Reporting it as "no undo here" would dress a damaged
+        // database as an ordinary missing one, which is the confusion this record
+        // format exists to end.
+        spdlog::error("block_store::read_undo: record at {} belongs to another block",
+            pos.to_string());
+        std::fclose(file);
+        return std::unexpected(result_code::db_corrupt);
+    }
+
     if (std::fread(&undo_size, sizeof(undo_size), 1, file) != 1) {
         std::fclose(file);
         return std::unexpected(result_code::other);
     }
 
-    // Verify magic
-    if (file_magic != magic_) {
-        spdlog::error("block_store::read_undo: Magic mismatch at {}", pos.to_string());
+    // Bound it before it is used as a length. A corrupted size would otherwise
+    // be handed straight to an allocation — several gigabytes of it — and the
+    // addition below would overflow first. The scanner checks this on the way
+    // in; a record can be damaged after that, so the read checks it too.
+    if (undo_size == 0 || undo_size > max_undo_size) {
+        spdlog::error("block_store::read_undo: implausible payload size {} at {}",
+            undo_size, pos.to_string());
         std::fclose(file);
-        return std::unexpected(result_code::other);
+        return std::unexpected(result_code::db_corrupt);
     }
 
     // Read undo data + checksum
-    data_chunk data(undo_size + undo_checksum_size);
+    data_chunk data(static_cast<size_t>(undo_size) + undo_checksum_size);
     if (std::fread(data.data(), 1, data.size(), file) != data.size()) {
         std::fclose(file);
         return std::unexpected(result_code::other);
@@ -546,18 +818,12 @@ block_store::read_undo(flat_file_pos const& pos, hash_digest const& prev_hash) c
     std::fclose(file);
 
     // Extract undo data and checksum
-    data_chunk undo_data(data.begin(), data.begin() + undo_size);
+    data_chunk undo_data(data.begin(), data.begin() + static_cast<ptrdiff_t>(undo_size));
     hash_digest stored_checksum;
-    std::copy(data.begin() + undo_size, data.end(), stored_checksum.begin());
+    std::copy(data.begin() + static_cast<ptrdiff_t>(undo_size), data.end(),
+        stored_checksum.begin());
 
-    // Verify checksum: SHA256(prev_hash || undo_data)
-    data_chunk checksum_input;
-    checksum_input.reserve(prev_hash.size() + undo_data.size());
-    checksum_input.insert(checksum_input.end(), prev_hash.begin(), prev_hash.end());
-    checksum_input.insert(checksum_input.end(), undo_data.begin(), undo_data.end());
-
-    auto computed_checksum = bitcoin_hash(checksum_input);
-    if (computed_checksum != stored_checksum) {
+    if (undo_checksum(prev_hash, undo_data) != stored_checksum) {
         spdlog::error("block_store::read_undo: Checksum mismatch at {}", pos.to_string());
         return std::unexpected(result_code::other);
     }
@@ -710,7 +976,8 @@ bool block_store::write_block_to_disk(data_chunk const& raw_block, flat_file_pos
     return true;
 }
 
-bool block_store::write_undo_to_disk(block_undo const& undo, flat_file_pos& pos, hash_digest const& prev_hash) {
+bool block_store::write_undo_to_disk(block_undo const& undo, flat_file_pos& pos,
+                                     hash_digest const& block_hash, hash_digest const& prev_hash) {
     FILE* file = undo_files_.open(pos, false);
     if (!file) {
         spdlog::error("block_store::write_undo_to_disk: Failed to open file");
@@ -720,8 +987,13 @@ bool block_store::write_undo_to_disk(block_undo const& undo, flat_file_pos& pos,
     auto const undo_data = undo.to_data();
     auto const undo_size = static_cast<uint32_t>(undo_data.size());
 
-    // Write header: magic + size
-    if (std::fwrite(magic_.data(), 1, magic_.size(), file) != magic_.size()) {
+    // Write header: undo marker + owning block hash + size
+    if (std::fwrite(undo_magic_v2.data(), 1, undo_magic_v2.size(), file) != undo_magic_v2.size()) {
+        std::fclose(file);
+        return false;
+    }
+
+    if (std::fwrite(block_hash.data(), 1, block_hash.size(), file) != block_hash.size()) {
         std::fclose(file);
         return false;
     }

--- a/src/database/src/flat_file_seq.cpp
+++ b/src/database/src/flat_file_seq.cpp
@@ -4,6 +4,8 @@
 
 #include <kth/database/flat_file_seq.hpp>
 
+#include <kth/database/native_file.hpp>
+
 #include <cerrno>
 #include <cstdio>
 #include <stdexcept>
@@ -48,7 +50,7 @@ FILE* flat_file_seq::open(flat_file_pos const& pos, bool read_only) const {
     auto const path = file_name(pos);
 
     // Try to open existing file
-    FILE* file = std::fopen(path.c_str(), read_only ? "rb" : "rb+");
+    FILE* file = open_native(path, read_only ? "rb" : "rb+");
 
     if (!file) {
         // Create directory if needed
@@ -58,7 +60,7 @@ FILE* flat_file_seq::open(flat_file_pos const& pos, bool read_only) const {
 
     // For write mode, create if doesn't exist
     if (!file && !read_only) {
-        file = std::fopen(path.c_str(), "wb+");
+        file = open_native(path, "wb+");
     }
 
     if (!file) {

--- a/src/node/test/reorg_cycle.cpp
+++ b/src/node/test/reorg_cycle.cpp
@@ -4,6 +4,9 @@
 
 #include <test_helpers.hpp>
 
+#include <cstdio>
+#include <filesystem>
+
 #include <chrono>
 #include <vector>
 
@@ -515,4 +518,164 @@ TEST_CASE("a switch whose header write fails is fatal, and the restart is cohere
     auto const retry = fixture.organizer().add_headers(headers_of(branch_b));
     CHECK(retry.reorg_candidate);
     CHECK(retry.reorg_fork_height == int32_t(trunk_len));
+}
+
+TEST_CASE("a reorganization after a restart can disconnect what was connected before it",
+          "[reorg][cycle][restart]") {
+    // The restart test above reorganizes and *then* restarts, so nothing it
+    // disconnects was connected in an earlier process. This is the other order,
+    // and it is the one that needs undo data to survive: the blocks being rolled
+    // back were connected before the node came down.
+    //
+    // Undo records live in the rev files and their positions live in the header
+    // index, which is rebuilt at startup. Whether that rebuild restores them is
+    // exactly what this pins.
+    test::chain_fixture fixture("reorg_after_restart");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+
+    constexpr uint32_t trunk_len = 12;
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+
+    std::vector<domain::chain::block> trunk;
+    auto prev = genesis.hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+    REQUIRE(fixture.organizer().add_headers(headers_of(trunk)).headers_added == trunk_len);
+    persist_headers(fixture, trunk, 1);
+    connect_bodies(fixture, trunk, 1);
+
+    // Branch A, connected in this process: two blocks that a later branch will
+    // have to roll back.
+    std::vector<domain::chain::block> branch_a;
+    prev = trunk.back().hash();
+    for (uint32_t h = 13; h <= 14; ++h) {
+        branch_a.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 1, {}, 0));
+        prev = branch_a.back().hash();
+    }
+    REQUIRE(fixture.organizer().add_headers(headers_of(branch_a)).headers_added == 2);
+    persist_headers(fixture, branch_a, 13);
+    connect_bodies(fixture, branch_a, 13);
+
+    {
+        auto const built = fixture.chain().get_utxo_built_height();
+        REQUIRE(built);
+        REQUIRE(*built == 14);
+    }
+
+    // Undo data exists for them, in this process.
+    {
+        auto& index = fixture.chain().headers();
+        for (uint32_t h = 13; h <= 14; ++h) {
+            auto const idx = index.active_at(int32_t(h));
+            REQUIRE(idx != blockchain::header_index::null_index);
+            INFO("before the restart, height " << h);
+            CHECK(index.has_undo_data(idx));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Drop everything held in memory. The rev files stay on disk.
+    // -------------------------------------------------------------------------
+    REQUIRE(fixture.restart());
+
+    {
+        auto& index = fixture.chain().headers();
+        for (uint32_t h = 13; h <= 14; ++h) {
+            auto const idx = index.active_at(int32_t(h));
+            REQUIRE(idx != blockchain::header_index::null_index);
+            INFO("after the restart, height " << h);
+            CHECK(index.has_undo_data(idx));
+        }
+    }
+
+    // Branch B forks at 12 and outweighs A, so switching to it has to disconnect
+    // 13 and 14 — the two connected before the restart.
+    std::vector<domain::chain::block> branch_b;
+    prev = trunk.back().hash();
+    for (uint32_t h = 13; h <= 15; ++h) {
+        branch_b.push_back(test::mine_block(prev, h, base_time + h * block_spacing + 60, 2, {}, 0));
+        prev = branch_b.back().hash();
+    }
+    auto const b_result = fixture.organizer().add_headers(headers_of(branch_b));
+    REQUIRE(b_result.reorg_candidate);
+
+    reorg_outcome reorg;
+    {
+        ::asio::io_context switch_ctx;
+        ::asio::co_spawn(switch_ctx,
+            execute_reorg(fixture.chain(), fixture.organizer(), b_result.reorg_branch_head,
+                trunk_len, [] { return false; }, real_persister(fixture.chain())),
+            [&reorg](std::exception_ptr, reorg_outcome result) { reorg = result; });
+        switch_ctx.run_for(std::chrono::seconds(30));
+    }
+
+    INFO("the switch has to disconnect two blocks connected before the restart");
+    REQUIRE(reorg.result.ok);
+    REQUIRE_FALSE(reorg.fatal);
+
+    connect_bodies(fixture, branch_b, 13);
+
+    auto const built = fixture.chain().get_utxo_built_height();
+    REQUIRE(built);
+    CHECK(*built == 15);
+}
+
+TEST_CASE("an undo record whose block hash was altered stops the node starting",
+          "[reorg][cycle][restart]") {
+    // What justifies skipping a record whose block the index does not hold. That
+    // is ordinary for a branch that lost a reorganization, and locally
+    // indistinguishable from an active record with a flipped bit in its stored
+    // hash — which would otherwise leave a connected block quietly without undo,
+    // unable to be disconnected, and nothing would say so.
+    //
+    // The separation is global rather than local: every block on the active chain
+    // that was connected must still have its undo. Altering one hash makes that
+    // coverage short, and the start has to refuse.
+    test::chain_fixture fixture("undo_hash_altered");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+
+    constexpr uint32_t trunk_len = 6;
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+
+    std::vector<domain::chain::block> trunk;
+    auto prev = genesis.hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+    REQUIRE(fixture.organizer().add_headers(headers_of(trunk)).headers_added == trunk_len);
+    persist_headers(fixture, trunk, 1);
+    connect_bodies(fixture, trunk, 1);
+
+    {
+        auto const built = fixture.chain().get_utxo_built_height();
+        REQUIRE(built);
+        REQUIRE(*built == trunk_len);
+    }
+
+    // Flip a bit of the first record's stored block hash, which sits four bytes
+    // past the marker. The checksum still passes — it covers the payload and is
+    // seeded with the parent — so nothing but the coverage check can catch this.
+    auto const rev_path = fixture.dir() / "blocks" / "rev00000.dat";
+    REQUIRE(std::filesystem::exists(rev_path));
+    {
+        FILE* file = std::fopen(rev_path.string().c_str(), "r+b");
+        REQUIRE(file != nullptr);
+        REQUIRE(std::fseek(file, 4, SEEK_SET) == 0);
+        int const original = std::fgetc(file);
+        REQUIRE(original != EOF);
+        REQUIRE(std::fseek(file, 4, SEEK_SET) == 0);
+        REQUIRE(std::fputc(original ^ 0x01, file) != EOF);
+        std::fclose(file);
+    }
+
+    // The altered record now names a block the index does not hold, so the scan
+    // passes it over — and the block it belonged to is left without undo.
+    CHECK_FALSE(fixture.restart());
 }


### PR DESCRIPTION
## The problem

Undo positions live only in the header index, which is rebuilt from disk at
startup — and that rebuild restored block positions and nothing else. So after
any ordinary restart no block had undo data, the bytes sat unreachable in the rev
files, and a reorganization that had to roll back a block connected before the
restart could not run. This is the state after every clean shutdown, not a crash
window.

Nothing already on disk could attribute a record to its block. Order cannot: a
rev file holds undo for a subset of the blocks in its blk file, and the ones that
never got any leave no gap. The checksum cannot: it is seeded with the parent
hash, so every sibling validates the same record — and two siblings built from
the same transactions with different coinbases produce byte-identical undo data.

## The solution

The record carries its owning block's hash, behind a marker of its own so the two
formats can be told apart. `scan_undo_positions` mirrors `scan_block_positions`
and runs beside it at startup, validating each record — marker, size, resolvable
owner, payload, checksum — and publishing nothing until every file has been read.

A record naming a block the index no longer holds is skipped and counted: after a
reorganization, a branch that lost is forgotten while its records remain. What
keeps that from hiding a damaged active record is a coverage check — every block
between the checkpoint and the built height must have undo — read from the
by-height table recorded while headers load, since the organizer publishes the
active view only after startup.

A durable index keyed by block hash was the alternative and is worse: it
reintroduces the window #600 is about, between writing the bytes and writing the
reference, across two stores that then need ordering.

## Format incompatibility

Databases written before this keep records with no identity, and the association
cannot be recovered from what is on disk. Startup reports the format and refuses,
asking for a rebuild, rather than starting a node that cannot reorganize.

## Tests

Two node regressions: connect, restart, then reorganize away blocks connected
before the restart — which fails on master in three places; and altering a single
byte of an active record's block hash, which must stop the start.

Seventeen database-level cases driving `block_store` against real files: round
trip; sibling identity; legacy records, on both the scan and the read path;
truncated payloads and partial headers; invalid markers; altered contents;
zeroes followed by content; unattributable and duplicate records, including a duplicate the index no longer holds; implausible payload sizes; blocks with no
record; several rev files; and a file that exists and will not open.

Full blockchain and node suites pass.

Closes #603. Independent of #602, which stays draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup recovery and validation of blockchain headers and undo data.
  * Detects corrupted, incomplete, outdated, duplicated, or unrecognized undo records and prevents unsafe startup.
  * Ensures undo data remains correctly associated with its block and supports reliable chain reorganizations after restart.

* **Tests**
  * Added comprehensive coverage for undo scanning, corruption handling, legacy formats, truncated files, and restart-based reorganizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->