### PR TITLE
domain: enforce integer signedness with concepts

### DIFF
--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -583,6 +583,7 @@ if (ENABLE_TEST AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
         test/machine/operation.cpp
         test/machine/program.cpp
 
+        test/math/domain_limits_constraints.cpp
         test/math/limits.cpp
         test/math/stealth.cpp
 

--- a/src/domain/include/kth/domain/math/limits.hpp
+++ b/src/domain/include/kth/domain/math/limits.hpp
@@ -6,6 +6,7 @@
 #define KTH_LIMITS_HPP
 
 #include <algorithm>
+#include <concepts>
 #include <limits>
 #include <stdexcept>
 
@@ -13,17 +14,6 @@
 #include <kth/infrastructure/utility/assert.hpp>
 
 namespace kth::domain {
-
-#define IF(T) std::enable_if<T>
-#define SIGN(T) std::is_signed<T>::value
-#define UNSIGN(T) std::is_unsigned<T>::value
-
-#define SIGNED(A) IF(SIGN(A))
-#define UNSIGNED(A) IF(UNSIGN(A))
-#define SIGNED_SIGNED(A, B) IF(SIGN(A) && SIGN(B))
-#define SIGNED_UNSIGNED(A, B) IF(SIGN(A) && UNSIGN(B))
-#define UNSIGNED_SIGNED(A, B) IF(UNSIGN(A) && SIGN(B))
-#define UNSIGNED_UNSIGNED(A, B) IF(UNSIGN(A) && UNSIGN(B))
 
 template <typename Space, typename Integer>
 Space cast_add(Integer left, Integer right) {
@@ -35,19 +25,19 @@ Space cast_subtract(Integer left, Integer right) {
     return static_cast<Space>(left) - static_cast<Space>(right);
 }
 
-template <typename Integer, typename = UNSIGNED(Integer)>
+template <std::unsigned_integral Integer>
 Integer ceiling_add(Integer left, Integer right) {
     static auto const ceiling = (std::numeric_limits<Integer>::max)();
     return left > ceiling - right ? ceiling : left + right;
 }
 
-template <typename Integer, typename = UNSIGNED(Integer)>
+template <std::unsigned_integral Integer>
 Integer floor_subtract(Integer left, Integer right) {
     static auto const floor = (std::numeric_limits<Integer>::min)();
     return right >= left ? floor : left - right;
 }
 
-template <typename Integer, typename = UNSIGNED(Integer)>
+template <std::unsigned_integral Integer>
 Integer safe_add(Integer left, Integer right) {
     static auto const maximum = (std::numeric_limits<Integer>::max)();
 
@@ -57,7 +47,7 @@ Integer safe_add(Integer left, Integer right) {
     return left + right;
 }
 
-template <typename Integer, typename = UNSIGNED(Integer)>
+template <std::unsigned_integral Integer>
 Integer safe_subtract(Integer left, Integer right) {
     static auto const minimum = (std::numeric_limits<Integer>::min)();
 
@@ -67,19 +57,20 @@ Integer safe_subtract(Integer left, Integer right) {
     return left - right;
 }
 
-template <typename Integer>
+template <std::unsigned_integral Integer>
 void safe_increment(Integer& value) {
     static constexpr auto one = Integer{1};
     value = safe_add(value, one);
 }
 
-template <typename Integer>
+template <std::unsigned_integral Integer>
 void safe_decrement(Integer& value) {
     static constexpr auto one = Integer{1};
     value = safe_subtract(value, one);
 }
 
-template <typename To, typename From, typename = SIGNED_SIGNED(To, From)>
+template <typename To, typename From>
+    requires std::signed_integral<To> && std::signed_integral<From>
 To safe_signed(From signed_value) {
     static auto const signed_minimum = (std::numeric_limits<To>::min)();
     static auto const signed_maximum = (std::numeric_limits<To>::max)();
@@ -90,7 +81,8 @@ To safe_signed(From signed_value) {
     return static_cast<To>(signed_value);
 }
 
-template <typename To, typename From, typename = UNSIGNED_UNSIGNED(To, From)>
+template <typename To, typename From>
+    requires std::unsigned_integral<To> && std::unsigned_integral<From>
 To safe_unsigned(From unsigned_value) {
     static auto const unsigned_minimum = (std::numeric_limits<To>::min)();
     static auto const unsigned_maximum = (std::numeric_limits<To>::max)();
@@ -101,7 +93,8 @@ To safe_unsigned(From unsigned_value) {
     return static_cast<To>(unsigned_value);
 }
 
-template <typename To, typename From, typename = SIGNED_UNSIGNED(To, From)>
+template <typename To, typename From>
+    requires std::signed_integral<To> && std::unsigned_integral<From>
 To safe_to_signed(From unsigned_value) {
     static_assert(sizeof(uint64_t) >= sizeof(To), "safe assign out of range");
     static auto const signed_maximum = (std::numeric_limits<To>::max)();
@@ -112,7 +105,8 @@ To safe_to_signed(From unsigned_value) {
     return static_cast<To>(unsigned_value);
 }
 
-template <typename To, typename From, typename = UNSIGNED_SIGNED(To, From)>
+template <typename To, typename From>
+    requires std::unsigned_integral<To> && std::signed_integral<From>
 To safe_to_unsigned(From signed_value) {
     static_assert(sizeof(uint64_t) >= sizeof(To), "safe assign out of range");
     static auto const unsigned_maximum = (std::numeric_limits<To>::max)();
@@ -150,16 +144,6 @@ To range_constrain(From value, To minimum, To maximum) {
 
     return static_cast<To>(value);
 }
-
-#undef IF
-#undef SIGN
-#undef UNSIGN
-#undef SIGNED
-#undef UNSIGNED
-#undef SIGNED_SIGNED
-#undef SIGNED_UNSIGNED
-#undef UNSIGNED_SIGNED
-#undef UNSIGNED_UNSIGNED
 
 } // namespace kth::domain
 

--- a/src/domain/test/math/domain_limits_constraints.cpp
+++ b/src/domain/test/math/domain_limits_constraints.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kth/domain/math/limits.hpp>
+
+#include <concepts>
+#include <cstdint>
+
+namespace {
+
+namespace kd = kth::domain;
+
+template <typename Integer>
+concept ceiling_add_invocable = requires(Integer value) {
+    kd::ceiling_add(value, value);
+};
+
+template <typename Integer>
+concept floor_subtract_invocable = requires(Integer value) {
+    kd::floor_subtract(value, value);
+};
+
+template <typename Integer>
+concept safe_add_invocable = requires(Integer value) {
+    kd::safe_add(value, value);
+};
+
+template <typename Integer>
+concept safe_subtract_invocable = requires(Integer value) {
+    kd::safe_subtract(value, value);
+};
+
+template <typename Integer>
+concept safe_increment_invocable = requires(Integer value) {
+    kd::safe_increment(value);
+};
+
+template <typename Integer>
+concept safe_decrement_invocable = requires(Integer value) {
+    kd::safe_decrement(value);
+};
+
+template <typename To, typename From>
+concept safe_signed_invocable = requires(From value) {
+    kd::safe_signed<To, From>(value);
+};
+
+template <typename To, typename From>
+concept safe_unsigned_invocable = requires(From value) {
+    kd::safe_unsigned<To, From>(value);
+};
+
+template <typename To, typename From>
+concept safe_to_signed_invocable = requires(From value) {
+    kd::safe_to_signed<To, From>(value);
+};
+
+template <typename To, typename From>
+concept safe_to_unsigned_invocable = requires(From value) {
+    kd::safe_to_unsigned<To, From>(value);
+};
+
+static_assert(ceiling_add_invocable<uint32_t>);
+static_assert( ! ceiling_add_invocable<int32_t>);
+static_assert(floor_subtract_invocable<uint32_t>);
+static_assert( ! floor_subtract_invocable<int32_t>);
+static_assert(safe_add_invocable<uint32_t>);
+static_assert( ! safe_add_invocable<int32_t>);
+static_assert(safe_subtract_invocable<uint32_t>);
+static_assert( ! safe_subtract_invocable<int32_t>);
+static_assert(safe_increment_invocable<uint32_t>);
+static_assert( ! safe_increment_invocable<int32_t>);
+static_assert(safe_decrement_invocable<uint32_t>);
+static_assert( ! safe_decrement_invocable<int32_t>);
+
+static_assert(safe_signed_invocable<int32_t, int64_t>);
+static_assert( ! safe_signed_invocable<uint32_t, int64_t>);
+static_assert( ! safe_signed_invocable<int32_t, uint64_t>);
+
+static_assert(safe_unsigned_invocable<uint32_t, uint64_t>);
+static_assert( ! safe_unsigned_invocable<int32_t, uint64_t>);
+static_assert( ! safe_unsigned_invocable<uint32_t, int64_t>);
+
+static_assert(safe_to_signed_invocable<int32_t, uint64_t>);
+static_assert( ! safe_to_signed_invocable<uint32_t, uint64_t>);
+static_assert( ! safe_to_signed_invocable<int32_t, int64_t>);
+
+static_assert(safe_to_unsigned_invocable<uint32_t, int64_t>);
+static_assert( ! safe_to_unsigned_invocable<int32_t, int64_t>);
+static_assert( ! safe_to_unsigned_invocable<uint32_t, uint64_t>);
+
+} // namespace


### PR DESCRIPTION
## Problem

The signedness constraints in `domain/math/limits.hpp` use `std::enable_if<T>` itself as a default template argument. Since `std::enable_if<false>` is still a valid type, every constraint is inert and unsigned-only arithmetic accepts signed integers.

## Change

- replace the SFINAE macros with `std::unsigned_integral` on unsigned arithmetic and increment/decrement;
- constrain both `To` and `From` independently on all four conversion functions;
- remove the obsolete macro machinery;
- add positive and negative compile-time invocability tests for every constrained function.

## Scope discovered during review

This repairs the public domain header, but deliberately does not close #623. `block_chain.cpp` defines a separate non-template `kth::floor_subtract(time_t, time_t)` with signed minimum as its floor; overload resolution selects it in `is_stale()`. That active blockchain defect is separate from this domain-header change and remains tracked by #623.

The duplicate domain header has no direct production include today. Removing or consolidating it with infrastructure is also outside this focused change.

## Validation

- domain, blockchain and node compile;
- all 61 `[limits]` tests pass;
- compile-time contract test passes with Clang and GCC in C++23 mode;
- restoring the inert constraint makes the negative assertion fail compilation;
- rejecting valid pairs makes the corresponding positive assertion fail.

Addresses part of #623; does not close it.