### PR TITLE
fix: keep the stale cutoff in the timestamp domain

### DIFF
--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -43,15 +43,6 @@
 
 #include <utxoz/logging.hpp>
 
-namespace kth {
-
-time_t floor_subtract(time_t left, time_t right) {
-    static auto const floor = (std::numeric_limits<time_t>::min)();
-    return right >= left ? floor : left - right;
-}
-
-} // namespace kth
-
 namespace kth::blockchain {
 
 using spent_value_type = std::pair<hash_digest, uint32_t>;
@@ -1383,7 +1374,16 @@ bool block_chain::is_stale() const {
     }
 
     auto const timestamp = top ? top->header().timestamp() : last_timestamp;
-    return timestamp < floor_subtract(zulu_time(), notify_limit_seconds_);
+    auto const now = static_cast<uint32_t>(zulu_time());
+    auto const limit = notify_limit_seconds_ > time_t(std::numeric_limits<uint32_t>::max())
+        ? std::numeric_limits<uint32_t>::max()
+        : static_cast<uint32_t>(notify_limit_seconds_);
+
+    // Keep both operands unsigned so floor_subtract saturates at zero. The old
+    // local time_t overload saturated at TIME_MIN and bypassed the constrained
+    // helper entirely; its comparison happened to produce the expected boolean
+    // while expressing the wrong cutoff.
+    return timestamp < floor_subtract(now, limit);
 }
 
 settings const& block_chain::chain_settings() const {


### PR DESCRIPTION
## Problem

The concepts migration in #625 deliberately left one live workaround outside its scope: `block_chain.cpp` defined an unconstrained `kth::floor_subtract(time_t, time_t)`.

That overload won overload resolution in `is_stale()` and saturated underflow at `TIME_MIN`, while timestamps live in a 32-bit unsigned domain and the intended floor is zero. The final comparison happened to return the expected boolean, but only because no valid timestamp is below `TIME_MIN`.

## Change

- Remove the local signed overload.
- Clamp the configured limit to `uint32_t`, matching the timestamp domain.
- Call the constrained unsigned helper, whose underflow floor is zero.

This keeps `is_stale()` on its existing stored-block-marker semantics; it does not mix this cleanup with the published-chain synchronization work.

## Validation

- `git diff --check`
- Built `kth_blockchain_test` with Apple Clang 21 / C++23.
- Blockchain suite: 215 test cases, 3,751 assertions, all passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale-block detection by safely handling notification limits that exceed supported time ranges.
  * Ensured time comparisons use consistent unsigned values for more reliable blockchain freshness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->