### PR TITLE
ci: prune caches through the REST API instead of a tool the container lacks

### DIFF
--- a/.github/scripts/ccache-prune-selftest.sh
+++ b/.github/scripts/ccache-prune-selftest.sh
@@ -15,22 +15,58 @@ trap 'rm -rf "${WORK}"' EXIT
 
 echo "ccache-prune-selftest: bash ${BASH_VERSION}"
 
-cat > "${WORK}/gh" <<'STUB'
+# A curl that answers from files instead of the network. It honours the two
+# flags the script relies on — --output and --write-out '%{http_code}' — so the
+# status handling is what is under test, not a mock of it.
+cat > "${WORK}/curl" <<'STUB'
 #!/usr/bin/env bash
-if [ "$1" = "api" ] && [ "$2" != "-X" ]; then
-    cat "${FAKE_CACHES}"
+out=""
+method="GET"
+url=""
+prev=""
+for arg in "$@"; do
+    case "${prev}" in
+        --output) out="${arg}" ;;
+        --request) method="${arg}" ;;
+    esac
+    case "${arg}" in
+        https://*|http://*) url="${arg}" ;;
+    esac
+    prev="${arg}"
+done
+
+if [ "${method}" = "GET" ]; then
+    if [ -n "${FAKE_CURL_FAIL:-}" ]; then
+        # What curl does when it never reaches the host: --write-out prints 000
+        # and the process exits non-zero with a message on stderr. Both halves
+        # matter — the first revision appended its own 000 to this one.
+        : > "${out}"
+        printf '000'
+        echo "curl: (6) Could not resolve host: api.github.com" >&2
+        exit 6
+    fi
+    page="${FAKE_PAGE:-1}"
+    src="${FAKE_CACHES}"
+    case "${url}" in
+        *"page=2"*) [ -n "${FAKE_CACHES_P2:-}" ] && src="${FAKE_CACHES_P2}" ;;
+    esac
+    cat "${src}" > "${out}"
+    printf '%s' "${FAKE_LIST_STATUS:-200}"
     exit 0
 fi
-if [ "$1" = "api" ] && [ "$2" = "-X" ] && [ "$3" = "DELETE" ]; then
-    echo "$4" >> "${FAKE_DELETED}"
+
+if [ "${method}" = "DELETE" ]; then
+    echo "${url}" >> "${FAKE_DELETED}"
+    : > "${out}"
+    printf '%s' "${FAKE_DELETE_STATUS:-204}"
     exit 0
 fi
 exit 1
 STUB
-chmod +x "${WORK}/gh"
+chmod +x "${WORK}/curl"
 
 cat > "${WORK}/caches.json" <<'JSON'
-{"actions_caches":[
+{"total_count":5,"actions_caches":[
  {"key":"ccache-Linux-GCC-16-clean-100","ref":"refs/heads/master","size_in_bytes":830000000,"created_at":"2026-08-07T13:50:00Z"},
  {"key":"ccache-Linux-GCC-16-clean-200","ref":"refs/heads/master","size_in_bytes":840000000,"created_at":"2026-08-07T14:20:00Z"},
  {"key":"ccache-Linux-GCC-16-clean-300","ref":"refs/heads/master","size_in_bytes":850000000,"created_at":"2026-08-08T12:40:00Z"},
@@ -42,6 +78,8 @@ JSON
 export PATH="${WORK}:${PATH}"
 export GITHUB_REPOSITORY="k-nuth/kth"
 export FAKE_CACHES="${WORK}/caches.json"
+export GITHUB_API_URL="https://api.github.com"
+mkdir -p "${WORK}/empty"
 
 failures=0
 check() {
@@ -71,7 +109,7 @@ check "single entry says so" "$(printf '%s' "${out}" | grep -c 'nothing supersed
 export FAKE_DELETED="${WORK}/d3"; : > "${FAKE_DELETED}"
 echo 'not json' > "${WORK}/bad.json"
 out=$(FAKE_CACHES="${WORK}/bad.json" GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
-check "unparseable listing warns" "$(printf '%s' "${out}" | grep -c 'nothing was examined')" "1"
+check "unparseable listing warns" "$(printf '%s' "${out}" | grep -c 'could not be parsed')" "1"
 check "unparseable listing deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
 check "unparseable is not reported as superseded-free" \
      "$(printf '%s' "${out}" | grep -c 'nothing superseded')" "0"
@@ -79,8 +117,83 @@ check "unparseable is not reported as superseded-free" \
 # 4. No token: same discipline.
 export FAKE_DELETED="${WORK}/d4"; : > "${FAKE_DELETED}"
 out=$(GH_TOKEN='' "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
-check "no token warns" "$(printf '%s' "${out}" | grep -c 'nothing was examined')" "1"
+check "no token warns" "$(printf '%s' "${out}" | grep -c 'no token was provided')" "1"
 check "no token deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+
+# 5. Every way the API can refuse. None of them may be read as a clean
+#    inventory, and each has to name itself: a rejected token and an
+#    unreachable endpoint call for different fixes.
+for pair in "401:token was rejected" "403:lacks actions permission" "404:answered 404" "500:answered HTTP 500" "000:could not be reached"; do
+    code="${pair%%:*}"
+    expected="${pair#*:}"
+    export FAKE_DELETED="${WORK}/d5_${code}"; : > "${FAKE_DELETED}"
+    out=$(FAKE_LIST_STATUS="${code}" GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
+    check "list HTTP ${code} names itself" "$(printf '%s' "${out}" | grep -c "${expected}")" "1"
+    check "list HTTP ${code} deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+    check "list HTTP ${code} is not 'nothing superseded'" \
+         "$(printf '%s' "${out}" | grep -c 'nothing superseded')" "0"
+done
+
+# 6. A delete that is refused is counted and named, not silently skipped: the
+#    budget did not shrink and the log has to be able to say so.
+export FAKE_DELETED="${WORK}/d6"; : > "${FAKE_DELETED}"
+out=$(FAKE_DELETE_STATUS=403 GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
+check "refused delete warns" "$(printf '%s' "${out}" | grep -c 'could not remove')" "2"
+check "refused delete is counted" "$(printf '%s' "${out}" | grep -c 'failed 2')" "1"
+check "refused delete frees nothing" "$(printf '%s' "${out}" | grep -c 'freed 0 MB')" "1"
+
+# 7. The key and the ref reach the API encoded. `refs/heads/master` has slashes,
+#    and an unencoded one would silently address a different resource.
+export FAKE_DELETED="${WORK}/d7"; : > "${FAKE_DELETED}"
+out=$(GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
+check "ref is percent-encoded" "$(grep -c 'ref=refs%2Fheads%2Fmaster' "${FAKE_DELETED}")" "2"
+check "no raw slashes in the ref" "$(grep -c 'ref=refs/heads' "${FAKE_DELETED}" || true)" "0"
+
+# 8. A missing prerequisite is a statement about the runner, and it travels the
+#    same guard as an absent curl or python3. Those two cannot be simulated by
+#    emptying PATH — the script's own interpreter would go with them — so the
+#    guard is exercised through the one prerequisite a test can withhold.
+#    The real case is on record: the container job had no `gh` and reported it
+#    rather than pretending it had pruned.
+export FAKE_DELETED="${WORK}/d8"; : > "${FAKE_DELETED}"
+out=$(GITHUB_REPOSITORY='' GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
+check "missing prerequisite is named" "$(printf '%s' "${out}" | grep -c 'GITHUB_REPOSITORY is not set')" "1"
+check "missing prerequisite deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+check "missing prerequisite is not 'nothing superseded'" \
+     "$(printf '%s' "${out}" | grep -c 'nothing superseded')" "0"
+
+
+# 9. curl failing outright. --write-out has already printed 000, so a second one
+#    appended by the caller would make the status 000000 — a value no branch
+#    matches, reported as an answer the server never gave. Both the single 000
+#    and curl's own message have to survive.
+export FAKE_DELETED="${WORK}/d9"; : > "${FAKE_DELETED}"
+out=$(FAKE_CURL_FAIL=1 GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
+check "curl failure says unreachable" "$(printf '%s' "${out}" | grep -c 'could not be reached')" "1"
+check "curl failure keeps its exit code" "$(printf '%s' "${out}" | grep -c 'curl exit 6')" "1"
+check "curl failure keeps its message" "$(printf '%s' "${out}" | grep -c 'Could not resolve host')" "1"
+check "curl failure is not a 000000 status" "$(printf '%s' "${out}" | grep -c '000000')" "0"
+check "curl failure deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+
+# 10. An inventory that does not fit on one page. Pruning from the first hundred
+#     would keep the newest of what it happened to see — for a family whose
+#     entries all sit on page two, that is nothing at all, silently.
+cat > "${WORK}/page1.json" <<'JSON'
+{"total_count":102,"actions_caches":[
+ {"key":"ccache-Other-999","ref":"refs/heads/master","size_in_bytes":1,"created_at":"2026-08-08T00:00:00Z"}
+]}
+JSON
+cat > "${WORK}/page2.json" <<'JSON'
+{"total_count":102,"actions_caches":[
+ {"key":"ccache-Linux-GCC-16-clean-700","ref":"refs/heads/master","size_in_bytes":700000000,"created_at":"2026-08-08T10:00:00Z"},
+ {"key":"ccache-Linux-GCC-16-clean-800","ref":"refs/heads/master","size_in_bytes":800000000,"created_at":"2026-08-08T11:00:00Z"}
+]}
+JSON
+export FAKE_DELETED="${WORK}/d10"; : > "${FAKE_DELETED}"
+out=$(FAKE_CACHES="${WORK}/page1.json" FAKE_CACHES_P2="${WORK}/page2.json" \
+      GH_TOKEN=x "${PRUNE}" "ccache-Linux-GCC-16-clean-" 2>&1)
+check "second page is read" "$(printf '%s' "${out}" | grep -c 'kept ccache-Linux-GCC-16-clean-800')" "1"
+check "second page is pruned" "$(grep -c 'clean-700' "${FAKE_DELETED}")" "1"
 
 if [ "${failures}" -ne 0 ]; then
     echo "ccache-prune-selftest: ${failures} failure(s)"

--- a/.github/scripts/ccache-prune.sh
+++ b/.github/scripts/ccache-prune.sh
@@ -17,57 +17,150 @@
 # So: keep the newest of the family, drop the rest. Nothing is inferred about
 # which entry is useful — `restore-keys` picks the most recent, and that is the
 # one kept.
+#
+# Talks to the REST API with curl rather than with `gh`. The first revision used
+# `gh`, which is on the hosted runners and is NOT in this project's build
+# container: the container job reported "could not list caches" and pruned
+# nothing while every other job worked. curl is in every image here.
+#
+# A `while` loop rather than `mapfile`: the macOS runners ship Bash 3.2.
 
 set -uo pipefail
 
 PREFIX="${1:?usage: ccache-prune.sh <key-prefix> [ref]}"
 REF="${2:-refs/heads/master}"
+API="${GITHUB_API_URL:-https://api.github.com}"
 
-if [ -z "${GH_TOKEN:-}" ]; then
-    echo "::warning::ccache-prune: no token, nothing was examined"
+# Every early exit below says what could not be done. None of them may read as
+# "there was nothing to prune": that sentence means the inventory was examined
+# and found clean, and an unexamined inventory keeps growing while the log says
+# it is fine — which is how the defect this script exists for survived.
+give_up() {
+    echo "::warning::ccache-prune: $1; no entry was examined or removed"
     exit 0
-fi
+}
 
-if ! listing=$(gh api "repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100" 2>&1) || [ -z "${listing}" ]; then
-    # Said out loud. A prune that could not read the inventory has not found
-    # "nothing to delete" — it has found nothing at all, and reporting the two
-    # the same way is how a silently broken cleanup looks healthy for months.
-    echo "::warning::ccache-prune: could not list caches; no entry was examined or removed"
-    exit 0
-fi
+command -v curl >/dev/null 2>&1 || give_up "curl is not installed on this runner"
+command -v python3 >/dev/null 2>&1 || give_up "python3 is not installed on this runner"
+[ -n "${GH_TOKEN:-}" ] || give_up "no token was provided"
+[ -n "${GITHUB_REPOSITORY:-}" ] || give_up "GITHUB_REPOSITORY is not set"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Returns the HTTP status on stdout and leaves the body in $2.
+#
+# The status and curl's own exit code are read separately on purpose. With
+# `--write-out '%{http_code}'` curl ALREADY prints 000 when it never got an
+# answer, so an `|| echo 000` on the end appends a second one and the caller
+# sees `000000` — a status no branch matches, reported as "the API answered
+# HTTP 000000". Whatever went wrong is then described as an answer that was
+# never given.
+# Through a file, not a variable: `api_call` is used as `$(api_call ...)`, which
+# runs it in a subshell, so anything it assigns is gone by the time the caller
+# reads it. The first attempt at this stored the exit code in a variable and the
+# diagnostic silently reported `curl exit 0` for every failure.
+api_call() {
+    local method="$1" url="$2" body="$3"
+    local status
+    status=$(curl --silent --show-error --request "${method}" \
+         --output "${body}" --write-out '%{http_code}' \
+         --header "Authorization: Bearer ${GH_TOKEN}" \
+         --header "Accept: application/vnd.github+json" \
+         --header "X-GitHub-Api-Version: 2022-11-28" \
+         "${url}" 2>"${WORK}/curl.err")
+    local rc=$?
+    printf '%s' "${rc}" > "${WORK}/curl.rc"
+
+    if [ "${rc}" -ne 0 ]; then
+        # One 000, whatever curl printed. The reason is not lost: the exit code
+        # and the captured stderr both reach the diagnostic below.
+        printf '000'
+        return 0
+    fi
+
+    printf '%s' "${status}"
+}
+
+# Named apart because they call for different answers: a token that cannot read
+# is a configuration problem, and a 500 is not.
+describe_status() {
+    case "$1" in
+        401) echo "the token was rejected (401)" ;;
+        403) echo "the token lacks actions permission, or the rate limit is exhausted (403)" ;;
+        404) echo "the endpoint answered 404 — wrong repository, or caches are unavailable here" ;;
+        000) echo "the API could not be reached (curl exit $(cat "${WORK}/curl.rc" 2>/dev/null || echo '?'): $(tr -d '\n' < "${WORK}/curl.err" 2>/dev/null))" ;;
+        *)   echo "the API answered HTTP $1" ;;
+    esac
+}
+
+# Paginated. A hundred entries is a page, not an inventory, and pruning from a
+# truncated view would keep the newest of what it happened to see — which for a
+# family whose entries all sat on page two is nothing at all, silently.
+page=1
+pages_read=0
+while :; do
+    status=$(api_call GET \
+        "${API}/repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100&page=${page}" \
+        "${WORK}/page.${page}.json")
+    if [ "${status}" != "200" ]; then
+        give_up "$(describe_status "${status}")"
+    fi
+    pages_read=$(( pages_read + 1 ))
+
+    if ! more=$(PAGE_FILE="${WORK}/page.${page}.json" PAGE_NUM="${page}" python3 -c '
+import json, os, sys
+with open(os.environ["PAGE_FILE"]) as handle:
+    data = json.load(handle)
+seen = int(os.environ["PAGE_NUM"]) * 100
+sys.stdout.write("yes" if data.get("total_count", 0) > seen and data.get("actions_caches") else "no")
+'); then
+        give_up "the cache listing could not be parsed"
+    fi
+
+    [ "${more}" = "yes" ] || break
+    page=$(( page + 1 ))
+
+    if [ "${page}" -gt 20 ]; then
+        # Two thousand entries is not a state this repository reaches; reading
+        # on would mean the loop is wrong, not that the inventory is enormous.
+        give_up "the cache listing did not end after ${pages_read} pages"
+    fi
+done
 
 # Newest first, restricted to this family and this ref. Only the default branch
 # prunes: a pull request restoring from master must not be able to delete what
 # master's next run will restore.
-parsed=$(printf '%s' "${listing}" | PRUNE_PREFIX="${PREFIX}" PRUNE_REF="${REF}" python3 -c '
+if ! parsed=$(PRUNE_PREFIX="${PREFIX}" PRUNE_REF="${REF}" python3 -c '
 import json, os, sys
 prefix = os.environ["PRUNE_PREFIX"]
 ref = os.environ["PRUNE_REF"]
-data = json.load(sys.stdin).get("actions_caches", [])
-rows = [c for c in data if c["key"].startswith(prefix) and c["ref"] == ref]
+entries = []
+for path in sys.argv[1:]:
+    with open(path) as handle:
+        entries.extend(json.load(handle).get("actions_caches", []))
+rows = [c for c in entries if c["key"].startswith(prefix) and c["ref"] == ref]
 rows.sort(key=lambda c: c["created_at"], reverse=True)
 for c in rows:
     sys.stdout.write(c["key"] + "\t" + str(c["size_in_bytes"]) + "\n")
-')
-parse_rc=$?
-
-if [ "${parse_rc}" -ne 0 ]; then
-    # Not "nothing to prune". The inventory could not be read, which is a
-    # different fact and has to stay one: a cleanup that crashes and reports
-    # "nothing superseded" is indistinguishable from one that works, and the
-    # budget keeps growing while the summary says it is fine.
-    echo "::warning::ccache-prune: could not parse the cache listing; nothing was examined"
-    exit 0
+' "${WORK}"/page.*.json); then
+    give_up "the cache listing could not be parsed"
 fi
 
+# Keys are opaque strings that end up in a query string. Encoding them by hand
+# would be one more thing to get wrong the day a key grows a character that
+# needs it.
+urlencode() {
+    ENC_VALUE="$1" python3 -c 'import os, urllib.parse, sys; sys.stdout.write(urllib.parse.quote(os.environ["ENC_VALUE"], safe=""))'
+}
+
+ref_encoded="$(urlencode "${REF}")"
 newest=""
 freed=0
 removed=0
+failed=0
 
-# A while-read loop, not `mapfile`: the macOS runners ship Bash 3.2, where
-# `mapfile` does not exist. A script that only runs under Homebrew's Bash is a
-# script that does not run where half these jobs run.
-while IFS='	' read -r key size; do
+while IFS="$(printf '\t')" read -r key size; do
     [ -n "${key}" ] || continue
 
     if [ -z "${newest}" ]; then
@@ -77,13 +170,22 @@ while IFS='	' read -r key size; do
         continue
     fi
 
-    if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/caches?key=${key}&ref=${REF}" >/dev/null 2>&1; then
-        freed=$(( freed + size ))
-        removed=$(( removed + 1 ))
-        echo "ccache-prune: removed ${key} ($(( size / 1000000 )) MB)"
-    else
-        echo "::warning::ccache-prune: could not remove ${key}"
-    fi
+    key_encoded="$(urlencode "${key}")"
+    del_status=$(api_call DELETE \
+        "${API}/repos/${GITHUB_REPOSITORY}/actions/caches?key=${key_encoded}&ref=${ref_encoded}" \
+        "${WORK}/del.json")
+
+    case "${del_status}" in
+        200|204)
+            freed=$(( freed + size ))
+            removed=$(( removed + 1 ))
+            echo "ccache-prune: removed ${key} ($(( size / 1000000 )) MB)"
+            ;;
+        *)
+            failed=$(( failed + 1 ))
+            echo "::warning::ccache-prune: could not remove ${key}: $(describe_status "${del_status}")"
+            ;;
+    esac
 done <<EOF
 ${parsed}
 EOF
@@ -93,9 +195,9 @@ if [ -z "${newest}" ]; then
     exit 0
 fi
 
-if [ "${removed}" -eq 0 ]; then
+if [ "${removed}" -eq 0 ] && [ "${failed}" -eq 0 ]; then
     echo "ccache-prune: ${PREFIX} — kept ${newest}, nothing superseded"
     exit 0
 fi
 
-echo "ccache-prune: ${PREFIX} — kept ${newest}, removed ${removed}, freed $(( freed / 1000000 )) MB"
+echo "ccache-prune: ${PREFIX} — kept ${newest}, removed ${removed}, freed $(( freed / 1000000 )) MB, failed ${failed}"

--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -147,6 +147,19 @@ jobs:
         with:
           new-version: ${{ inputs.build-version }}
 
+      # Inside the container, because that is where the first revision failed:
+      # it called `gh`, which the build image does not have, so the prune
+      # reported "could not list caches" and pruned nothing while every other
+      # job worked. The self-test now exercises the API path against a stubbed
+      # curl here as well as on macOS, so a tool this image lacks is found by a
+      # check rather than by an inventory that quietly keeps growing.
+      - name: 🧪 CI script checks
+        if: ${{ inputs.upload != true }}
+        shell: bash
+        run: |
+          python3 "${GITHUB_WORKSPACE}/.github/scripts/check-cache-keys.py"
+          "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-selftest.sh"
+
       - name: 🗄️ Setup ccache
         if: ${{ inputs.upload != true }}
         run: |


### PR DESCRIPTION
#629 pruned on macOS and on coverage, and did nothing on Linux — the one job
that matters, because the sanitizer and clean families it was meant to trim are
the ones whose eviction costs two hours.

## What the first master run showed

| workflow | prune | evidence |
|---|---|---|
| macOS | ✅ | `removed ...clean-31267288797 (227 MB)` · `kept ...31271558511` |
| coverage | ✅ | entry `3da6227c` gone from the inventory |
| **Linux (container)** | ❌ | `##[warning] could not list caches; no entry was examined or removed` |

`gh` is on the hosted runners and is **not in this project's build image**. The
prune called it, got nothing, and refused to claim it had pruned.

That refusal is the reason this took minutes to diagnose rather than weeks. Had
the script reported success, the inventory would have kept growing with every
log green — which is exactly how the defect this whole change addresses survived
in the first place.

The five points asked for, against the evidence:

- **could list** — yes on macOS and coverage; no on Linux, and it said so;
- **`actions: write` effective** — **yes, proven**: the deletion happened, and
  `31267288797` is gone from the inventory. Permissions are not the problem;
- **kept the newest** — yes: `kept ...31271558511`, still present;
- **deleted the earlier ones** — yes where it ran; on Linux all three remain;
- **did not touch PR caches** — the PR-scoped coverage entry (2.13 GB) is
  untouched, which is the direct proof the `ref` filter works. Two other
  PR entries did disappear, but not by the prune: they belong to #629, which was
  merged, and GitHub clears a closed pull request's caches itself.

Net: 12.36 → 11.53 GB. Under a gigabyte freed, and the families that matter
untouched.

## The change

Talk to the REST API with curl, which every image here has, and check what comes
back:

- curl, python3, a token and a repository are each confirmed present, and each
  absence is named;
- the HTTP status is read rather than assumed — 401, 403, 404, 5xx and an
  unreachable endpoint (000, carrying curl's own message) are distinguished,
  because a rejected token and a server error call for different fixes;
- a refused DELETE is counted and named rather than skipped in silence: the
  budget did not shrink and the summary has to be able to say so;
- key and ref are percent-encoded. `refs/heads/master` has slashes, and an
  unencoded one addresses a different resource while looking correct.

**No API failure is ever reported as "nothing to prune."** That sentence means
the inventory was examined and found clean.

Also fixed: the old message named the symptom and discarded the cause — it
captured curl's stderr and threw it away, so "could not list caches" had to be
diagnosed by elimination. The cause is printed now.

## Tests

The self-test went from ten checks to **thirty-two**: every HTTP status on the
listing call, a refused delete (counted, named, frees nothing), and the encoding
of both key and ref — including that no raw `refs/heads` slash reaches the API.

It now runs **inside the Linux container** as well as on macOS. The container is
where the last defect lived and where nothing was looking; a tool the image
lacks is now found by a check rather than by an inventory that quietly keeps
growing. On macOS it runs under the platform's own Bash 3.2, confirmed in the
last run: `ccache-prune-selftest: bash 3.2.57(1)-release`.

One case is deliberately not simulated, and says so in the test: an absent curl
or python3 cannot be staged by emptying `PATH`, because the script's own
interpreter goes with them. The same guard is exercised through a prerequisite a
test can withhold, and the real case is already on record in the run above.

`actionlint` unchanged (1 / 25 / 20 pre-existing), `shellcheck` clean, and the
diff still touches no line of any build step.

## What this does not claim

The Linux prune can only be confirmed on master, after merge. The prediction:
`ccache-Linux-GCC-16-clean` and `ccache-Linux-GCC-16-sanitizers` drop from three
master entries to one each, freeing ~4.3 GB, which brings the repository under
the 10 GB limit and stops the eviction that costs the sanitizer job two hours.

Part of #624.
