### PR TITLE
blockchain: make validating a transaction and admitting one two calls rather than one call and a flag

### DIFF
--- a/src/blockchain/include/kth/blockchain/validate/block_validation.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/block_validation.hpp
@@ -23,9 +23,6 @@ struct block_validation {
     uint64_t originator = 0;
     code error = error::not_found;
     domain::chain::chain_state::ptr state = nullptr;
-
-    // Simulate organization and instead just validate the block.
-    bool simulate = false;
 };
 
 /// Owns the per-block validation state keyed by block hash. See

--- a/src/blockchain/include/kth/blockchain/validate/transaction_validation.hpp
+++ b/src/blockchain/include/kth/blockchain/validate/transaction_validation.hpp
@@ -23,9 +23,6 @@ struct transaction_validation {
     // The unconfirmed tx is validated at the block's current fork state.
     bool current = false;
 
-    // Simulate organization and instead just validate the transaction.
-    bool simulate = false;
-
     // The transaction was validated before its insertion in the mempool.
     bool validated = false;
 };

--- a/src/blockchain/src/pools/transaction_organizer.cpp
+++ b/src/blockchain/src/pools/transaction_organizer.cpp
@@ -230,17 +230,9 @@ bool transaction_organizer::stop() {
         co_return connected.error();
     }
 
-    // TODO: create a simulated validation path that does not block others.
-    bool simulate = false;
-    chain_.transaction_validations().visit(tx->hash(), [&](auto const& tv){ simulate = tv.simulate; });
-
-    // Last read of the store entry; safe to drop it now for every path below.
+    // Validation is over and nothing below reads the entry, so drop it here
+    // rather than repeating the erase down each remaining exit.
     erase_tx_validation();
-
-    if (simulate) {
-        mutex_.unlock_low_priority();
-        co_return error::success;
-    }
 
     //#########################################################################
     // Admit to the mempool. The tx is already validated (accept / fee / dust /

--- a/src/c-api/include/kth/capi/chain/chain_other.h
+++ b/src/c-api/include/kth/capi/chain/chain_other.h
@@ -32,10 +32,6 @@ void kth_chain_unsubscribe(kth_chain_t chain);
 KTH_EXPORT
 void kth_chain_transaction_validate(kth_chain_t chain, void* ctx, kth_transaction_mut_t tx, kth_validate_tx_handler_t handler);
 
-KTH_EXPORT
-void kth_chain_transaction_validate_sequential(kth_chain_t chain, void* ctx, kth_transaction_mut_t tx, kth_validate_tx_handler_t handler);
-
-
 // Queries.
 //-------------------------------------------------------------------------
 

--- a/src/c-api/src/chain/chain_other.cpp
+++ b/src/c-api/src/chain/chain_other.cpp
@@ -179,25 +179,6 @@ void kth_chain_unsubscribe(kth_chain_t /*chain*/) {
     // Callers should return 0 from their handler to unsubscribe
 }
 
-void kth_chain_transaction_validate_sequential(kth_chain_t chain, void* ctx, kth_transaction_mut_t tx, kth_validate_tx_handler_t handler) {
-    if (handler == nullptr) return;
-
-    auto tx_cpp = tx_shared(tx);
-
-    auto& bc = safe_chain(chain);
-    // `simulate` moved off the transaction value type into the validator's
-    // per-tx store; set it there before organizing.
-    bc.transaction_validations().mutate(tx_cpp->hash(), [](auto& tv){ tv.simulate = true; });
-    ::asio::co_spawn(bc.executor(), [&bc, tx_cpp, chain, ctx, handler]() -> ::asio::awaitable<void> {
-        auto ec = co_await bc.organize(tx_cpp);
-        if (ec) {
-            handler(chain, ctx, kth::to_c_err(ec), ec.message().c_str());
-        } else {
-            handler(chain, ctx, kth::to_c_err(ec), nullptr);
-        }
-    }, ::asio::detached);
-}
-
 void kth_chain_transaction_validate(kth_chain_t chain, void* ctx, kth_transaction_mut_t tx, kth_validate_tx_handler_t handler) {
     if (handler == nullptr) return;
 
@@ -232,28 +213,6 @@ kth_bool_t kth_chain_is_stale(kth_chain_t chain) {
 
 //-------------------------------------------------------------------------
 
-// kth_transaction_t kth_chain_hex_to_tx(char const* tx_hex) {
-//
-//    static auto const version = kth::domain::chain::version::level::canonical;
-//
-////    auto const tx = std::make_shared<kth::domain::chain::transaction>();
-//    auto* tx = new kth::domain::chain::transaction;
-//
-//    std::string tx_hex_cpp(tx_hex);
-//    std::vector<uint8_t> data(tx_hex_cpp.size() / 2); // (tx_hex_cpp.begin(), tx_hex_cpp.end());
-//    //data.reserve(tx_hex_cpp.size() / 2);
-//
-//    hex2bin(tx_hex_cpp.c_str(), data.data());
-//
-//    if ( ! tx->from_data(version, data)) {
-//        return nullptr;
-//    }
-//
-//    // Simulate organization into our chain.
-//    tx->validation.simulate = true;
-//
-//    return tx;
-//}
 
 
 

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -296,6 +296,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
           test/check_list.cpp
           test/chunk_coordinator.cpp
           test/fatal_shutdown.cpp
+          test/mempool_admission.cpp
           test/mempool_connect_wiring.cpp
           test/reorg_cycle.cpp
           test/reorg_stale_chunk_drop.cpp

--- a/src/node/test/mempool_admission.cpp
+++ b/src/node/test/mempool_admission.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <chrono>
+#include <future>
+#include <utility>
+#include <vector>
+
+#include <asio/co_spawn.hpp>
+#include <asio/use_future.hpp>
+
+#include <kth/blockchain/pools/mempool.hpp>
+
+#include "sync_harness.hpp"
+
+using namespace kth;
+using namespace kth::test;
+
+// =============================================================================
+// Validating a transaction, and admitting one
+// =============================================================================
+//
+// These are two operations, and the difference between them used to be a flag:
+// `organize` read `transaction_validation::simulate` and returned early before
+// the mempool, so the caller that wanted validation alone set the flag on a
+// store entry and called the admitting path anyway. What a call did was decided
+// somewhere other than the call.
+//
+// `transaction_validate` is the explicit path and always was. What is pinned
+// here is that the two do different things through their own names — nothing
+// else says so once the flag is gone.
+
+namespace {
+
+// Run one of the chain's coroutines where the node runs them: on the chain's own
+// priority pool, which its threads are already servicing.
+//
+// The wait is unbounded on purpose. These coroutines hold the chain and the
+// transaction by reference and cannot be cancelled, so a deadline here could
+// only abandon one — and an abandoned coroutine would still be running when the
+// fixture tears the chain down underneath it. A test that hangs is diagnosable;
+// one that returns while its work continues into freed memory is not. Bounding
+// how long a test may run is the harness's job, and CI's.
+template <typename Make>
+code run_on_chain(blockchain::block_chain& chain, Make make) {
+    auto future = ::asio::co_spawn(chain.executor(),
+        [make = std::move(make)]() -> ::asio::awaitable<code> {
+            co_return co_await make();
+        },
+        ::asio::use_future);
+
+    return future.get();
+}
+
+// A chain of `trunk_len` blocks built through the node's own connect path, so
+// the UTXO set a transaction is validated against was written the way the node
+// writes it.
+struct admission_chain {
+    test::chain_fixture fixture;
+    std::vector<domain::chain::block> trunk;
+
+    explicit admission_chain(char const* tag, uint32_t trunk_len)
+        : fixture(tag)
+    {
+        REQUIRE(fixture.created());
+        REQUIRE(fixture.start());
+
+        auto const genesis = domain::chain::block::genesis_regtest();
+        auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+
+        auto prev = genesis.hash();
+        for (uint32_t h = 1; h <= trunk_len; ++h) {
+            trunk.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+            prev = trunk.back().hash();
+        }
+
+        auto const added = fixture.organizer().add_headers(headers_of(trunk));
+        REQUIRE(added.headers_added == trunk_len);
+        persist_headers(fixture, trunk, 1);
+        connect_bodies(fixture, trunk, 1);
+
+        // The chain computes the state a transaction is validated against once,
+        // at startup, and nothing advances it as blocks connect (#605). So a
+        // chain built in this process is stuck validating at the height it was
+        // created at, and every prevout reads as missing. Restarting recomputes
+        // it, which is the only way to reach a usable state today — a way around
+        // #605 for this test, not something a running node may rely on.
+        REQUIRE(fixture.restart());
+        auto const state = fixture.chain().chain_state();
+        REQUIRE(state);
+        REQUIRE(state->height() == trunk_len + 1u);
+    }
+
+    blockchain::block_chain& chain() { return fixture.chain(); }
+
+    // A signed spend of the coinbase of block 1, which has matured by the tip of
+    // a hundred-block trunk.
+    [[nodiscard]]
+    domain::chain::transaction matured_spend(uint64_t fee) {
+        auto const& coinbase = trunk.front().transactions().front();
+        return test::spend_p2pkh(coinbase, 0, coinbase.outputs()[0].value() - fee,
+                                 chain().chain_settings().enabled_flags());
+    }
+};
+
+constexpr uint32_t trunk_len = 100;
+constexpr uint64_t fee = 1000;
+
+} // namespace
+
+TEST_CASE("validating a transaction does not admit it to the mempool", "[mempool][admission]") {
+    admission_chain built("validate_only", trunk_len);
+    auto& chain = built.chain();
+
+    auto const tx = std::make_shared<domain::message::transaction>(built.matured_spend(fee));
+    REQUIRE(chain.mempool_ref().size() == 0);
+
+    auto const ec = run_on_chain(chain, [&chain, tx] { return chain.transaction_validate(tx); });
+
+    // Validation ran and the transaction passed it — otherwise the pool being
+    // empty below would prove nothing, since a rejected transaction is not
+    // admitted either.
+    CHECK(ec == error::success);
+    CHECK(chain.mempool_ref().size() == 0);
+    CHECK_FALSE(chain.mempool_ref().contains(tx->hash()));
+}
+
+TEST_CASE("organizing a valid transaction admits it to the mempool", "[mempool][admission]") {
+    admission_chain built("organize_admits", trunk_len);
+    auto& chain = built.chain();
+
+    auto const tx = std::make_shared<domain::message::transaction>(built.matured_spend(fee));
+    REQUIRE(chain.mempool_ref().size() == 0);
+
+    auto const ec = run_on_chain(chain, [&chain, tx] { return chain.organize(tx); });
+
+    CHECK(ec == error::success);
+    CHECK(chain.mempool_ref().size() == 1);
+    CHECK(chain.mempool_ref().contains(tx->hash()));
+}


### PR DESCRIPTION
`organize` did both. Which one it did was decided by `simulate`, a bool the caller wrote into the tx-validation store before calling: set it, and organize ran the whole validation and then returned just before the mempool. The same call did two different things depending on state written somewhere else, and reading the call told you nothing about which.

The explicit path was already there. `transaction_validate` validates and does not admit — exactly what the flag was for — and it is what the C API's `kth_chain_transaction_validate` has always called. What the flag bought was a second way to reach that behaviour through the admitting path, so it goes, along with `kth_chain_transaction_validate_sequential`, which existed only to set it.

**Breaking surface change:** `kth_chain_transaction_validate_sequential` is removed from the C API. Callers wanting validation without admission use `kth_chain_transaction_validate`, unchanged and already doing this; callers wanting admission use the organize path. No signatures change.

## Tests

Two node tests pin the distinction the names now carry, against a chain built through the node's own connect path: validating a valid transaction leaves the pool empty, organizing the same transaction puts it in. Both assert the transaction passed validation first — an empty pool proves nothing about a transaction that was rejected.

## Why the tests restart the chain

A way around a bug, not a property of the design. The state a transaction is validated against is computed once at startup and nothing advances it as blocks connect, so without the restart validation runs at the height the chain was created at and every prevout reads as missing. A running node cannot restart itself to stay correct — the state has to advance where it is published. Opened as #605, including what it means for the evidence #584 was filed on.

Closes #506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified transaction handling so successfully validated transactions proceed to mempool admission.
  * Added coverage verifying the distinction between validation and mempool organization.

* **Bug Fixes**
  * Removed obsolete simulated-validation behavior from transaction and block validation workflows.
  * Removed the deprecated sequential transaction-validation C API.

* **Tests**
  * Added mempool admission tests covering valid transaction validation and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->