### PR TITLE
blockchain: build the block template from a set the mempool was actually in

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -303,6 +303,7 @@ if (ENABLE_TEST)
         test/branch.cpp
         test/validate_transaction.cpp
         test/mempool_block_connect.cpp
+        test/mempool_lease_bench.cpp
         test/mempool_test.cpp
         test/mempool_persistence_test.cpp
         test/block_template_test.cpp

--- a/src/blockchain/include/kth/blockchain/pools/block_template.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/block_template.hpp
@@ -47,14 +47,24 @@ struct block_template_context {
     uint64_t coinbase_reserve_sigchecks = default_coinbase_reserve_sigchecks;
 };
 
-// Assemble a block template from the mempool, mirroring BCHN's BlockAssembler
+// Assemble a block template from `entries`, mirroring BCHN's BlockAssembler
 // (miner.cpp addTxs): order candidates by individual fee-rate and add each once
 // all its in-mempool parents are in, so the result is dependency-complete under
 // CTOR without CPFP / ancestor-package scoring. Enforces the block size and
 // sigchecks limits (with a coinbase reserve) and per-tx finality at the
 // template height.
+//
+// `entries` must be a coherent view of the pool: a set the pool actually held
+// at some instant. The dependency rule above is only meaningful on a set closed
+// under "in-mempool parents" — a prevout whose txid is absent is read as
+// already confirmed, so a child collected without its parent would be selected
+// alone, and the block would spend an output that is neither in it nor on the
+// chain (#611). This takes the entries rather than the pool precisely so that
+// obligation lands on the caller holding the exclusion, where it can be met;
+// walking a live concurrent map cannot meet it.
 KB_API
-block_template build_block_template(mempool const& pool, block_template_context const& ctx);
+block_template build_block_template(std::vector<mempool_entry> const& entries,
+                                    block_template_context const& ctx);
 
 // A full mining template: the transaction selection plus every header-level field
 // a miner needs to assemble and solve the next block. This is what the getblock-

--- a/src/blockchain/include/kth/blockchain/pools/mempool.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/mempool.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <kth/domain.hpp>
+#include <kth/infrastructure/utility/prioritized_mutex.hpp>
 
 #include <kth/blockchain/define.hpp>
 #include <kth/blockchain/pools/mempool_hashers.hpp>
@@ -147,6 +148,34 @@ private:
     mempool_stats stats_;
     std::atomic<uint64_t> generation_{0};
 };
+
+// A set of entries the pool actually held, and the number that labels it.
+struct pool_view {
+    std::vector<mempool_entry> entries;
+    uint64_t generation;
+};
+
+/// Copy the pool coherently, under the same exclusion its writers take.
+///
+/// `for_each` walks a map that locks per element, so on its own it collects a
+/// set gathered over an interval rather than a state the pool was ever in. That
+/// distinction is not academic: a template built from such a set can select a
+/// transaction without its unconfirmed parent, because a prevout whose txid is
+/// absent reads as already confirmed (#611). Holding the writers' mutex for the
+/// walk is what makes the result a state; sampling the generation inside the
+/// same lease is what makes the label describe these entries rather than some
+/// instant near them.
+///
+/// The lease covers the copy and nothing else — everything a caller does with
+/// the result touches only its own copy, and the exclusion stops admission, so
+/// its length is paid by every transaction arriving meanwhile. The low-priority
+/// side is deliberate: connecting a block must not wait behind a reader.
+///
+/// Must not be called with a suspension point inside a caller's use of it: a
+/// shared_mutex may only be released by the thread that took it, and a
+/// coroutine may resume on another. The copy itself is synchronous.
+KB_API
+pool_view lease_pool_view(prioritized_mutex& mutex, mempool const& pool);
 
 } // namespace kth::blockchain
 

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1840,7 +1840,9 @@ block_chain::fetch_template() const {
         co_return std::unexpected(error::not_found);
     }
 
-    co_return build_block_template(mempool_, block_template_context{
+    auto const view = lease_pool_view(validation_mutex_, mempool_);
+
+    co_return build_block_template(view.entries, block_template_context{
         state->dynamic_max_block_size(),
         state->dynamic_max_block_sigchecks(),
         state->height(),
@@ -1871,6 +1873,10 @@ block_chain::fetch_mining_template(uint64_t coinbase_reserve_size) const {
         previous = *prev;
     }
 
+    // Only decides whether to rebuild, so it is read without the lease: a value
+    // that has already moved on costs one extra rebuild, and paying the
+    // exclusion on every cache hit would cost far more. The label stored with a
+    // rebuilt template comes from inside the lease instead — see below.
     auto const generation = mempool_.generation();
     auto const now = static_cast<uint32_t>(zulu_time());
 
@@ -1919,7 +1925,12 @@ block_chain::fetch_mining_template(uint64_t coinbase_reserve_size) const {
         co_return snapshot->value;
     }
 
-    auto selection = build_block_template(mempool_, block_template_context{
+    // Lock order: template_rebuild_mutex_ (held above) then the validation
+    // mutex. Nothing takes them the other way round — the organizers hold the
+    // validation mutex and know nothing about the template cache.
+    auto const view = lease_pool_view(validation_mutex_, mempool_);
+
+    auto selection = build_block_template(view.entries, block_template_context{
         state->dynamic_max_block_size(),
         state->dynamic_max_block_sigchecks(),
         height,
@@ -1940,7 +1951,7 @@ block_chain::fetch_mining_template(uint64_t coinbase_reserve_size) const {
         std::move(selection));
 
     auto next = boost::make_shared<template_snapshot>(
-        template_snapshot{std::move(built), previous, generation, now, coinbase_reserve_size});
+        template_snapshot{std::move(built), previous, view.generation, now, coinbase_reserve_size});
     template_cache_.store(next);
     co_return next->value;
 }

--- a/src/blockchain/src/pools/block_template.cpp
+++ b/src/blockchain/src/pools/block_template.cpp
@@ -44,14 +44,12 @@ bool canonical_less(transaction_const_ptr const& a, transaction_const_ptr const&
 
 } // namespace
 
-block_template build_block_template(mempool const& pool, block_template_context const& ctx) {
-    // 1. Point-in-time snapshot of the pool. The mempool is lock-free, so we copy
-    //    the entries out (cheap: shared_ptr + a few ints) and build the template
-    //    from a self-consistent view instead of querying the live maps.
-    std::vector<mempool_entry> entries;
-    entries.reserve(pool.size());
-    pool.for_each([&](mempool_entry const& e) { entries.push_back(e); });
-
+block_template build_block_template(std::vector<mempool_entry> const& entries,
+                                    block_template_context const& ctx) {
+    // 1. The caller's view of the pool. Everything below reads only `entries`,
+    //    so nothing here can be disturbed by a concurrent admission — but that
+    //    is the easy half. The half that matters is that the view was coherent
+    //    when it was taken; see the note on the declaration.
     auto const n = entries.size();
 
     block_template result{};

--- a/src/blockchain/src/pools/mempool.cpp
+++ b/src/blockchain/src/pools/mempool.cpp
@@ -371,4 +371,30 @@ mempool_totals mempool::summary() const {
     return totals;
 }
 
+namespace {
+
+// The copy allocates, so the release must not rest on the body never throwing.
+struct low_priority_lease {
+    explicit low_priority_lease(prioritized_mutex& mutex) : mutex_(mutex) {
+        mutex_.lock_low_priority();
+    }
+    ~low_priority_lease() { mutex_.unlock_low_priority(); }
+    low_priority_lease(low_priority_lease const&) = delete;
+    low_priority_lease& operator=(low_priority_lease const&) = delete;
+private:
+    prioritized_mutex& mutex_;
+};
+
+} // namespace
+
+pool_view lease_pool_view(prioritized_mutex& mutex, mempool const& pool) {
+    pool_view view;
+
+    low_priority_lease const lease(mutex);
+    view.entries.reserve(pool.size());
+    pool.for_each([&](mempool_entry const& entry) { view.entries.push_back(entry); });
+    view.generation = pool.generation();
+    return view;
+}
+
 } // namespace kth::blockchain

--- a/src/blockchain/test/block_template_test.cpp
+++ b/src/blockchain/test/block_template_test.cpp
@@ -32,6 +32,17 @@ using kth::blockchain::make_mining_template;
 
 namespace {
 
+// The builder takes a coherent set of entries rather than the pool, so that the
+// obligation to have one lands on the caller holding the exclusion (#611). A
+// test pool has no concurrent writer, so copying it out here is coherent by
+// construction — that is exactly the assumption production could not make.
+std::vector<mempool_entry> view_of(mempool const& pool) {
+    std::vector<mempool_entry> entries;
+    entries.reserve(pool.size());
+    pool.for_each([&](mempool_entry const& entry) { entries.push_back(entry); });
+    return entries;
+}
+
 hash_digest make_hash(uint64_t seed) {
     hash_digest h{};
     for (int i = 0; i < 8; ++i) {
@@ -113,7 +124,7 @@ void check_template_invariants(block_template const& tpl) {
 
 TEST_CASE("block_template: empty pool yields empty template", "[block_template]") {
     mempool pool(0x1111u, 0x2222u);
-    auto const tpl = build_block_template(pool, unlimited_ctx());
+    auto const tpl = build_block_template(view_of(pool), unlimited_ctx());
 
     REQUIRE(tpl.txs.empty());
     REQUIRE(tpl.total_fees == 0u);
@@ -131,7 +142,7 @@ TEST_CASE("block_template: includes all independent txs, CTOR-ordered, totals su
         REQUIRE(pool.add(make_entry(tx, /*fee*/ 100u * (i + 1), /*size*/ 200u, /*sigchecks*/ 3u)));
     }
 
-    auto const tpl = build_block_template(pool, unlimited_ctx());
+    auto const tpl = build_block_template(view_of(pool), unlimited_ctx());
 
     REQUIRE(tpl.txs.size() == 5u);
     check_template_invariants(tpl);
@@ -155,7 +166,7 @@ TEST_CASE("block_template: size limit selects highest fee-rate first", "[block_t
     auto ctx = unlimited_ctx();
     ctx.max_block_size = 1000u + 250u;
 
-    auto const tpl = build_block_template(pool, ctx);
+    auto const tpl = build_block_template(view_of(pool), ctx);
 
     REQUIRE(tpl.txs.size() == 2u);
     check_template_invariants(tpl);
@@ -185,7 +196,7 @@ TEST_CASE("block_template: a larger coinbase size reserve shrinks the selection"
     ctx.max_block_size = 1000u + 250u;
     ctx.coinbase_reserve_size = 1100u;
 
-    auto const tpl = build_block_template(pool, ctx);
+    auto const tpl = build_block_template(view_of(pool), ctx);
 
     REQUIRE(tpl.txs.size() == 1u);
     REQUIRE(tpl.total_fees == 300u);   // only the top fee-rate tx.
@@ -205,7 +216,7 @@ TEST_CASE("block_template: a larger coinbase sigchecks reserve caps selection", 
     ctx.max_block_sigchecks = 200u;
     ctx.coinbase_reserve_sigchecks = 130u;
 
-    auto const tpl = build_block_template(pool, ctx);
+    auto const tpl = build_block_template(view_of(pool), ctx);
 
     REQUIRE(tpl.txs.size() == 1u);
     REQUIRE(tpl.total_sigchecks == 40u);
@@ -225,7 +236,7 @@ TEST_CASE("block_template: sigchecks limit caps selection", "[block_template]") 
     auto ctx = unlimited_ctx();
     ctx.max_block_sigchecks = 100u + 100u;
 
-    auto const tpl = build_block_template(pool, ctx);
+    auto const tpl = build_block_template(view_of(pool), ctx);
 
     REQUIRE(tpl.txs.size() == 2u);
     REQUIRE(tpl.total_sigchecks == 80u);
@@ -241,7 +252,7 @@ TEST_CASE("block_template: child added only after its parent (dependency complet
     REQUIRE(pool.add(make_entry(parent, /*fee*/ 100u, /*size*/ 100u, 1u)));
     REQUIRE(pool.add(make_entry(child,  /*fee*/ 900u, /*size*/ 100u, 1u)));
 
-    auto const tpl = build_block_template(pool, unlimited_ctx());
+    auto const tpl = build_block_template(view_of(pool), unlimited_ctx());
 
     REQUIRE(tpl.txs.size() == 2u);
     check_template_invariants(tpl);
@@ -271,7 +282,7 @@ TEST_CASE("block_template: child dropped when parent does not fit", "[block_temp
     auto ctx = unlimited_ctx();
     ctx.max_block_size = 1000u + 350u;
 
-    auto const tpl = build_block_template(pool, ctx);
+    auto const tpl = build_block_template(view_of(pool), ctx);
 
     check_template_invariants(tpl);
     std::set<hash_digest> present;
@@ -294,7 +305,7 @@ TEST_CASE("block_template: non-final tx is excluded", "[block_template]") {
     REQUIRE(pool.add(make_entry(final_tx,  100u, 100u, 1u)));
     REQUIRE(pool.add(make_entry(non_final, 900u, 100u, 1u)));
 
-    auto const tpl = build_block_template(pool, unlimited_ctx());
+    auto const tpl = build_block_template(view_of(pool), unlimited_ctx());
 
     std::set<hash_digest> present;
     for (auto const& tx : tpl.txs) present.insert(tx->hash());
@@ -361,4 +372,61 @@ TEST_CASE("difficulty_from_bits scales with the exponent", "[block_template]") {
 TEST_CASE("difficulty_from_bits is zero for a zero mantissa", "[block_template]") {
     using kth::blockchain::difficulty_from_bits;
     REQUIRE(difficulty_from_bits(0x1d000000u) == Catch::Approx(0.0));
+}
+
+// =============================================================================
+// Why the builder takes entries and not the pool (#611)
+// =============================================================================
+
+TEST_CASE("an incoherent view selects a child whose parent is missing", "[block_template][coherence]") {
+    // The dependency rule reads a prevout whose txid is absent from the view as
+    // already confirmed — it has no other way to tell an unconfirmed parent from
+    // a chain output. So on a view that is missing a parent it holds, the child
+    // looks spendable and is selected alone, and the block would spend an output
+    // that is neither in it nor on the chain.
+    //
+    // This is what the builder does with a set the pool was never in, which is
+    // what walking the live map produced. It is not a defect of the selection:
+    // no rule over a set can recover what the set omits. It is the reason the
+    // coherent view is the caller's obligation, and the reason this signature
+    // takes entries rather than the pool.
+    auto const parent = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto const child = as_ptr(make_tx({output_point{parent->hash(), 0}}, 1, 2));
+
+    std::vector<mempool_entry> const incoherent{make_entry(child, 5000, 250, 1)};
+
+    auto const tpl = build_block_template(incoherent, unlimited_ctx());
+
+    REQUIRE(tpl.txs.size() == 1);
+    CHECK(tpl.txs.front()->hash() == child->hash());
+
+    // Stated the other way round, since that is the property callers rely on:
+    // the selection is closed under in-mempool parents *of the view given*, and
+    // the parent is not in it.
+    auto const& only_input = tpl.txs.front()->inputs().front();
+    CHECK(only_input.previous_output().hash() == parent->hash());
+}
+
+TEST_CASE("a coherent view keeps the child with its parent", "[block_template][coherence]") {
+    // The same two transactions, this time as a set the pool could have held.
+    auto const parent = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    auto const child = as_ptr(make_tx({output_point{parent->hash(), 0}}, 1, 2));
+
+    // The child pays far better, so fee-rate order alone would place it first;
+    // only the dependency rule keeps them together and in CTOR order.
+    std::vector<mempool_entry> const coherent{
+        make_entry(parent, 100, 250, 1),
+        make_entry(child, 50000, 250, 1)};
+
+    auto const tpl = build_block_template(coherent, unlimited_ctx());
+
+    REQUIRE(tpl.txs.size() == 2);
+    check_template_invariants(tpl);
+
+    std::set<hash_digest> selected;
+    for (auto const& tx : tpl.txs) {
+        selected.insert(tx->hash());
+    }
+    CHECK(selected.contains(parent->hash()));
+    CHECK(selected.contains(child->hash()));
 }

--- a/src/blockchain/test/mempool_lease_bench.cpp
+++ b/src/blockchain/test/mempool_lease_bench.cpp
@@ -1,0 +1,338 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// What the coherent view costs (#611).
+//
+// The fix takes the writers' own exclusion for the length of the copy, so the
+// question it has to answer is not whether the copy is fast but what it does to
+// the two things it excludes: admitting a transaction and connecting a block.
+// A number for the copy alone would say nothing about either.
+//
+// Hidden behind the `[.lease-bench]` tag: this measures, it does not assert, and
+// it takes minutes. Run it deliberately:
+//
+//     kth_blockchain_test "[.lease-bench]"
+
+#include <test_helpers.hpp>
+
+#include <kth/blockchain/pools/mempool.hpp>
+#include <kth/domain.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <tuple>
+#include <thread>
+#include <vector>
+
+using namespace kth;
+using namespace kth::domain::chain;
+using kth::blockchain::mempool;
+using kth::blockchain::mempool_entry;
+using kth::blockchain::lease_pool_view;
+
+namespace {
+
+using clock_type = std::chrono::steady_clock;
+using ns = std::chrono::nanoseconds;
+
+hash_digest bench_hash(uint64_t seed) {
+    hash_digest h{};
+    for (int i = 0; i < 8; ++i) {
+        h[i] = static_cast<uint8_t>(seed >> (8 * i));
+    }
+    h[16] = static_cast<uint8_t>(seed >> 5);
+    h[31] = static_cast<uint8_t>(seed >> 11);
+    return h;
+}
+
+// One input, two outputs — near the shape of an ordinary payment, which is what
+// sets the per-entry copy cost (a shared_ptr bump and four scalars) and the
+// serialized size the summary reports.
+transaction_const_ptr bench_tx(uint64_t seed) {
+    input::list ins;
+    ins.emplace_back(output_point{bench_hash(seed), 0}, script{}, 0xffffffffu);
+
+    output::list outs;
+    for (uint32_t i = 0; i < 2; ++i) {
+        output o;
+        o.set_value(1000u + i);
+        o.set_script(script{});
+        outs.push_back(std::move(o));
+    }
+
+    return std::make_shared<domain::message::transaction>(
+        transaction{1u, 0u, std::move(ins), std::move(outs)});
+}
+
+void fill(mempool& pool, size_t count, uint64_t base_seed) {
+    for (size_t i = 0; i < count; ++i) {
+        auto const tx = bench_tx(base_seed + i);
+        pool.add(mempool_entry{tx, 1000, 250, 1, 0});
+    }
+}
+
+struct distribution {
+    uint64_t count{0};
+    double mean_us{0};
+    double p50_us{0};
+    double p99_us{0};
+    double max_us{0};
+};
+
+distribution summarize(std::vector<ns>& samples) {
+    distribution d;
+    if (samples.empty()) {
+        return d;
+    }
+    std::sort(samples.begin(), samples.end());
+    auto const at = [&](double q) {
+        auto idx = static_cast<size_t>(q * double(samples.size() - 1));
+        return double(samples[idx].count()) / 1000.0;
+    };
+    auto const total = std::accumulate(samples.begin(), samples.end(), ns{0});
+    d.count = samples.size();
+    d.mean_us = double(total.count()) / double(samples.size()) / 1000.0;
+    d.p50_us = at(0.50);
+    d.p99_us = at(0.99);
+    d.max_us = double(samples.back().count()) / 1000.0;
+    return d;
+}
+
+// The operational line for "this operation waited on the exclusion rather than
+// doing its own work": three orders of magnitude above the uncontended p99, so
+// crossing it is not jitter.
+constexpr ns blocking_wait{50'000};
+
+void report(std::string const& label, distribution const& d) {
+    WARN(label << ": n=" << d.count
+        << "  mean=" << d.mean_us << "us"
+        << "  p50=" << d.p50_us << "us"
+        << "  p99=" << d.p99_us << "us"
+        << "  max=" << d.max_us << "us");
+}
+
+} // namespace
+
+TEST_CASE("what the lease costs on its own", "[.lease-bench]") {
+    // The copy with nothing contending: the floor, and how it scales.
+    for (size_t const size : {1000u, 10000u, 50000u, 100000u}) {
+        mempool pool(0x1111u, 0x2222u);
+        prioritized_mutex mutex;
+        fill(pool, size, 1'000'000);
+        REQUIRE(pool.size() == size);
+
+        std::vector<ns> samples;
+        samples.reserve(200);
+        size_t copied = 0;
+        for (int i = 0; i < 200; ++i) {
+            auto const t0 = clock_type::now();
+            auto const view = lease_pool_view(mutex, pool);
+            samples.push_back(std::chrono::duration_cast<ns>(clock_type::now() - t0));
+            copied = view.entries.size();
+        }
+
+        report("lease size=" + std::to_string(size), summarize(samples));
+        WARN("  copied " << copied << " entries, "
+             << (copied * sizeof(mempool_entry)) / 1024 << " KiB of entry structs"
+             << " (the transactions themselves are shared, not copied)");
+    }
+}
+
+TEST_CASE("what the lease costs the two things it excludes", "[.lease-bench]") {
+    // Admission takes the low side, connecting a block the high side, and the
+    // lease takes the low side. Each is measured alone and then against a reader
+    // leasing as fast as it can — the worst case a template can impose, since a
+    // real one also has to build, order and select between leases.
+    //
+    // Measured over a fixed span rather than a fixed count. A count-bounded run
+    // finishes in a few milliseconds, during which a 0.3 ms lease can only
+    // happen a handful of times, so almost nothing collides and the percentiles
+    // describe an encounter that mostly did not occur.
+    //
+    // What is timed is the exclusion — acquire, a fixed-cost read, release —
+    // and not the work each side does inside it. Two reasons. The work is what
+    // this change does not touch: `add` costs about a microsecond either way,
+    // measured below and unaffected by any of this. And admitting for two
+    // seconds would grow the pool thirty-fold, so the lease being measured
+    // against would get steadily more expensive and the pool size in the label
+    // would mean nothing.
+    //
+    // Two counts are reported, because they answer different questions. Waits
+    // past 50us can only have been spent behind a lease — the uncontended p99 is
+    // three orders of magnitude below it — so that count is what says the run
+    // exercised the collision at all. Waits past the uncontended p99 are mostly
+    // scheduler jitter; counting those as collisions would give a figure that
+    // moves with the machine rather than with the change, which is why 50us is
+    // the operational line and the jitter count is reported beside it rather
+    // than in place of it.
+    constexpr size_t pool_size = 50000;
+    constexpr auto span = std::chrono::seconds(2);
+
+    struct outcome {
+        distribution d;
+        uint64_t leases;
+        uint64_t blocked;
+        uint64_t jittered;
+    };
+
+    auto const measure = [&](bool with_reader, bool high_priority, double jitter_line_us) {
+        mempool pool(0x3333u, 0x4444u);
+        prioritized_mutex mutex;
+        fill(pool, pool_size, 2'000'000);
+
+        std::atomic<bool> stop{false};
+        std::atomic<uint64_t> leases{0};
+        std::thread reader;
+        if (with_reader) {
+            reader = std::thread([&] {
+                while ( ! stop) {
+                    auto const view = lease_pool_view(mutex, pool);
+                    (void)view.generation;
+                    ++leases;
+                }
+            });
+        }
+
+        std::vector<ns> samples;
+        samples.reserve(1u << 21);
+        uint64_t seed = 2'000'000;
+        auto const deadline = clock_type::now() + span;
+        while (clock_type::now() < deadline) {
+            auto const key = bench_hash(seed++ % pool_size + 2'000'000);
+            auto const t0 = clock_type::now();
+            if (high_priority) {
+                mutex.lock_high_priority();
+                (void)pool.contains(key);
+                mutex.unlock_high_priority();
+            } else {
+                mutex.lock_low_priority();
+                (void)pool.contains(key);
+                mutex.unlock_low_priority();
+            }
+            samples.push_back(std::chrono::duration_cast<ns>(clock_type::now() - t0));
+        }
+
+        stop = true;
+        if (reader.joinable()) {
+            reader.join();
+        }
+
+        auto const blocked = std::count_if(samples.begin(), samples.end(),
+            [](ns dur) { return dur > blocking_wait; });
+        auto const jittered = jitter_line_us <= 0.0 ? 0 : std::count_if(
+            samples.begin(), samples.end(),
+            [&](ns dur) { return double(dur.count()) / 1000.0 > jitter_line_us; });
+
+        return outcome{summarize(samples), leases.load(),
+                       uint64_t(blocked), uint64_t(jittered)};
+    };
+
+    auto const show_idle = [&](std::string const& label, outcome const& r) {
+        report(label, r.d);
+        WARN("  no reader; " << r.blocked << " of " << r.d.count
+             << " waited past 50us");
+    };
+
+    auto const show_busy = [&](std::string const& label, outcome const& r, double line) {
+        report(label, r.d);
+        WARN("  " << r.leases << " leases ran alongside; "
+             << r.blocked << " of " << r.d.count << " waited past 50us ("
+             << (100.0 * double(r.blocked) / double(r.d.count)) << "%); "
+             << r.jittered << " above the uncontended p99 of " << line << "us");
+    };
+
+    // Each side runs uncontended first, so the jitter line its contended run is
+    // measured against comes from the same machine at the same moment.
+    auto const low_idle = measure(false, false, 0.0);
+    show_idle("exclusion (low), no reader   ", low_idle);
+    show_busy("exclusion (low), reader busy ",
+              measure(true, false, low_idle.d.p99_us), low_idle.d.p99_us);
+
+    auto const high_idle = measure(false, true, 0.0);
+    show_idle("exclusion (high), no reader ", high_idle);
+    show_busy("exclusion (high), reader bsy",
+              measure(true, true, high_idle.d.p99_us), high_idle.d.p99_us);
+}
+
+TEST_CASE("whether a lease starves behind consecutive blocks", "[.lease-bench]") {
+    // The reason the lease takes the low side is that connecting a block must
+    // not wait behind a template. The cost of that choice is on the other side:
+    // a run of high-priority holders can keep a low-priority waiter out. This
+    // measures how long the wait actually gets while blocks arrive back to back.
+    //
+    // Bounded, because the thing being measured is the thing that could hang it.
+    // `prioritized_mutex` has no timed acquire, so a starved lease blocks inside
+    // the call and no deadline checked around it would fire. The leases run on
+    // their own thread; if they have not finished by the deadline, the connector
+    // is stopped — which releases the pressure and lets the outstanding lease
+    // through — and what completed is reported as a bound rather than a result.
+    // A starvation benchmark that hangs when it finds starvation measures
+    // nothing.
+    constexpr size_t pool_size = 50000;
+    constexpr int wanted = 200;
+    constexpr auto deadline_after = std::chrono::seconds(30);
+
+    mempool pool(0x5555u, 0x6666u);
+    prioritized_mutex mutex;
+    fill(pool, pool_size, 3'000'000);
+
+    std::atomic<bool> stop{false};
+    std::atomic<uint64_t> connections{0};
+    std::atomic<int> completed{0};
+
+    // Back-to-back connections, each holding the exclusion for roughly what a
+    // mempool update for a full block costs.
+    std::thread connector([&] {
+        while ( ! stop) {
+            mutex.lock_high_priority();
+            for (int i = 0; i < 200; ++i) {
+                (void)pool.contains(bench_hash(3'000'000 + uint64_t(i)));
+            }
+            mutex.unlock_high_priority();
+            ++connections;
+        }
+    });
+
+    std::vector<ns> waits(wanted);
+    std::thread leaser([&] {
+        for (int i = 0; i < wanted; ++i) {
+            auto const t0 = clock_type::now();
+            auto const view = lease_pool_view(mutex, pool);
+            waits[size_t(i)] = std::chrono::duration_cast<ns>(clock_type::now() - t0);
+            (void)view.generation;
+            completed.store(i + 1, std::memory_order_relaxed);
+        }
+    });
+
+    auto const deadline = clock_type::now() + deadline_after;
+    while (completed.load(std::memory_order_relaxed) < wanted &&
+           clock_type::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    auto const done = completed.load(std::memory_order_relaxed);
+    bool const timed_out = done < wanted;
+
+    // Stopping the connector is what unblocks a lease that is starved, so it
+    // has to happen before the join either way.
+    stop = true;
+    leaser.join();
+    connector.join();
+
+    waits.resize(size_t(std::max(done, 1)));
+    report("lease while blocks connect   ", summarize(waits));
+    WARN("  (" << connections.load() << " connections ran during " << done
+         << " of " << wanted << " leases)");
+    if (timed_out) {
+        WARN("  BOUNDED: the deadline of " << deadline_after.count()
+             << "s expired with " << done << " leases done — the connector was"
+             << " stopped to release the outstanding one. Treat the figures above"
+             << " as a lower bound on the wait, not a measurement of it.");
+    }
+}

--- a/src/blockchain/test/mempool_test.cpp
+++ b/src/blockchain/test/mempool_test.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -659,4 +660,128 @@ TEST_CASE("mempool concurrent stress 16 threads", "[mempool][concurrent]") {
 
 TEST_CASE("mempool concurrent stress 32 threads", "[mempool][concurrent]") {
     run_concurrent(32);
+}
+
+// =============================================================================
+// The leased view is a state the pool was in (#611)
+// =============================================================================
+
+TEST_CASE("a leased view is closed under in-mempool parents while admissions run", "[mempool][lease]") {
+    // `for_each` alone locks per element, so a walk racing an admission collects
+    // a set gathered over an interval — one that can hold a child and not the
+    // parent it spends, because bucket order follows the hash and not insertion
+    // order. A template built from such a set selects the child alone.
+    //
+    // The lease is what makes the result a state: it takes the same exclusion
+    // the writers take, so nothing is admitted while the copy runs. Here a
+    // writer admits chained pairs through that exclusion, parent first, while a
+    // reader leases repeatedly. Since a parent is always admitted before its
+    // child, any state of the pool holding the child holds the parent — so any
+    // view holding a child without its parent is not a state, and that is the
+    // whole assertion.
+    mempool pool(0x1122334455667788ull, 0x99aabbccddeeff00ull);
+    prioritized_mutex mutex;
+
+    constexpr uint64_t pairs = 400;
+
+    // The transactions are deterministic, so both threads can name them without
+    // sharing anything: no ambiguity about which entry is whose parent, and no
+    // second race introduced by the checking.
+    std::vector<transaction_const_ptr> parents;
+    std::vector<transaction_const_ptr> children;
+    parents.reserve(pairs);
+    children.reserve(pairs);
+    for (uint64_t i = 0; i < pairs; ++i) {
+        auto const parent = as_ptr(make_tx({op(500000 + i, 0)}, 1, 7000 + i));
+        children.push_back(as_ptr(make_tx({output_point{parent->hash(), 0}}, 1, 8000 + i)));
+        parents.push_back(parent);
+    }
+
+    std::atomic<bool> writing{true};
+    std::atomic<uint64_t> admitted{0};
+    std::atomic<bool> saw_partial{false};
+
+    // The writer pauses once a quarter of the pairs are in and does not resume
+    // until the reader reports a view that is neither empty nor the whole set.
+    // Without that handshake the reader's leases could all land before the
+    // writer starts or after it finishes, and every assertion below would hold
+    // without a concurrent walk ever happening — the false green this test
+    // exists to rule out. Bounded so a failure to interleave fails the test
+    // instead of hanging it.
+    constexpr uint64_t handshake_at = pairs / 4;
+    std::atomic<bool> handshake_timed_out{false};
+
+    std::thread writer([&] {
+        for (uint64_t i = 0; i < pairs; ++i) {
+            // Through the writers' own exclusion, as the organizers hold it.
+            mutex.lock_high_priority();
+            bool const p = pool.add(mempool_entry{parents[i], 1000, 250, 1, 0});
+            bool const c = pool.add(mempool_entry{children[i], 1000, 250, 1, 0});
+            mutex.unlock_high_priority();
+
+            if (p) ++admitted;
+            if (c) ++admitted;
+
+            if (i == handshake_at) {
+                auto const limit = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+                while ( ! saw_partial.load(std::memory_order_acquire)) {
+                    if (std::chrono::steady_clock::now() > limit) {
+                        handshake_timed_out = true;
+                        break;
+                    }
+                    std::this_thread::yield();
+                }
+            }
+        }
+        writing = false;
+    });
+
+    uint64_t leases = 0;
+    uint64_t orphans = 0;
+    uint64_t children_seen = 0;
+    uint64_t widest = 0;
+    uint64_t partial = 0;
+
+    while (writing || leases < 4) {
+        auto const view = kth::blockchain::lease_pool_view(mutex, pool);
+        ++leases;
+        widest = std::max<uint64_t>(widest, view.entries.size());
+        if ( ! view.entries.empty() && view.entries.size() < pairs * 2) {
+            ++partial;
+            saw_partial.store(true, std::memory_order_release);
+        }
+
+        std::set<hash_digest> present;
+        for (auto const& entry : view.entries) {
+            present.insert(entry.tx->hash());
+        }
+
+        for (uint64_t i = 0; i < pairs; ++i) {
+            if ( ! present.contains(children[i]->hash())) {
+                continue;
+            }
+            ++children_seen;
+            if ( ! present.contains(parents[i]->hash())) {
+                ++orphans;
+            }
+        }
+    }
+
+    writer.join();
+
+    CHECK(orphans == 0);
+
+    // And the run has to have exercised what it claims: every pair admitted,
+    // more than one view taken while that was happening, and views that
+    // actually held children — an empty or single view would satisfy the
+    // assertion above without testing it.
+    CHECK(admitted == pairs * 2);
+    CHECK(leases > 1);
+    CHECK(children_seen > 0);
+    CHECK(widest > 0);
+
+    // The ones that keep this from passing without testing anything: the writer
+    // was made to wait for a view taken mid-fill, and it got one.
+    CHECK_FALSE(handshake_timed_out.load());
+    CHECK(partial > 0);
 }


### PR DESCRIPTION
`build_block_template` took the pool and copied the entries out, calling the result a point-in-time snapshot. It is not one: `for_each` reaches `boost::concurrent_flat_map::cvisit_all`, which locks per element while the callback runs, so a walk racing an admission collects a set gathered **over an interval** rather than a state the pool ever held.

That distinction decides whether the template is valid. Bucket order follows the hash, not insertion order, so:

1. the walk passes where a parent would live — empty;
2. `add(parent)`, then `add(child)` — legal, its parent is now pooled;
3. the walk reaches the child's bucket and collects it;
4. the set holds the child and not the parent.

The dependency rule derives adjacency from the collected set alone — it has no other way to tell an unconfirmed parent from a chain output — so a prevout absent from the set reads as **already confirmed**. The child is selected without its parent, and the block spends an output that is neither in it nor on the chain.

## The fix

The exclusion needed already existed and the reader simply was not taking it: `add` runs under the organizers' mutex at low priority, both `remove_for_block` call sites at high. `lease_pool_view` takes it too, for the length of the copy and nothing else, sampling the generation inside the same lease so the label describes the entries rather than an instant near them.

**Low priority, deliberately**: connecting a block must not wait behind a template.

`build_block_template` now takes the entries instead of the pool. Walking a live concurrent map cannot produce a coherent set, so the obligation belongs where it can be met — with the caller holding the exclusion. With the old signature the caller was not even told there was one.

The template cache keeps its cheap read: the generation deciding whether to rebuild is loaded without the lease (a stale value costs one extra rebuild; paying the exclusion on every cache hit would cost far more). Only the label stored with a rebuilt template comes from inside.

## Measured

50k pool, reader leasing continuously — ~1800/s, where a miner asks a few times per second. `kth_blockchain_test "[.lease-bench]"`.

| lease alone | 1k | 10k | 50k | 100k |
|---|---|---|---|---|
| mean | 67 µs | 108 µs | 309 µs | 584 µs |
| p99 | 70 µs | 114 µs | 430 µs | 1043 µs |
| copied | 39 KiB | 390 KiB | 1953 KiB | 3906 KiB |

| exclusion | p50 idle → busy | p99 idle → busy | waited >50 µs |
|---|---|---|---|
| admission (low) | 0.19 → 0.18 µs | 0.22 → 0.38 µs | 3559 / 3.4M (0.10%) |
| connection (high) | 0.11 → 0.11 µs | 0.13 → 0.18 µs | 4169 / 5.0M (0.08%) |

**Each lease blocks essentially one operation** — 3569 leases against 3559 waits, 4185 against 4169. No starvation appeared: with 8019 connections running during 200 leases the lease waited ~85 µs beyond its own copy. Caveat: the synthetic connector's critical section is shorter than a real mempool update for a block.

## Tests

- an incoherent view selects the orphan — why the precondition exists, not a defect in the selection;
- a coherent one keeps the child with its parent, even though the child pays far better and fee-rate order alone would split them;
- under concurrent admission every leased view is closed under the parents it holds, with a check that at least one view was taken mid-fill — leases landing entirely before or after the writer would satisfy the rest without exercising a concurrent walk at all.

Blockchain 3758/208 and node 1585/144 green.

## Not fixed here

`fetch_mining_template` is still not correct: this fixes the transaction set, #605 fixes the chain epoch it is built against. Both are needed.

Closes #611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved block template generation to work from a consistent snapshot of available transactions.
  * Added support for safely capturing a moment-in-time view of the transaction pool during processing.

* **Bug Fixes**
  * Reduced the chance of inconsistent transaction selection during concurrent pool updates.
  * Block template rebuilding now uses a stable snapshot for more reliable results.

* **Tests**
  * Added coverage for parent/child transaction consistency in shared views.
  * Added performance benchmarks for transaction-pool leasing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->