### PR TITLE
fix(ci): make the Conan update check actionable

### DIFF
--- a/.github/workflows/check-conan-updates.yml
+++ b/.github/workflows/check-conan-updates.yml
@@ -14,6 +14,11 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-updates:
     runs-on: ubuntu-24.04
@@ -30,14 +35,22 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyyaml
+          pip install 'conan>=2,<3' pyyaml
+
+      - name: Configure KTH Conan remote
+        run: conan remote add kth https://packages.kth.cash/api/ --force
+
+      - name: Test dependency checker
+        run: python -m unittest scripts/test_check_conan_updates.py
 
       - name: Check for Conan package updates
         id: check
         run: |
+          set +e
           python scripts/check_conan_updates.py > update_report.txt 2>&1
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
-        continue-on-error: true
+          status=$?
+          set -e
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
 
       - name: Display update report
         run: cat update_report.txt
@@ -51,23 +64,23 @@ jobs:
             const report = fs.readFileSync('update_report.txt', 'utf8');
 
             // Extract summary from report
-            const summaryMatch = report.match(/📊 Summary:.*?\n((?:  • .*\n)+)/s);
+            const summaryMatch = report.match(/📊 Summary:[^\n]*\n(?:\s*\n)?((?:  • .*(?:\n|$))+)/);
             const updates = summaryMatch ? summaryMatch[1].trim() : 'See workflow run for details';
 
             // Check if there's already an open issue
-            const issues = await github.rest.issues.listForRepo({
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'dependencies,conan'
+              per_page: 100
             });
 
-            const existingIssue = issues.data.find(issue =>
-              issue.title.includes('Conan package updates available')
+            const existingIssue = issues.find(issue =>
+              !issue.pull_request && issue.title === 'Conan package updates available'
             );
 
             const body = "## Conan Package Updates Available\n\n" +
-              "The weekly dependency check has found updates for Conan packages:\n\n" +
+              "The daily dependency check has found updates for Conan packages:\n\n" +
               updates + "\n\n" +
               "### How to Update\n\n" +
               "To update a specific package:\n" +
@@ -104,8 +117,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: 'Conan package updates available',
-                body: body,
-                labels: ['dependencies', 'conan']
+                body: body
               });
               console.log('Created new issue for Conan updates');
             }
@@ -117,3 +129,13 @@ jobs:
           name: conan-update-report
           path: update_report.txt
           retention-days: 30
+
+      - name: Fail if the dependency check was incomplete
+        if: >-
+          always() &&
+          steps.check.outcome != 'skipped' &&
+          steps.check.outputs.exit_code != '0' &&
+          steps.check.outputs.exit_code != '1'
+        run: |
+          echo "Dependency check did not complete (exit code: ${{ steps.check.outputs.exit_code }})."
+          exit 1

--- a/scripts/README_check_conan_updates.md
+++ b/scripts/README_check_conan_updates.md
@@ -50,6 +50,7 @@ The script provides colored output with the following indicators:
 
 - `0`: All packages are up to date, or updates were successfully applied
 - `1`: Updates are available (useful for CI/CD to detect outdated dependencies)
+- `2`: The check was incomplete because a package source could not be queried
 
 ## Automation
 
@@ -101,5 +102,6 @@ Checking boost... 🔄 Update available: 1.86.0 → 1.89.0
 - The script only checks packages listed in `self.requires()`, `self.test_requires()`, and `self.tool_requires()`
 - Commented-out dependencies are ignored
 - Custom package sources (e.g., `package@user/channel`) are skipped
+- `utxoz` and `secp256k1-precompute` are checked in the public KTH remote
 - Version comparison uses semantic versioning (major.minor.patch)
 - The script filters out non-standard version formats from CCI (e.g., "3.1w")

--- a/scripts/check_conan_updates.py
+++ b/scripts/check_conan_updates.py
@@ -16,13 +16,25 @@ Options:
 """
 
 import argparse
+import json
 import re
+import subprocess
 import sys
-import ssl
+import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional, Set
+from typing import Dict, List, Tuple, Optional
 import yaml
+
+
+CUSTOM_PACKAGE_REMOTES = {
+    "secp256k1-precompute": "kth",
+    "utxoz": "kth",
+}
+
+
+class PackageLookupError(RuntimeError):
+    """A package source could not provide a complete version listing."""
 
 
 class Version:
@@ -117,7 +129,7 @@ def parse_conanfile(conanfile_path: Path) -> Dict[str, str]:
     return packages
 
 
-def fetch_cci_versions(package_name: str) -> Optional[List[str]]:
+def fetch_cci_versions(package_name: str) -> List[str]:
     """
     Fetch available versions from Conan Center Index for a package.
 
@@ -125,32 +137,80 @@ def fetch_cci_versions(package_name: str) -> Optional[List[str]]:
         package_name: Name of the package (e.g., "boost", "fmt")
 
     Returns:
-        List of version strings, or None if package not found
+        List of version strings.
+
+    Raises:
+        PackageLookupError: The package could not be looked up completely.
     """
     url = f"https://raw.githubusercontent.com/conan-io/conan-center-index/master/recipes/{package_name}/config.yml"
 
     try:
-        # Create SSL context that doesn't verify certificates (for macOS compatibility)
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-
-        with urllib.request.urlopen(url, timeout=10, context=ctx) as response:
+        with urllib.request.urlopen(url, timeout=10) as response:
             content = response.read().decode('utf-8')
             data = yaml.safe_load(content)
 
-            if 'versions' in data:
+            if data.get('versions'):
                 return list(data['versions'].keys())
 
     except urllib.error.HTTPError as e:
         if e.code == 404:
-            print(f"  ⚠️  Package '{package_name}' not found in CCI", file=sys.stderr)
+            raise PackageLookupError(
+                "package not found in CCI; if it is hosted by KTH, add its "
+                "Conan remote to CUSTOM_PACKAGE_REMOTES"
+            ) from e
         else:
-            print(f"  ⚠️  HTTP error for '{package_name}': {e.code}", file=sys.stderr)
+            raise PackageLookupError(f"CCI returned HTTP {e.code}") from e
     except Exception as e:
-        print(f"  ⚠️  Error fetching '{package_name}': {e}", file=sys.stderr)
+        raise PackageLookupError(f"CCI lookup failed: {e}") from e
 
-    return None
+    raise PackageLookupError("CCI response contained no versions")
+
+
+def fetch_conan_remote_versions(package_name: str, remote: str) -> List[str]:
+    """Fetch recipe versions from a configured Conan remote."""
+    command = [
+        "conan", "list", f"{package_name}/*", "-r", remote, "--format=json"
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        raise PackageLookupError(f"Conan remote '{remote}' lookup failed: {e}") from e
+
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or f"exit status {completed.returncode}"
+        raise PackageLookupError(f"Conan remote '{remote}' lookup failed: {detail}")
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as e:
+        raise PackageLookupError(
+            f"Conan remote '{remote}' returned invalid JSON"
+        ) from e
+
+    versions = []
+    for recipes in payload.values():
+        if not isinstance(recipes, dict):
+            continue
+        for reference in recipes:
+            prefix = f"{package_name}/"
+            if not reference.startswith(prefix):
+                continue
+            version = reference[len(prefix):].split("@", 1)[0].split("#", 1)[0]
+            if version:
+                versions.append(version)
+
+    if not versions:
+        raise PackageLookupError(
+            f"package not found in Conan remote '{remote}'"
+        )
+
+    return versions
 
 
 def get_latest_version(versions: List[str]) -> Version:
@@ -201,7 +261,10 @@ def update_conanfile(conanfile_path: Path, updates: List[Tuple[str, str, str]]) 
         print(f"\n⚠️  No changes made to {conanfile_path.name}")
 
 
-def check_updates(conanfile_path: Path, package_filter: Optional[str] = None) -> List[Tuple[str, str, str]]:
+def check_updates(
+    conanfile_path: Path,
+    package_filter: Optional[str] = None,
+) -> Tuple[List[Tuple[str, str, str]], List[Tuple[str, str]]]:
     """
     Check for updates to packages in conanfile.py.
 
@@ -210,7 +273,7 @@ def check_updates(conanfile_path: Path, package_filter: Optional[str] = None) ->
         package_filter: If specified, only check this package
 
     Returns:
-        List of tuples (package_name, current_version, latest_version) for packages with updates
+        A pair containing updates and lookup failures.
     """
     print(f"📦 Checking dependencies in {conanfile_path.name}...")
     if package_filter:
@@ -224,33 +287,42 @@ def check_updates(conanfile_path: Path, package_filter: Optional[str] = None) ->
         if package_filter not in packages:
             print(f"❌ Package '{package_filter}' not found in conanfile.py")
             print(f"   Available packages: {', '.join(sorted(packages.keys()))}")
-            return []
+            return [], [(package_filter, "package not found in conanfile.py")]
         packages = {package_filter: packages[package_filter]}
 
     updates = []
+    failures = []
 
     for package_name, current_version in sorted(packages.items()):
         print(f"Checking {package_name}...", end=' ')
         sys.stdout.flush()
 
-        cci_versions = fetch_cci_versions(package_name)
-
-        if cci_versions is None:
-            print("❌ Not found in CCI")
+        remote = CUSTOM_PACKAGE_REMOTES.get(package_name)
+        source = f"{remote} remote" if remote else "CCI"
+        try:
+            versions = (
+                fetch_conan_remote_versions(package_name, remote)
+                if remote
+                else fetch_cci_versions(package_name)
+            )
+        except PackageLookupError as e:
+            print(f"❌ Lookup failed [{source}]: {e}")
+            failures.append((package_name, str(e)))
             continue
 
-        latest_version = get_latest_version(cci_versions)
+        latest_version = get_latest_version(versions)
         current = Version(current_version)
+        suffix = f" [{source}]"
 
         if current < latest_version:
-            print(f"🔄 Update available: {current_version} → {latest_version}")
+            print(f"🔄 Update available: {current_version} → {latest_version}{suffix}")
             updates.append((package_name, current_version, str(latest_version)))
         elif current == latest_version:
-            print(f"✅ Up to date ({current_version})")
+            print(f"✅ Up to date ({current_version}){suffix}")
         else:
-            print(f"⚡ Ahead of CCI ({current_version} > {latest_version})")
+            print(f"⚡ Ahead of {source} ({current_version} > {latest_version})")
 
-    return updates
+    return updates, failures
 
 
 def main():
@@ -293,15 +365,15 @@ Examples:
 
     if not conanfile.exists():
         print(f"❌ Error: {conanfile} not found", file=sys.stderr)
-        sys.exit(1)
+        sys.exit(2)
 
     try:
         import yaml
     except ImportError:
         print("❌ Error: PyYAML is required. Install it with: pip install pyyaml", file=sys.stderr)
-        sys.exit(1)
+        sys.exit(2)
 
-    updates = check_updates(conanfile, package_filter=args.package)
+    updates, failures = check_updates(conanfile, package_filter=args.package)
 
     print()
     print("=" * 70)
@@ -312,23 +384,48 @@ Examples:
         for package_name, current, latest in updates:
             print(f"  • {package_name}: {current} → {latest}")
 
-        if args.update:
+        if args.update and not failures:
             print()
             print("=" * 70)
             print("🔧 Updating conanfile.py...")
             update_conanfile(conanfile, updates)
-    else:
+    elif not failures:
         print("✨ All packages are up to date!")
+
+    if failures:
+        print()
+        print(f"❌ Incomplete check: {len(failures)} package lookup(s) failed:")
+        print()
+        for package_name, reason in failures:
+            print(f"  • {package_name}: {reason}")
 
     print("=" * 70)
 
-    # Exit with status 1 if there are updates (for CI/CD)
-    # Unless --update was used and updates were applied
-    if updates and not args.update:
+    # A partial result must never be reported as success or used to create an
+    # update issue: it cannot establish which dependencies are current.
+    if failures:
+        sys.exit(2)
+    elif updates and not args.update:
         sys.exit(1)
     else:
         sys.exit(0)
 
 
+def entrypoint():
+    """Run the checker while preserving the documented exit-code contract."""
+    try:
+        main()
+    except SystemExit:
+        # argparse and main() use SystemExit for the documented 0/1/2 outcomes.
+        raise
+    except Exception as e:
+        # Exit 1 has exactly one meaning: a complete check found updates.
+        # Anything the checker did not classify is an incomplete check instead,
+        # otherwise the scheduled workflow would publish a misleading update
+        # issue for a broken run.
+        print(f"❌ Unexpected dependency-check failure: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
 if __name__ == "__main__":
-    main()
+    entrypoint()

--- a/scripts/test_check_conan_updates.py
+++ b/scripts/test_check_conan_updates.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+"""Tests for the Conan dependency update checker."""
+
+import io
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import check_conan_updates as checker
+
+
+class ConanUpdateCheckerTests(unittest.TestCase):
+    def write_conanfile(self, text: str) -> Path:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "conanfile.py"
+        path.write_text(text)
+        return path
+
+    def test_cci_and_kth_packages_use_their_declared_sources(self):
+        conanfile = self.write_conanfile(
+            'self.requires("fmt/12.1.0")\n'
+            'self.requires("utxoz/0.8.0")\n'
+            'self.tool_requires("secp256k1-precompute/1.0.0")\n'
+        )
+
+        with mock.patch.object(checker, "fetch_cci_versions", return_value=["12.2.0"]) as cci, \
+             mock.patch.object(
+                 checker,
+                 "fetch_conan_remote_versions",
+                 side_effect=[["1.0.0"], ["0.8.0"]],
+             ) as custom:
+            updates, failures = checker.check_updates(conanfile)
+
+        self.assertEqual(updates, [("fmt", "12.1.0", "12.2.0")])
+        self.assertEqual(failures, [])
+        cci.assert_called_once_with("fmt")
+        self.assertEqual(
+            custom.call_args_list,
+            [
+                mock.call("secp256k1-precompute", "kth"),
+                mock.call("utxoz", "kth"),
+            ],
+        )
+
+    def test_lookup_failure_makes_the_result_incomplete(self):
+        conanfile = self.write_conanfile('self.requires("fmt/12.1.0")\n')
+        with mock.patch.object(
+            checker,
+            "fetch_cci_versions",
+            side_effect=checker.PackageLookupError("network unavailable"),
+        ):
+            updates, failures = checker.check_updates(conanfile)
+
+        self.assertEqual(updates, [])
+        self.assertEqual(failures, [("fmt", "network unavailable")])
+
+    def test_empty_cci_versions_are_an_incomplete_lookup(self):
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = b"versions: {}\n"
+
+        with mock.patch.object(checker.urllib.request, "urlopen", return_value=response):
+            with self.assertRaisesRegex(
+                checker.PackageLookupError,
+                "CCI response contained no versions",
+            ):
+                checker.fetch_cci_versions("fmt")
+
+    def test_unexpected_exception_uses_incomplete_exit_code(self):
+        stderr = io.StringIO()
+        with mock.patch.object(checker, "main", side_effect=ValueError("broken response")), \
+             mock.patch.object(checker.sys, "stderr", stderr):
+            with self.assertRaises(SystemExit) as raised:
+                checker.entrypoint()
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("Unexpected dependency-check failure", stderr.getvalue())
+
+    def test_no_updates_is_a_complete_result(self):
+        conanfile = self.write_conanfile('self.requires("fmt/12.2.0")\n')
+        with mock.patch.object(checker, "fetch_cci_versions", return_value=["12.2.0"]):
+            updates, failures = checker.check_updates(conanfile)
+
+        self.assertEqual(updates, [])
+        self.assertEqual(failures, [])
+
+    @mock.patch("subprocess.run")
+    def test_conan_remote_json_is_parsed(self, run):
+        run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps({
+                "kth": {
+                    "utxoz/0.8.0": {},
+                    "utxoz/0.9.0-commit.12": {},
+                }
+            }),
+            stderr="",
+        )
+
+        self.assertEqual(
+            checker.fetch_conan_remote_versions("utxoz", "kth"),
+            ["0.8.0", "0.9.0-commit.12"],
+        )
+
+    @mock.patch("subprocess.run")
+    def test_conan_remote_error_is_not_not_found_or_up_to_date(self, run):
+        run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="remote unavailable"
+        )
+
+        with self.assertRaisesRegex(checker.PackageLookupError, "remote unavailable"):
+            checker.fetch_conan_remote_versions("utxoz", "kth")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #612.

## What changed

- preserves the dependency checker exit status instead of losing it to the shell's `-e` behavior;
- distinguishes a clean check (`0`), updates found (`1`), and an incomplete check (`2`);
- queries `utxoz` and `secp256k1-precompute` from the public KTH Conan remote;
- fails closed when CCI or a custom remote cannot be queried completely;
- grants the scheduled workflow permission to create or update its issue;
- removes the dependency on repository labels that do not exist;
- fixes summary extraction for the blank line emitted by the report;
- adds unit coverage for CCI packages, KTH packages, clean results, updates, and lookup failures.

## Root cause

The checker deliberately returns `1` when it finds updates. GitHub's shell stopped at that command, so the following line never wrote `exit_code` to `$GITHUB_OUTPUT`. `continue-on-error` kept the step green but did not resume the script, leaving the issue-creation condition false.

The two KTH packages were independently misclassified because the checker queried only Conan Center Index and did not consult the repository from which they are installed.

## Validation

- `python3 -m unittest scripts/test_check_conan_updates.py`
- `python3 -m py_compile scripts/check_conan_updates.py scripts/test_check_conan_updates.py`
- `actionlint 1.7.12 .github/workflows/check-conan-updates.yml`
- live read-only check against CCI and `https://packages.kth.cash/api/`:
  - eight updates reported with exit code `1`;
  - `utxoz/0.8.0` reported current from `kth`;
  - `secp256k1-precompute/1.0.0` reported current from `kth`;
- the JavaScript summary expression extracts all eight reported updates.

The workflow remains read-only on pull requests. Issue creation is still limited to scheduled executions.
