### PR TITLE
blockchain: publish the chain state, the tip it describes and their label as one thing

### DIFF
--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -378,7 +378,56 @@ struct KB_API block_chain {
     // CHAIN STATE
     // =========================================================================
 
-    domain::chain::chain_state::ptr chain_state() const;
+    /// The chain state, the tip it describes and the number that labels the
+    /// pair — published together, read together.
+    ///
+    /// Everything a caller needs about the connected chain comes from one
+    /// reference. That is not a convenience: the state used to be computed once
+    /// at startup and never advance, and the readers that noticed combined it
+    /// with a fresh read of the height or the tip hash — a stale value beside a
+    /// current one, describing a chain that never existed (#605). With the three
+    /// in one immutable object behind one pointer, a reader sees the old triple
+    /// or the new one and there is no third possibility to reason about.
+    struct published_chain_view {
+        /// The context for validating the block after the connected tip, so its
+        /// height is the tip's plus one.
+        domain::chain::chain_state::ptr state;
+        /// The hash of the block at the connected tip.
+        hash_digest tip_hash;
+        /// Advances once per coherent state published — never per internal step,
+        /// and monotonically, including a reorganization that moves the tip
+        /// down.
+        uint64_t generation;
+    };
+
+    using chain_view_ptr = boost::shared_ptr<published_chain_view const>;
+
+    /// The published view. Null only before the first publication, which
+    /// start() performs.
+    [[nodiscard]]
+    chain_view_ptr chain_view() const;
+
+    /// Build the view for `connected_tip_height` and publish it.
+    ///
+    /// `connected_tip_height` is the last block whose state — the UTXO delta,
+    /// the undo records, the by-height header table and the mempool — is
+    /// coherently applied. Headers arriving on their own connect nothing, so
+    /// they neither publish nor advance the generation.
+    ///
+    /// The height is the only thing the caller supplies. State and hash are
+    /// derived from it here, so a caller cannot assemble a combination that
+    /// never existed; the generation advances internally, once.
+    ///
+    /// Fails rather than keeping the previous view: at the close of a batch or a
+    /// reorganization, being unable to publish means the coherent state that was
+    /// just reached cannot be described, and the caller must treat that as fatal
+    /// rather than carry on against a view that describes an older chain.
+    [[nodiscard]]
+    code publish_chain_view(size_t connected_tip_height);
+
+    /// The state for a branch under consideration, seeded from the published
+    /// one. Block validation only; the published view is what everything else
+    /// reads.
     domain::chain::chain_state::ptr chain_state(branch::const_ptr branch) const;
 
     /// Validator-owned side store for transient per-block validation state,
@@ -629,7 +678,6 @@ private:
     template <typename Handler, typename... Args>
     bool finish_read(handle sequence, Handler handler, Args... args) const;
 
-    code set_chain_state(domain::chain::chain_state::ptr previous);
 
     // <datadir>/mempool.dat — sibling of the blocks/ and utxoz/ directories.
     std::filesystem::path mempool_dat_path() const;
@@ -648,9 +696,16 @@ private:
     populate_chain_state const chain_state_populator_;
     database::data_base database_;
 
-    // Protected by mutex
-    domain::chain::chain_state::ptr pool_state_;
-    mutable shared_mutex pool_state_mutex_;
+    /// The published state on its own. Private: a caller that wants the state
+    /// wants the tip and the generation that go with it, and reading them apart
+    /// is what produced the combinations #605 was about. The one legitimate use
+    /// is seeding a branch's state below.
+    [[nodiscard]]
+    domain::chain::chain_state::ptr chain_state() const;
+
+    // One swap publishes the whole triple; see published_chain_view.
+    mutable boost::atomic_shared_ptr<published_chain_view const> chain_view_;
+    std::atomic<uint64_t> view_generation_{0};
 
     // Thread safe
     mutable prioritized_mutex validation_mutex_;

--- a/src/blockchain/include/kth/blockchain/populate/populate_chain_state.hpp
+++ b/src/blockchain/include/kth/blockchain/populate/populate_chain_state.hpp
@@ -23,7 +23,15 @@ struct KB_API populate_chain_state {
     populate_chain_state(block_chain const& chain, settings const& settings, domain::config::network network);
 
     /// Populate chain state for the tx pool (start).
-    domain::chain::chain_state::ptr populate() const;
+    /// Build the state for the block after `connected_top`.
+    ///
+    /// The height is given rather than read, because the two tips differ: during
+    /// initial sync the header table runs thousands of blocks ahead of what is
+    /// connected, and a state built from that tip would carry a height, a median
+    /// time past and a set of activation flags for a block whose UTXO delta has
+    /// not been applied — internally consistent and describing nothing (#605).
+    /// Only the caller holding the exclusion knows which height is coherent.
+    domain::chain::chain_state::ptr populate(size_t connected_top) const;
 
     /// Populate chain state for the top block in the branch (try).
     domain::chain::chain_state::ptr populate(domain::chain::chain_state::ptr pool, branch::const_ptr branch) const;

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -169,9 +169,15 @@ bool block_chain::start(uint32_t disk_magic) {
     }
     spdlog::info("[blockchain] Block store initialized at {}", blocks_path.string());
 
-    pool_state_ = chain_state_populator_.populate();
-    if ( ! pool_state_) {
-        spdlog::error("[blockchain] Failed to initialize chain state.");
+    // From the connected tip, never the header tip: the two differ by the whole
+    // of an unfinished sync, and the state describes what is connected.
+    auto const connected = get_last_heights();
+    if ( ! connected) {
+        spdlog::error("[blockchain] Failed to read the last heights.");
+        return false;
+    }
+    if (auto const ec = publish_chain_view(connected->block); ec) {
+        spdlog::error("[blockchain] Failed to initialize chain state: {}", ec.message());
         return false;
     }
 
@@ -1128,13 +1134,70 @@ void block_chain::clear_utxo_bloom() {
 // CHAIN STATE
 // =============================================================================
 
+block_chain::chain_view_ptr block_chain::chain_view() const {
+    return chain_view_.load();
+}
+
+code block_chain::publish_chain_view(size_t connected_tip_height) {
+    // Both halves come from the one height, under whatever exclusion the caller
+    // holds — so the state and the hash cannot describe different chains, and
+    // there is no combination for a caller to assemble.
+    auto state = chain_state_populator_.populate(connected_tip_height);
+    if ( ! state) {
+        spdlog::error("[blockchain] Could not build the chain state at height {}", connected_tip_height);
+        return error::pool_state_failed;
+    }
+
+    auto const tip_hash = get_block_hash(connected_tip_height);
+    if ( ! tip_hash) {
+        spdlog::error("[blockchain] Could not resolve the block hash at height {}", connected_tip_height);
+        return error::pool_state_failed;
+    }
+
+    // Allocate before the counter moves, and take the number last. Reversed —
+    // reading the counter while building the argument — an allocation that threw
+    // would leave a generation that no published view carries: a reader
+    // comparing numbers would see one it can never be given, and conclude
+    // something was published that was not.
+    boost::shared_ptr<published_chain_view> built;
+    try {
+        built = boost::make_shared<published_chain_view>();
+    } catch (std::exception const& e) {
+        // The only throwing step here, and the reason this returns a code rather
+        // than letting it escape: the callers publish at the close of a batch or
+        // a reorganization and decide what to do about a failure. An exception
+        // out of an API that promises a code would bypass that decision.
+        spdlog::error("[blockchain] Could not allocate the chain view at height {}: {}",
+                      connected_tip_height, e.what());
+        return error::pool_state_failed;
+    }
+
+    built->state = std::move(state);
+    built->tip_hash = *tip_hash;
+    built->generation = view_generation_.fetch_add(1, std::memory_order_relaxed) + 1;
+
+    // One swap. A reader holds the previous triple or this one.
+    chain_view_.store(boost::shared_ptr<published_chain_view const>(std::move(built)));
+    return error::success;
+}
+
 domain::chain::chain_state::ptr block_chain::chain_state() const {
-    shared_lock lock(pool_state_mutex_);
-    return pool_state_;
+    auto const view = chain_view();
+    return view ? view->state : nullptr;
 }
 
 domain::chain::chain_state::ptr block_chain::chain_state(branch::const_ptr branch) const {
-    return chain_state_populator_.populate(chain_state(), branch);
+    // The branch's state is seeded from the published one, and `populate`
+    // dereferences that seed. Before the first publication there is nothing to
+    // seed from, so this answers null rather than reading through it — the one
+    // window is a chain constructed but not started, which start() closes by
+    // publishing.
+    auto const seed = chain_state();
+    if ( ! seed) {
+        spdlog::error("[blockchain] A branch state was asked for before any chain view was published");
+        return {};
+    }
+    return chain_state_populator_.populate(seed, branch);
 }
 
 block_validation_store& block_chain::block_validations() const {
@@ -1193,12 +1256,6 @@ blockchain::mempool& block_chain::mempool_ref() {
 
 blockchain::mempool const& block_chain::mempool_ref() const {
     return mempool_;
-}
-
-code block_chain::set_chain_state(domain::chain::chain_state::ptr previous) {
-    unique_lock lock(pool_state_mutex_);
-    pool_state_ = chain_state_populator_.populate(previous);
-    return pool_state_ ? error::success : error::pool_state_failed;
 }
 
 // =============================================================================
@@ -1835,10 +1892,11 @@ block_chain::fetch_template() const {
         co_return std::unexpected(error::service_stopped);
     }
 
-    auto const state = chain_state();
-    if ( ! state) {
+    auto const published = chain_view();
+    if ( ! published) {
         co_return std::unexpected(error::not_found);
     }
+    auto const& state = published->state;
 
     auto const view = lease_pool_view(validation_mutex_, mempool_);
 
@@ -1855,23 +1913,20 @@ block_chain::fetch_mining_template(uint64_t coinbase_reserve_size) const {
         co_return std::unexpected(error::service_stopped);
     }
 
-    auto const state = chain_state();
-    if ( ! state) {
+    auto const published = chain_view();
+    if ( ! published) {
         co_return std::unexpected(error::not_found);
     }
+    auto const& state = published->state;
 
     auto const height = state->height();
 
-    // Previous block hash = the tip, i.e. the block one below the template height.
-    // Together with the mempool generation it forms the cache key.
-    hash_digest previous = null_hash;
-    if (height > 0) {
-        auto const prev = get_block_hash(height - 1);
-        if ( ! prev) {
-            co_return std::unexpected(error::not_found);
-        }
-        previous = *prev;
-    }
+    // The parent comes from the same publication as the height, not from a
+    // second lookup keyed on it. That pairing is what used to be wrong: the
+    // height was frozen at startup and the hash was read now, so the template
+    // could name a parent the chain had left behind — and the cache's guard
+    // against exactly that is keyed on this value, so it could never fire.
+    hash_digest const previous = published->tip_hash;
 
     // Only decides whether to rebuild, so it is read without the lease: a value
     // that has already moved on costs one extra rebuild, and paying the
@@ -1962,18 +2017,17 @@ block_chain::fetch_mining_info() const {
         co_return std::unexpected(error::service_stopped);
     }
 
-    auto const state = chain_state();
-    if ( ! state) {
+    auto const published = chain_view();
+    if ( ! published) {
         co_return std::unexpected(error::not_found);
     }
+    auto const& state = published->state;
 
-    auto const heights = co_await fetch_last_height();
-    if ( ! heights) {
-        co_return std::unexpected(heights.error());
-    }
-
+    // Every field from the one publication. Reading the height separately is
+    // how this reported the current tip beside the difficulty in force when the
+    // node started.
     co_return blockchain::mining_info{
-        heights->block,
+        uint32_t(state->height() - 1u),
         difficulty_from_bits(state->work_required()),
         mempool_.size(),
         state->network()};

--- a/src/blockchain/src/populate/populate_chain_state.cpp
+++ b/src/blockchain/src/populate/populate_chain_state.cpp
@@ -263,23 +263,18 @@ chain_state::assert_anchor_block_info_t populate_chain_state::get_assert_anchor_
 
 #endif // defined(KTH_CURRENCY_BCH)
 
-chain_state::ptr populate_chain_state::populate() const {
-    auto const heights = chain_.get_last_heights();
-    if ( ! heights) {
-        spdlog::error("[blockchain] Failed to populate chain state, last height.");
-        return {};
-    }
-    auto const top = heights->header;
-    auto const header_result = chain_.get_header_and_abla_state(top);
+chain_state::ptr populate_chain_state::populate(size_t connected_top) const {
+    auto const header_result = chain_.get_header_and_abla_state(connected_top);
     if ( ! header_result) {
-        spdlog::error("[blockchain] Failed to populate chain state, last header.");
+        spdlog::error("[blockchain] Failed to populate chain state: no header at height {}",
+                      connected_top);
         return {};
     }
     auto const& [last_header, block_size, control_block_size, elastic_buffer_size] = *header_result;
 
     chain_state::data data;
     data.hash = null_hash;
-    data.height = *safe_add(size_t(top), size_t(1));
+    data.height = *safe_add(connected_top, size_t(1));
 
     if (block_size == 0) {
         data.abla_state = abla::state(settings_.abla_config, static_max_block_size(network_));
@@ -289,7 +284,7 @@ chain_state::ptr populate_chain_state::populate() const {
         data.abla_state.elastic_buffer_size = elastic_buffer_size;
     }
 
-    auto branch_ptr = std::make_shared<branch>(top, chain_.block_validations());
+    auto branch_ptr = std::make_shared<branch>(connected_top, chain_.block_validations());
 
     // Use an empty branch to represent the transaction pool.
     if ( ! populate_all(data, branch_ptr)) {

--- a/src/blockchain/src/validate/validate_transaction.cpp
+++ b/src/blockchain/src/validate/validate_transaction.cpp
@@ -82,7 +82,10 @@ void validate_transaction::stop()
     // store write happens off the organizer mutex, but the tx is private to
     // the caller so no other worker touches this hash concurrently.
     {
-        auto const state = chain_.chain_state();
+        // One reference: the state a transaction is validated against and the
+        // chain it describes are published together (#605).
+        auto const published = chain_.chain_view();
+        auto const state = published ? published->state : nullptr;
         chain_.transaction_validations().mutate(tx->hash(), [&](auto& tv){ tv.state = state; });
         if ( ! state) {
             co_return error::transaction_validation_state_failed;

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -293,6 +293,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   find_package(Catch2 3 REQUIRED)
 
   add_executable(kth_node_test
+          test/chain_view.cpp
           test/check_list.cpp
           test/chunk_coordinator.cpp
           test/fatal_shutdown.cpp

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -2163,12 +2163,42 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
                 co_return;
             }
         }
-        auto deferred = chain.utxo_deferred_deletions_size();
+        // The deletions the store deferred are part of this batch's delta, not
+        // work that follows it: until they run, outputs these blocks spent are
+        // still in the set. So they come before the state is published, and a
+        // failure is fatal rather than logged — a spent output left behind is a
+        // double spend the node would accept.
+        //
+        // The marker at which this becomes recoverable rather than merely fatal
+        // is #600, and #602 is the change that adds it. This orders the work
+        // correctly and refuses to continue past a failure; it does not make the
+        // window crash-safe, and the two must not be confused.
+        auto const deferred = chain.utxo_deferred_deletions_size();
         if (deferred > 0) {
             auto [deleted, failed] = chain.utxo_process_pending_deletions();
             if ( ! failed.empty()) {
-                spdlog::error("[utxo_build] {} deferred deletions failed", failed.size());
+                spdlog::critical("[utxo_build] {} deferred deletion(s) failed at batch {}-{}: the "
+                    "UTXO set still holds outputs these blocks spent", failed.size(),
+                    batch_start, batch_end);
+                on_fatal("a batch left spent outputs in the UTXO set");
+                co_return;
             }
+        }
+
+        // Now the batch is closed: the delta is applied in full, the undo records
+        // are written, the height marker has moved and the mempool no longer
+        // holds what these blocks confirmed. Only now does a coherent state exist
+        // to describe, and publishing it is what makes the chain state advance —
+        // it used to be computed once at startup and left behind (#605).
+        //
+        // `batch_end` is the last height actually applied: it is clamped to the
+        // checkpoint and to the undo batch limit above, so it is the tip and not
+        // the range that was asked for.
+        if (auto const ec = chain.publish_chain_view(batch_end); ec) {
+            spdlog::critical("[utxo_build] Could not publish the chain state at height {}: {}",
+                batch_end, ec.message());
+            on_fatal("a connected batch could not be described by a chain state");
+            co_return;
         }
 
         spdlog::info("[utxo_build] UTXO built to height {}/{}", utxo_built_height, current_contiguous - 1);

--- a/src/node/src/sync/reorg.cpp
+++ b/src/node/src/sync/reorg.cpp
@@ -211,6 +211,26 @@ bool persist_active_headers(
         // next header batch can arrive as soon as the pause is gone.
         if (outcome.validated_tip) {
             organizer.note_block_validated(static_cast<int32_t>(*outcome.validated_tip));
+
+            // The transition is closed: the UTXO set, the by-height table, the
+            // adopted tip and the mempool all describe the new fork. Publish the
+            // state here, while the writers are still parked — this is the one
+            // moment nothing else can read a half-switched chain (#605).
+            //
+            // The validated tip, not the branch head. The switch rewound the
+            // connected chain to the fork; the blocks above it are headers, and
+            // they get connected by the ordinary path, which publishes at each
+            // batch. Publishing the branch head would describe a chain whose
+            // UTXO delta has not been applied — the height moving down here
+            // while the generation moves up is the transition being honest.
+            if ( ! fatal) {
+                if (auto const ec = chain.publish_chain_view(*outcome.validated_tip); ec) {
+                    spdlog::critical("[reorg] Could not publish the chain state at the fork "
+                        "height {}: {}. The node would keep validating against the branch it "
+                        "just left", *outcome.validated_tip, ec.message());
+                    fatal = true;
+                }
+            }
         }
     }
 

--- a/src/node/test/chain_view.cpp
+++ b/src/node/test/chain_view.cpp
@@ -1,0 +1,316 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <optional>
+#include <thread>
+#include <vector>
+
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+
+#include <kth/blockchain/pools/branch.hpp>
+#include <kth/database/settings.hpp>
+
+#include "sync_harness.hpp"
+
+using namespace kth;
+using namespace kth::test;
+
+// =============================================================================
+// What the chain publishes about itself
+// =============================================================================
+//
+// The state a transaction is validated against, the tip it describes and the
+// number that labels the pair used to be three separate things: the state was
+// computed once at startup and never advanced, and the readers that noticed
+// combined it with a fresh read of the height or the hash — a stale value beside
+// a current one, describing a chain that never existed (#605).
+//
+// These drive the node's own connect and reorganization paths, because when the
+// state advances is a property of those paths and not of the chain object.
+
+namespace {
+
+constexpr uint32_t trunk_len = 40;
+
+// A chain of `len` blocks, connected the way the node connects them.
+struct built_chain {
+    test::chain_fixture fixture;
+    std::vector<domain::chain::block> trunk;
+    uint32_t base_time;
+
+    explicit built_chain(char const* tag, uint32_t len)
+        : fixture(tag)
+        , base_time(uint32_t(zulu_time()) - (len + 30) * block_spacing)
+    {
+        REQUIRE(fixture.created());
+        REQUIRE(fixture.start());
+
+        auto prev = domain::chain::block::genesis_regtest().hash();
+        for (uint32_t h = 1; h <= len; ++h) {
+            trunk.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+            prev = trunk.back().hash();
+        }
+    }
+
+    blockchain::block_chain& chain() { return fixture.chain(); }
+
+    void add_headers(std::vector<domain::chain::block> const& blocks, uint32_t start) {
+        auto const added = fixture.organizer().add_headers(headers_of(blocks));
+        REQUIRE(added.headers_added == blocks.size());
+        persist_headers(fixture, blocks, start);
+    }
+};
+
+} // namespace
+
+TEST_CASE("a started chain publishes the tip it has connected", "[chain_view]") {
+    built_chain built("view_initial", trunk_len);
+
+    auto const view = built.chain().chain_view();
+    REQUIRE(view);
+    // Nothing connected yet: the genesis block is the tip, and the state is the
+    // context for the block after it.
+    CHECK(view->state->height() == 1u);
+    CHECK(view->tip_hash == domain::chain::block::genesis_regtest().hash());
+}
+
+TEST_CASE("headers alone move neither the view nor the generation", "[chain_view]") {
+    // Headers arrive thousands of blocks ahead of what is connected during a
+    // sync. Building the state from that tip would give a height, a median time
+    // past and a set of activation flags for a block whose UTXO delta has not
+    // been applied — internally consistent and describing nothing.
+    built_chain built("view_headers_only", trunk_len);
+
+    auto const before = built.chain().chain_view();
+    REQUIRE(before);
+
+    built.add_headers(built.trunk, 1);
+
+    auto const after = built.chain().chain_view();
+    REQUIRE(after);
+    CHECK(after->generation == before->generation);
+    CHECK(after->state->height() == before->state->height());
+    CHECK(after->tip_hash == before->tip_hash);
+
+    // And specifically not the header tip, which is now far above.
+    CHECK(built.chain().headers().active_tip_height() == int32_t(trunk_len));
+    CHECK(after->state->height() == 1u);
+}
+
+TEST_CASE("connecting a batch publishes the height after its last block", "[chain_view]") {
+    built_chain built("view_batch", trunk_len);
+    built.add_headers(built.trunk, 1);
+
+    auto const before = built.chain().chain_view();
+    REQUIRE(before);
+
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto const after = built.chain().chain_view();
+    REQUIRE(after);
+    CHECK(after->state->height() == trunk_len + 1u);
+    CHECK(after->tip_hash == built.trunk.back().hash());
+    CHECK(after->generation > before->generation);
+}
+
+TEST_CASE("a second batch advances the view again", "[chain_view]") {
+    built_chain built("view_two_batches", trunk_len);
+
+    std::vector<domain::chain::block> first(built.trunk.begin(), built.trunk.begin() + 20);
+    std::vector<domain::chain::block> second(built.trunk.begin() + 20, built.trunk.end());
+
+    built.add_headers(built.trunk, 1);
+
+    connect_bodies(built.fixture, first, 1);
+    auto const after_first = built.chain().chain_view();
+    REQUIRE(after_first);
+    CHECK(after_first->state->height() == 21u);
+    CHECK(after_first->tip_hash == first.back().hash());
+
+    connect_bodies(built.fixture, second, 21);
+    auto const after_second = built.chain().chain_view();
+    REQUIRE(after_second);
+    CHECK(after_second->state->height() == trunk_len + 1u);
+    CHECK(after_second->tip_hash == built.trunk.back().hash());
+    CHECK(after_second->generation > after_first->generation);
+}
+
+TEST_CASE("the triple is read whole under concurrent publication", "[chain_view]") {
+    // The point of publishing one object rather than three fields: a reader
+    // holds the previous triple or the next one, never a state from one and a
+    // hash from another. Readers run while batches are being connected, and
+    // every view they take must agree with itself.
+    built_chain built("view_atomic", trunk_len);
+    built.add_headers(built.trunk, 1);
+
+    std::atomic<bool> stop{false};
+    std::atomic<uint64_t> reads{0};
+    uint64_t mismatches = 0;
+
+    std::thread reader([&] {
+        while ( ! stop) {
+            // Spinning as hard as this thread can would starve the connect path
+            // it is supposed to be racing, which is the opposite of the point.
+            std::this_thread::yield();
+
+            auto const view = built.chain().chain_view();
+            if ( ! view) continue;
+            ++reads;
+
+            // The hash the view carries must be the hash of the block one below
+            // the height it carries. A torn read would pair them across
+            // publications and this would not hold.
+            auto const tip_height = view->state->height() - 1u;
+            auto const expected = tip_height == 0
+                ? domain::chain::block::genesis_regtest().hash()
+                : built.trunk[tip_height - 1].hash();
+            if (view->tip_hash != expected) ++mismatches;
+        }
+    });
+
+    for (uint32_t start = 1; start <= trunk_len; start += 10) {
+        std::vector<domain::chain::block> batch(
+            built.trunk.begin() + (start - 1), built.trunk.begin() + (start - 1) + 10);
+        connect_bodies(built.fixture, batch, start);
+    }
+
+    stop = true;
+    reader.join();
+
+    CHECK(mismatches == 0);
+    CHECK(reads > 0);
+    CHECK(built.chain().chain_view()->state->height() == trunk_len + 1u);
+}
+
+TEST_CASE("mining info reports one publication, not a height beside an old difficulty", "[chain_view]") {
+    // It used to take the work required from the frozen state and the height
+    // from a fresh read, so it described a chain that never existed.
+    built_chain built("view_mining_info", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto const view = built.chain().chain_view();
+    REQUIRE(view);
+
+    ::asio::io_context ctx;
+    std::optional<blockchain::mining_info> info;
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        if (auto const r = co_await built.chain().fetch_mining_info(); r) info = *r;
+    }, ::asio::detached);
+    ctx.run_for(std::chrono::seconds(30));
+
+    REQUIRE(info);
+    CHECK(info->blocks == view->state->height() - 1u);
+    CHECK(info->blocks == trunk_len);
+}
+
+TEST_CASE("a failed publication leaves the view and the generation alone", "[chain_view]") {
+    // Failing rather than keeping the old view quietly is the point: at the
+    // close of a batch or a reorganization, being unable to describe the state
+    // just reached is not something to carry on from. What must not happen is a
+    // half-published triple, or a generation that moved without a state to go
+    // with it — a reader would then see a number saying something changed and a
+    // view saying it did not.
+    built_chain built("view_publish_failure", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto const before = built.chain().chain_view();
+    REQUIRE(before);
+
+    // A height the chain cannot resolve: past everything it holds.
+    auto const ec = built.chain().publish_chain_view(trunk_len + 5000u);
+    CHECK(ec);
+
+    auto const after = built.chain().chain_view();
+    REQUIRE(after);
+    CHECK(after->generation == before->generation);
+    CHECK(after->state->height() == before->state->height());
+    CHECK(after->tip_hash == before->tip_hash);
+
+    // The previous view is still there and still coherent — which is why the
+    // caller has to treat the error as fatal rather than read on: nothing in the
+    // view itself says it is out of date.
+    CHECK(after->state->height() == trunk_len + 1u);
+
+    // And the generation has no hole in it. A failure that moved the counter
+    // without publishing would leave a number no view ever carries, so a reader
+    // comparing generations would see one it can never be given and conclude
+    // something was published that was not. Several failures, then a success
+    // that lands exactly one above where it started.
+    for (int i = 0; i < 5; ++i) {
+        CHECK(built.chain().publish_chain_view(trunk_len + 5000u + uint32_t(i)));
+    }
+    CHECK(built.chain().chain_view()->generation == before->generation);
+
+    REQUIRE_FALSE(built.chain().publish_chain_view(trunk_len));
+    CHECK(built.chain().chain_view()->generation == before->generation + 1u);
+}
+
+TEST_CASE("a template built after a batch names the new tip", "[chain_view]") {
+    // The template cache refuses to serve a snapshot from a previous tip, and it
+    // decides that by comparing the parent hash. That guard could never fire
+    // while the parent came from a height frozen at startup: the key never
+    // changed, so a template built before a batch would keep being served after
+    // it — on a parent the chain had left behind.
+    built_chain built("view_template_cache", trunk_len);
+    built.add_headers(built.trunk, 1);
+
+    std::vector<domain::chain::block> first(built.trunk.begin(), built.trunk.begin() + 20);
+    std::vector<domain::chain::block> second(built.trunk.begin() + 20, built.trunk.end());
+    connect_bodies(built.fixture, first, 1);
+
+    auto const fetch = [&]() -> std::optional<blockchain::mining_template> {
+        ::asio::io_context ctx;
+        std::optional<blockchain::mining_template> out;
+        ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+            if (auto const r = co_await built.chain().fetch_mining_template(1000u); r) out = *r;
+        }, ::asio::detached);
+        ctx.run_for(std::chrono::seconds(30));
+        return out;
+    };
+
+    auto const early = fetch();
+    REQUIRE(early);
+    CHECK(early->previous_block_hash == first.back().hash());
+    CHECK(early->height == 21u);
+
+    connect_bodies(built.fixture, second, 21);
+
+    auto const later = fetch();
+    REQUIRE(later);
+    CHECK(later->previous_block_hash == built.trunk.back().hash());
+    CHECK(later->height == trunk_len + 1u);
+
+    // And specifically not the earlier one served again.
+    CHECK(later->previous_block_hash != early->previous_block_hash);
+}
+
+TEST_CASE("the branch path answers null before anything is published", "[chain_view]") {
+    // A branch's state is seeded from the published one, and building it reads
+    // through that seed. There is exactly one window where none exists — a chain
+    // constructed but not started, since start() is what publishes the first —
+    // and the branch path has to answer rather than read through nothing.
+    test::chain_fixture fixture("view_unstarted");
+    REQUIRE(fixture.created());
+
+    // Deliberately not started.
+    blockchain::settings chain_settings(domain::config::network::regtest);
+    database::settings db_settings;
+    db_settings.directory = fixture.dir();
+
+    blockchain::block_chain chain(chain_settings, db_settings,
+                                  domain::config::network::regtest,
+                                  /*relay_transactions*/ false);
+
+    REQUIRE(chain.chain_view() == nullptr);
+
+    auto const branch_ptr = std::make_shared<blockchain::branch>(0u, chain.block_validations());
+    CHECK(chain.chain_state(branch_ptr) == nullptr);
+}

--- a/src/node/test/mempool_admission.cpp
+++ b/src/node/test/mempool_admission.cpp
@@ -82,16 +82,14 @@ struct admission_chain {
         persist_headers(fixture, trunk, 1);
         connect_bodies(fixture, trunk, 1);
 
-        // The chain computes the state a transaction is validated against once,
-        // at startup, and nothing advances it as blocks connect (#605). So a
-        // chain built in this process is stuck validating at the height it was
-        // created at, and every prevout reads as missing. Restarting recomputes
-        // it, which is the only way to reach a usable state today — a way around
-        // #605 for this test, not something a running node may rely on.
-        REQUIRE(fixture.restart());
-        auto const state = fixture.chain().chain_state();
-        REQUIRE(state);
-        REQUIRE(state->height() == trunk_len + 1u);
+        // No restart. The connect path publishes the chain state at the close of
+        // every batch (#605), so the state a transaction is validated against is
+        // the one this chain just reached — which is what a running node needs,
+        // since a node cannot restart itself to stay correct.
+        auto const view = fixture.chain().chain_view();
+        REQUIRE(view);
+        REQUIRE(view->state->height() == trunk_len + 1u);
+        REQUIRE(view->tip_hash == trunk.back().hash());
     }
 
     blockchain::block_chain& chain() { return fixture.chain(); }

--- a/src/node/test/reorg_cycle.cpp
+++ b/src/node/test/reorg_cycle.cpp
@@ -142,6 +142,12 @@ TEST_CASE("the node reorganizes onto a heavier branch and back to a consistent s
         prev = branch_b.back().hash();
     }
 
+    // The published state as it stands on A, to compare against after the switch.
+    auto const view_on_a = chain.chain_view();
+    REQUIRE(view_on_a);
+    REQUIRE(view_on_a->state->height() == 102u);
+    REQUIRE(view_on_a->tip_hash == a101.hash());
+
     auto const generation_before = index.generation();
     auto const b_result = fixture.organizer().add_headers(headers_of(branch_b));
     REQUIRE(b_result.reorg_candidate);
@@ -178,6 +184,23 @@ TEST_CASE("the node reorganizes onto a heavier branch and back to a consistent s
     // switch releases the pause — so a height left over from the branch just
     // abandoned would be read before anything corrected it.
     CHECK(fixture.organizer().validated_height() == int32_t(trunk_len));
+
+    // The published state followed the switch, and followed it *down*: the
+    // connected chain is back at the fork, so the height fell — while the
+    // generation rose, because a state was published. That pairing is the whole
+    // point of counting published states rather than heights; a counter derived
+    // from the height would have gone backwards here, and a reader comparing it
+    // would conclude nothing had changed (#605).
+    //
+    // The fork, not B's head: the switch rewound the connected chain, and B's
+    // blocks are headers until the ordinary connect path applies their deltas.
+    auto const view_on_b = chain.chain_view();
+    REQUIRE(view_on_b);
+    CHECK(view_on_b->state->height() == trunk_len + 1u);
+    CHECK(view_on_b->state->height() < view_on_a->state->height());
+    CHECK(view_on_b->tip_hash == trunk.back().hash());
+    CHECK(view_on_b->tip_hash != view_on_a->tip_hash);
+    CHECK(view_on_b->generation > view_on_a->generation);
 
     // A's block is disconnected: its coinbase is out of the set and the coinbase it
     // spent is back, at the height it was originally created — not at 101, which


### PR DESCRIPTION
`chain_state()` was computed once, in `start()`, and never advanced — its only mutator, `set_chain_state`, had no callers. A running node validated every transaction against the height it had when the process began, along with the median time past and the fork-activation flags in force then.

**Admission was one of four readers**, and the only one anyone had proposed to fix. The other three are mining, and two already combined the frozen value with a fresh read:

- `fetch_mining_info` reported the current height beside the difficulty in force at startup;
- `fetch_mining_template` derived the template's parent from the frozen height — `get_block_hash(height - 1)` — so on a node that had connected anything, that was not the tip. The cache guards against exactly this, refusing a snapshot from a previous tip, and it decides by comparing that hash. **A guard whose input never changes is a guard that keeps passing.**

## What changes

The state, the tip and a number labelling the pair travel together, in one immutable object behind one pointer, swapped once. A reader holds the previous triple or the next one. The two mixing readers have nothing left to mix: `get_block_hash` and `fetch_last_height` are gone from those paths — not by discipline, but because there is nothing to call.

`publish_chain_view(connected_tip_height)` takes one thing: the last block whose state is coherently applied. State and hash are derived from it here, the generation advances internally, so a caller cannot assemble a combination that never existed. It returns a `code` and **fails rather than keeping the previous view** — the old view is still coherent and says nothing about being stale, so the return value is the only signal there is.

The height is given and not read, because the two tips differ. `populate()` built from `heights.header`, which during a sync runs thousands of blocks ahead of what is connected: a state carrying a height, an MTP and activation flags for a block whose UTXO delta has not been applied. Internally consistent, describing nothing. That overload is gone; so is `set_chain_state`; and `chain_state()` alone is now private.

## Where it publishes

| | |
|---|---|
| startup | from `heights.block`, never `heights.header` |
| batch close | after the delta, the undo records, the height marker and the mempool update |
| reorg close | with the writers still parked, from the **validated tip** — not the branch head |

The switch rewinds the connected chain to the fork; blocks above are headers until the ordinary path applies their deltas. So a reorganization moves the height **down** while the generation moves **up** — which is what counting published states rather than heights is for. A counter derived from the height would have gone backwards, and a reader comparing it would conclude nothing had changed.

## Tests

Nine. Initial publication; headers arriving without connecting anything, moving neither view nor generation; a batch, and a second; the triple read whole while batches are published, checking that the hash a view carries belongs to the block below the height it carries; mining info from one publication; a template naming the new tip rather than the cached one; a failed publication leaving view *and* generation untouched; and the reorganization — height down, hash changed, generation up.

**The admission tests from #607 no longer restart the chain.** That restart was explicitly a way around this bug, and not something a running node could do.

Blockchain 3751/208, node 2191/152.

## What this does not fix

During a transition, template construction can still run against stores that are mid-mutation. This makes the published state coherent and whole; keeping readers out of the window while it is being reached is separate, and depends on settling ownership and readiness with #590.

Closes #605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a consistent, immutable chain snapshot containing the current state, tip, and generation.
  - Chain updates are published automatically after synchronization, batch processing, and reorganizations.
  - Mining information, templates, and transaction validation now use the same snapshot for consistent results.

- **Bug Fixes**
  - Improved handling of chain reorganizations and height changes.
  - Added failure detection when updated chain information cannot be published.

- **Tests**
  - Added coverage for concurrent reads, synchronization, reorganizations, mining data, and publication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->