### PR TITLE
ci: run github-script on Node.js 24

### DIFF
--- a/.github/workflows/check-conan-updates.yml
+++ b/.github/workflows/check-conan-updates.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create issue if updates available
         if: steps.check.outputs.exit_code == '1' && github.event_name == 'schedule'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Closes #618.

## What changed

Pins `actions/github-script` to the v8.0.0 commit in the Conan dependency workflow.

## Why

Version 7 targets Node.js 20, which GitHub has deprecated and currently forces through the Node.js 24 runtime with a warning. Version 8 declares `node24` directly.

The repository-wide workflow audit found no other active `actions/github-script` use. Version 9 was not selected because it adds unrelated breaking API changes; v8 is the minimal runtime migration, and the existing script uses only the injected `github` and `context` objects supported by it.

## Validation

- actionlint 1.7.12
- YAML parsing with PyYAML
- `python3 -m unittest scripts/test_check_conan_updates.py` (7 tests)
- repository-wide search for active `actions/github-script` and Node.js 20 workflow references
