### PR TITLE
ci: reclaim the cache a merged pull request leaves behind

### DIFF
--- a/.github/scripts/ccache-prune-closed-prs-selftest.sh
+++ b/.github/scripts/ccache-prune-closed-prs-selftest.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Exercises ccache-prune-closed-prs.sh against a synthetic inventory.
+#
+# The check that matters is the one that must never fire: an open pull request's
+# cache is worth a full cold build to whoever is waiting on it, and this script
+# deletes things. Every refusal below is a case where deleting would have been
+# cheap to write and expensive to be wrong about.
+#
+# Runs under the platform's own /bin/bash, which on the macOS runners is 3.2.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PRUNE="${HERE}/ccache-prune-closed-prs.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+echo "ccache-prune-closed-prs-selftest: bash ${BASH_VERSION}"
+
+# A curl that answers from files. It honours --output and --write-out, so the
+# status handling under test is the real one.
+cat > "${WORK}/curl" <<'STUB'
+#!/usr/bin/env bash
+out=""; method="GET"; url=""; prev=""
+for arg in "$@"; do
+    case "${prev}" in
+        --output) out="${arg}" ;;
+        --request) method="${arg}" ;;
+    esac
+    case "${arg}" in https://*|http://*) url="${arg}" ;; esac
+    prev="${arg}"
+done
+
+case "${url}" in
+    *"/actions/caches?per_page"*)
+        cat "${FAKE_CACHES}" > "${out}"; printf '%s' "${FAKE_LIST_STATUS:-200}"; exit 0 ;;
+    *"/pulls/"*)
+        number="${url##*/pulls/}"
+        if [ "${FAKE_PR_STATUS:-200}" != "200" ]; then
+            : > "${out}"; printf '%s' "${FAKE_PR_STATUS}"; exit 0
+        fi
+        state="closed"
+        case " ${FAKE_OPEN_PRS:-} " in *" ${number} "*) state="open" ;; esac
+        printf '{"state":"%s"}' "${state}" > "${out}"
+        printf '200'; exit 0 ;;
+    *"/actions/caches?key="*)
+        echo "${url}" >> "${FAKE_DELETED}"; : > "${out}"
+        printf '%s' "${FAKE_DELETE_STATUS:-204}"; exit 0 ;;
+esac
+exit 1
+STUB
+chmod +x "${WORK}/curl"
+
+cat > "${WORK}/caches.json" <<'JSON'
+{"total_count":4,"actions_caches":[
+ {"key":"ccache-coverage-aaa","ref":"refs/pull/100/merge","size_in_bytes":2230000000,"created_at":"2026-08-09T10:00:00Z"},
+ {"key":"ccache-coverage-bbb","ref":"refs/pull/200/merge","size_in_bytes":2330000000,"created_at":"2026-08-09T11:00:00Z"},
+ {"key":"ccache-coverage-ccc","ref":"refs/heads/master","size_in_bytes":2230000000,"created_at":"2026-08-09T12:00:00Z"},
+ {"key":"ccache-Linux-GCC-16-clean-ddd","ref":"refs/heads/master","size_in_bytes":830000000,"created_at":"2026-08-09T12:00:00Z"}
+]}
+JSON
+
+export PATH="${WORK}:${PATH}"
+export GITHUB_REPOSITORY="k-nuth/kth"
+export GITHUB_API_URL="https://api.github.com"
+export FAKE_CACHES="${WORK}/caches.json"
+
+failures=0
+check() {
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected [$3], got [$2]"
+        failures=$(( failures + 1 ))
+    fi
+}
+
+# 1. Both pull requests closed: both caches go, and neither branch cache is
+#    touched. Branches are the family prune's business.
+export FAKE_DELETED="${WORK}/d1"; : > "${FAKE_DELETED}"
+out=$(GH_TOKEN=x "${PRUNE}" 2>&1)
+check "removes both closed-PR caches" "$(grep -c . "${FAKE_DELETED}")" "2"
+check "never touches a branch cache" "$(grep -c 'refs%2Fheads' "${FAKE_DELETED}" || true)" "0"
+check "reports what it freed" "$(printf '%s' "${out}" | grep -c 'freed 4560 MB')" "1"
+
+# 2. THE CONTROL. One of them is open. Its cache must survive, and the closed
+#    one must still go — a blanket refusal would pass check 2 while doing
+#    nothing useful.
+export FAKE_DELETED="${WORK}/d2"; : > "${FAKE_DELETED}"
+out=$(FAKE_OPEN_PRS="100" GH_TOKEN=x "${PRUNE}" 2>&1)
+check "an OPEN pull request's cache is never deleted" \
+     "$(grep -c 'ccache-coverage-aaa' "${FAKE_DELETED}" || true)" "0"
+check "the open one is named as kept" "$(printf '%s' "${out}" | grep -c 'PR #100 is open')" "1"
+check "the closed one is still removed" \
+     "$(grep -c 'ccache-coverage-bbb' "${FAKE_DELETED}")" "1"
+check "the count of kept-open is reported" "$(printf '%s' "${out}" | grep -c 'kept 1 open')" "1"
+
+# 3. Every pull request open: nothing is deleted at all.
+export FAKE_DELETED="${WORK}/d3"; : > "${FAKE_DELETED}"
+out=$(FAKE_OPEN_PRS="100 200" GH_TOKEN=x "${PRUNE}" 2>&1)
+check "all open deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+check "all open frees nothing" "$(printf '%s' "${out}" | grep -c 'freed 0 MB')" "1"
+
+# 4. A pull request whose state cannot be read is NOT closed. This is the case
+#    that would be easiest to get wrong: treating an API hiccup as permission to
+#    delete a live branch's cache.
+export FAKE_DELETED="${WORK}/d4"; : > "${FAKE_DELETED}"
+out=$(FAKE_PR_STATUS=500 GH_TOKEN=x "${PRUNE}" 2>&1)
+check "unreadable PR state deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+check "unreadable PR state says unknown is not closed" \
+     "$(printf '%s' "${out}" | grep -c 'unknown is not closed')" "2"
+check "unresolved are counted" "$(printf '%s' "${out}" | grep -c 'kept 2 unresolved')" "1"
+
+# 5. The inventory itself failing is not an empty inventory.
+export FAKE_DELETED="${WORK}/d5"; : > "${FAKE_DELETED}"
+out=$(FAKE_LIST_STATUS=403 GH_TOKEN=x "${PRUNE}" 2>&1)
+check "a refused listing is named" "$(printf '%s' "${out}" | grep -c 'lacks actions permission')" "1"
+check "a refused listing deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+check "a refused listing is not 'nothing to consider'" \
+     "$(printf '%s' "${out}" | grep -c 'nothing to consider')" "0"
+
+# 6. No pull-request-scoped cache at all is a clean, honest answer.
+cat > "${WORK}/branches.json" <<'JSON'
+{"total_count":1,"actions_caches":[
+ {"key":"ccache-coverage-ccc","ref":"refs/heads/master","size_in_bytes":2230000000,"created_at":"2026-08-09T12:00:00Z"}
+]}
+JSON
+export FAKE_DELETED="${WORK}/d6"; : > "${FAKE_DELETED}"
+out=$(FAKE_CACHES="${WORK}/branches.json" GH_TOKEN=x "${PRUNE}" 2>&1)
+check "branch-only inventory deletes nothing" "$(grep -c . "${FAKE_DELETED}" || true)" "0"
+check "branch-only inventory says so" "$(printf '%s' "${out}" | grep -c 'nothing to consider')" "1"
+
+# 7. A refused DELETE is named and does not inflate the freed total.
+export FAKE_DELETED="${WORK}/d7"; : > "${FAKE_DELETED}"
+out=$(FAKE_DELETE_STATUS=403 GH_TOKEN=x "${PRUNE}" 2>&1)
+check "refused delete is named" "$(printf '%s' "${out}" | grep -c 'could not remove')" "2"
+check "refused delete frees nothing" "$(printf '%s' "${out}" | grep -c 'freed 0 MB')" "1"
+
+# 8. The ref is percent-encoded before it reaches the API.
+export FAKE_DELETED="${WORK}/d8"; : > "${FAKE_DELETED}"
+out=$(GH_TOKEN=x "${PRUNE}" 2>&1)
+check "ref is encoded" "$(grep -c 'ref=refs%2Fpull%2F' "${FAKE_DELETED}")" "2"
+check "no raw slashes in the ref" "$(grep -c 'ref=refs/pull' "${FAKE_DELETED}" || true)" "0"
+
+if [ "${failures}" -ne 0 ]; then
+    echo "ccache-prune-closed-prs-selftest: ${failures} failure(s)"
+    exit 1
+fi
+echo "ccache-prune-closed-prs-selftest: all checks passed"

--- a/.github/scripts/ccache-prune-closed-prs.sh
+++ b/.github/scripts/ccache-prune-closed-prs.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Delete the caches left behind by pull requests that are closed.
+#
+# Measured on this repository after the family prune of #630 landed: 8.91 GB in
+# twelve entries, of which 4.56 GB — **51 %** — belonged to two merged pull
+# requests. A closed pull request's cache can never be restored by anything:
+# its ref is gone, no run will ever key against it, and GitHub's own cleanup is
+# not prompt (both entries were still there hours after the merges).
+#
+# The other reading of the same numbers is that `ccache-coverage` is 76 % of the
+# budget at ~2.2 GB per entry. It is the same 4.56 GB: the closed-PR waste IS
+# coverage. Shrinking that cache is a second, riskier change — it would trade
+# the coverage job's own hit rate for space — so this takes the half that is
+# pure waste and leaves the half that is doing work.
+#
+# The rule is one line: an OPEN pull request's cache is never touched, and
+# neither is a ref this script cannot resolve to a closed pull request. Unknown
+# is not closed.
+
+set -uo pipefail
+
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is not set}"
+API="${GITHUB_API_URL:-https://api.github.com}"
+
+give_up() {
+    echo "::warning::ccache-prune-closed-prs: $1; no entry was examined or removed"
+    exit 0
+}
+
+command -v curl >/dev/null 2>&1 || give_up "curl is not installed on this runner"
+command -v python3 >/dev/null 2>&1 || give_up "python3 is not installed on this runner"
+[ -n "${GH_TOKEN:-}" ] || give_up "no token was provided"
+
+# shellcheck source=.github/scripts/gh-api-lib.sh
+. "$(dirname "$0")/gh-api-lib.sh"
+
+# ---------------------------------------------------------------------------
+# Inventory, paginated. A hundred entries is a page, not an inventory.
+# ---------------------------------------------------------------------------
+page=1
+while :; do
+    status=$(api_call GET \
+        "${API}/repos/${REPO}/actions/caches?per_page=100&page=${page}" \
+        "${WORK}/page.${page}.json")
+    [ "${status}" = "200" ] || give_up "$(describe_status "${status}")"
+
+    if ! more=$(PAGE_FILE="${WORK}/page.${page}.json" PAGE_NUM="${page}" python3 -c '
+import json, os, sys
+with open(os.environ["PAGE_FILE"]) as handle:
+    data = json.load(handle)
+seen = int(os.environ["PAGE_NUM"]) * 100
+sys.stdout.write("yes" if data.get("total_count", 0) > seen and data.get("actions_caches") else "no")
+'); then
+        give_up "the cache listing could not be parsed"
+    fi
+
+    [ "${more}" = "yes" ] || break
+    page=$(( page + 1 ))
+    [ "${page}" -gt 20 ] && give_up "the cache listing did not end after 20 pages"
+done
+
+# Only caches whose ref names a pull request. `refs/heads/*` is out of scope
+# here: those are the family prune's business, and a branch is not a request
+# that can be closed.
+if ! candidates=$(python3 -c '
+import json, re, sys
+rows = []
+for path in sys.argv[1:]:
+    with open(path) as handle:
+        rows.extend(json.load(handle).get("actions_caches", []))
+seen = set()
+for c in rows:
+    m = re.fullmatch(r"refs/pull/(\d+)/(merge|head)", c["ref"])
+    if not m:
+        continue
+    key = (c["key"], c["ref"])
+    if key in seen:
+        continue
+    seen.add(key)
+    sys.stdout.write(m.group(1) + "\t" + c["key"] + "\t" + c["ref"] + "\t" + str(c["size_in_bytes"]) + "\n")
+' "${WORK}"/page.*.json); then
+    give_up "the cache listing could not be parsed"
+fi
+
+if [ -z "${candidates}" ]; then
+    echo "ccache-prune-closed-prs: no pull-request-scoped cache exists; nothing to consider"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Delete only what belongs to a pull request that is closed.
+# ---------------------------------------------------------------------------
+freed=0
+removed=0
+kept_open=0
+kept_unknown=0
+
+ref_state() {
+    # Answers "closed", "open", or "unknown". Never guesses: a request whose
+    # state could not be read is left alone, because deleting a live pull
+    # request's cache costs it a full cold build and nothing here is urgent
+    # enough to risk that.
+    local number="$1"
+    local s
+    s=$(api_call GET "${API}/repos/${REPO}/pulls/${number}" "${WORK}/pr.json")
+    if [ "${s}" != "200" ]; then
+        printf 'unknown'
+        return
+    fi
+    PR_FILE="${WORK}/pr.json" python3 -c '
+import json, os, sys
+with open(os.environ["PR_FILE"]) as handle:
+    data = json.load(handle)
+state = data.get("state")
+sys.stdout.write(state if state in ("open", "closed") else "unknown")
+' 2>/dev/null || printf 'unknown'
+}
+
+while IFS="$(printf '\t')" read -r number key ref size; do
+    [ -n "${key}" ] || continue
+
+    state="$(ref_state "${number}")"
+    case "${state}" in
+        closed) ;;
+        open)
+            kept_open=$(( kept_open + 1 ))
+            echo "ccache-prune-closed-prs: kept ${key} — PR #${number} is open"
+            continue
+            ;;
+        *)
+            kept_unknown=$(( kept_unknown + 1 ))
+            echo "::warning::ccache-prune-closed-prs: kept ${key} — the state of PR #${number} could not be read, and unknown is not closed"
+            continue
+            ;;
+    esac
+
+    key_encoded="$(ENC="${key}" python3 -c 'import os,urllib.parse,sys; sys.stdout.write(urllib.parse.quote(os.environ["ENC"], safe=""))')"
+    ref_encoded="$(ENC="${ref}" python3 -c 'import os,urllib.parse,sys; sys.stdout.write(urllib.parse.quote(os.environ["ENC"], safe=""))')"
+
+    del=$(api_call DELETE \
+        "${API}/repos/${REPO}/actions/caches?key=${key_encoded}&ref=${ref_encoded}" \
+        "${WORK}/del.json")
+    case "${del}" in
+        200|204)
+            freed=$(( freed + size ))
+            removed=$(( removed + 1 ))
+            echo "ccache-prune-closed-prs: removed ${key} ($(( size / 1000000 )) MB, PR #${number} closed)"
+            ;;
+        *)
+            echo "::warning::ccache-prune-closed-prs: could not remove ${key}: $(describe_status "${del}")"
+            ;;
+    esac
+done <<EOF
+${candidates}
+EOF
+
+echo "ccache-prune-closed-prs: removed ${removed}, freed $(( freed / 1000000 )) MB, kept ${kept_open} open, kept ${kept_unknown} unresolved"

--- a/.github/scripts/ccache-prune.sh
+++ b/.github/scripts/ccache-prune.sh
@@ -45,54 +45,9 @@ command -v python3 >/dev/null 2>&1 || give_up "python3 is not installed on this 
 [ -n "${GH_TOKEN:-}" ] || give_up "no token was provided"
 [ -n "${GITHUB_REPOSITORY:-}" ] || give_up "GITHUB_REPOSITORY is not set"
 
-WORK="$(mktemp -d)"
-trap 'rm -rf "${WORK}"' EXIT
+# shellcheck source=.github/scripts/gh-api-lib.sh
+. "$(dirname "$0")/gh-api-lib.sh"
 
-# Returns the HTTP status on stdout and leaves the body in $2.
-#
-# The status and curl's own exit code are read separately on purpose. With
-# `--write-out '%{http_code}'` curl ALREADY prints 000 when it never got an
-# answer, so an `|| echo 000` on the end appends a second one and the caller
-# sees `000000` — a status no branch matches, reported as "the API answered
-# HTTP 000000". Whatever went wrong is then described as an answer that was
-# never given.
-# Through a file, not a variable: `api_call` is used as `$(api_call ...)`, which
-# runs it in a subshell, so anything it assigns is gone by the time the caller
-# reads it. The first attempt at this stored the exit code in a variable and the
-# diagnostic silently reported `curl exit 0` for every failure.
-api_call() {
-    local method="$1" url="$2" body="$3"
-    local status
-    status=$(curl --silent --show-error --request "${method}" \
-         --output "${body}" --write-out '%{http_code}' \
-         --header "Authorization: Bearer ${GH_TOKEN}" \
-         --header "Accept: application/vnd.github+json" \
-         --header "X-GitHub-Api-Version: 2022-11-28" \
-         "${url}" 2>"${WORK}/curl.err")
-    local rc=$?
-    printf '%s' "${rc}" > "${WORK}/curl.rc"
-
-    if [ "${rc}" -ne 0 ]; then
-        # One 000, whatever curl printed. The reason is not lost: the exit code
-        # and the captured stderr both reach the diagnostic below.
-        printf '000'
-        return 0
-    fi
-
-    printf '%s' "${status}"
-}
-
-# Named apart because they call for different answers: a token that cannot read
-# is a configuration problem, and a 500 is not.
-describe_status() {
-    case "$1" in
-        401) echo "the token was rejected (401)" ;;
-        403) echo "the token lacks actions permission, or the rate limit is exhausted (403)" ;;
-        404) echo "the endpoint answered 404 — wrong repository, or caches are unavailable here" ;;
-        000) echo "the API could not be reached (curl exit $(cat "${WORK}/curl.rc" 2>/dev/null || echo '?'): $(tr -d '\n' < "${WORK}/curl.err" 2>/dev/null))" ;;
-        *)   echo "the API answered HTTP $1" ;;
-    esac
-}
 
 # Paginated. A hundred entries is a page, not an inventory, and pruning from a
 # truncated view would keep the newest of what it happened to see — which for a

--- a/.github/scripts/gh-api-lib.sh
+++ b/.github/scripts/gh-api-lib.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Shared GitHub REST plumbing for the cache scripts.
+#
+# One copy on purpose. The subtleties here are the ones that already went wrong
+# once: `--write-out '%{http_code}'` prints 000 by itself when curl never
+# reaches the host, so appending another gives 000000 — a status no branch
+# matches, reported as an answer the server never gave. And `api_call` is used
+# as `$(api_call ...)`, which is a subshell, so anything it assigns is lost:
+# the exit code travels through a file.
+#
+# Sourced, not executed. The caller owns the failure policy.
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Returns the HTTP status on stdout and leaves the body in $2.
+#
+# The status and curl's own exit code are read separately on purpose. With
+# `--write-out '%{http_code}'` curl ALREADY prints 000 when it never got an
+# answer, so an `|| echo 000` on the end appends a second one and the caller
+# sees `000000` — a status no branch matches, reported as "the API answered
+# HTTP 000000". Whatever went wrong is then described as an answer that was
+# never given.
+# Through a file, not a variable: `api_call` is used as `$(api_call ...)`, which
+# runs it in a subshell, so anything it assigns is gone by the time the caller
+# reads it. The first attempt at this stored the exit code in a variable and the
+# diagnostic silently reported `curl exit 0` for every failure.
+api_call() {
+    local method="$1" url="$2" body="$3"
+    local status
+    status=$(curl --silent --show-error --request "${method}" \
+         --output "${body}" --write-out '%{http_code}' \
+         --header "Authorization: Bearer ${GH_TOKEN}" \
+         --header "Accept: application/vnd.github+json" \
+         --header "X-GitHub-Api-Version: 2022-11-28" \
+         "${url}" 2>"${WORK}/curl.err")
+    local rc=$?
+    printf '%s' "${rc}" > "${WORK}/curl.rc"
+
+    if [ "${rc}" -ne 0 ]; then
+        # One 000, whatever curl printed. The reason is not lost: the exit code
+        # and the captured stderr both reach the diagnostic below.
+        printf '000'
+        return 0
+    fi
+
+    printf '%s' "${status}"
+}
+
+# Named apart because they call for different answers: a token that cannot read
+# is a configuration problem, and a 500 is not.
+describe_status() {
+    case "$1" in
+        401) echo "the token was rejected (401)" ;;
+        403) echo "the token lacks actions permission, or the rate limit is exhausted (403)" ;;
+        404) echo "the endpoint answered 404 — wrong repository, or caches are unavailable here" ;;
+        000) echo "the API could not be reached (curl exit $(cat "${WORK}/curl.rc" 2>/dev/null || echo '?'): $(tr -d '\n' < "${WORK}/curl.err" 2>/dev/null))" ;;
+        *)   echo "the API answered HTTP $1" ;;
+    esac
+}

--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -159,6 +159,7 @@ jobs:
         run: |
           python3 "${GITHUB_WORKSPACE}/.github/scripts/check-cache-keys.py"
           "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-selftest.sh"
+          "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-closed-prs-selftest.sh"
 
       - name: 🗄️ Setup ccache
         if: ${{ inputs.upload != true }}
@@ -407,6 +408,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune.sh" "ccache-${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ (inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) && 'sanitizers' || 'clean' }}-"
+
+      # Repository-wide, so exactly one job does it. Measured after #630 landed:
+      # 8.91 GB in twelve entries, of which 4.56 GB — 51 % — belonged to two
+      # merged pull requests whose caches can never be restored by anything.
+      - name: 🧹 Prune caches of closed pull requests
+        if: ${{ always() && inputs.upload != true && github.ref == 'refs/heads/master' && !(inputs.enable-asan || inputs.enable-ubsan || inputs.enable-tsan) }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-closed-prs.sh"
 
       - name: 📊 Build summary
         if: always()

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -132,6 +132,7 @@ jobs:
         run: |
           python3 "${GITHUB_WORKSPACE}/.github/scripts/check-cache-keys.py"
           "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-selftest.sh"
+          "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-closed-prs-selftest.sh"
 
       - name: 🗄️ Setup ccache
         if: ${{ inputs.upload != true }}


### PR DESCRIPTION
An exact inventory after the family prune of #630 landed, split by scope and by
family.

**By scope**

| scope | entries | size | share |
|---|---:|---:|---:|
| master | 10 | 4.35 GB | 49 % |
| PR #637 (**closed**) | 1 | 2.23 GB | 25 % |
| PR #639 (**closed**) | 1 | 2.33 GB | 26 % |
| **open** pull requests | 0 | 0.00 GB | 0 % |
| | **12** | **8.91 GB** | |

**By family**

| family | entries | size | share |
|---|---:|---:|---:|
| `ccache-coverage` | 3 | **6.79 GB** | **76.2 %** |
| `ccache-Linux-GCC-16-clean` | 1 | 0.83 GB | 9.4 % |
| `ccache-Linux-GCC-16-sanitizers` | 1 | 0.56 GB | 6.3 % |
| `ccache-macOS-apple-clang-21-clean` | 2 | 0.46 GB | 5.2 % |
| conan2 (4 families) | 6 | 0.26 GB | 3.0 % |

## Which dominates: both, and they are the same 4.56 GB

Coverage is 76 % of the budget by family. Closed pull requests hold 51 % by
scope. The closed-PR waste **is** coverage, at ~2.2 GB left behind per merged
pull request.

That splits the problem cleanly:

- **half of coverage's footprint is doing work** — it is what makes the coverage
  job's own rebuilds cheap;
- **the other half belongs to pull requests that no longer exist.** Their refs
  are gone, no run will ever key against them, and GitHub's own cleanup is not
  prompt: both entries were still there hours after their merges.

This PR takes the half that is pure waste. Shrinking the coverage cache itself
is a second change with a real trade-off — space against that job's hit rate —
and it deserves its own evidence rather than being folded in here.

## The rule

An **open** pull request's cache is never touched, and neither is a ref that
cannot be resolved to a closed pull request. **Unknown is not closed**: an API
hiccup must not become permission to delete the cache a live branch is about to
restore, because that costs whoever is waiting a full cold build.

Branch caches are out of scope — those are the family prune's business, and a
branch is not a request that can be closed.

## The control you asked for, and the rest

Twenty-one checks, most of them refusals:

| case | required |
|---|---|
| **one open, one closed** | the open one survives, **the closed one is still deleted** |
| every pull request open | nothing is deleted, `freed 0 MB` |
| pull-request state unreadable | nothing deleted, says *unknown is not closed* |
| listing refused (403) | named, and **not** reported as an empty inventory |
| branch-only inventory | nothing deleted, says *nothing to consider* |
| DELETE refused | named, and does not inflate the freed total |
| ref in the query | percent-encoded, no raw `refs/pull` slashes |

The one-open-one-closed case is the one that keeps the control honest: a script
that refused to delete anything would pass "an open cache survives" while being
useless.

Runs on macOS under Bash 3.2 and inside the Linux container.

## A note on the diff size

The REST plumbing moved into a sourced library instead of being copied into the
new script. Both bugs that cost a revision in #630 lived exactly there — the
doubled `000` from `--write-out`, and an exit code lost to the subshell in
`$(api_call ...)` — and a second copy would have been a second chance to
reintroduce them. The existing 40-check self-test still passes over the
extracted version.

One job runs the prune: it is repository-wide rather than per-platform, and
three jobs racing to delete the same entries would trade a warning for nothing.

`actionlint` unchanged (25 / 20 / 1 pre-existing), `shellcheck -x` clean.

## What this cannot show until it runs on master

The prune only acts on the default branch. Expected on the first master run:
the two closed-PR entries go, ~4.56 GB freed, the repository drops to ~4.35 GB
— comfortably under the 10 GB limit, which is the condition that stops the
eviction that costs the sanitizer job two hours.

Part of #624.
