### PR TITLE
ci: make a slow run explain itself in the job summary

### DIFF
--- a/.github/scripts/ci-metrics.sh
+++ b/.github/scripts/ci-metrics.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# Records what a CI job spent its time on, and renders it into the job summary.
+#
+# Why a script and not inline shell: the point of this is comparing a slow run
+# against a normal one, and two summaries can only be compared if they were
+# produced by the same code. Three workflows calling one script keeps the shape
+# identical; three copies of inline shell would drift within a month.
+#
+# Nothing here may change what the job DOES. It measures and reports.
+#
+# Subcommands
+#   phase-start <name>            note when a phase began
+#   phase-end   <name> [rc]       note how long it took, and how it ended
+#   ccache-snapshot <before|after>
+#   note <key> <value>            record one fact for the summary
+#   summary                       render everything into $GITHUB_STEP_SUMMARY
+#
+# State lives in a directory rather than in $GITHUB_ENV, because a phase that
+# fails still has to be reportable and $GITHUB_ENV is only read between steps.
+
+set -uo pipefail
+
+STATE_DIR="${CI_METRICS_DIR:-${RUNNER_TEMP:-/tmp}/ci-metrics}"
+mkdir -p "${STATE_DIR}"
+
+now_seconds() {
+    date +%s
+}
+
+# ---------------------------------------------------------------------------
+# Timing
+# ---------------------------------------------------------------------------
+
+phase_start() {
+    local name="$1"
+    now_seconds > "${STATE_DIR}/${name}.start"
+}
+
+phase_end() {
+    local name="$1"
+    local rc="${2:-0}"
+    local start end
+
+    if [ ! -f "${STATE_DIR}/${name}.start" ]; then
+        # Said, not guessed. A phase whose start was never recorded has no
+        # duration, and printing one would invent it.
+        echo "unstarted" > "${STATE_DIR}/${name}.duration"
+        echo "${rc}" > "${STATE_DIR}/${name}.rc"
+        return 0
+    fi
+
+    start=$(cat "${STATE_DIR}/${name}.start")
+    end=$(now_seconds)
+    echo $(( end - start )) > "${STATE_DIR}/${name}.duration"
+    echo "${rc}" > "${STATE_DIR}/${name}.rc"
+}
+
+note() {
+    local key="$1"
+    shift
+    printf '%s\n' "$*" > "${STATE_DIR}/note.${key}"
+}
+
+# ---------------------------------------------------------------------------
+# ccache
+# ---------------------------------------------------------------------------
+
+# Absence is an answer and so is an unreadable stat file. Neither is zero: a
+# summary reporting "0 hits" for a run where ccache was never installed would
+# send someone hunting for a cache problem that does not exist, and one
+# reporting nothing at all would let a silently missing ccache look normal.
+ccache_snapshot() {
+    local label="$1"
+    local out="${STATE_DIR}/ccache.${label}"
+
+    if ! command -v ccache >/dev/null 2>&1; then
+        printf 'status\tabsent\n' > "${out}"
+        return 0
+    fi
+
+    local version
+    version=$(ccache --version 2>/dev/null | head -n 1)
+    printf 'version\t%s\n' "${version:-unknown}" > "${out}"
+
+    # --print-stats is the machine-readable form (ccache >= 4.4). Parsing the
+    # human table instead would break on every release that reflows it.
+    local machine
+    if machine=$(ccache --print-stats 2>/dev/null) && [ -n "${machine}" ]; then
+        printf 'status\tok\n' >> "${out}"
+        printf '%s\n' "${machine}" >> "${out}"
+        return 0
+    fi
+
+    # Older ccache: keep the raw text so a human still has something, and say
+    # the numbers could not be read rather than showing zeros for them.
+    local human
+    if human=$(ccache --show-stats 2>/dev/null) && [ -n "${human}" ]; then
+        printf 'status\tunparsed\n' >> "${out}"
+        printf '%s\n' "${human}" | sed 's/^/raw\t/' >> "${out}"
+        return 0
+    fi
+
+    printf 'status\tunreadable\n' >> "${out}"
+}
+
+ccache_field() {
+    local label="$1" key="$2"
+    local file="${STATE_DIR}/ccache.${label}"
+    [ -f "${file}" ] || { printf 'n/a'; return; }
+    local value
+    value=$(awk -F'\t' -v k="${key}" '$1 == k { print $2; exit }' "${file}")
+    printf '%s' "${value:-n/a}"
+}
+
+ccache_status() {
+    ccache_field "$1" status
+}
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+# A phase is in exactly one of four states, and they are not interchangeable.
+# "Not reached" and "measurement unavailable" both have no duration, and a
+# reader chasing a slow run needs to know which: the first says an earlier phase
+# failed, the second says this phase started and the job died inside it.
+#
+# A missing timing file is never a duration of zero. Zero is a measurement, and
+# there is none.
+phase_state() {
+    local name="$1"
+
+    if [ ! -f "${STATE_DIR}/${name}.start" ] && [ ! -f "${STATE_DIR}/${name}.duration" ]; then
+        printf 'not-reached'
+        return
+    fi
+
+    if [ ! -f "${STATE_DIR}/${name}.duration" ] || [ ! -f "${STATE_DIR}/${name}.rc" ]; then
+        # Started and never closed: the step was killed, timed out, or the
+        # runner went away mid-phase.
+        printf 'unavailable'
+        return
+    fi
+
+    if [ "$(cat "${STATE_DIR}/${name}.duration")" = "unstarted" ]; then
+        # Closed without ever being opened — the instrumentation was wired
+        # wrong, and saying so beats printing a number derived from nothing.
+        printf 'unavailable'
+        return
+    fi
+
+    if [ "$(cat "${STATE_DIR}/${name}.rc")" = "0" ]; then
+        printf 'ok'
+    else
+        printf 'failed'
+    fi
+}
+
+duration_of() {
+    local name="$1"
+    case "$(phase_state "${name}")" in
+        not-reached) printf '—' ;;
+        unavailable) printf '—' ;;
+        *)
+            local value
+            value=$(cat "${STATE_DIR}/${name}.duration")
+            printf '%dm %02ds' $(( value / 60 )) $(( value % 60 ))
+            ;;
+    esac
+}
+
+outcome_of() {
+    local name="$1"
+    case "$(phase_state "${name}")" in
+        not-reached) printf 'not reached (an earlier phase failed)' ;;
+        unavailable) printf 'measurement unavailable' ;;
+        ok)          printf 'ok' ;;
+        failed)      printf 'failed (exit %s)' "$(cat "${STATE_DIR}/${name}.rc")" ;;
+    esac
+}
+
+note_of() {
+    local key="$1"
+    local file="${STATE_DIR}/note.${key}"
+    if [ -f "${file}" ]; then cat "${file}"; else printf 'n/a'; fi
+}
+
+emit() {
+    printf '%s\n' "$*" >> "${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+}
+
+ccache_table() {
+    local before after
+    before=$(ccache_status before)
+    after=$(ccache_status after)
+
+    emit "#### ccache"
+    emit ""
+
+    if [ "${before}" = "absent" ] || [ "${after}" = "absent" ]; then
+        emit "**ccache is not installed on this runner.** Every compile ran cold."
+        emit ""
+        emit "This is a statement about the runner, not a measurement of zero hits."
+        return
+    fi
+
+    if [ "${after}" = "unreadable" ]; then
+        emit "**ccache is installed but its statistics could not be read.**"
+        emit ""
+        emit "Version: \`$(ccache_field after version)\`. The numbers below are"
+        emit "unavailable — not zero. A cache-hit problem cannot be ruled in or out"
+        emit "from this run."
+        return
+    fi
+
+    if [ "${after}" = "unparsed" ]; then
+        emit "**This ccache is too old for machine-readable statistics**"
+        emit "(\`$(ccache_field after version)\`), so the fields below could not be"
+        emit "extracted. The raw output is in the job log."
+        return
+    fi
+
+    # Both lines come from the workflow, because the answer differs by
+    # workflow: where the save is a post-job action its outcome is not knowable
+    # here and the note says so, and where it is an explicit prior step the note
+    # carries its real result. A sentence written here would have to be true of
+    # every caller, and no such sentence exists.
+    emit "Restore: **$(note_of ccache_restore)**"
+    emit ""
+    emit "Save: **$(note_of ccache_save)**"
+    emit ""
+    emit "| | Before build | After build |"
+    emit "|---|---:|---:|"
+    emit "| Direct hits | $(ccache_field before direct_cache_hit) | $(ccache_field after direct_cache_hit) |"
+    emit "| Preprocessed hits | $(ccache_field before preprocessed_cache_hit) | $(ccache_field after preprocessed_cache_hit) |"
+    emit "| Misses | $(ccache_field before cache_miss) | $(ccache_field after cache_miss) |"
+    emit "| Uncacheable calls | $(ccache_field before uncacheable) | $(ccache_field after uncacheable) |"
+    emit "| Cache size (KiB) | $(ccache_field before cache_size_kibibyte) | $(ccache_field after cache_size_kibibyte) |"
+    emit "| Cleanups (evictions) | $(ccache_field before cleanups_performed) | $(ccache_field after cleanups_performed) |"
+    emit ""
+    emit "Counters are zeroed between the two snapshots, so the *after* column is"
+    emit "this run's work and the *before* column is what the restored cache"
+    emit "already held. Size and cleanups are cumulative in both."
+    emit ""
+    emit "ccache: \`$(ccache_field after version)\`"
+}
+
+summary() {
+    emit ""
+    emit "### Where the time went"
+    emit ""
+    emit "| Phase | Duration | Outcome |"
+    emit "|---|---:|---|"
+    emit "| Dependency resolution | $(duration_of deps) | $(outcome_of deps) |"
+    emit "| CMake configuration | $(duration_of configure) | $(outcome_of configure) |"
+    emit "| Compilation | $(duration_of compile) | $(outcome_of compile) |"
+    emit "| Tests | $(duration_of tests) | $(outcome_of tests) |"
+
+    # Coverage-only phases. Shown when the job recorded them, absent otherwise,
+    # so one renderer serves every workflow without inventing rows a build job
+    # never had.
+    if [ -f "${STATE_DIR}/coverage_generate.start" ] || \
+       [ -f "${STATE_DIR}/coverage_generate.duration" ]; then
+        emit "| Coverage generation | $(duration_of coverage_generate) | $(outcome_of coverage_generate) |"
+        emit "| Tracefile validation | $(duration_of coverage_validate) | $(outcome_of coverage_validate) |"
+        emit "| Upload | $(duration_of upload) | $(outcome_of upload) |"
+    fi
+    emit ""
+    emit "A phase with no duration is never shown as zero. **Not reached** means an"
+    emit "earlier phase failed and this one never began; **measurement unavailable**"
+    emit "means it began and the job ended inside it."
+    emit ""
+    emit "#### Toolchain"
+    emit ""
+    emit "| | |"
+    emit "|---|---|"
+    emit "| \`CMAKE_CXX_COMPILER\` | \`$(note_of cmake_cxx_compiler)\` |"
+    emit "| \`CMAKE_CXX_COMPILER_LAUNCHER\` | \`$(note_of cmake_cxx_launcher)\` |"
+    emit "| Compiler \`--version\` | \`$(note_of compiler_version)\` |"
+    emit ""
+    emit "The launcher is not the compiler. A ccache in front of clang is still"
+    emit "clang doing the compiling, and reading the launcher's version as the"
+    emit "toolchain's is how a compiler change goes unnoticed."
+    emit ""
+    emit "#### Parallelism"
+    emit ""
+    emit "| | |"
+    emit "|---|---|"
+    emit "| CPUs visible to the runner | \`$(note_of cpus_visible)\` |"
+    emit "| \`CMAKE_BUILD_PARALLEL_LEVEL\` | \`$(note_of cmake_parallel_level)\` |"
+    emit "| \`--parallel\` argument | \`$(note_of parallel_argument)\` |"
+    emit "| Generator / build tool | \`$(note_of build_tool)\` |"
+    emit ""
+    emit "These are what was **asked for**. How many compiler processes actually"
+    emit "ran at once is not observed here, so nothing above should be read as a"
+    emit "measurement of achieved concurrency."
+    emit ""
+    ccache_table
+}
+
+# ---------------------------------------------------------------------------
+
+case "${1:-}" in
+    phase-start)     phase_start "$2" ;;
+    phase-end)       phase_end "$2" "${3:-0}" ;;
+    ccache-snapshot) ccache_snapshot "$2" ;;
+    note)            key="$2"; shift 2; note "${key}" "$@" ;;
+    summary)         summary ;;
+    *)
+        echo "usage: $0 {phase-start|phase-end|ccache-snapshot|note|summary} ..." >&2
+        exit 2
+        ;;
+esac

--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -267,8 +267,19 @@ jobs:
           else
             echo "🔨 Development build - direct compilation with tests"
             conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh $EXTRA_CONAN_OPTS
+            METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
+
+            "$METRICS" phase-start deps
+            set +e
             conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh -o tests=True $EXTRA_CONAN_OPTS
-            
+            rc=$?
+            set -e
+            "$METRICS" phase-end deps "$rc"
+            if [ "$rc" != 0 ]; then exit "$rc"; fi
+
+            # Before the counters are zeroed: this is the restored cache.
+            "$METRICS" ccache-snapshot before
+
             CCACHE_OPT=""
             if command -v ccache &>/dev/null; then
               export PATH="/usr/lib/ccache:$PATH"
@@ -276,18 +287,52 @@ jobs:
               CCACHE_OPT="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
             fi
 
+            "$METRICS" phase-start configure
+            set +e
             cmake --preset conan-release \
                  -DCMAKE_VERBOSE_MAKEFILE=ON \
                  -DGLOBAL_BUILD=ON \
                  -DENABLE_TEST=ON \
                  -DCMAKE_BUILD_TYPE=Release \
                  $CCACHE_OPT
+            rc=$?
+            set -e
+            "$METRICS" phase-end configure "$rc"
+            if [ "$rc" != 0 ]; then exit "$rc"; fi
 
-            cmake --build --preset conan-release -j"$(nproc)"
+            CPUS="$(nproc)"
 
+            "$METRICS" phase-start compile
+            set +e
+            cmake --build --preset conan-release -j"$CPUS"
+            rc=$?
+            set -e
+            "$METRICS" phase-end compile "$rc"
+
+            CACHE_FILE="build/build/Release/CMakeCache.txt"
+            CXX_COMPILER="$(awk -F= '/^CMAKE_CXX_COMPILER:/ { print $2 }' "$CACHE_FILE" 2>/dev/null)"
+            CXX_LAUNCHER="$(awk -F= '/^CMAKE_CXX_COMPILER_LAUNCHER:/ { print $2 }' "$CACHE_FILE" 2>/dev/null)"
+            "$METRICS" note cmake_cxx_compiler "${CXX_COMPILER:-unreadable}"
+            "$METRICS" note cmake_cxx_launcher "${CXX_LAUNCHER:-unset}"
+            if [ -n "${CXX_COMPILER:-}" ] && [ -x "${CXX_COMPILER}" ]; then
+              "$METRICS" note compiler_version "$("${CXX_COMPILER}" --version 2>/dev/null | head -n 1)"
+            else
+              "$METRICS" note compiler_version "unreadable"
+            fi
+
+            "$METRICS" note cpus_visible "$CPUS"
+            "$METRICS" note cmake_parallel_level "${CMAKE_BUILD_PARALLEL_LEVEL:-unset}"
+            "$METRICS" note parallel_argument "$CPUS"
+            "$METRICS" note build_tool "$(awk -F= '/^CMAKE_GENERATOR:/ { print $2 }' "$CACHE_FILE" 2>/dev/null || echo unreadable)"
+
+            "$METRICS" ccache-snapshot after
             if command -v ccache &>/dev/null; then
               ccache --show-stats
             fi
+
+            # Diagnostics above, verdict here. Without this the step would exit
+            # on the last note and a failed build would read as a green one.
+            exit "$rc"
           fi
 
       # Persist caches as soon as the build finishes — saves get the
@@ -315,6 +360,7 @@ jobs:
           key: ${{ steps.restore-conan.outputs.cache-primary-key }}
 
       - name: 🗄️ Save ccache
+        id: save-ccache
         # Save on every non-upload run. The old gate
         # `cache-hit != 'true'` skipped saves for every run whose
         # `conanfile.py`-hashed key already existed, freezing the cache
@@ -422,6 +468,12 @@ jobs:
       # short-circuit on the first failure), but a non-zero rc is recorded
       # in $GITHUB_ENV. The final gate step reads that and fails the job
       # so the workflow correctly surfaces test failures.
+      - name: ⏱️ Tests start
+        if: ${{ inputs.skip-tests != true && inputs.upload != true }}
+        shell: bash
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh" phase-start tests
+
       - name: 🧪 secp256k1 (tests + exhaustive)
         if: ${{ inputs.skip-tests != true && inputs.upload != true }}
         working-directory: build/build/Release
@@ -524,11 +576,39 @@ jobs:
       - name: 🧪 Test results gate
         if: ${{ always() && inputs.skip-tests != true && inputs.upload != true }}
         run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh" phase-end tests "${TESTS_FAILED:-0}"
           if [ "${TESTS_FAILED:-0}" = "1" ]; then
             echo "::error::One or more test binaries failed or timed out (see annotations above)"
             exit 1
           fi
           echo "All test binaries passed"
+
+      # Its own step, and always: a run that failed in configure, in the build
+      # or in the tests is exactly the run this is for. It reports; the steps
+      # that failed have already failed and nothing here changes that.
+      #
+      # Unlike the container-less workflow, the ccache save here is an explicit
+      # step that runs before this one, so its real outcome is knowable and is
+      # reported rather than described as scheduled.
+      - name: 📊 Where the time went
+        if: ${{ always() && inputs.upload != true }}
+        shell: bash
+        run: |
+          METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
+
+          # actions/cache/restore documents cache-primary-key and
+          # cache-matched-key, so here the restore can be reported exactly.
+          if [ "${{ steps.restore-ccache.outcome }}" = "skipped" ]; then
+            "$METRICS" note ccache_restore "not attempted (step skipped)"
+          elif [ -n "${{ steps.restore-ccache.outputs.cache-matched-key }}" ]; then
+            "$METRICS" note ccache_restore "matched \`${{ steps.restore-ccache.outputs.cache-matched-key }}\`"
+          else
+            "$METRICS" note ccache_restore "no key matched; nothing restored"
+          fi
+
+          "$METRICS" note ccache_save "${{ steps.save-ccache.outcome }} (explicit step, ran before this summary)"
+
+          "$METRICS" summary
 
       - name: ⏭️ Skip tests info
         if: ${{ inputs.skip-tests == true }}

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -127,6 +127,7 @@ jobs:
           ccache --version || true
 
       - name: 🗄️ Restore ccache
+        id: ccache-restore
         if: ${{ inputs.upload != true }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -219,26 +220,76 @@ jobs:
           else
             echo "🔨 Development build - direct compilation with tests"
             conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b general-ci-cd -pr:h general-ci-cd
+            METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
+
+            "$METRICS" phase-start deps
+            set +e
             conan install conanfile.py --lockfile=build/conan.lock -of build --build=missing -pr:b general-ci-cd -pr:h general-ci-cd -o tests=True
-            
+            rc=$?
+            set -e
+            "$METRICS" phase-end deps "$rc"
+            if [ "$rc" != 0 ]; then exit "$rc"; fi
+
+            # The cache as it was restored, before the counters are zeroed. This
+            # is the only moment that state is observable.
+            "$METRICS" ccache-snapshot before
+
             CCACHE_OPT=""
             if command -v ccache &>/dev/null; then
               ccache --zero-stats
               CCACHE_OPT="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
             fi
 
+            "$METRICS" phase-start configure
+            set +e
             cmake --preset conan-release \
                  -DCMAKE_VERBOSE_MAKEFILE=ON \
                  -DGLOBAL_BUILD=ON \
                  -DENABLE_TEST=ON \
                  -DCMAKE_BUILD_TYPE=Release \
                  $CCACHE_OPT
+            rc=$?
+            set -e
+            "$METRICS" phase-end configure "$rc"
+            if [ "$rc" != 0 ]; then exit "$rc"; fi
 
-            cmake --build --preset conan-release -j"$(sysctl -n hw.ncpu 2>/dev/null || nproc)"
+            CPUS="$(sysctl -n hw.ncpu 2>/dev/null || nproc)"
 
+            "$METRICS" phase-start compile
+            set +e
+            cmake --build --preset conan-release -j"$CPUS"
+            rc=$?
+            set -e
+            "$METRICS" phase-end compile "$rc"
+
+            # Read out of the cache CMake wrote, so the launcher is not mistaken
+            # for the compiler and neither is guessed at.
+            CACHE_FILE="build/build/Release/CMakeCache.txt"
+            CXX_COMPILER="$(awk -F= '/^CMAKE_CXX_COMPILER:/ { print $2 }' "$CACHE_FILE" 2>/dev/null)"
+            CXX_LAUNCHER="$(awk -F= '/^CMAKE_CXX_COMPILER_LAUNCHER:/ { print $2 }' "$CACHE_FILE" 2>/dev/null)"
+            "$METRICS" note cmake_cxx_compiler "${CXX_COMPILER:-unreadable}"
+            "$METRICS" note cmake_cxx_launcher "${CXX_LAUNCHER:-unset}"
+            if [ -n "${CXX_COMPILER:-}" ] && [ -x "${CXX_COMPILER}" ]; then
+              "$METRICS" note compiler_version "$("${CXX_COMPILER}" --version 2>/dev/null | head -n 1)"
+            else
+              "$METRICS" note compiler_version "unreadable"
+            fi
+
+            "$METRICS" note cpus_visible "$CPUS"
+            "$METRICS" note cmake_parallel_level "${CMAKE_BUILD_PARALLEL_LEVEL:-unset}"
+            "$METRICS" note parallel_argument "$CPUS"
+            "$METRICS" note build_tool "$(awk -F= '/^CMAKE_GENERATOR:/ { print $2 }' "$CACHE_FILE" 2>/dev/null || echo unreadable)"
+
+            "$METRICS" ccache-snapshot after
             if command -v ccache &>/dev/null; then
               ccache --show-stats
             fi
+
+            # Last, and explicit: every line above this one is diagnostics, and
+            # none of them may decide whether the build passed. Without this the
+            # step would exit on the final note and a failed build would read as
+            # a green one.
+            exit "$rc"
           fi
 
       - name: 📊 Build summary
@@ -319,13 +370,16 @@ jobs:
           # still exits 0 so the rest of the workflow can run, but a non-zero
           # rc is recorded in $GITHUB_ENV and the gate step below fails the
           # job. Mirrors the pattern in build-with-container.yml.
+          METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
           cd build/build/Release
           rc=0
+          "$METRICS" phase-start tests
           if [ "${{ inputs.enable-asan }}" = "true" ] || [ "${{ inputs.enable-ubsan }}" = "true" ] || [ "$TSAN_ENABLED_FOR_TESTS" = "true" ]; then
             timeout 1800 ctest --output-on-failure --parallel 2 || rc=$?
           else
             ctest --output-on-failure --parallel 4 || rc=$?
           fi
+          "$METRICS" phase-end tests "$rc"
           if [ "$rc" != 0 ]; then
             echo "::error::ctest failed or timed out (exit=$rc)"
             echo 'TESTS_FAILED=1' >> "$GITHUB_ENV"
@@ -342,6 +396,37 @@ jobs:
             exit 1
           fi
           echo "All tests passed"
+
+      # Its own step, and always: a run that failed in configure, in the build
+      # or in the tests is exactly the run someone needs this for, and a summary
+      # written at the end of the build step would not exist for any of them.
+      # It reports; it does not decide. The steps that failed have already
+      # failed, and nothing here changes that.
+      - name: 📊 Where the time went
+        if: ${{ always() && inputs.upload != true }}
+        run: |
+          METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
+
+          # `cache-hit` is the only output `actions/cache` documents. It answers
+          # one question — did the PRIMARY key match — and this workflow's primary
+          # key ends in the run id on purpose, so it never does. Whether a
+          # restore-key matched is not exposed by this action, and inferring it
+          # from an undocumented output or from the step's outcome would be a
+          # guess dressed as a measurement. The empirical answer is the ccache
+          # "before" snapshot further down: a restored cache has entries.
+          if [ "${{ steps.ccache-restore.outcome }}" = "skipped" ]; then
+            "$METRICS" note ccache_restore "not attempted (step skipped)"
+          elif [ "${{ steps.ccache-restore.outputs.cache-hit }}" = "true" ]; then
+            "$METRICS" note ccache_restore "primary key matched"
+          else
+            "$METRICS" note ccache_restore "no primary-key match; whether a restore-key matched is not reported by actions/cache — see the *before* column"
+          fi
+
+          # The save is a post-job action and runs after this. Saying it was
+          # saved would be reporting something that has not happened.
+          "$METRICS" note ccache_save "scheduled (post-job; result unavailable at summary time)"
+
+          "$METRICS" summary
 
       # ccache log helps diagnose hit-rate problems on macOS-hosted
       # runners — upload it as an artifact so we can post-mortem the

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,6 +56,10 @@ jobs:
         uses: ./ci_utils/.github/actions/setup-kthbuild
 
       - name: 🗄️ Setup ccache
+        # Declared rather than inherited: inside a container the default shell
+        # is whatever the image provides, and `&&`/`||` chains parsed by a
+        # non-bash `sh` behave differently enough to matter.
+        shell: bash
         run: |
           apt-get update -qq && apt-get install -y -qq ccache > /dev/null 2>&1 || true
           ccache --version || true
@@ -90,14 +94,27 @@ jobs:
           restore-keys: ccache-coverage-
 
       - name: 📦 Install dependencies
+        shell: bash
         run: |
+          METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
+          "$METRICS" phase-start deps
+          set +e
           conan install conanfile.py --version 0.0.0 -of build --build=missing \
             -pr:b linux-ci-cd -pr:h linux-ci-cd \
             -o march_id=ZLm9Pjh -o tests=True
+          rc=$?
+          set -e
+          "$METRICS" phase-end deps "$rc"
+          exit "$rc"
 
       - name: 🔨 Build with coverage
+        shell: bash
         run: |
+          METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
           export PATH="/usr/lib/ccache:$PATH"
+
+          # Before zeroing: this is what the restore actually produced.
+          "$METRICS" ccache-snapshot before
           ccache --zero-stats
 
           # Force -O0 on the coverage build. PR #309 dropped this
@@ -109,6 +126,8 @@ jobs:
           # master (24851108475, 2026-04-23) was on -O0 with gcovr
           # finishing in ~4 min. Slower tests are the right trade —
           # this job's purpose is the report, not benchmarking.
+          "$METRICS" phase-start configure
+          set +e
           cmake --preset conan-release \
             -DCMAKE_VERBOSE_MAKEFILE=OFF \
             -DGLOBAL_BUILD=ON \
@@ -119,9 +138,45 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          rc=$?
+          set -e
+          "$METRICS" phase-end configure "$rc"
+          if [ "$rc" != 0 ]; then exit "$rc"; fi
 
-          cmake --build --preset conan-release -j$(nproc)
+          CPUS="$(nproc)"
+
+          "$METRICS" phase-start compile
+          set +e
+          cmake --build --preset conan-release -j"$CPUS"
+          rc=$?
+          set -e
+          "$METRICS" phase-end compile "$rc"
+
+          # The compiler this CONTAINER used, read out of the cache CMake wrote
+          # inside it. The host runner's toolchain is a different thing and is
+          # not what produced these objects — reporting it would describe a
+          # build that did not happen.
+          CACHE_FILE="build/build/Release/CMakeCache.txt"
+          CXX_COMPILER="$(awk -F= '/^CMAKE_CXX_COMPILER:/ { print $2 }' "$CACHE_FILE" 2>/dev/null)"
+          CXX_LAUNCHER="$(awk -F= '/^CMAKE_CXX_COMPILER_LAUNCHER:/ { print $2 }' "$CACHE_FILE" 2>/dev/null)"
+          "$METRICS" note cmake_cxx_compiler "${CXX_COMPILER:-unreadable}"
+          "$METRICS" note cmake_cxx_launcher "${CXX_LAUNCHER:-unset}"
+          if [ -n "${CXX_COMPILER:-}" ] && [ -x "${CXX_COMPILER}" ]; then
+            "$METRICS" note compiler_version "$("${CXX_COMPILER}" --version 2>/dev/null | head -n 1)"
+          else
+            "$METRICS" note compiler_version "unreadable"
+          fi
+
+          "$METRICS" note cpus_visible "$CPUS"
+          "$METRICS" note cmake_parallel_level "${CMAKE_BUILD_PARALLEL_LEVEL:-unset}"
+          "$METRICS" note parallel_argument "$CPUS"
+          "$METRICS" note build_tool "$(awk -F= '/^CMAKE_GENERATOR:/ { print $2 }' "$CACHE_FILE" 2>/dev/null || echo unreadable)"
+
+          "$METRICS" ccache-snapshot after
           ccache --show-stats
+
+          # Diagnostics above, verdict here.
+          exit "$rc"
 
       # Persist ccache as soon as the build finishes — the compile
       # output is what populates it, so saving here gets the most
@@ -130,6 +185,7 @@ jobs:
       # save from failing the whole job; the failure becomes a
       # non-fatal warning.
       - name: 🗄️ Save ccache
+        id: save-ccache
         if: always() && steps.restore-ccache.outputs.cache-hit != 'true'
         continue-on-error: true
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -138,8 +194,16 @@ jobs:
           key: ccache-coverage-${{ github.sha }}
 
       - name: 🧪 Run tests
+        shell: bash
         run: |
-          ctest --preset conan-release --output-on-failure -j$(nproc)
+          METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
+          "$METRICS" phase-start tests
+          set +e
+          ctest --preset conan-release --output-on-failure -j"$(nproc)"
+          rc=$?
+          set -e
+          "$METRICS" phase-end tests "$rc"
+          exit "$rc"
 
       - name: 📊 Generate coverage report
         if: always()
@@ -198,6 +262,8 @@ jobs:
           # `branch_coverage=0` is the lcov-2.x spelling of the
           # legacy `lcov_branch_coverage` option (still accepted,
           # but emits a deprecation warning per invocation).
+          METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
+          "$METRICS" phase-start coverage_generate
           lcov --capture \
                --directory build/build/Release/src/domain \
                --directory build/build/Release/src/infrastructure \
@@ -237,16 +303,25 @@ jobs:
           # treats a missing file as a warning. That is how the dead step
           # above stayed invisible: nothing between "produced nothing" and
           # "uploaded nothing" ever said so.
+          "$METRICS" phase-end coverage_generate 0
+
+          # Generation and validation are timed apart on purpose: lcov producing
+          # a tracefile and that tracefile being worth anything are different
+          # facts, and a run that is slow in one says nothing about the other.
+          "$METRICS" phase-start coverage_validate
           test -s coverage.info || {
+            "$METRICS" phase-end coverage_validate 1
             echo "::error::coverage.info is missing or empty"
             exit 1
           }
           records=$(grep -c '^SF:' coverage.info || true)
           bytes=$(wc -c < coverage.info)
           test "${records}" -gt 0 || {
+            "$METRICS" phase-end coverage_validate 1
             echo "::error::coverage.info holds no SF: records — nothing was captured"
             exit 1
           }
+          "$METRICS" phase-end coverage_validate 0
           totals=$(lcov --list coverage.info | tail -1)
           echo "coverage.info: ${bytes} bytes, ${records} source files"
           echo "${totals}"
@@ -318,7 +393,18 @@ jobs:
             echo '</details>'
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      # Opened here so the phase has a beginning. Ending a phase that never
+      # started reports "measurement unavailable" — truthfully, which is why the
+      # gap was invisible: the summary was right about not knowing, and nobody
+      # had told it.
+      - name: ⏱️ Upload start
+        if: always()
+        shell: bash
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh" phase-start upload
+
       - name: ☁️ Upload to Codecov
+        id: codecov-upload
         if: always()
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
@@ -326,3 +412,37 @@ jobs:
           fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true
+
+      # Always, and last: a run that failed in the build, in generation or in
+      # the upload is exactly the run someone opens this for. It reports what
+      # happened; it does not change any of it. `continue-on-error` on the cache
+      # steps and the job's own setting are untouched — nothing here decides an
+      # exit code.
+      - name: 📊 Where the time went
+        if: always()
+        shell: bash
+        run: |
+          METRICS="${GITHUB_WORKSPACE}/.github/scripts/ci-metrics.sh"
+
+          # Three outcomes, kept apart. "Not reached" is a step that never ran
+          # because the job ended before it; a failed upload is a step that ran
+          # and did not work. Folding them together would hide a broken token
+          # behind an unrelated build failure.
+          case "${{ steps.codecov-upload.outcome }}" in
+            success)  "$METRICS" phase-end upload 0 ;;
+            failure)  "$METRICS" phase-end upload 1 ;;
+            skipped|"") : ;;   # never ran: left as "not reached"
+            *)        "$METRICS" phase-end upload 1 ;;
+          esac
+
+          if [ "${{ steps.restore-ccache.outcome }}" = "skipped" ]; then
+            "$METRICS" note ccache_restore "not attempted (step skipped)"
+          elif [ -n "${{ steps.restore-ccache.outputs.cache-matched-key }}" ]; then
+            "$METRICS" note ccache_restore "matched \`${{ steps.restore-ccache.outputs.cache-matched-key }}\`"
+          else
+            "$METRICS" note ccache_restore "no key matched; nothing restored"
+          fi
+
+          "$METRICS" note ccache_save "${{ steps.save-ccache.outcome }} (explicit step, ran before this summary)"
+
+          "$METRICS" summary


### PR DESCRIPTION
Stage one of #624: a slow run should explain itself from the summary, without
reading a full build transcript and comparing it against a remembered one.

**Observability only.** Nothing here changes cache keys, parallelism, the
generator, PCH, unity builds or the shape of any workflow, and nothing is made
advisory. #624 stays open for the optimization these measurements exist to
inform.

## What each job now records

Dependency resolution, CMake configuration, compilation and tests — and for
coverage also report generation, tracefile validation and upload — with the
toolchain, the parallelism that was *requested*, and what ccache did.

One script (`.github/scripts/ci-metrics.sh`) rather than three copies of inline
shell: the whole point is comparing two runs, and two summaries can only be
compared if the same code produced them.

## What it refuses to say

This is the part worth reviewing, because each of these is a way a summary can
look informative and be wrong.

**ccache absent, too old for machine-readable stats, and unreadable are three
statements, and none of them is "0 hits."** A summary reporting zero for a
runner that never had ccache sends someone hunting a cache problem that does not
exist.

**A phase that was never reached and one whose measurement is missing are
different facts, and neither is a duration of zero.** *Not reached* says an
earlier phase failed and this one never began; *measurement unavailable* says it
began and the job ended inside it.

**Only documented outputs.** `actions/cache` documents `cache-hit` and nothing
else, so where that action is used the summary says a restore-key match is not
reported rather than inferring one — and points at the ccache *before* column,
which is the empirical answer. Where `actions/cache/restore` is used,
`cache-matched-key` is documented and is printed.

**The save is reported as what it is.** A post-job action in one workflow —
*scheduled*, not done, because it has not happened yet — and an explicit prior
step in the other two, where its real outcome is knowable and printed.

**The launcher is not the compiler.** ccache in front of clang is still clang.
They are recorded apart, and inside the containers the compiler is read from the
CMake cache written *there*, not from the host runner.

**Requested is not achieved.** Visible CPUs, the `--parallel` argument and
`CMAKE_BUILD_PARALLEL_LEVEL` are reported as requests. How many compiler
processes actually ran at once is not observed, and is not claimed.

## The instrumentation cannot decide a job's result

Every timed phase captures its exit code, records the timing, then exits with
what it captured. Verified in both directions rather than reasoned about:

| | Step exit code | Summary written |
|---|---|---|
| With the explicit `exit "$rc"` | **2** — job red | yes, *Compilation — failed (exit 2)* |
| Without it (the obvious pattern) | **0** — silently advisory | yes |

That second row is the failure this guards against, and it is invisible without
the control: the step goes green, the summary still renders, and everything
looks fine.

The summary is its own `always()` step, so it exists for the runs that need it
most — the ones that failed in configure, in the build, or in the tests.

## Validation

`actionlint` reports **no new findings** on any of the three workflows,
compared category by category against the same file at `master` (20, 25 and 3
pre-existing). Two of coverage's three are fixed here as a byproduct: the
instrumentation had to read the parallelism argument anyway, and quoting it
resolved them. `shellcheck` is clean on the script. Steps in containers that use
bash syntax now declare `shell: bash`.

## Still to come on this PR

The three real summaries — container-less build, container build, coverage —
pasted here from this branch's own run, once it finishes. They are the only
thing that can validate the rendered format and the actions' outputs, and until
they are here this PR is not ready to merge.

Part of #624, which stays open.
