### PR TITLE
ci: stop the cache budget from evicting the cache that matters

### DIFF
--- a/.github/scripts/ccache-prune-selftest.sh
+++ b/.github/scripts/ccache-prune-selftest.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Exercises ccache-prune.sh against a synthetic inventory, with `gh` stubbed.
+#
+# Run by CI on the macOS job with the platform's own /bin/bash, which is 3.2.
+# The first revision of this work used `mapfile`, which that Bash does not have:
+# a script tested only under a newer Bash is a script that has not been tested
+# where half these jobs run.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PRUNE="${HERE}/ccache-prune.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+echo "ccache-prune-selftest: bash ${BASH_VERSION}"
+
+cat > "${WORK}/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ] && [ "$2" != "-X" ]; then
+    cat "${FAKE_CACHES}"
+    exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "-X" ] && [ "$3" = "DELETE" ]; then
+    echo "$4" >> "${FAKE_DELETED}"
+    exit 0
+fi
+exit 1
+STUB
+chmod +x "${WORK}/gh"
+
+cat > "${WORK}/caches.json" <<'JSON'
+{"actions_caches":[
+ {"key":"ccache-Linux-GCC-16-clean-100","ref":"refs/heads/master","size_in_bytes":830000000,"created_at":"2026-08-07T13:50:00Z"},
+ {"key":"ccache-Linux-GCC-16-clean-200","ref":"refs/heads/master","size_in_bytes":840000000,"created_at":"2026-08-07T14:20:00Z"},
+ {"key":"ccache-Linux-GCC-16-clean-300","ref":"refs/heads/master","size_in_bytes":850000000,"created_at":"2026-08-08T12:40:00Z"},
+ {"key":"ccache-Linux-GCC-16-clean-999","ref":"refs/pull/9/merge","size_in_bytes":800000000,"created_at":"2026-08-08T13:00:00Z"},
+ {"key":"ccache-Linux-GCC-16-sanitizers-300","ref":"refs/heads/master","size_in_bytes":1100000000,"created_at":"2026-08-08T12:45:00Z"}
+]}
+JSON
+
+export PATH="${WORK}:${PATH}"
+export GITHUB_REPOSITORY="k-nuth/kth"
+export FAKE_CACHES="${WORK}/caches.json"
+
+failures=0
+check() {
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected [$3], got [$2]"
+        failures=$(( failures + 1 ))
+    fi
+}
+
+# 1. Three master entries in one family: keep the newest, drop the two older,
+#    and never touch the pull-request-scoped one.
+export FAKE_DELETED="${WORK}/d1"; : > "${FAKE_DELETED}"
+out=$(GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
+check "keeps the newest" "$(printf '%s' "${out}" | grep -c 'kept ccache-Linux-GCC-16-clean-300')" "1"
+check "removes two" "$(grep -c . "${FAKE_DELETED}")" "2"
+check "leaves the PR-scoped entry" "$(grep -c 'clean-999' "${FAKE_DELETED}" || true)" "0"
+
+# 2. A family with a single entry has nothing superseded.
+export FAKE_DELETED="${WORK}/d2"; : > "${FAKE_DELETED}"
+out=$(GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-sanitizers-" 2>&1)
+check "single entry deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+check "single entry says so" "$(printf '%s' "${out}" | grep -c 'nothing superseded')" "1"
+
+# 3. An unreadable inventory is reported as not examined — never as clean.
+export FAKE_DELETED="${WORK}/d3"; : > "${FAKE_DELETED}"
+echo 'not json' > "${WORK}/bad.json"
+out=$(FAKE_CACHES="${WORK}/bad.json" GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
+check "unparseable listing warns" "$(printf '%s' "${out}" | grep -c 'nothing was examined')" "1"
+check "unparseable listing deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+check "unparseable is not reported as superseded-free" \
+     "$(printf '%s' "${out}" | grep -c 'nothing superseded')" "0"
+
+# 4. No token: same discipline.
+export FAKE_DELETED="${WORK}/d4"; : > "${FAKE_DELETED}"
+out=$(GH_TOKEN='' "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
+check "no token warns" "$(printf '%s' "${out}" | grep -c 'nothing was examined')" "1"
+check "no token deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+
+if [ "${failures}" -ne 0 ]; then
+    echo "ccache-prune-selftest: ${failures} failure(s)"
+    exit 1
+fi
+echo "ccache-prune-selftest: all checks passed"

--- a/.github/scripts/ccache-prune.sh
+++ b/.github/scripts/ccache-prune.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Delete the ccache entries a family no longer needs.
+#
+# The primary key ends in the run id on purpose: with a split restore/save, a
+# save whose key already exists is rejected, so a unique key is what makes the
+# save fire at all. The cost is that every run mints a new ~1 GB entry, and
+# `restore-keys` only ever restores the newest of them. The rest are dead weight
+# against a hard 10 GB repository budget — and when that budget is exceeded
+# GitHub evicts by least-recently-used, which takes out the family written
+# LEAST often rather than the one wasting the most space.
+#
+# Measured on this repository (#624): six `clean` entries at 4.97 GB, six macOS
+# at 1.36 GB, two coverage at 3.73 GB, 13.14 GB total against a 10 GB limit —
+# and exactly one `sanitizers` entry, whose restore then found nothing at all
+# and paid a 100 %-miss build of 8389 s against 149 s when it survives.
+#
+# So: keep the newest of the family, drop the rest. Nothing is inferred about
+# which entry is useful — `restore-keys` picks the most recent, and that is the
+# one kept.
+
+set -uo pipefail
+
+PREFIX="${1:?usage: ccache-prune.sh <key-prefix> [ref]}"
+REF="${2:-refs/heads/master}"
+
+if [ -z "${GH_TOKEN:-}" ]; then
+    echo "::warning::ccache-prune: no token, nothing was examined"
+    exit 0
+fi
+
+if ! listing=$(gh api "repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100" 2>&1) || [ -z "${listing}" ]; then
+    # Said out loud. A prune that could not read the inventory has not found
+    # "nothing to delete" — it has found nothing at all, and reporting the two
+    # the same way is how a silently broken cleanup looks healthy for months.
+    echo "::warning::ccache-prune: could not list caches; no entry was examined or removed"
+    exit 0
+fi
+
+# Newest first, restricted to this family and this ref. Only the default branch
+# prunes: a pull request restoring from master must not be able to delete what
+# master's next run will restore.
+parsed=$(printf '%s' "${listing}" | PRUNE_PREFIX="${PREFIX}" PRUNE_REF="${REF}" python3 -c '
+import json, os, sys
+prefix = os.environ["PRUNE_PREFIX"]
+ref = os.environ["PRUNE_REF"]
+data = json.load(sys.stdin).get("actions_caches", [])
+rows = [c for c in data if c["key"].startswith(prefix) and c["ref"] == ref]
+rows.sort(key=lambda c: c["created_at"], reverse=True)
+for c in rows:
+    sys.stdout.write(c["key"] + "\t" + str(c["size_in_bytes"]) + "\n")
+')
+parse_rc=$?
+
+if [ "${parse_rc}" -ne 0 ]; then
+    # Not "nothing to prune". The inventory could not be read, which is a
+    # different fact and has to stay one: a cleanup that crashes and reports
+    # "nothing superseded" is indistinguishable from one that works, and the
+    # budget keeps growing while the summary says it is fine.
+    echo "::warning::ccache-prune: could not parse the cache listing; nothing was examined"
+    exit 0
+fi
+
+newest=""
+freed=0
+removed=0
+
+# A while-read loop, not `mapfile`: the macOS runners ship Bash 3.2, where
+# `mapfile` does not exist. A script that only runs under Homebrew's Bash is a
+# script that does not run where half these jobs run.
+while IFS='	' read -r key size; do
+    [ -n "${key}" ] || continue
+
+    if [ -z "${newest}" ]; then
+        # The list arrives newest-first, and this is the one `restore-keys`
+        # would pick. Keeping anything else would be choosing for it.
+        newest="${key}"
+        continue
+    fi
+
+    if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/caches?key=${key}&ref=${REF}" >/dev/null 2>&1; then
+        freed=$(( freed + size ))
+        removed=$(( removed + 1 ))
+        echo "ccache-prune: removed ${key} ($(( size / 1000000 )) MB)"
+    else
+        echo "::warning::ccache-prune: could not remove ${key}"
+    fi
+done <<EOF
+${parsed}
+EOF
+
+if [ -z "${newest}" ]; then
+    echo "ccache-prune: ${PREFIX} has no entry on ${REF}; nothing superseded"
+    exit 0
+fi
+
+if [ "${removed}" -eq 0 ]; then
+    echo "ccache-prune: ${PREFIX} — kept ${newest}, nothing superseded"
+    exit 0
+fi
+
+echo "ccache-prune: ${PREFIX} — kept ${newest}, removed ${removed}, freed $(( freed / 1000000 )) MB"

--- a/.github/scripts/check-cache-keys.py
+++ b/.github/scripts/check-cache-keys.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Assert that every ccache restore keeps both `key` and `restore-keys`.
+
+This exists because of a defect that shipped in the first revision of #629: an
+edit inserted a step between a restore's `key` and its `restore-keys`, and the
+`restore-keys` line landed inside the new step's `run:` block. The YAML stayed
+valid, actionlint had nothing to say, and the only symptom would have been every
+container build compiling cold — the exact failure that PR was written to fix,
+introduced by the fix.
+
+A primary key that ends in the run id can never match. `restore-keys` is the
+only thing that makes a restore possible at all, so losing it is not a
+degradation, it is a total loss, and it is invisible to every other check.
+"""
+
+import sys
+import pathlib
+import yaml
+
+WORKFLOWS = pathlib.Path(".github/workflows")
+
+
+def restore_steps(doc):
+    for job in (doc.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            uses = step.get("uses") or ""
+            if "actions/cache" in uses and "/save" not in uses:
+                yield step
+
+
+def main() -> int:
+    failures = []
+    checked = 0
+
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            # Unreadable is not "no findings". Say which file and stop.
+            failures.append(f"{path}: could not be parsed ({exc.__class__.__name__})")
+            continue
+        if not isinstance(doc, dict):
+            continue
+
+        for step in restore_steps(doc):
+            name = step.get("name", "<unnamed>")
+            with_ = step.get("with") or {}
+            key = str(with_.get("key", ""))
+
+            # Only the caches whose key rotates per run depend on restore-keys.
+            # A key that is stable across runs matches on its own.
+            if "github.run_id" not in key and "github.sha" not in key:
+                continue
+
+            checked += 1
+            if "restore-keys" not in with_:
+                failures.append(
+                    f"{path}: step {name!r} has a per-run primary key and no "
+                    f"restore-keys, so it can never restore anything"
+                )
+
+    if checked == 0:
+        # Nothing examined is its own answer: either the workflows changed shape
+        # or this check is looking in the wrong place. Either way it is not a
+        # pass, because a check that silently examines nothing always passes.
+        print("::error::check-cache-keys: no per-run cache restore was examined", file=sys.stderr)
+        return 1
+
+    for f in failures:
+        print(f"::error::check-cache-keys: {f}", file=sys.stderr)
+
+    if failures:
+        return 1
+
+    print(f"check-cache-keys: {checked} per-run cache restore(s), all keep restore-keys")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -376,6 +376,25 @@ jobs:
           path: /github/home/.cache/ccache
           key: ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-${{ github.run_id }}
 
+      # The measured cause of the slow runs (#624): every run mints a new ~1 GB
+      # entry because the key must be unique for the save to fire, `restore-keys`
+      # only ever restores the newest, and the rest push the repository past its
+      # 10 GB budget. GitHub then evicts least-recently-used, which removes the
+      # family written least often - the sanitizer cache - and that job's build
+      # goes from 149 s to 8389 s with every translation unit missing.
+      #
+      # After the save, so what is pruned is never what this run just wrote.
+      # Only master prunes, and only master-scoped entries: a pull request must
+      # not be able to delete what master's next run will restore.
+      - name: 🧹 Prune superseded ccache entries
+        if: ${{ always() && inputs.upload != true && github.ref == 'refs/heads/master' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune.sh" "ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-"
+
       - name: 📊 Build summary
         if: always()
         run: |

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -120,6 +120,19 @@ jobs:
         with:
           new-version: ${{ inputs.build-version }}
 
+      # Runs with the platform's own /bin/bash, which on the macOS runners is
+      # 3.2. The prune script used `mapfile` in its first revision — a Bash 4
+      # builtin — so it passed every local test and would have failed here.
+      # And the key check exists because an edit once moved a `restore-keys`
+      # line into a neighbouring step's `run:` block: valid YAML, nothing for
+      # actionlint to say, and every container build silently cold.
+      - name: 🧪 CI script checks
+        if: ${{ inputs.upload != true }}
+        shell: /bin/bash -e {0}
+        run: |
+          python3 "${GITHUB_WORKSPACE}/.github/scripts/check-cache-keys.py"
+          "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-selftest.sh"
+
       - name: 🗄️ Setup ccache
         if: ${{ inputs.upload != true }}
         run: |
@@ -427,6 +440,21 @@ jobs:
           "$METRICS" note ccache_save "scheduled (post-job; result unavailable at summary time)"
 
           "$METRICS" summary
+
+
+      # See #624 and .github/scripts/ccache-prune.sh: the run-unique key is what
+      # makes the save fire, and the entries it leaves behind are what push the
+      # repository past its cache budget. This job's own save is a post-job
+      # action that has not run yet, so what is pruned here is what earlier runs
+      # left — which is exactly the accumulation that matters.
+      - name: 🧹 Prune superseded ccache entries
+        if: ${{ always() && inputs.upload != true && github.ref == 'refs/heads/master' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune.sh" "ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-"
 
       # ccache log helps diagnose hit-rate problems on macOS-hosted
       # runners — upload it as an artifact so we can post-mortem the

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -193,6 +193,19 @@ jobs:
           path: /github/home/.cache/ccache
           key: ccache-coverage-${{ github.sha }}
 
+
+      # The two coverage entries are the largest single consumers of the
+      # repository's cache budget (1.92 GB + 1.81 GB measured in #624), and only
+      # the newest is ever restored.
+      - name: 🧹 Prune superseded ccache entries
+        if: ${{ always() && github.ref == 'refs/heads/master' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune.sh" "ccache-coverage-"
+
       - name: 🧪 Run tests
         shell: bash
         run: |


### PR DESCRIPTION
The optimization #624 asked for, aimed at the mechanism the #627 instrumentation
measured.

## What a slow run is actually waiting for

Not Build & Test. The **Sanitizers** job, which decides the workflow's wall
clock, and within it a single step:

| run | Build & Test (linux) | **Sanitizers** | sanitizer build step | ccache hits |
|---|---:|---:|---:|---:|
| 31184472387 | 1673s | **7745s** | 6901s | **0.00 %** |
| 31184501817 | 1732s | **9027s** | 8156s | **0.00 %** |
| 31184550805 | 1872s | **9269s** | 8389s | **0.00 %** |
| 31225631374 | 4590s | **8965s** | 7947s | **0.00 %** |
| 31257578342 | 450s | **1100s** | **149s** | **99.56 %** |

The 149-second run is not a different job. It is the same job on a run where the
cache survived. Wall clock for the whole workflow: 131, 152, 157, 152 minutes —
and 21.

## Why the cache does not survive

The primary key ends in `github.run_id`. That is deliberate and load-bearing:
under a split restore/save, a save whose key already exists is rejected, so a
stable key froze the cache — which is what the comments in the workflows already
record. The cost was never accounted for: **every run mints a fresh ~1 GB entry**
while `restore-keys` only ever restores the newest.

Measured inventory:

| family | entries | size |
|---|---:|---:|
| `ccache-Linux-GCC-16-clean` | 6 | 4.97 GB |
| `ccache-macOS-apple-clang-21-clean` | 6 | 1.36 GB |
| `ccache-coverage-*` | 2 | 3.73 GB |
| `ccache-Linux-GCC-16-sanitizers` | **1** | 1.10 GB |
| | | **13.14 GB** against a 10 GB limit |

Over budget, GitHub evicts least-recently-used. That does **not** remove the six
redundant `clean` copies wasting five gigabytes — it removes the family written
*least often*, which is the sanitizer cache: one job per run against several for
`clean`. The job that needs the cache most is the one that loses it, and then
compiles 1135 of 1135 translation units cold.

The slow runs say it outright:

```
Cache not found for input keys: ccache-Linux-GCC-16-sanitizers-31184550805,
                                ccache-Linux-GCC-16-sanitizers-
Hits: 0 / 1135 (0.00%)   Misses: 1135 / 1135 (100.0%)
```

Not even the prefix matched. The family was gone.

## The change

Delete the superseded entries after each master run, keeping the newest of each
family — the one `restore-keys` would pick anyway. Keys, restore behaviour,
parallelism, generator and workflow topology are untouched.

Only master prunes, and only master-scoped entries: a pull request restoring
from master must not be able to delete what master's next run will restore.

## Two hypotheses measured and dropped first

**ccache itself is healthy.** 99.9 % hits on both platforms when the cache is
present, cacheable calls 100 %, no internal evictions, 0.8 GiB of a 5 GiB local
limit. Not the mechanism.

**Parallelism is not being wasted.** Instrumented locally at the runner's `-j4`
on a sparse rebuild, the build kept four compilers busy **92.7 %** of the wall
clock, averaging 4.16 active, idle 0.3 %. The Makefile generator is not starving
cores, so switching generators would not have bought the time. Refuted, and not
attempted.

## Controls

The prune reports what it did **and what it did not**: no token, an unreadable
listing and an unparseable one are each reported as *nothing was examined*, never
as *nothing superseded*. Verified — including the case where the parse crashes,
which in the first draft of this script printed "nothing superseded" and would
have let a broken cleanup look healthy indefinitely. That is the same defect this
PR is about, one level down.

Behaviour verified against a synthetic inventory: three master entries plus one
PR-scoped entry in the same family leaves the newest master entry, deletes the
two older ones, frees 1670 MB, and never touches the PR-scoped one. A family with
a single entry reports nothing superseded and deletes nothing.

**Build failures still fail the job.** The prune is a separate step with
`continue-on-error`, and the diff touches **no line of any build step** — it is
additions only. #627's exit-code propagation is intact by construction.

`actionlint` reports no new findings on any of the three workflows (1, 25 and 20
pre-existing, unchanged). `shellcheck` clean on both scripts.

## What this does not claim

The before/after cannot be shown until this runs on master: the prune only acts
there. The prediction is explicit — freeing ~5.5 GB brings the repository under
the 10 GB limit, eviction stops, and the sanitizer family survives between runs,
taking that job's build from ~8000s to ~150s and the workflow's wall clock from
~150 minutes to ~20. If that does not happen, the hypothesis was wrong and the
next one is queued.

Part of #624, which stays open until the effect is confirmed on master.
