### PR TITLE
blockchain: admit a template's capture or refuse it, rather than asking whether a transition is running

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -186,6 +186,7 @@ set(kth_sources_just_legacy
   src/pools/transaction_organizer.cpp
   src/pools/mempool.cpp
   src/pools/block_template.cpp
+  src/pools/capture_gate.cpp
   src/pools/mempool_transaction_summary.cpp
   src/populate/populate_base.cpp
   src/populate/populate_chain_state.cpp
@@ -229,6 +230,7 @@ set(kth_headers
   include/kth/blockchain/validate/validate_transaction.hpp
   include/kth/blockchain/pools/block_entry.hpp
   include/kth/blockchain/pools/block_template.hpp
+  include/kth/blockchain/pools/capture_gate.hpp
   include/kth/blockchain/pools/mempool.hpp
   include/kth/blockchain/pools/mempool_config.hpp
   include/kth/blockchain/pools/mempool_hashers.hpp
@@ -303,6 +305,7 @@ if (ENABLE_TEST)
         test/branch.cpp
         test/validate_transaction.cpp
         test/mempool_block_connect.cpp
+        test/capture_gate.cpp
         test/mempool_lease_bench.cpp
         test/mempool_test.cpp
         test/mempool_persistence_test.cpp

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -35,6 +35,7 @@
 #include <kth/blockchain/header_index.hpp>
 #include <kth/blockchain/pools/block_organizer.hpp>
 #include <kth/blockchain/pools/branch.hpp>
+#include <kth/blockchain/pools/capture_gate.hpp>
 #include <kth/blockchain/pools/block_template.hpp>
 #include <kth/blockchain/pools/mempool.hpp>
 #include <kth/blockchain/pools/mempool_transaction_summary.hpp>
@@ -286,6 +287,13 @@ struct KB_API block_chain {
         // (nothing was touched); the caller must then leave its counters alone
         // rather than treat it as height 0.
         std::optional<uint32_t> validated_tip;
+        // Whether any block was actually disconnected. Carried rather than
+        // inferred: several rejections happen before anything is touched and
+        // still report the current tip, so comparing heights cannot tell them
+        // from a switch that rewound to where the chain already was. A caller
+        // that republished on those would move the generation and drop the
+        // template cache for a switch that did nothing.
+        bool mutated{false};
     };
 
     [[nodiscard]]
@@ -392,6 +400,11 @@ struct KB_API block_chain {
         /// The context for validating the block after the connected tip, so its
         /// height is the tip's plus one.
         domain::chain::chain_state::ptr state;
+        /// The height of the connected tip. Carried rather than derived: every
+        /// reader that wanted it was subtracting one from the state's height,
+        /// and an off-by-one in a comparison against the header tip is the kind
+        /// of thing that reads as "not caught up" forever.
+        size_t connected_tip_height;
         /// The hash of the block at the connected tip.
         hash_digest tip_hash;
         /// Advances once per coherent state published — never per internal step,
@@ -424,6 +437,42 @@ struct KB_API block_chain {
     /// rather than carry on against a view that describes an older chain.
     [[nodiscard]]
     code publish_chain_view(size_t connected_tip_height);
+
+    /// Close template capture and wait for the captures already admitted.
+    ///
+    /// Called before the first mutation of a batch or a reorganization, so that
+    /// nothing captures the stores while they are being changed. Returns false
+    /// if a transition is already running, which the caller must treat as fatal
+    /// rather than proceed: two at once is not a state this has an answer for.
+    [[nodiscard]]
+    bool begin_transition();
+
+    /// Reopen capture. Only after the transition's state has been published —
+    /// a failure leaves the gate closed while the node winds down, which is why
+    /// this is a call and not a scope guard.
+    void end_transition();
+
+    [[nodiscard]]
+    bool transition_in_progress() const;
+
+    /// Whether this node should be serving mining work: it has connected
+    /// everything it has headers for, and that tip is recent.
+    ///
+    /// Two components, because they fail for different reasons and only one is
+    /// about the clock. `caught_up` compares the published view's connected tip
+    /// against the active header tip — not the stored block marker, which
+    /// during a sync sits far ahead of both. `fresh` measures the published
+    /// tip's timestamp against the configured limit; a limit of zero disables
+    /// that half only, and never turns a node that is behind into one that is
+    /// caught up.
+    struct sync_status {
+        bool caught_up;
+        bool fresh;
+        [[nodiscard]] bool synchronized() const { return caught_up && fresh; }
+    };
+
+    [[nodiscard]]
+    sync_status synchronization() const;
 
     /// The state for a branch under consideration, seeded from the published
     /// one. Block validation only; the published view is what everything else
@@ -702,6 +751,8 @@ private:
     /// is seeding a branch's state below.
     [[nodiscard]]
     domain::chain::chain_state::ptr chain_state() const;
+
+    mutable capture_gate capture_gate_;
 
     // One swap publishes the whole triple; see published_chain_view.
     mutable boost::atomic_shared_ptr<published_chain_view const> chain_view_;

--- a/src/blockchain/include/kth/blockchain/pools/block_template.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/block_template.hpp
@@ -94,11 +94,19 @@ mining_template make_mining_template(
 
 // A snapshot of mining-relevant chain state, for the getmininginfo RPC and its
 // C-API counterpart.
+// A composite diagnostic, deliberately not a snapshot: `blocks`, `difficulty`
+// and `chain` come from one published chain view, while `pooled_tx` and the two
+// flags are read live. It stays answerable during a transition precisely because
+// that is when someone is looking at it, and describing it as internally atomic
+// would be a claim it cannot keep.
 struct mining_info {
     size_t blocks;                      // current block height (tip)
     double difficulty;                  // difficulty of the next required work
     size_t pooled_tx;                   // transactions in the mempool
     domain::config::network chain;      // network the node is on
+    bool transition_in_progress;        // a batch or reorganization is mutating
+    bool caught_up;                     // connected chain has reached its headers
+    bool fresh;                         // that tip is within the configured age
 };
 
 // The Bitcoin difficulty a compact nBits target represents (target 1 == 1.0).

--- a/src/blockchain/include/kth/blockchain/pools/capture_gate.hpp
+++ b/src/blockchain/include/kth/blockchain/pools/capture_gate.hpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_POOLS_CAPTURE_GATE_HPP
+#define KTH_BLOCKCHAIN_POOLS_CAPTURE_GATE_HPP
+
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+#include <optional>
+
+#include <kth/blockchain/define.hpp>
+
+namespace kth::blockchain {
+
+/// Keeps captures and transitions apart, which a flag cannot do.
+///
+/// A template is built from a chain view and a copy of the mempool. Asking
+/// whether a transition is running and then capturing are two moments, and a
+/// transition that begins between them mutates the stores the capture is about
+/// to read. What joins them is entry: a capture is admitted or refused, and a
+/// transition cannot start mutating until every admitted capture has finished.
+///
+/// A capture that was admitted before the close completes on what it took —
+/// its copies are private by then, so nothing a transition does can reach them.
+/// What the close stops is the next one.
+///
+/// Reopening is earned, not unwound. `end_transition` is called after the
+/// coherent state has been published, and only then; a scope guard that reopened
+/// on the way out would reopen after a failure too, which is the one case where
+/// the gate must stay shut while the node winds down.
+struct KB_API capture_gate {
+
+    /// Admits a capture, or refuses because a transition holds the gate.
+    /// Balanced by leave_capture; use captured_lease rather than pairing by hand.
+    [[nodiscard]]
+    bool try_enter_capture();
+
+    void leave_capture();
+
+    /// Closes entry and waits for every admitted capture to finish. Returns
+    /// false if a transition is already running — two at once is not a state
+    /// this has an answer for, and sharing a flag would let the first to finish
+    /// reopen for both.
+    [[nodiscard]]
+    bool begin_transition();
+
+    /// Reopens. Only after the transition's state has been published.
+    void end_transition();
+
+    [[nodiscard]]
+    bool transition_in_progress() const;
+
+    /// Diagnostic only.
+    [[nodiscard]]
+    size_t captures_in_flight() const;
+
+private:
+    mutable std::mutex mutex_;
+    std::condition_variable drained_;
+    bool open_{true};
+    bool in_transition_{false};
+    size_t capturing_{0};
+};
+
+/// An admitted capture. Falsey when the gate refused.
+///
+/// Deliberately not held across the build: everything after the copy runs on
+/// private data, and holding it there would make a transition wait for work
+/// that cannot be affected by it.
+struct KB_API captured_lease {
+    explicit captured_lease(capture_gate& gate)
+        : gate_(gate.try_enter_capture() ? &gate : nullptr)
+    {}
+
+    ~captured_lease() { release(); }
+
+    captured_lease(captured_lease const&) = delete;
+    captured_lease& operator=(captured_lease const&) = delete;
+
+    [[nodiscard]]
+    explicit operator bool() const { return gate_ != nullptr; }
+
+    /// Leaves early, so the build that follows runs outside the gate.
+    void release() {
+        if (gate_ != nullptr) {
+            gate_->leave_capture();
+            gate_ = nullptr;
+        }
+    }
+
+private:
+    capture_gate* gate_;
+};
+
+} // namespace kth::blockchain
+
+#endif // KTH_BLOCKCHAIN_POOLS_CAPTURE_GATE_HPP

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -1030,6 +1030,11 @@ block_chain::switch_result block_chain::switch_to_branch(
     // strand the still-missing blocks below it, never requested again.
     uint32_t validated_tip = heights->block;
 
+    // Whether any block was actually disconnected. A fork above the validated
+    // tip disconnects nothing and several rejections above return before this
+    // point, so "the tip is where it was" is not evidence either way.
+    bool mutated = false;
+
     if (fork_height > heights->block) {
         spdlog::info("[blockchain] Reorg: fork at {} is above the validated tip {}, nothing to disconnect",
             fork_height, heights->block);
@@ -1046,6 +1051,8 @@ block_chain::switch_result block_chain::switch_to_branch(
             auto const result = disconnect_block(h);
 
             if (result == database::disconnect_result::unclean) {
+                // The delta was applied, so this counts as a mutation even
+                // though the switch is abandoned.
                 // The inverse delta was applied but the markers could not be
                 // written: the UTXO set is at h-1 while the markers still say h.
                 // Reporting h as a resumable tip would re-download from a height
@@ -1054,7 +1061,7 @@ block_chain::switch_result block_chain::switch_to_branch(
                 spdlog::error("[blockchain] Reorg: UTXO set and height markers diverged at {} "
                     "(set is at {}, markers say {}); aborting without a resumable tip",
                     h, h - 1, h);
-                return {false, std::nullopt};
+                return {false, std::nullopt, /*mutated*/ true};
             }
 
             if (result != database::disconnect_result::ok) {
@@ -1064,8 +1071,11 @@ block_chain::switch_result block_chain::switch_to_branch(
                 // range, never re-downloaded).
                 spdlog::error("[blockchain] Reorg: failed to disconnect block at height {}, "
                     "aborting the switch (validated tip is now {})", h, h);
-                return {false, h};
+                return {false, h, mutated};
             }
+
+            // Applied. From here the chain has moved, whatever happens next.
+            mutated = true;
         }
     }
 
@@ -1078,7 +1088,7 @@ block_chain::switch_result block_chain::switch_to_branch(
     // other. The caller adopts the branch head as soon as this returns.
     spdlog::warn("[blockchain] Reorg: UTXO state rewound to the fork at {}; the branch head is "
         "published by the caller", fork_height);
-    return {true, validated_tip};
+    return {true, validated_tip, mutated};
 }
 #endif
 
@@ -1134,6 +1144,60 @@ void block_chain::clear_utxo_bloom() {
 // CHAIN STATE
 // =============================================================================
 
+bool block_chain::begin_transition() {
+    return capture_gate_.begin_transition();
+}
+
+void block_chain::end_transition() {
+    capture_gate_.end_transition();
+}
+
+bool block_chain::transition_in_progress() const {
+    return capture_gate_.transition_in_progress();
+}
+
+block_chain::sync_status block_chain::synchronization() const {
+    auto const view = chain_view();
+    if ( ! view) {
+        return {false, false};
+    }
+
+    // The connected tip against the header tip. The stored block marker is not
+    // this: during a sync it runs thousands of blocks ahead of what is
+    // connected, so a node with fresh headers and an unbuilt UTXO set would
+    // read as caught up (#605 was the same confusion one level down).
+    auto const header_tip = header_index_.active_tip_height();
+    bool const caught_up = header_tip >= 0 &&
+        view->connected_tip_height == size_t(header_tip);
+
+    // A limit of zero disables the clock half. It does not say the node is at
+    // the head — that is what caught_up is for, and it still has to hold.
+    if (notify_limit_seconds_ == 0) {
+        return {caught_up, true};
+    }
+
+    auto const tip_header = get_header(view->connected_tip_height);
+    if ( ! tip_header) {
+        return {caught_up, false};
+    }
+
+    auto const now = static_cast<uint32_t>(zulu_time());
+    auto const stamp = tip_header->timestamp();
+
+    // Subtract from now rather than add to the stamp. The sum is one addition
+    // away from wrapping wherever it lands in 32 bits, and a wrapped sum reads
+    // as fresh — the direction that keeps a stale node serving mining work.
+    // Subtracting cannot wrap: it floors at zero, where every timestamp is
+    // fresh, which is also the honest answer for a limit longer than the epoch.
+    // Both operands are uint32_t so the floor is zero and not a signed minimum.
+    auto const limit = notify_limit_seconds_ > time_t(std::numeric_limits<uint32_t>::max())
+        ? std::numeric_limits<uint32_t>::max()
+        : static_cast<uint32_t>(notify_limit_seconds_);
+
+    bool const fresh = stamp >= floor_subtract(now, limit);
+    return {caught_up, fresh};
+}
+
 block_chain::chain_view_ptr block_chain::chain_view() const {
     return chain_view_.load();
 }
@@ -1173,6 +1237,7 @@ code block_chain::publish_chain_view(size_t connected_tip_height) {
     }
 
     built->state = std::move(state);
+    built->connected_tip_height = connected_tip_height;
     built->tip_hash = *tip_hash;
     built->generation = view_generation_.fetch_add(1, std::memory_order_relaxed) + 1;
 
@@ -1892,13 +1957,29 @@ block_chain::fetch_template() const {
         co_return std::unexpected(error::service_stopped);
     }
 
-    auto const published = chain_view();
-    if ( ! published) {
-        co_return std::unexpected(error::not_found);
+    auto const ready = synchronization();
+    if ( ! ready.synchronized()) {
+        co_return std::unexpected(ready.caught_up ? error::node_stale : error::node_behind);
     }
-    auto const& state = published->state;
 
-    auto const view = lease_pool_view(validation_mutex_, mempool_);
+    // Capture inside the gate, build outside it. Asking whether a transition is
+    // running and then capturing are two moments; entry is what joins them.
+    chain_view_ptr published;
+    blockchain::pool_view view;
+    {
+        captured_lease const lease(capture_gate_);
+        if ( ! lease) {
+            co_return std::unexpected(error::transition_in_progress);
+        }
+
+        published = chain_view();
+        if ( ! published) {
+            co_return std::unexpected(error::not_found);
+        }
+        view = lease_pool_view(validation_mutex_, mempool_);
+    }
+
+    auto const& state = published->state;
 
     co_return build_block_template(view.entries, block_template_context{
         state->dynamic_max_block_size(),
@@ -1913,43 +1994,54 @@ block_chain::fetch_mining_template(uint64_t coinbase_reserve_size) const {
         co_return std::unexpected(error::service_stopped);
     }
 
-    auto const published = chain_view();
-    if ( ! published) {
-        co_return std::unexpected(error::not_found);
+    auto const ready = synchronization();
+    if ( ! ready.synchronized()) {
+        co_return std::unexpected(ready.caught_up ? error::node_stale : error::node_behind);
     }
-    auto const& state = published->state;
 
-    auto const height = state->height();
+    // This capture decides only whether an ALREADY BUILT template can be served.
+    // That is a weaker requirement than building one: a template is a coherent
+    // copy, so a request admitted before a transition may legitimately finish
+    // with it. Nothing here may feed a rebuild — see the recapture below.
+    hash_digest served_previous;
+    {
+        captured_lease const lease(capture_gate_);
+        if ( ! lease) {
+            co_return std::unexpected(error::transition_in_progress);
+        }
 
-    // The parent comes from the same publication as the height, not from a
-    // second lookup keyed on it. That pairing is what used to be wrong: the
-    // height was frozen at startup and the hash was read now, so the template
-    // could name a parent the chain had left behind — and the cache's guard
-    // against exactly that is keyed on this value, so it could never fire.
-    hash_digest const previous = published->tip_hash;
+        auto const published = chain_view();
+        if ( ! published) {
+            co_return std::unexpected(error::not_found);
+        }
+
+        served_previous = published->tip_hash;
+    }
 
     // Only decides whether to rebuild, so it is read without the lease: a value
     // that has already moved on costs one extra rebuild, and paying the
     // exclusion on every cache hit would cost far more. The label stored with a
     // rebuilt template comes from inside the lease instead — see below.
     auto const generation = mempool_.generation();
-    auto const now = static_cast<uint32_t>(zulu_time());
+    auto now = static_cast<uint32_t>(zulu_time());
 
     // A snapshot is usable while the tip is unchanged and the mempool is either
     // unchanged or its last change is still within the refresh window; a new tip
-    // always forces a rebuild.
-    auto const usable = [&](boost::shared_ptr<template_snapshot> const& s) {
+    // always forces a rebuild. The tip and generation are parameters rather than
+    // captures because this is asked twice, against two different captures.
+    auto const usable = [&](boost::shared_ptr<template_snapshot> const& s,
+                            hash_digest const& tip, uint64_t gen, uint32_t at) {
         return s &&
-               s->previous == previous &&
+               s->previous == tip &&
                s->coinbase_reserve_size == coinbase_reserve_size &&
-               (s->generation == generation ||
-                now - s->time < settings_.gbt_template_refresh_seconds);
+               (s->generation == gen ||
+                at - s->time < settings_.gbt_template_refresh_seconds);
     };
 
     // Lock-free read: rebuilds are expensive (full mempool scan + fee-rate
     // ordering), so serve the published snapshot when it is still usable.
     auto snapshot = template_cache_.load();
-    if (usable(snapshot)) {
+    if (usable(snapshot, served_previous, generation, now)) {
         co_return snapshot->value;
     }
 
@@ -1968,23 +2060,70 @@ block_chain::fetch_mining_template(uint64_t coinbase_reserve_size) const {
         // rather than block. Never serve a snapshot from a previous tip: a
         // wrong-parent template would orphan the miner's block, so wait for the
         // rebuild in that case (a cold start with no snapshot also waits).
-        if (snapshot && snapshot->previous == previous) {
+        // The same tip AND the same coinbase budget. A snapshot built for a
+        // different reserve leaves a different amount of room for the coinbase,
+        // so serving it here would answer this request with someone else's
+        // budget — and the caller asked for that number precisely because its
+        // coinbase does not fit the default. Wait for the rebuild instead.
+        if (snapshot && snapshot->previous == served_previous &&
+            snapshot->coinbase_reserve_size == coinbase_reserve_size) {
             co_return snapshot->value;
         }
         lock.lock();
     }
 
-    // Re-check under the lock: another thread may have published while we waited.
-    snapshot = template_cache_.load();
-    if (usable(snapshot)) {
-        co_return snapshot->value;
+    // Everything a rebuild consumes is captured HERE, inside one lease: the
+    // chain state, the tip it names, the height, and the mempool. Reading the
+    // chain view under one lease and the pool under another is not the same
+    // thing, however briefly each half was admitted — a whole transition can
+    // run between the two, and the template would then pair a pre-transition
+    // parent and height with a post-transition pool. Each half is coherent with
+    // the gate and the pair is coherent with nothing.
+    //
+    // Lock order: template_rebuild_mutex_ (held above), then the capture gate,
+    // then the validation mutex. Nothing takes them the other way round — the
+    // organizers hold the validation mutex and know nothing about the template
+    // cache, and a transition drains the gate without taking either.
+    chain_view_ptr published;
+    blockchain::pool_view view;
+    {
+        captured_lease const lease(capture_gate_);
+        if ( ! lease) {
+            co_return std::unexpected(error::transition_in_progress);
+        }
+
+        published = chain_view();
+        if ( ! published) {
+            co_return std::unexpected(error::not_found);
+        }
+
+        // Re-check against the publication just captured rather than the one
+        // the fast path used. The wait on the rebuild mutex may have spanned a
+        // whole transition, in which case that earlier check decided nothing —
+        // and asking before copying the pool keeps a hit from paying for a copy
+        // it will discard.
+        now = static_cast<uint32_t>(zulu_time());
+        snapshot = template_cache_.load();
+        if (usable(snapshot, published->tip_hash, mempool_.generation(), now)) {
+            co_return snapshot->value;
+        }
+
+        view = lease_pool_view(validation_mutex_, mempool_);
     }
 
-    // Lock order: template_rebuild_mutex_ (held above) then the validation
-    // mutex. Nothing takes them the other way round — the organizers hold the
-    // validation mutex and know nothing about the template cache.
-    auto const view = lease_pool_view(validation_mutex_, mempool_);
+    auto const& state = published->state;
 
+    // The parent comes from the same capture as the height and the state, not
+    // from a second lookup keyed on it. That pairing is what used to be wrong:
+    // the height was frozen at startup and the hash was read now, so the
+    // template could name a parent the chain had left behind — and the cache's
+    // guard against exactly that is keyed on this value, so it could never fire.
+    hash_digest const previous = published->tip_hash;
+    auto const height = state->height();
+
+    // Everything below runs on the copy, outside the gate: holding it across
+    // the graph, the ordering and the selection would make a transition wait on
+    // work that cannot be affected by it.
     auto selection = build_block_template(view.entries, block_template_context{
         state->dynamic_max_block_size(),
         state->dynamic_max_block_sigchecks(),
@@ -2026,11 +2165,16 @@ block_chain::fetch_mining_info() const {
     // Every field from the one publication. Reading the height separately is
     // how this reported the current tip beside the difficulty in force when the
     // node started.
+    auto const ready = synchronization();
+
     co_return blockchain::mining_info{
-        uint32_t(state->height() - 1u),
+        uint32_t(published->connected_tip_height),
         difficulty_from_bits(state->work_required()),
         mempool_.size(),
-        state->network()};
+        state->network(),
+        transition_in_progress(),
+        ready.caught_up,
+        ready.fresh};
 }
 
 awaitable_expected<inventory_ptr>

--- a/src/blockchain/src/pools/capture_gate.cpp
+++ b/src/blockchain/src/pools/capture_gate.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/blockchain/pools/capture_gate.hpp>
+
+#include <spdlog/spdlog.h>
+
+namespace kth::blockchain {
+
+bool capture_gate::try_enter_capture() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if ( ! open_) {
+        return false;
+    }
+    ++capturing_;
+    return true;
+}
+
+void capture_gate::leave_capture() {
+    bool notify = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        --capturing_;
+        notify = (capturing_ == 0);
+    }
+    // Outside the lock: the waiter has to take it to observe the count.
+    if (notify) {
+        drained_.notify_all();
+    }
+}
+
+bool capture_gate::begin_transition() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (in_transition_) {
+        spdlog::critical("[blockchain] A transition began while another was already running");
+        return false;
+    }
+
+    in_transition_ = true;
+    open_ = false;
+
+    // Captures admitted before the close finish on copies they already hold.
+    // Waiting for them is what makes "no capture is reading these stores" true
+    // rather than merely likely.
+    drained_.wait(lock, [this] { return capturing_ == 0; });
+    return true;
+}
+
+void capture_gate::end_transition() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if ( ! in_transition_) {
+            spdlog::critical("[blockchain] A transition ended that had not begun");
+            return;
+        }
+        in_transition_ = false;
+        open_ = true;
+    }
+    // Nothing waits on the gate opening — captures are refused, not queued, so
+    // the caller retries rather than blocking on a transition of unknown length.
+}
+
+bool capture_gate::transition_in_progress() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return in_transition_;
+}
+
+size_t capture_gate::captures_in_flight() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return capturing_;
+}
+
+} // namespace kth::blockchain

--- a/src/blockchain/test/capture_gate.cpp
+++ b/src/blockchain/test/capture_gate.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <kth/blockchain/pools/capture_gate.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace kth;
+using kth::blockchain::capture_gate;
+using kth::blockchain::captured_lease;
+
+// =============================================================================
+// Keeping captures and transitions apart (#621)
+// =============================================================================
+//
+// A flag read on entry cannot do this: asking whether a transition is running
+// and then capturing are two moments, and a transition that begins between them
+// mutates the stores the capture is about to read. What joins them is that entry
+// is admitted or refused, and that a transition cannot start mutating until
+// every admitted capture has finished.
+
+TEST_CASE("a capture is admitted while nothing is transitioning", "[capture_gate]") {
+    capture_gate gate;
+
+    captured_lease const lease(gate);
+    CHECK(bool(lease));
+    CHECK(gate.captures_in_flight() == 1u);
+    CHECK_FALSE(gate.transition_in_progress());
+}
+
+TEST_CASE("a capture is refused while a transition holds the gate", "[capture_gate]") {
+    capture_gate gate;
+    REQUIRE(gate.begin_transition());
+
+    captured_lease const lease(gate);
+    CHECK_FALSE(bool(lease));
+    CHECK(gate.transition_in_progress());
+
+    gate.end_transition();
+    captured_lease const after(gate);
+    CHECK(bool(after));
+}
+
+TEST_CASE("a transition waits for a capture that was already admitted", "[capture_gate]") {
+    // The crossing the whole design is about, provoked rather than observed: a
+    // capture is admitted and parked, a transition tries to begin, and the
+    // transition must not be able to proceed until that capture is done.
+    capture_gate gate;
+
+    captured_lease lease(gate);
+    REQUIRE(bool(lease));
+
+    std::atomic<bool> began{false};
+    std::atomic<bool> started{false};
+
+    // Catch2's macros are not thread-safe: a failure inside a spawned thread
+    // throws out of it and terminates, and the handler mutates run state the
+    // main thread is also writing. The thread records, the main thread asserts.
+    std::atomic<bool> begin_ok{false};
+
+    std::thread transition([&] {
+        started = true;
+        begin_ok = gate.begin_transition();
+        began = true;
+    });
+
+    // Give it every chance to finish early. If begin_transition returned while a
+    // capture was still in flight, this is where it would show.
+    while ( ! started) std::this_thread::yield();
+    for (int i = 0; i < 200 && ! began; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    CHECK_FALSE(began.load());
+    CHECK(gate.captures_in_flight() == 1u);
+
+    // The capture finishes; only now may the transition proceed.
+    lease.release();
+    transition.join();
+    CHECK(begin_ok.load());
+    CHECK(began.load());
+    CHECK(gate.captures_in_flight() == 0u);
+
+    gate.end_transition();
+}
+
+TEST_CASE("a capture admitted before the close is not interrupted by it", "[capture_gate]") {
+    // The other half: closing entry stops the next capture, not the one that is
+    // already holding copies. Nothing revokes an admitted lease.
+    capture_gate gate;
+
+    captured_lease lease(gate);
+    REQUIRE(bool(lease));
+
+    std::atomic<bool> begin_ok{false};
+    std::thread transition([&] { begin_ok = gate.begin_transition(); });
+
+    // Still admitted while the transition waits.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    CHECK(gate.captures_in_flight() == 1u);
+
+    lease.release();
+    transition.join();
+    CHECK(begin_ok.load());
+    gate.end_transition();
+}
+
+TEST_CASE("a second transition is refused rather than nested", "[capture_gate]") {
+    // Sharing a flag would let the first to finish reopen for both.
+    capture_gate gate;
+    REQUIRE(gate.begin_transition());
+    CHECK_FALSE(gate.begin_transition());
+
+    gate.end_transition();
+    CHECK(gate.begin_transition());
+    gate.end_transition();
+}
+
+TEST_CASE("the gate stays closed until a transition ends", "[capture_gate]") {
+    // Reopening is earned. There is no path that reopens on the way out of a
+    // scope, because a failure inside the window must leave it shut.
+    capture_gate gate;
+    REQUIRE(gate.begin_transition());
+
+    for (int i = 0; i < 5; ++i) {
+        captured_lease const refused(gate);
+        CHECK_FALSE(bool(refused));
+    }
+
+    gate.end_transition();
+    captured_lease const admitted(gate);
+    CHECK(bool(admitted));
+}
+
+TEST_CASE("many captures drain before a transition begins", "[capture_gate]") {
+    capture_gate gate;
+
+    constexpr int readers = 8;
+    std::atomic<int> admitted{0};
+    std::atomic<bool> release{false};
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < readers; ++i) {
+        threads.emplace_back([&] {
+            captured_lease lease(gate);
+            if (lease) {
+                ++admitted;
+                while ( ! release) std::this_thread::yield();
+            }
+        });
+    }
+
+    while (admitted < readers) std::this_thread::yield();
+    CHECK(gate.captures_in_flight() == size_t(readers));
+
+    std::atomic<bool> began{false};
+    std::atomic<bool> begin_ok{false};
+    std::thread transition([&] {
+        begin_ok = gate.begin_transition();
+        began = true;
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    CHECK_FALSE(began.load());
+
+    release = true;
+    for (auto& t : threads) t.join();
+    transition.join();
+
+    CHECK(begin_ok.load());
+    CHECK(began.load());
+    CHECK(gate.captures_in_flight() == 0u);
+    gate.end_transition();
+}

--- a/src/blockchain/test/reorg_chain_fixture.hpp
+++ b/src/blockchain/test/reorg_chain_fixture.hpp
@@ -29,6 +29,17 @@ namespace kth::test {
 // Regtest is used deliberately: its proof-of-work target is trivial, so a test
 // can build competing chains without mining.
 struct chain_fixture {
+    // The freshness half of synchronization compares the connected tip's
+    // timestamp against notify_limit_hours. A test that needs a chain which is
+    // complete but stale cannot move the clock or the blocks — the connect path
+    // refuses a chain old enough to look like initial sync — so it moves the
+    // limit instead.
+    chain_fixture(char const* tag, uint32_t notify_limit_hours)
+        : chain_fixture(tag)
+    {
+        chain_settings_.notify_limit_hours = notify_limit_hours;
+    }
+
     explicit chain_fixture(char const* tag)
         : dir_(make_dir(tag))
         , chain_settings_(domain::config::network::regtest)
@@ -99,6 +110,18 @@ struct chain_fixture {
         organizer_.reset();
         chain_.reset();
         return start();
+    }
+
+    // Bring the chain down and leave it down, so the directory can be opened by
+    // something else — a second block_chain with different settings reading the
+    // data this one wrote. Two live opens of one data directory is not something
+    // the stack supports: the LMDB environment, UTXO-Z and the flat-file stores
+    // each hold their own handles and cached state for that path.
+    //
+    // `chain()` and `organizer()` must not be used after this.
+    void close() {
+        organizer_.reset();
+        chain_.reset();
     }
 
     [[nodiscard]] blockchain::header_organizer& organizer() { return *organizer_; }

--- a/src/c-api/include/kth/capi/chain/mining_info.h
+++ b/src/c-api/include/kth/capi/chain/mining_info.h
@@ -5,13 +5,26 @@
 #ifndef KTH_CAPI_CHAIN_MINING_INFO_H_
 #define KTH_CAPI_CHAIN_MINING_INFO_H_
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
+// Mirrors kth::blockchain::mining_info. The conversion names every field
+// (mining_info_conversion.hpp) rather than copying the bytes. The C field order
+// remains ABI; it is no longer coupled to the C++ declaration order.
+//
+// A composite diagnostic rather than a snapshot — blocks, difficulty and chain
+// come from one published chain view, pooled_tx and the three flags are read
+// live. Answerable while the node refuses to serve mining work, which is when
+// it is worth reading.
 typedef struct kth_mining_info {
     size_t blocks;
     double difficulty;
     size_t pooled_tx;
     uint32_t chain;
+    bool transition_in_progress;   // a batch or reorganization is mutating
+    bool caught_up;                // connected chain has reached its headers
+    bool fresh;                    // that tip is within the configured age
 } kth_mining_info_t;
 
 #endif // KTH_CAPI_CHAIN_MINING_INFO_H_

--- a/src/c-api/include/kth/capi/chain/mining_info_conversion.hpp
+++ b/src/c-api/include/kth/capi/chain/mining_info_conversion.hpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_CAPI_CHAIN_MINING_INFO_CONVERSION_HPP_
+#define KTH_CAPI_CHAIN_MINING_INFO_CONVERSION_HPP_
+
+#include <cstdint>
+
+#include <kth/capi/chain/mining_info.h>
+#include <kth/capi/helpers.hpp>
+
+#include <kth/blockchain/pools/block_template.hpp>
+
+namespace kth {
+
+// Both sides opt out of the byte copy, so a later call that reaches the generic
+// path with either type fails to compile rather than quietly putting layout,
+// padding and declaration order back into the ABI.
+template <> struct forbids_struct_cast<blockchain::mining_info> : std::true_type {};
+template <> struct forbids_struct_cast<kth_mining_info_t> : std::true_type {};
+
+// `kth::blockchain::mining_info` crosses to C field by field rather than by
+// memcpy.
+//
+// The generic conversion copies the bytes and asserts the two structs are the
+// same size, which makes layout, padding and DECLARATION ORDER part of the ABI
+// without saying so: three trailing `bool` fields pack into the same size in
+// either order, so swapping two of them changes what every caller reads and
+// nothing — not the size assertion, not the compiler — objects. Naming each
+// field costs nothing at runtime and makes a rename fail to compile and a
+// reorder harmless.
+//
+// It also removes the one real type mismatch: `chain` is an enum on the C++
+// side and a `uint32_t` on the C side, so the conversion is a cast, and a cast
+// is better written than implied by a memcpy.
+template <>
+inline
+kth_mining_info_t to_c_struct<kth_mining_info_t, blockchain::mining_info>(
+    blockchain::mining_info const& cpp) {
+
+    // Zero-initialized, so a field added to the C struct before its assignment
+    // is written here crosses as zero rather than as whatever was on the stack.
+    kth_mining_info_t out{};
+    out.blocks = cpp.blocks;
+    out.difficulty = cpp.difficulty;
+    out.pooled_tx = cpp.pooled_tx;
+    out.chain = static_cast<uint32_t>(cpp.chain);
+    out.transition_in_progress = cpp.transition_in_progress;
+    out.caught_up = cpp.caught_up;
+    out.fresh = cpp.fresh;
+    return out;
+}
+
+} // namespace kth
+
+#endif // KTH_CAPI_CHAIN_MINING_INFO_CONVERSION_HPP_

--- a/src/c-api/include/kth/capi/conversions.hpp
+++ b/src/c-api/include/kth/capi/conversions.hpp
@@ -46,6 +46,13 @@
 #include <kth/blockchain/interface/block_chain.hpp>
 // #endif
 
+// Field-by-field conversion for the one POD that would otherwise cross by
+// memcpy with its declaration order load-bearing. Included here, from the
+// umbrella every binding TU takes, so the specialization is always visible
+// before the call — a TU that saw only the generic template would silently get
+// the memcpy back.
+#include <kth/capi/chain/mining_info_conversion.hpp>
+
 // Element type for the hand-written `kth_wallet_ec_compressed_list`
 // binding. The list stores the raw 33-byte EC compressed public keys
 // by value, not wrapped `kth::domain::wallet::ec_compressed` objects.

--- a/src/c-api/include/kth/capi/helpers.hpp
+++ b/src/c-api/include/kth/capi/helpers.hpp
@@ -317,8 +317,18 @@ inline std::optional<T> optional_cpp_ref(void const* h) {
 // small struct memcpy to register moves). static_assert guards that the
 // source and destination structs have the same size.
 // Works both directions: C→C++ and C++→C.
+// A type that has an explicit field-by-field conversion opts out of the byte
+// copy here, on both sides of the crossing. Specialize it next to that
+// conversion; the generic path below then refuses the type instead of silently
+// reintroducing the coupling the explicit conversion exists to remove.
+template<typename T>
+struct forbids_struct_cast : std::false_type {};
+
 template<typename To, typename From>
 inline To struct_cast(From const& src) {
+    static_assert( ! forbids_struct_cast<To>::value && ! forbids_struct_cast<From>::value,
+                  "this type crosses field by field; the memcpy conversion would put its "
+                  "layout, padding and declaration order back into the ABI");
     static_assert(sizeof(To) == sizeof(From),
                   "C and C++ struct sizes must match for memcpy conversion");
     static_assert(std::is_trivially_copyable_v<To> && std::is_trivially_copyable_v<From>,

--- a/src/infrastructure/include/kth/infrastructure/error.hpp
+++ b/src/infrastructure/include/kth/infrastructure/error.hpp
@@ -184,7 +184,8 @@ enum error_code_t {
     reorganize_empty_blocks,              
     chain_state_invalid,                  
     pool_state_failed,
-    transaction_lookup_failed,            
+
+    transaction_lookup_failed,
     branch_work_failed,
     block_validation_state_failed,
     transaction_validation_state_failed,
@@ -303,6 +304,17 @@ enum error_code_t {
     invalid_split_range,                // SPLIT position out of range
     invalid_number_encoding,            // BIN2NUM result not minimally encoded
     operand_size_mismatch,              // Bitwise operation operands differ in size
+
+    // Why mining work is not being served. Three states, not one: a transition
+    // is a correctness barrier and clears in milliseconds, while the other two
+    // are operational and clear when the node catches up.
+    //
+    // Appended here rather than filed next to the other blockchain codes on
+    // purpose: these values cross the C API, so inserting mid-enum would
+    // renumber every code below the insertion point for no gain.
+    transition_in_progress,   ///< A batch or reorganization is mutating the stores.
+    node_behind,              ///< Connected chain has not reached the headers it holds.
+    node_stale,               ///< Caught up, but the tip is older than the configured limit.
 
     // Last error code.
     last_error_code

--- a/src/infrastructure/src/error.cpp
+++ b/src/infrastructure/src/error.cpp
@@ -284,6 +284,11 @@ std::string error_category_impl::message(int ev) const noexcept {
         { error::hash_not_found, "hash not found" },
         { error::empty_cache, "empty cache" },
         { error::utxo_not_found, "utxo not found" },
+
+        // Why mining work is not being served.
+        { error::transition_in_progress, "a batch or reorganization is in progress" },
+        { error::node_behind, "the connected chain has not caught up with its headers" },
+        { error::node_stale, "the chain tip is older than the configured limit" },
     };
 
     auto const message = messages.find(ev);

--- a/src/node/src/rpc/mining.cpp
+++ b/src/node/src/rpc/mining.cpp
@@ -73,6 +73,12 @@ std::string render_mining_info(blockchain::mining_info const& info) {
     w.field("difficulty", info.difficulty);
     w.field("pooledtx", static_cast<std::uint64_t>(info.pooled_tx));
     w.field("chain", domain::config::name(info.chain));
+    // Why mining work may be refused, reported apart. A transition is a
+    // correctness barrier and clears in milliseconds; the other two are
+    // operational and clear when the node catches up.
+    w.field("transitioninprogress", info.transition_in_progress);
+    w.field("caughtup", info.caught_up);
+    w.field("fresh", info.fresh);
     w.field("warnings", "");
     w.end_object();
     return w.str();

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -2099,6 +2099,16 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             timestamp_window.push_back(block_timestamp);
         }
 
+        // Entry closes here, before the first mutation, and the captures already
+        // admitted are drained before anything moves. A template that entered
+        // earlier finishes on copies it already holds; nothing new may capture
+        // stores that are about to change (#621).
+        if ( ! chain.begin_transition()) {
+            spdlog::critical("[utxo_build] A batch began while another transition was running");
+            on_fatal("two chain transitions overlapped");
+            co_return;
+        }
+
         // Apply to UTXO-Z
         if ( ! delta.empty()) {
             auto result = chain.apply_utxo_delta_raw(delta.inserts, delta.deletes);
@@ -2197,9 +2207,15 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
         if (auto const ec = chain.publish_chain_view(batch_end); ec) {
             spdlog::critical("[utxo_build] Could not publish the chain state at height {}: {}",
                 batch_end, ec.message());
+            // Deliberately not reopened: the coherent state was never published,
+            // so there is nothing for a capture to be coherent with. The gate
+            // stays shut while the node winds down.
             on_fatal("a connected batch could not be described by a chain state");
             co_return;
         }
+
+        // Earned, not unwound.
+        chain.end_transition();
 
         spdlog::info("[utxo_build] UTXO built to height {}/{}", utxo_built_height, current_contiguous - 1);
     }

--- a/src/node/src/sync/reorg.cpp
+++ b/src/node/src/sync/reorg.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <exception>
 
 #include <asio/as_tuple.hpp>
 #include <asio/steady_timer.hpp>
@@ -69,64 +70,19 @@ bool persist_active_headers(
     return true;
 }
 
-::asio::awaitable<reorg_outcome> execute_reorg(
+namespace {
+
+// Everything between closing entry and reopening it.
+//
+// Split out so the whole of it sits inside one try in the caller: from
+// `begin_transition` on, an exception that unwinds past here leaves the gate
+// shut with nobody told.
+::asio::awaitable<reorg_outcome> switch_publish_and_reopen(
     blockchain::block_chain& chain,
     blockchain::header_organizer& organizer,
     blockchain::header_index::index_t branch_head,
     uint32_t fork_height,
-    std::function<bool()> abort,
-    header_persister persist) {
-
-    // Before anything is touched: without somewhere to write the replaced range,
-    // a switch has no way to become survivable, and finding that out after the
-    // chain has already moved is finding out too late.
-    KTH_CONTRACT(persist);
-
-    auto executor = co_await ::asio::this_coro::executor;
-
-    // Quiesce the writers: the switch rewrites the UTXO set and the validated
-    // height, so it must run alone. Lifting the pause is tied to the scope: a
-    // pause left on stops every registered writer for the rest of the run, and
-    // there are several ways out of here (an abort, a throw from the switch).
-    struct pause_scope {
-        blockchain::block_chain& chain;
-        explicit pause_scope(blockchain::block_chain& c) : chain(c) { chain.request_reorg_pause(true); }
-        ~pause_scope() { chain.request_reorg_pause(false); }
-        pause_scope(pause_scope const&) = delete;
-        pause_scope& operator=(pause_scope const&) = delete;
-    } const pause(chain);
-
-    // Bounded: a registered writer that never parks is a bug, and waiting on it
-    // forever would hold the pause open and stall sync with nothing in the log.
-    // Long enough that a legitimately slow batch — a UTXO build parks between
-    // batches, and one batch runs full validation over a hundred blocks — is not
-    // cut off.
-    constexpr auto barrier_deadline = std::chrono::minutes(5);
-    auto const wait_started = std::chrono::steady_clock::now();
-    bool timed_out = false;
-
-    while ( ! chain.reorg_barrier_reached() && ! abort()) {
-        if (std::chrono::steady_clock::now() - wait_started > barrier_deadline) {
-            timed_out = true;
-            break;
-        }
-        ::asio::steady_timer wait_timer(executor);
-        wait_timer.expires_after(std::chrono::milliseconds(50));
-        co_await wait_timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
-    }
-
-    if (timed_out) {
-        auto const [parked, registered] = chain.reorg_barrier_state();
-        spdlog::error("[reorg] Gave up waiting for the reorg barrier after {} minutes: {} of {} "
-            "writers parked. The chain was not touched; the branch will be reconsidered when it is "
-            "announced again", barrier_deadline.count(), parked, registered);
-        co_return reorg_outcome{};
-    }
-
-    if (abort()) {
-        spdlog::info("[reorg] Aborted while waiting for the barrier; the chain was not touched");
-        co_return reorg_outcome{};
-    }
+    header_persister const& persist) {
 
     auto const outcome = co_await chain.switch_to_branch_async(branch_head, fork_height);
 
@@ -211,30 +167,152 @@ bool persist_active_headers(
         // next header batch can arrive as soon as the pause is gone.
         if (outcome.validated_tip) {
             organizer.note_block_validated(static_cast<int32_t>(*outcome.validated_tip));
-
-            // The transition is closed: the UTXO set, the by-height table, the
-            // adopted tip and the mempool all describe the new fork. Publish the
-            // state here, while the writers are still parked — this is the one
-            // moment nothing else can read a half-switched chain (#605).
-            //
-            // The validated tip, not the branch head. The switch rewound the
-            // connected chain to the fork; the blocks above it are headers, and
-            // they get connected by the ordinary path, which publishes at each
-            // batch. Publishing the branch head would describe a chain whose
-            // UTXO delta has not been applied — the height moving down here
-            // while the generation moves up is the transition being honest.
-            if ( ! fatal) {
-                if (auto const ec = chain.publish_chain_view(*outcome.validated_tip); ec) {
-                    spdlog::critical("[reorg] Could not publish the chain state at the fork "
-                        "height {}: {}. The node would keep validating against the branch it "
-                        "just left", *outcome.validated_tip, ec.message());
-                    fatal = true;
-                }
-            }
         }
     }
 
+    // Publish where the connected chain actually ended up, and only then reopen.
+    //
+    // The validated tip, not the branch head: the switch rewound the connected
+    // chain to the fork, and the blocks above it are headers until the ordinary
+    // path applies their deltas. Publishing the branch head would describe a
+    // chain whose UTXO delta has not been applied — the height moving down here
+    // while the generation moves up is the transition being honest (#605).
+    //
+    //
+    // Both outcomes come through here. A switch that reports failure may still
+    // have rewound part way — `validated_tip` is how far it got, not where it
+    // started — so the published state has to describe that, and a node that
+    // resyncs from there can serve work again. A switch that touched nothing
+    // reports no tip, and there is nothing to republish.
+    if ( ! fatal && ! outcome.mutated) {
+        // Rejected before touching anything — a null head, a fork that is not
+        // above the tip, an ancestry mismatch. Those report the current tip, so
+        // publishing on them would move the generation and drop the template
+        // cache for a switch that did nothing. Reopen and leave the view alone.
+        spdlog::info("[reorg] The switch was rejected before touching the chain; "
+            "the published state is unchanged");
+        chain.end_transition();
+        co_return reorg_outcome{outcome, fatal};
+    }
+
+    // Mutated, and no tip to describe it. The chain has been moved and nothing
+    // says where to, so there is no height to publish and no state a capture
+    // could be coherent with — reopening here would hand out templates built on
+    // a view that describes the branch the node just left. Fatal, and the gate
+    // stays shut.
+    if ( ! fatal && ! outcome.validated_tip) {
+        spdlog::critical("[reorg] The switch disconnected blocks and reported no tip. The chain "
+            "has moved and nothing says where to; capture stays closed and the node winds down");
+        fatal = true;
+    }
+
+    if ( ! fatal && outcome.validated_tip) {
+        if (auto const ec = chain.publish_chain_view(*outcome.validated_tip); ec) {
+            spdlog::critical("[reorg] Could not publish the chain state at height {}: {}. The "
+                "node would keep validating against the branch it just left",
+                *outcome.validated_tip, ec.message());
+            fatal = true;
+        }
+    }
+
+    if ( ! fatal) {
+        // Earned. A failure above leaves capture closed while the node winds
+        // down: there is no coherent state for a capture to be coherent with.
+        chain.end_transition();
+    }
+
     co_return reorg_outcome{outcome, fatal};
+}
+
+} // namespace
+
+::asio::awaitable<reorg_outcome> execute_reorg(
+    blockchain::block_chain& chain,
+    blockchain::header_organizer& organizer,
+    blockchain::header_index::index_t branch_head,
+    uint32_t fork_height,
+    std::function<bool()> abort,
+    header_persister persist) {
+
+    // Before anything is touched: without somewhere to write the replaced range,
+    // a switch has no way to become survivable, and finding that out after the
+    // chain has already moved is finding out too late.
+    KTH_CONTRACT(persist);
+
+    auto executor = co_await ::asio::this_coro::executor;
+
+    // Quiesce the writers: the switch rewrites the UTXO set and the validated
+    // height, so it must run alone. Lifting the pause is tied to the scope: a
+    // pause left on stops every registered writer for the rest of the run, and
+    // there are several ways out of here (an abort, a throw from the switch).
+    struct pause_scope {
+        blockchain::block_chain& chain;
+        explicit pause_scope(blockchain::block_chain& c) : chain(c) { chain.request_reorg_pause(true); }
+        ~pause_scope() { chain.request_reorg_pause(false); }
+        pause_scope(pause_scope const&) = delete;
+        pause_scope& operator=(pause_scope const&) = delete;
+    } const pause(chain);
+
+    // Bounded: a registered writer that never parks is a bug, and waiting on it
+    // forever would hold the pause open and stall sync with nothing in the log.
+    // Long enough that a legitimately slow batch — a UTXO build parks between
+    // batches, and one batch runs full validation over a hundred blocks — is not
+    // cut off.
+    constexpr auto barrier_deadline = std::chrono::minutes(5);
+    auto const wait_started = std::chrono::steady_clock::now();
+    bool timed_out = false;
+
+    while ( ! chain.reorg_barrier_reached() && ! abort()) {
+        if (std::chrono::steady_clock::now() - wait_started > barrier_deadline) {
+            timed_out = true;
+            break;
+        }
+        ::asio::steady_timer wait_timer(executor);
+        wait_timer.expires_after(std::chrono::milliseconds(50));
+        co_await wait_timer.async_wait(::asio::as_tuple(::asio::use_awaitable));
+    }
+
+    if (timed_out) {
+        auto const [parked, registered] = chain.reorg_barrier_state();
+        spdlog::error("[reorg] Gave up waiting for the reorg barrier after {} minutes: {} of {} "
+            "writers parked. The chain was not touched; the branch will be reconsidered when it is "
+            "announced again", barrier_deadline.count(), parked, registered);
+        co_return reorg_outcome{};
+    }
+
+    if (abort()) {
+        spdlog::info("[reorg] Aborted while waiting for the barrier; the chain was not touched");
+        co_return reorg_outcome{};
+    }
+
+    // Entry closes before the switch touches anything, and the captures already
+    // admitted are drained first. A template that entered earlier finishes on
+    // copies it holds; nothing new may capture a half-switched chain (#621).
+    if ( ! chain.begin_transition()) {
+        spdlog::critical("[reorg] A reorganization began while another transition was running");
+        co_return reorg_outcome{{}, /*fatal*/ true};
+    }
+
+    // From here the gate is closed, and reopening it is the last thing a path
+    // that ends well does. An exception unwinding past this point would leave it
+    // closed with nobody told: `pause_scope` lifts the pause on the way out and
+    // the sync loop carries on, so the node keeps working with every template
+    // request refused for the rest of the process — a stop that never announces
+    // itself. Convert it into the outcome the caller already knows how to act
+    // on, and leave the gate shut on purpose: after a throw there is no coherent
+    // state for a capture to be coherent with.
+    try {
+        co_return co_await switch_publish_and_reopen(
+            chain, organizer, branch_head, fork_height, persist);
+    } catch (std::exception const& e) {
+        spdlog::critical("[reorg] The switch threw after the transition began: {}. The chain may "
+            "be part way onto the branch; capture stays closed and the node winds down", e.what());
+        co_return reorg_outcome{{}, /*fatal*/ true};
+    } catch (...) {
+        spdlog::critical("[reorg] The switch threw after the transition began. The chain may be "
+            "part way onto the branch; capture stays closed and the node winds down");
+        co_return reorg_outcome{{}, /*fatal*/ true};
+    }
 }
 
 } // namespace kth::node::sync

--- a/src/node/test/chain_view.cpp
+++ b/src/node/test/chain_view.cpp
@@ -4,7 +4,12 @@
 
 #include <test_helpers.hpp>
 
+#include <algorithm>
 #include <atomic>
+#include <cstdio>
+#include <expected>
+#include <memory>
+#include <tuple>
 #include <chrono>
 #include <optional>
 #include <thread>
@@ -13,7 +18,11 @@
 #include <asio/co_spawn.hpp>
 #include <asio/detached.hpp>
 
+#include <kth/blockchain/pools/block_template.hpp>
 #include <kth/blockchain/pools/branch.hpp>
+#include <kth/blockchain/pools/header_organizer.hpp>
+#include <kth/blockchain/pools/mempool.hpp>
+#include <kth/database/native_file.hpp>
 #include <kth/database/settings.hpp>
 
 #include "sync_harness.hpp"
@@ -37,6 +46,39 @@ using namespace kth::test;
 namespace {
 
 constexpr uint32_t trunk_len = 40;
+
+// Enough pooled transactions that assembling a template takes long enough to be
+// a window a second request can arrive inside. Sized against the build, not the
+// pool: see the measurement in the recapture test.
+constexpr uint64_t pool_entries = 200000;
+
+// The coinbase-budget test needs contention, not a transition landing inside
+// it, so its window is the arrival of one request while another builds — a
+// shorter thing to hit, and a smaller pool.
+constexpr uint64_t reserve_pool_entries = 60000;
+
+// A pooled transaction, synthetic. The template builder is a pure function of
+// the entry set — it resolves parents within that set and nothing against the
+// chain — so these need to be well-formed and distinct, not spendable.
+inline domain::chain::transaction pooled_tx(uint64_t tag) {
+    hash_digest prevout{};
+    for (int i = 0; i < 8; ++i) {
+        prevout[i] = uint8_t(tag >> (8 * i));
+    }
+
+    domain::chain::input::list ins;
+    ins.emplace_back(domain::chain::output_point{prevout, 0},
+                     domain::chain::script{}, 0xffffffffu);
+
+    domain::chain::output out;
+    out.set_value(1000u + tag);
+    out.set_script(domain::chain::script{});
+
+    domain::chain::output::list outs;
+    outs.push_back(std::move(out));
+
+    return domain::chain::transaction{1u, 0u, std::move(ins), std::move(outs)};
+}
 
 // A chain of `len` blocks, connected the way the node connects them.
 struct built_chain {
@@ -66,6 +108,78 @@ struct built_chain {
         persist_headers(fixture, blocks, start);
     }
 };
+
+// Make the undo record at `height` disown its block, so disconnecting that block
+// fails while the ones above it succeed.
+//
+// An undo record carries the hash of the block that owns it, and `read_undo`
+// refuses one that disagrees (#604) — before the inverse delta is applied, which
+// is what makes this a clean failure rather than a half-applied one. Nothing is
+// restarted: the position comes from the in-memory index, which still holds it.
+inline void corrupt_undo_owner(test::chain_fixture& fixture,
+                               blockchain::block_chain& chain, uint32_t height) {
+    // marker(4) + owning block hash(32) + payload size(4). `undo_pos` points just
+    // past that, so the hash begins four bytes into the header.
+    constexpr size_t header_size = 4 + std::tuple_size<hash_digest>::value + sizeof(uint32_t);
+
+    auto const idx = chain.headers().active_at(static_cast<int32_t>(height));
+    REQUIRE(idx != database::header_index::null_index);
+    REQUIRE(chain.headers().has_undo_data(idx));
+
+    auto const file = chain.headers().get_file_number(idx);
+    auto const undo_pos = chain.headers().get_undo_pos(idx);
+    REQUIRE(file >= 0);
+    REQUIRE(undo_pos >= header_size);
+
+    auto const path = fixture.dir() / fmt::format("blocks/rev{:05}.dat", file);
+    FILE* rev = database::open_native(path, "r+b");
+    REQUIRE(rev != nullptr);
+    REQUIRE(std::fseek(rev, static_cast<long>(undo_pos - header_size + 4), SEEK_SET) == 0);
+
+    uint8_t first = 0;
+    REQUIRE(std::fread(&first, 1, 1, rev) == 1);
+    first ^= 0xFFu;
+    REQUIRE(std::fseek(rev, static_cast<long>(undo_pos - header_size + 4), SEEK_SET) == 0);
+    REQUIRE(std::fwrite(&first, 1, 1, rev) == 1);
+    std::fclose(rev);
+}
+
+// A competing branch from `fork_height`, with its headers in. Returns its head.
+//
+// Long enough to survive deep-reorg parking, which is not the same as merely
+// heavier: a branch that would rewind validated blocks has to have accumulated
+// twice the work the active chain gained since the fork (BCHN's -parkdeepreorg).
+// Against four blocks above the fork, five would be heavier and still parked.
+//
+// A switch needs somewhere to switch *to*: `switch_to_branch` derives the fork
+// rather than taking the caller's word for it, so handing it the active chain's
+// own head is rejected before anything is disconnected.
+inline database::header_index::index_t competing_branch(
+    built_chain& built, uint32_t fork_height, uint32_t length) {
+
+    std::vector<domain::chain::block> branch;
+    auto prev = built.trunk[fork_height - 1].hash();
+    for (uint32_t i = 0; i < length; ++i) {
+        auto const h = fork_height + 1 + i;
+        // A different salt, so these are not the trunk's blocks again.
+        branch.push_back(test::mine_block(prev, h, built.base_time + h * block_spacing + 60,
+                                          /*salt*/ 7, {}, 0));
+        prev = branch.back().hash();
+    }
+
+    // Deep-reorg parking measures the rewind against the height the organizer
+    // believes is validated, and nothing in this harness tells it — the node's
+    // sync tasks do that in production. Without it a fork a few blocks down
+    // looks like a rewind of the whole chain and is parked, so the switch never
+    // becomes a candidate.
+    built.fixture.organizer().note_block_validated(
+        static_cast<int32_t>(built.chain().chain_view()->connected_tip_height));
+
+    auto const result = built.fixture.organizer().add_headers(headers_of(branch));
+    REQUIRE(result.reorg_candidate);
+    REQUIRE(result.reorg_fork_height == int32_t(fork_height));
+    return result.reorg_branch_head;
+}
 
 } // namespace
 
@@ -260,10 +374,14 @@ TEST_CASE("a template built after a batch names the new tip", "[chain_view]") {
     // changed, so a template built before a batch would keep being served after
     // it — on a parent the chain had left behind.
     built_chain built("view_template_cache", trunk_len);
-    built.add_headers(built.trunk, 1);
 
     std::vector<domain::chain::block> first(built.trunk.begin(), built.trunk.begin() + 20);
     std::vector<domain::chain::block> second(built.trunk.begin() + 20, built.trunk.end());
+
+    // Headers arrive with the blocks they describe. Adding all forty first would
+    // leave the node holding headers it has not connected — a node that is
+    // behind, and one that is behind does not serve mining work (#621).
+    built.add_headers(first, 1);
     connect_bodies(built.fixture, first, 1);
 
     auto const fetch = [&]() -> std::optional<blockchain::mining_template> {
@@ -281,6 +399,7 @@ TEST_CASE("a template built after a batch names the new tip", "[chain_view]") {
     CHECK(early->previous_block_hash == first.back().hash());
     CHECK(early->height == 21u);
 
+    built.add_headers(second, 21);
     connect_bodies(built.fixture, second, 21);
 
     auto const later = fetch();
@@ -313,4 +432,677 @@ TEST_CASE("the branch path answers null before anything is published", "[chain_v
 
     auto const branch_ptr = std::make_shared<blockchain::branch>(0u, chain.block_validations());
     CHECK(chain.chain_state(branch_ptr) == nullptr);
+}
+
+// =============================================================================
+// When this node should be serving mining work (#621)
+// =============================================================================
+
+TEST_CASE("headers ahead of the connected chain mean the node is behind", "[chain_view][sync]") {
+    // Recent headers say nothing about having connected them. This is the case
+    // the old `is_stale()` got wrong: it read the stored block marker, which
+    // during a sync sits with the headers rather than with the UTXO set, so a
+    // node in the middle of downloading looked synchronized.
+    built_chain built("sync_behind", trunk_len);
+    built.add_headers(built.trunk, 1);
+
+    // Half connected, so the tip that is published is recent while the headers
+    // run past it. Freshness holding is what makes this test about catching up
+    // and not about the clock.
+    std::vector<domain::chain::block> first(built.trunk.begin(), built.trunk.begin() + 20);
+    connect_bodies(built.fixture, first, 1);
+
+    auto const ready = built.chain().synchronization();
+    CHECK_FALSE(ready.caught_up);
+    CHECK(ready.fresh);
+    CHECK_FALSE(ready.synchronized());
+}
+
+TEST_CASE("a chain that has connected nothing is behind and stale at once", "[chain_view][sync]") {
+    // The connected tip is the genesis block, whose timestamp is from 2011. Both
+    // halves fail, and they fail for their own reasons rather than one standing
+    // in for the other.
+    built_chain built("sync_nothing", trunk_len);
+    built.add_headers(built.trunk, 1);
+
+    auto const ready = built.chain().synchronization();
+    CHECK_FALSE(ready.caught_up);
+    CHECK_FALSE(ready.fresh);
+    CHECK_FALSE(ready.synchronized());
+}
+
+TEST_CASE("a connected chain at its header tip is caught up", "[chain_view][sync]") {
+    built_chain built("sync_caught_up", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto const ready = built.chain().synchronization();
+    CHECK(ready.caught_up);
+    CHECK(ready.fresh);
+    CHECK(ready.synchronized());
+}
+
+TEST_CASE("a caught-up chain whose tip is old is not synchronized", "[chain_view][sync]") {
+    // Caught up and stale is a different problem from behind — a clock or a
+    // connectivity one — with a different remedy, which is why the two are named
+    // apart rather than folded into one answer.
+    //
+    // The chain cannot simply be built old: `utxo_batch_len` takes `is_stale()`
+    // and switches to thousand-block batches when it holds, so a short chain old
+    // enough to be stale is a chain the connect path never builds. The two
+    // notions of "old" share one setting. So the chain is built by a node with
+    // the ordinary limit and then read by one configured tighter — the same
+    // blocks on disk, judged against a freshness window they fall outside.
+    // Built with its own offset rather than the shared one: the default chain
+    // ends exactly one hour back, and `fresh` is `stamp + limit >= now`, so
+    // against a one-hour limit it sits precisely on the boundary and the answer
+    // turns on how many seconds the rest of the suite took. Four hours back is
+    // unambiguously outside it, and still well inside the twenty-four hours the
+    // building node judges by, so the connect path does not switch to
+    // thousand-block batches.
+    test::chain_fixture fixture("sync_stale");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 120) * block_spacing;
+    std::vector<domain::chain::block> trunk;
+    auto prev = domain::chain::block::genesis_regtest().hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+
+    auto const added = fixture.organizer().add_headers(headers_of(trunk));
+    REQUIRE(added.headers_added == trunk.size());
+    persist_headers(fixture, trunk, 1);
+    connect_bodies(fixture, trunk, 1);
+    REQUIRE(fixture.chain().synchronization().synchronized());
+
+    // Down before the other comes up. The two never share the directory: one
+    // process opening a data directory twice is not a supported state — the LMDB
+    // environment, UTXO-Z and the flat-file stores each hold handles and cached
+    // file state for that path — and a conflict there would surface as a
+    // freshness answer that looks like the thing under test.
+    fixture.close();
+
+    blockchain::settings strict(domain::config::network::regtest);
+    strict.notify_limit_hours = 1u;
+    database::settings db_settings;
+    db_settings.directory = fixture.dir();
+
+    blockchain::block_chain tight(strict, db_settings, domain::config::network::regtest,
+                                  /*relay_transactions*/ false);
+    REQUIRE(tight.start(kth::get_disk_magic(domain::config::network::regtest)));
+
+    // start() loads the headers; the active chain by height is materialized by
+    // the organizer, and `caught_up` reads the active tip. A node does this at
+    // startup, so a test that skipped it would be measuring against a header
+    // index that answers nothing — and would read as behind for the wrong
+    // reason.
+    blockchain::header_organizer organizer(tight.headers(), strict,
+                                           domain::config::network::regtest);
+    REQUIRE(organizer.start());
+    organizer.sync_tip();
+
+    auto const ready = tight.synchronization();
+    CHECK(ready.caught_up);
+    CHECK_FALSE(ready.fresh);
+    CHECK_FALSE(ready.synchronized());
+}
+
+TEST_CASE("a limit of zero disables freshness and nothing else", "[chain_view][sync]") {
+    // "Do not judge by the clock" is not "you are at the head". A node that has
+    // not connected its headers stays unsynchronized however the limit is set.
+    test::chain_fixture unlimited("sync_no_limit_zero", /*notify_limit_hours*/ 0u);
+    REQUIRE(unlimited.created());
+    REQUIRE(unlimited.start());
+
+    auto const genesis = domain::chain::block::genesis_regtest();
+    auto const base_time = uint32_t(zulu_time()) - (trunk_len + 30) * block_spacing;
+    std::vector<domain::chain::block> trunk;
+    auto prev = genesis.hash();
+    for (uint32_t h = 1; h <= trunk_len; ++h) {
+        trunk.push_back(test::mine_block(prev, h, base_time + h * block_spacing, 0, {}, 0));
+        prev = trunk.back().hash();
+    }
+    auto const added = unlimited.organizer().add_headers(headers_of(trunk));
+    REQUIRE(added.headers_added == trunk.size());
+    persist_headers(unlimited, trunk, 1);
+
+    // Headers in, nothing connected: freshness is switched off, and the node is
+    // still not synchronized.
+    auto const ready = unlimited.chain().synchronization();
+    CHECK(ready.fresh);
+    CHECK_FALSE(ready.caught_up);
+    CHECK_FALSE(ready.synchronized());
+}
+
+// =============================================================================
+// Nothing captures while a transition is mutating (#621)
+// =============================================================================
+
+TEST_CASE("a template is refused while a transition holds the gate", "[chain_view][gate]") {
+    // The refusal a caller sees, and its reason. A transition is not the same
+    // answer as a node that is behind: it clears in milliseconds and the caller
+    // retries, where the other two clear when the node catches up.
+    built_chain built("gate_refusal", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto& chain = built.chain();
+    REQUIRE(chain.synchronization().synchronized());
+
+    auto const fetch = [&]() -> std::expected<blockchain::mining_template, code> {
+        ::asio::io_context ctx;
+        std::optional<std::expected<blockchain::mining_template, code>> out;
+        ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+            out = co_await chain.fetch_mining_template(1000u);
+        }, ::asio::detached);
+        ctx.run_for(std::chrono::seconds(30));
+        REQUIRE(out);
+        return *out;
+    };
+
+    // Served while nothing is transitioning.
+    REQUIRE(fetch().has_value());
+
+    REQUIRE(chain.begin_transition());
+    CHECK(chain.transition_in_progress());
+
+    auto const refused = fetch();
+    REQUIRE_FALSE(refused.has_value());
+    CHECK(refused.error() == error::transition_in_progress);
+
+    // And served again once the transition publishes and reopens.
+    chain.end_transition();
+    CHECK_FALSE(chain.transition_in_progress());
+    CHECK(fetch().has_value());
+}
+
+TEST_CASE("mining info answers while a transition holds the gate", "[chain_view][gate]") {
+    // It observes rather than constructs, so it stays available exactly when
+    // something is wrong — and it says which of the three reasons applies.
+    built_chain built("gate_mining_info", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto& chain = built.chain();
+    REQUIRE(chain.begin_transition());
+
+    ::asio::io_context ctx;
+    std::optional<blockchain::mining_info> info;
+    ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+        if (auto const r = co_await chain.fetch_mining_info(); r) info = *r;
+    }, ::asio::detached);
+    ctx.run_for(std::chrono::seconds(30));
+
+    REQUIRE(info);
+    CHECK(info->transition_in_progress);
+    CHECK(info->caught_up);
+    CHECK(info->fresh);
+    CHECK(info->blocks == trunk_len);
+
+    chain.end_transition();
+}
+
+TEST_CASE("the gate is not held across the template build", "[chain_view][gate]") {
+    // Everything after the capture runs on private copies, so holding the gate
+    // there would make a transition wait on work it cannot affect — the
+    // exclusion measured in #611 plus the whole build, for nothing.
+    //
+    // Provoked rather than reasoned: a transition begun while a template is
+    // being served must not be blocked by it for anything like the time the
+    // build takes.
+    built_chain built("gate_released", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto& chain = built.chain();
+
+    std::atomic<bool> serving{true};
+    std::thread server([&] {
+        for (int i = 0; i < 20; ++i) {
+            ::asio::io_context ctx;
+            ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+                (void)co_await chain.fetch_mining_template(1000u + uint64_t(i));
+            }, ::asio::detached);
+            ctx.run_for(std::chrono::seconds(30));
+        }
+        serving = false;
+    });
+
+    // Transitions keep succeeding while templates are being served: the gate is
+    // free between captures rather than held for the length of a request.
+    //
+    // Bounded, because the failure this looks for is a transition that blocks:
+    // if the gate were held across a build, `begin_transition` would wait inside
+    // the call and an unbounded loop would hang rather than fail. The deadline
+    // is generous against twenty template builds and tight against one that
+    // never returns.
+    auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(120);
+    int transitions = 0;
+    bool timed_out = false;
+
+    // do/while, so at least one transition is attempted even if the server
+    // thread finished all twenty builds before this loop was first scheduled.
+    // With `while (serving)` the count could be zero for a reason that has
+    // nothing to do with the gate, and a test that can pass without exercising
+    // what it names is not a test.
+    do {
+        if (std::chrono::steady_clock::now() > deadline) {
+            timed_out = true;
+            break;
+        }
+        if (chain.begin_transition()) {
+            chain.end_transition();
+            ++transitions;
+        }
+        std::this_thread::yield();
+    } while (serving);
+    server.join();
+
+    CHECK_FALSE(timed_out);
+    CHECK(transitions > 0);
+}
+
+TEST_CASE("a queued rebuild recaptures the chain it builds on", "[chain_view][gate]") {
+    // The defect this pins down: a rebuild that reads the chain view under one
+    // lease and copies the pool under another. Each half is admitted by the
+    // gate, so each half looks correct — but a whole transition can run between
+    // them, and the template then names a parent the chain has left behind while
+    // selecting from a pool that has moved past it. A capture is the pair, not
+    // either half of it.
+    //
+    // The window is opened rather than waited for. Requests coalesce on the
+    // rebuild mutex, so a second request arriving while the first is still
+    // building blocks *between* the two reads — exactly where the transition
+    // has to land. The transition is driven through the chain's own primitives
+    // because here it is the fixture, not the subject: what is under test is
+    // what the second request builds on when it wakes.
+    built_chain built("gate_recapture", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto& chain = built.chain();
+    REQUIRE(chain.synchronization().synchronized());
+
+    // A pool large enough that one build is a window rather than an instant.
+    auto& pool = chain.mempool_ref();
+    size_t admitted = 0;
+    for (uint64_t i = 0; i < pool_entries; ++i) {
+        auto const tx = pooled_tx(i);
+        admitted += pool.add(blockchain::mempool_entry{
+            std::make_shared<domain::message::transaction>(tx),
+            /*fee*/ 1000u + i,
+            /*size*/ uint32_t(tx.serialized_size(true)),
+            /*sigchecks*/ 1u,
+            /*time_seen*/ i});
+    }
+    REQUIRE(admitted == pool_entries);
+    REQUIRE(pool.size() == pool_entries);
+
+    // How long a build takes on this machine, measured rather than assumed: the
+    // ordering below is expressed in fractions of it, so a slow runner (or a
+    // sanitizer build) stretches the window instead of losing it. The builder
+    // is a pure function of the entry set, so measuring it costs the chain
+    // nothing — in particular it does not warm the template cache, which has to
+    // stay cold for the second request to queue rather than be served.
+    std::vector<blockchain::mempool_entry> sample_entries;
+    sample_entries.reserve(pool_entries);
+    pool.for_each([&](blockchain::mempool_entry const& e) { sample_entries.push_back(e); });
+
+    auto const build_time = [&] {
+        auto const start = std::chrono::steady_clock::now();
+        auto const selection = blockchain::build_block_template(
+            sample_entries, blockchain::block_template_context{
+                /*max_block_size*/ 32u * 1000u * 1000u,
+                /*max_block_sigchecks*/ 1u * 1000u * 1000u,
+                /*height*/ trunk_len + 1u,
+                /*median_time_past*/ 0u});
+        REQUIRE_FALSE(selection.txs.empty());
+        return std::chrono::steady_clock::now() - start;
+    }();
+
+    // The block the transition connects. Built here so its hash is known to the
+    // assertions below.
+    auto const extra = test::mine_block(built.trunk.back().hash(), trunk_len + 1u,
+        built.base_time + (trunk_len + 1u) * block_spacing, 0, {}, 0);
+
+    using result = std::expected<blockchain::mining_template, code>;
+    std::optional<result> first_out;
+    std::optional<result> second_out;
+    std::atomic<int> completed{0};
+    int first_seq = 0;
+    int second_seq = 0;
+
+    auto const call = [&](uint64_t reserve, std::optional<result>& out, int& seq) {
+        ::asio::io_context ctx;
+        ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+            out = co_await chain.fetch_mining_template(reserve);
+        }, ::asio::detached);
+        ctx.run_for(std::chrono::seconds(300));
+        seq = ++completed;
+    };
+
+    // Distinct reserve sizes: the cache is keyed on this too, so the second
+    // request cannot be served the first one's snapshot and has to rebuild.
+    std::thread first([&] { call(1000u, first_out, first_seq); });
+    std::this_thread::sleep_for(build_time / 8);
+    std::thread second([&] { call(2000u, second_out, second_seq); });
+    std::this_thread::sleep_for(build_time / 8);
+
+    // Recorded here, asserted after the join. A Catch2 macro that fails throws,
+    // and throwing with two joinable threads outstanding terminates the process
+    // instead of failing the test — the report would be lost at the exact moment
+    // it is worth having.
+    bool const window_open_before = completed.load() == 0;
+
+    bool const began = chain.begin_transition();
+    if (began) {
+        built.add_headers(std::vector<domain::chain::block>{extra}, trunk_len + 1u);
+    }
+    code const published = began ? chain.publish_chain_view(trunk_len + 1u) : code{};
+
+    // Still open when the transition finished, which is what puts the transition
+    // strictly between the parked request's two reads.
+    bool const window_open_after = completed.load() == 0;
+
+    if (began) {
+        chain.end_transition();
+    }
+
+    first.join();
+    second.join();
+
+    // The fixture held: without these the rest proves nothing.
+    REQUIRE(began);
+    REQUIRE_FALSE(published);
+    REQUIRE(window_open_before);
+    REQUIRE(window_open_after);
+
+    // The first request was admitted before the transition and built on what it
+    // captured: the old tip. That is correct — a capture admitted before a
+    // transition finishes with what it captured.
+    REQUIRE(first_out);
+    REQUIRE(first_out->has_value());
+    CHECK((*first_out)->previous_block_hash == built.trunk.back().hash());
+    CHECK((*first_out)->height == trunk_len + 1u);
+
+    // The second was queued behind it, so it finished second — the ordering the
+    // whole construction depends on.
+    CHECK(first_seq == 1);
+    CHECK(second_seq == 2);
+
+    // And it builds on what it recaptured after waking, not on what it read
+    // before parking. Reading the chain once at the top and the pool again at
+    // the bottom would produce the old tip here, with the new pool.
+    REQUIRE(second_out);
+    REQUIRE(second_out->has_value());
+    CHECK((*second_out)->previous_block_hash == extra.hash());
+    CHECK((*second_out)->height == trunk_len + 2u);
+    CHECK((*second_out)->previous_block_hash != (*first_out)->previous_block_hash);
+}
+
+TEST_CASE("a queued request is not served another request's coinbase budget",
+          "[chain_view][gate]") {
+    // The other half of the fallback that serves a stale snapshot rather than
+    // block: it compared the tip and nothing else. A template is built against a
+    // coinbase budget, and the caller passes that number precisely because its
+    // coinbase does not fit the default — serving it a snapshot built for a
+    // different reserve answers it with someone else's budget, on the right
+    // parent, which is the kind of wrong that looks right.
+    built_chain built("gate_reserve", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto& chain = built.chain();
+    REQUIRE(chain.synchronization().synchronized());
+
+    auto& pool = chain.mempool_ref();
+    size_t admitted = 0;
+    for (uint64_t i = 0; i < reserve_pool_entries; ++i) {
+        auto const tx = pooled_tx(i);
+        admitted += pool.add(blockchain::mempool_entry{
+            std::make_shared<domain::message::transaction>(tx),
+            /*fee*/ 1000u + i,
+            /*size*/ uint32_t(tx.serialized_size(true)),
+            /*sigchecks*/ 1u,
+            /*time_seen*/ i});
+    }
+    REQUIRE(admitted == reserve_pool_entries);
+
+    auto const fetch = [&](uint64_t reserve) -> std::optional<blockchain::mining_template> {
+        ::asio::io_context ctx;
+        std::optional<blockchain::mining_template> out;
+        ::asio::co_spawn(ctx, [&]() -> ::asio::awaitable<void> {
+            if (auto const r = co_await chain.fetch_mining_template(reserve); r) out = *r;
+        }, ::asio::detached);
+        ctx.run_for(std::chrono::seconds(300));
+        return out;
+    };
+
+    // The snapshot the fallback would be tempted to hand out: the current tip,
+    // the default budget, and room for the whole pool.
+    auto const warm = fetch(1000u);
+    REQUIRE(warm);
+    REQUIRE(warm->selection.txs.size() > 1000u);
+
+    std::vector<blockchain::mempool_entry> sample_entries;
+    sample_entries.reserve(reserve_pool_entries);
+    pool.for_each([&](blockchain::mempool_entry const& e) { sample_entries.push_back(e); });
+
+    auto const build_time = [&] {
+        auto const start = std::chrono::steady_clock::now();
+        auto const selection = blockchain::build_block_template(
+            sample_entries, blockchain::block_template_context{
+                /*max_block_size*/ warm->size_limit,
+                /*max_block_sigchecks*/ warm->sigchecks_limit,
+                /*height*/ trunk_len + 1u,
+                /*median_time_past*/ 0u});
+        REQUIRE_FALSE(selection.txs.empty());
+        return std::chrono::steady_clock::now() - start;
+    }();
+
+    // A budget that leaves room for almost nothing, so what the queued request
+    // was given is legible in the answer: its own budget selects a handful of
+    // transactions where the warm snapshot holds the whole pool.
+    auto const tight_reserve = warm->size_limit - 1000u;
+
+    using result = std::optional<blockchain::mining_template>;
+    result holder_out;
+    result queued_out;
+    std::atomic<int> completed{0};
+    int holder_seq = 0;
+    int queued_seq = 0;
+
+    auto const call = [&](uint64_t reserve, result& out, int& seq) {
+        out = fetch(reserve);
+        seq = ++completed;
+    };
+
+    // A third budget, so this one misses the cache too and takes the rebuild
+    // mutex for the length of a build.
+    std::thread holder([&] { call(2000u, holder_out, holder_seq); });
+    std::this_thread::sleep_for(build_time / 8);
+
+    // Recorded, not asserted: a failing macro throws, and throwing with joinable
+    // threads outstanding terminates the process rather than reporting.
+    bool const holding_when_queued = completed.load() == 0;
+
+    std::thread queued([&] { call(tight_reserve, queued_out, queued_seq); });
+    std::this_thread::sleep_for(build_time / 8);
+
+    // Still building, so the second request is parked on the mutex rather than
+    // past it — which is the only place the fallback is reachable.
+    bool const still_holding = completed.load() == 0;
+
+    holder.join();
+    queued.join();
+
+    REQUIRE(holding_when_queued);
+    REQUIRE(still_holding);
+
+    // It waited instead of being served. Under the tip-only fallback it would
+    // have returned first, immediately, with the warm snapshot.
+    CHECK(holder_seq == 1);
+    CHECK(queued_seq == 2);
+
+    REQUIRE(queued_out);
+    CHECK(queued_out->previous_block_hash == warm->previous_block_hash);
+    CHECK(queued_out->selection.txs.size() < warm->selection.txs.size());
+    CHECK(queued_out->selection.total_size + tight_reserve <= warm->size_limit);
+}
+
+// =============================================================================
+// A switch that touched nothing publishes nothing (#621)
+// =============================================================================
+
+TEST_CASE("a switch rejected before touching the chain reopens without publishing",
+          "[chain_view][gate]") {
+    // Several rejections happen before the first disconnect and still report the
+    // current tip, so height alone cannot tell them from a switch that rewound
+    // to where the chain already was. Publishing on those would move the
+    // generation and drop the template cache for a switch that did nothing —
+    // which is why `switch_result` carries whether anything was mutated rather
+    // than leaving it to be inferred.
+    built_chain built("gate_no_mutation", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto& chain = built.chain();
+    auto const before = chain.chain_view();
+    REQUIRE(before);
+
+    // A null head is rejected at the top of switch_to_branch, before anything is
+    // read, let alone disconnected.
+    auto const outcome = chain.switch_to_branch(
+        database::header_index::null_index, trunk_len);
+
+    CHECK_FALSE(outcome.ok);
+    CHECK_FALSE(outcome.mutated);
+    // It still reports a tip — which is exactly why `mutated` has to be carried.
+    CHECK(outcome.validated_tip);
+
+    auto const after = chain.chain_view();
+    REQUIRE(after);
+    CHECK(after->generation == before->generation);
+    CHECK(after->tip_hash == before->tip_hash);
+}
+
+TEST_CASE("a fork above the connected tip disconnects nothing", "[chain_view][gate]") {
+    // The other shape of "nothing moved": the fork is above where the chain is
+    // connected, so the loop never runs. The tip does not move and neither does
+    // the generation.
+    built_chain built("gate_fork_above", trunk_len);
+    built.add_headers(built.trunk, 1);
+
+    // Connect only part of it, so there are headers above the connected tip.
+    std::vector<domain::chain::block> first(built.trunk.begin(), built.trunk.begin() + 20);
+    connect_bodies(built.fixture, first, 1);
+
+    auto& chain = built.chain();
+    auto const before = chain.chain_view();
+    REQUIRE(before);
+    REQUIRE(before->connected_tip_height == 20u);
+
+    // A branch that actually competes, forking at 30 — above the connected tip
+    // at 20. Handing `switch_to_branch` the active chain's own head instead
+    // would also be rejected without disconnecting anything, and from the
+    // outside the two look identical: same `ok`, same `mutated`, same view. The
+    // test would then pass while demonstrating nothing about a fork above the
+    // tip. Long enough to be heavier than the ten trunk headers above the fork.
+    auto const branch_head = competing_branch(built, 30u, 12u);
+
+    // The precondition that gives the rest its meaning, asserted rather than
+    // assumed: this head is off the active chain. Swap in the trunk's own head
+    // and the test fails here.
+    auto const head_hash = domain::chain::hash(chain.headers().get_header(branch_head));
+    REQUIRE(std::none_of(built.trunk.begin(), built.trunk.end(),
+        [&](domain::chain::block const& b) { return b.hash() == head_hash; }));
+
+    auto const outcome = chain.switch_to_branch(branch_head, 30u);
+    CHECK_FALSE(outcome.mutated);
+
+    auto const after = chain.chain_view();
+    REQUIRE(after);
+    CHECK(after->generation == before->generation);
+    CHECK(after->connected_tip_height == before->connected_tip_height);
+}
+
+TEST_CASE("a switch that failed after disconnecting publishes where it stopped",
+          "[chain_view][gate]") {
+    // The branch between the two above: some blocks came off and then the switch
+    // gave up. `mutated` has to be true there, because the chain did move and the
+    // published state has to say where it stopped — otherwise the node keeps
+    // validating against a tip it no longer has, and the gate never reopens.
+    //
+    // Provoked with a real failure rather than a seam: an undo record carries the
+    // hash of the block that owns it (#604), and `read_undo` refuses one that
+    // disagrees. Damaging that hash makes the disconnect of that block fail
+    // *before* its inverse delta is applied, which is a clean failure — the
+    // blocks already disconnected stay disconnected.
+    built_chain built("gate_partial_rewind", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto& chain = built.chain();
+    auto const before = chain.chain_view();
+    REQUIRE(before);
+    REQUIRE(before->connected_tip_height == trunk_len);
+
+    // Disconnection runs newest first, so damaging the second one down lets the
+    // top block come off before the failure.
+    corrupt_undo_owner(built.fixture, chain, trunk_len - 1u);
+
+    auto const fork_height = trunk_len - 4u;
+    auto const head = competing_branch(built, fork_height, /*length*/ 9u);
+
+    REQUIRE(chain.begin_transition());
+    auto const outcome = chain.switch_to_branch(head, fork_height);
+    CHECK_FALSE(outcome.ok);
+    CHECK(outcome.mutated);
+    REQUIRE(outcome.validated_tip);
+    // The top block came off; the damaged one did not.
+    CHECK(*outcome.validated_tip == trunk_len - 1u);
+
+    REQUIRE_FALSE(chain.publish_chain_view(*outcome.validated_tip));
+    chain.end_transition();
+
+    auto const after = chain.chain_view();
+    REQUIRE(after);
+    CHECK(after->connected_tip_height == trunk_len - 1u);
+    CHECK(after->generation == before->generation + 1u);
+    CHECK_FALSE(chain.transition_in_progress());
+
+    // Serving again, and honestly: the chain is now below its headers.
+    auto const ready = chain.synchronization();
+    CHECK_FALSE(ready.caught_up);
+}
+
+TEST_CASE("a switch that failed on its first disconnect publishes nothing",
+          "[chain_view][gate]") {
+    // The control for the case above. Damaging the undo of the *first* block to
+    // come off makes the switch fail before anything moves, so `mutated` is
+    // false — which is what shows it describes what happened rather than merely
+    // echoing `ok`.
+    built_chain built("gate_first_disconnect", trunk_len);
+    built.add_headers(built.trunk, 1);
+    connect_bodies(built.fixture, built.trunk, 1);
+
+    auto& chain = built.chain();
+    auto const before = chain.chain_view();
+    REQUIRE(before);
+
+    corrupt_undo_owner(built.fixture, chain, trunk_len);
+
+    auto const head = competing_branch(built, trunk_len - 4u, /*length*/ 9u);
+
+    auto const outcome = chain.switch_to_branch(head, trunk_len - 4u);
+    CHECK_FALSE(outcome.ok);
+    CHECK_FALSE(outcome.mutated);
+
+    auto const after = chain.chain_view();
+    REQUIRE(after);
+    CHECK(after->generation == before->generation);
+    CHECK(after->connected_tip_height == before->connected_tip_height);
 }

--- a/src/node/test/rpc_mining.cpp
+++ b/src/node/test/rpc_mining.cpp
@@ -38,12 +38,56 @@ TEST_CASE("render_mining_template serializes the GBT-light fields", "[rpc mining
 }
 
 TEST_CASE("render_mining_info serializes the getmininginfo fields", "[rpc mining]") {
+    // Designated rather than positional: the three flags are all `bool`, so a
+    // reorder of the struct would keep compiling and silently re-label them.
     blockchain::mining_info info{
-        /*blocks*/ 42u,
-        /*difficulty*/ 1.0,
-        /*pooled_tx*/ 3u,
-        /*chain*/ domain::config::network::mainnet};
+        .blocks = 42u,
+        .difficulty = 1.0,
+        .pooled_tx = 3u,
+        .chain = domain::config::network::mainnet,
+        .transition_in_progress = false,
+        .caught_up = true,
+        .fresh = true};
 
     REQUIRE(render_mining_info(info) ==
-        R"({"blocks":42,"difficulty":1.0,"pooledtx":3,"chain":"Mainnet","warnings":""})");
+        R"({"blocks":42,"difficulty":1.0,"pooledtx":3,"chain":"Mainnet",)"
+        R"("transitioninprogress":false,"caughtup":true,"fresh":true,"warnings":""})");
+}
+
+TEST_CASE("render_mining_info reports the three refusal reasons apart", "[rpc mining]") {
+    // Why mining work is being refused is what an operator reads here, and the
+    // three have different remedies: a transition clears in milliseconds, a node
+    // that is behind is downloading, and a node that is caught up but stale has
+    // a connectivity or a clock problem. One boolean could not tell them apart.
+    blockchain::mining_info info{
+        .blocks = 7u,
+        .difficulty = 2.5,
+        .pooled_tx = 0u,
+        .chain = domain::config::network::regtest,
+        .transition_in_progress = true,
+        .caught_up = false,
+        .fresh = false};
+
+    REQUIRE(render_mining_info(info) ==
+        R"({"blocks":7,"difficulty":2.5,"pooledtx":0,"chain":"Regtest",)"
+        R"("transitioninprogress":true,"caughtup":false,"fresh":false,"warnings":""})");
+}
+
+TEST_CASE("render_mining_info reports a caught-up but stale tip", "[rpc mining]") {
+    // The two operational flags are independent, and the cases above do not show
+    // it: both hold them equal, so a renderer that emitted `caught_up` for the
+    // `fresh` key would pass either one. This is the node that reached its
+    // headers and is sitting on a tip older than the configured age.
+    blockchain::mining_info info{
+        .blocks = 9u,
+        .difficulty = 1.0,
+        .pooled_tx = 1u,
+        .chain = domain::config::network::regtest,
+        .transition_in_progress = false,
+        .caught_up = true,
+        .fresh = false};
+
+    REQUIRE(render_mining_info(info) ==
+        R"({"blocks":9,"difficulty":1.0,"pooledtx":1,"chain":"Regtest",)"
+        R"("transitioninprogress":false,"caughtup":true,"fresh":false,"warnings":""})");
 }


### PR DESCRIPTION
Part B of #605. #615 made the published state coherent; this keeps a template from being built against stores that are mid-mutation, and separates the reasons one may be refused.

## A flag cannot close the window it names

The request reads it, the transition sets it and starts mutating, and the request captures during or after the mutation. **The check and the capture are two moments and nothing joins them.**

What joins them is entry. A template is admitted as a capture reader or refused; inside, it takes one chain view and one coherent copy of the pool, and leaves; it builds outside, on what it captured. A transition **closes entry first, waits for the captures already admitted to finish, and only then mutates**. So a request that finished capturing completes on copies nothing can reach, and no new one can capture stores that are about to change.

**Reopening is earned.** `end_transition` runs after the state has been published and nowhere else — a scope guard would reopen after a failure too, which is the one case where the gate must stay shut while the node winds down. A second `begin_transition` is refused rather than nested: sharing a flag would let the first to finish reopen for both.

**The lease covers the capture, not the build.** Everything after it runs on private copies, so holding it across the graph, the ordering and the selection would make a transition wait on work that cannot affect it — the exclusion #611 measured, plus the whole template.

## A capture is the pair, not either half of it

`fetch_mining_template` coalesces rebuilds on a mutex, and a request that waits on it is *between* its reads. Reading the chain view under one lease and copying the pool under another therefore admits each half separately while joining nothing: a whole transition can run in the gap, and the template comes out naming a parent the chain has left behind, selecting from a pool that has moved past it. Each half was admitted; the pair is coherent with nothing.

So the rebuild path takes **one** lease, after the mutex, and recaptures the chain view and the pool inside it — and re-asks the cache against *that* publication, since the check made before the wait decided nothing. The fast path keeps its earlier read: serving an already-built template is a weaker requirement, because a template is itself a coherent copy and a request admitted before a transition may finish with one.

The real order is `template_rebuild_mutex_` → capture gate → validation mutex, and the comment now says so. Nothing runs it the other way: the organizers hold the validation mutex and know nothing about the template cache, a transition drains the gate without taking either, and a refused entry returns instead of blocking, so there is no cycle to close.

## Three reasons, not one

A transition is a correctness barrier and clears in milliseconds. The other two are operational.

Freshness subtracts from now rather than adding to the tip's timestamp: the sum is one addition from wrapping wherever it lands in 32 bits, and a wrapped sum reads as fresh — the direction that keeps a stale node serving work. The limit is clamped to `uint32_t` first so both operands are unsigned and the floor is zero, where every timestamp is fresh, which is the honest answer for a window longer than the epoch.

`synchronized` is defined here rather than borrowed. **`is_stale()` could not be it**: it reads the stored block marker, which during a sync sits with the headers rather than with the UTXO set, so a node in the middle of downloading read as synchronized. Instead `caught_up` compares the published view's connected tip against the active header tip, and `fresh` measures that tip's age. A limit of zero disables the clock half and nothing else — *do not judge by the clock* is not *you are at the head*.

## A switch that touched nothing publishes nothing

`switch_result` now carries whether any block was disconnected. Several rejections happen before the first disconnect **and still report the current tip**, so comparing heights cannot tell them from a switch that rewound to where the chain already was — and publishing on those would move the generation and drop the template cache for a switch that did nothing. It is set after a disconnect applies, and forced on the unclean path, where the delta was applied even though the switch is abandoned. A rewind that failed part way still publishes where it ended up, so a node that resyncs from there can serve work again.

**Mutated with nowhere to resume from is fatal.** An unclean disconnect applies the inverse delta and then fails to write the height markers, so it reports movement and no tip. That combination used to fall through both branches — past the nothing-moved path because it mutated, past publication because there was no height — and reopen the gate over a chain whose UTXO set no longer matches the view still describing the pre-switch tip. There is no state a capture could be coherent with, so it is fatal and the gate stays shut.

**And a throw is an outcome, not an exit.** Everything between closing entry and reopening it now sits inside one `try`. An exception unwinding past `begin_transition` used to skip the fatal result the caller acts on while the pause guard lifted the pause on its way out — so the sync loop carried on with the gate shut for the life of the process, refusing every template with nothing said. It becomes the fatal outcome instead, and the gate is left shut deliberately: after a throw there is no coherent state for a capture to be coherent with.

## Breaking surface change

`kth_mining_info_t` gains `transition_in_progress`, `caught_up` and `fresh`; `getmininginfo` gains the three fields. Three rather than one because they have different remedies: a transition clears on its own, a node that is behind is downloading, and one caught up and stale has a clock or connectivity problem.

**The struct no longer crosses by memcpy — it is converted field by field.** The generic conversion copies the bytes under a size assertion, which had made layout, padding and the C++ *declaration order* part of the ABI without saying so: three trailing `bool` fields pack to the same size in any order, so swapping two of them would change what every caller reads and neither the size assertion nor the compiler would object. Naming each field also writes down the one real mismatch, `chain` being an enum on one side and a `uint32_t` on the other. The C++-side test initializers are designated for the same reason.

The C field order is still ABI for the struct's consumers, as it must be; what changed is that it is no longer coupled to the C++ declaration order.

**The byte copy is refused rather than merely bypassed.** Both types opt out through a trait the generic conversion asserts on, so a later call that reaches it with either of them fails to compile with the reason stated — the coupling cannot come back by someone adding a call site that does not know about the explicit conversion.

`error_code` gains `transition_in_progress`, `node_behind` and `node_stale`, **appended before `last_error_code`** rather than filed beside the other blockchain codes. The struct breaks ABI on purpose; renumbering every code below an insertion point is a second break with nothing to show for it.

## Tests

Twenty-four. Nine on the gate, including the crossing this exists for — a capture parked while a transition tries to begin, which must not proceed — and its converse. Seven at node level, five on synchronization, three on the rendered JSON — the third being a node caught up on a stale tip, the one case where the two operational flags disagree and so the only one that can catch a renderer emitting one of them under both keys.

**The recapture regression opens the window rather than waiting for it.** Requests coalesce on the rebuild mutex, so a second request arriving while the first is still building is parked exactly between the two reads; a pool large enough to make one build a measurable window puts it there, and the head start is expressed in fractions of that measured build so a slower runner stretches the window instead of losing it. The transition then runs to completion while the first request still holds the mutex — asserted, not assumed, before and after. It fails on the two-lease version, with the parked request returning the old tip at height 41 where the chain is at 42.

**The same shape covers the coinbase budget.** The fallback that serves a stale snapshot rather than block compared the tip and nothing else, so a request asking for a larger reserve — asking precisely because its coinbase does not fit the default — could be handed a template assembled against someone else's budget, on the right parent. The condition now includes the reserve, and a queued request waits for its own rebuild. Its test parks a third request behind a held rebuild mutex and asks for a budget that leaves room for almost nothing; against the tip-only fallback it returns first, immediately, carrying the warm snapshot's whole-pool selection.

Neither concurrent test asserts inside a spawned thread or between launching one and joining it: a failing Catch2 macro throws, and throwing with joinable threads outstanding terminates the process instead of reporting, losing the failure at the moment it is worth having. Both record and assert after the join. Both also assert the window was open before *and* after, so neither can pass without having exercised what it names.

Eleven seconds of the node suite's forty-three go to the recapture test and three to the budget one. That is the price of covering a defect class that survives code review, and it is why neither is hidden behind a slow tag.

Assertions no longer run inside spawned threads: Catch2's macros are not thread-safe, so a failure in a worker terminated the process instead of failing the test, and the handler wrote run state the main thread was also writing. The thread records into an atomic; the main thread asserts after the join.

The two that decide whether `mutated` describes what happened or echoes `ok` **provoke a real failure rather than adding a seam**: an undo record carries its owning block's hash and `read_undo` refuses one that disagrees, before the inverse delta is applied. Damaging the second record to be disconnected lets the block above come off and stops there; damaging the first stops before anything moves. These drive the transition through the chain's own primitives, so what they pin down is the contract of the pieces — a partial rewind publishes where it ended up and reopens — and not that `reorg.cpp` composes them that way, which the reorg tests cover separately.

Node 3318/169 and C-API 2790/735; blockchain 215 cases, all passing. Its assertion count is quoted as cases rather than assertions because it varies from run to run — a pre-existing concurrent mempool stress test asserts a data-dependent number of times.

## Not in scope

Admission is not gated here — its exclusion is the organizers' mutex and its restructuring is the W1/W2/A1/A2 work of #590, which needs #594 first.

Closes #621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mining status indicators for transition activity, synchronization, catch-up, and freshness.
  * Mining information and RPC responses now expose these statuses.
  * Added clear errors when mining is unavailable during transitions, while syncing, or when stale.
  * Improved chain transition handling to prevent inconsistent views during reorganizations and updates.

* **Bug Fixes**
  * Improved branch-switch reporting and publication after partial or unsuccessful changes.
  * Prevented concurrent chain transitions from interfering with active operations.

* **Tests**
  * Expanded coverage for transition gating, synchronization states, freshness limits, reorganizations, and mining-status responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
