### PR TITLE
ci: give the reusable workflows their own credential interface

### DIFF
--- a/.github/scripts/check-conan-credentials-selftest.py
+++ b/.github/scripts/check-conan-credentials-selftest.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Exercises check-conan-credentials.py against synthetic workflow trees.
+
+The boundary under test has two sides, and both need a control. It is easy to
+write a check that rejects everything — it would pass every "this must fail"
+case below and be worthless — so the passing cases are as load-bearing as the
+failing ones, and case 11 in particular makes sure an ordinary `conan-remote`
+input is not mistaken for a credential.
+
+The other control that matters is case 12: if this script ever stops finding
+the workflows, `check-conan-credentials` must fail rather than pass, because a
+green tick from a checker that examined nothing is worse than no checker.
+
+Case 15 exists because this reads files that sit next to secrets: it puts a
+literal that looks like a password into a workflow and asserts it never reaches
+the output.
+"""
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+CHECK = HERE / "check-conan-credentials.py"
+
+CALLEE_OK = """\
+name: reusable
+on:
+  workflow_call:
+    inputs:
+      conan-remote:
+        required: true
+        type: string
+    secrets:
+      conan_remote_username:
+        required: true
+      conan_remote_password:
+        required: true
+jobs:
+  reusable-build:
+    runs-on: ubuntu-24.04
+    steps:
+      # A step's `uses:` is not a job's `uses:`, and a parser that cannot tell
+      # them apart would look for a workflow named `actions/checkout@v4`.
+      - uses: actions/checkout@v4
+      - name: login
+        run: |
+          # These lines are shell, not YAML. A reader that treats them as
+          # mapping keys invents structure that was never in the file:
+          #   uses: not-a-workflow.yml
+          #   secrets: not-a-secrets-block
+          conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
+"""
+
+CALLER_OK = """\
+name: main
+on: [push]
+jobs:
+  build:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      conan-remote: kth
+    secrets:
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
+"""
+
+NO_CONAN_AT_ALL = """\
+name: unrelated
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo ${{ secrets.GITHUB_TOKEN }}
+"""
+
+FAILURES = []
+
+
+def run(root):
+    result = subprocess.run(
+        [sys.executable, str(CHECK), "--root", str(root)],
+        capture_output=True, text=True, check=False)
+    return result.returncode, result.stdout + result.stderr
+
+
+def tree(**files):
+    """A temporary repository root holding the given workflow files."""
+    root = pathlib.Path(tempfile.mkdtemp())
+    (root / ".github" / "workflows").mkdir(parents=True)
+    for name, text in files.items():
+        (root / ".github" / "workflows" / f"{name}.yml").write_text(text)
+    return root
+
+
+def check(label, actual, expected):
+    if actual == expected:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}: expected [{expected}], got [{actual}]")
+        FAILURES.append(label)
+
+
+print("check-conan-credentials-selftest")
+
+# 1. The shape this PR leaves behind: the reusable workflow speaks only the
+#    interface, the caller maps it from the physical secrets, and the parser is
+#    fooled by neither steps nor shell inside `run: |`.
+code, out = run(tree(reusable=CALLEE_OK, main=CALLER_OK))
+check("a consistent tree passes", code, 0)
+check("it reports what it examined", "1 call(s) mapping them" in out, True)
+check("it does not read a step's uses as a job's", "actions/checkout" in out, False)
+
+# 2. THE COUPLING THIS DESIGN FORBIDS. A reusable workflow that names a physical
+#    repository secret works today and is wrong: it can only ever be reused
+#    somewhere that happens to spell its secrets the same way.
+code, out = run(tree(
+    reusable=CALLEE_OK.replace("secrets.conan_remote_password",
+                               "secrets.CONAN_3_PASSWORD"),
+    main=CALLER_OK))
+check("a reusable workflow naming a physical secret fails", code, 1)
+check("it says why that is coupling", "couples it to this" in out, True)
+
+# 3. The interface is exactly two names, spelled exactly one way. Uppercase is
+#    the near miss most likely to be written by hand.
+code, out = run(tree(
+    reusable=CALLEE_OK.replace("conan_remote_password", "CONAN_REMOTE_PASSWORD"),
+    main=CALLER_OK.replace("conan_remote_password", "CONAN_REMOTE_PASSWORD")))
+check("an almost-right interface name fails", code, 1)
+
+# 4. The other direction: a root workflow may read the physical secrets and
+#    nothing else. The interface name is not a repository secret at all, so
+#    reading it there yields an empty string and a login that fails much later.
+code, out = run(tree(
+    reusable=CALLEE_OK,
+    main=CALLER_OK + """\
+  extra:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: conan remote login -p "${{ secrets.conan_remote_password }}" kth
+"""))
+check("a root workflow reading an interface name fails", code, 1)
+check("it says that is not a repository secret",
+      "not a repository secret" in out, True)
+
+# 5. A retired name coming back is named as retired, wherever it appears.
+code, out = run(tree(
+    reusable=CALLEE_OK.replace("secrets.conan_remote_password",
+                               "secrets.conan-password"),
+    main=CALLER_OK))
+check("a retired name fails", code, 1)
+check("the retired name is called retired", "retired" in out, True)
+
+# 6. Half a mapping. Valid YAML, silent to actionlint, fails at job start.
+code, out = run(tree(
+    reusable=CALLEE_OK,
+    main=CALLER_OK.replace(
+        "      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}\n", "")))
+check("mapping only one of the two fails", code, 1)
+check("the missing one is named", "without mapping `conan_remote_password`" in out, True)
+
+# 7. THE CROSSED PAIR. Both names present, both sources legitimate, and the
+#    login would send the password as the username. Nothing but a rule about
+#    which source feeds which name catches this.
+code, out = run(tree(
+    reusable=CALLEE_OK,
+    main=CALLER_OK
+        .replace("conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}",
+                 "conan_remote_username: ${{ secrets.CONAN_3_PASSWORD }}")
+        .replace("conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}",
+                 "conan_remote_password: ${{ secrets.CONAN_LOGIN_USERNAME }}")))
+check("a crossed mapping fails", code, 1)
+check("it says the pair is crossed", "the pair is crossed" in out, True)
+
+# 8. A source that is not one of the two physical secrets.
+code, out = run(tree(
+    reusable=CALLEE_OK,
+    main=CALLER_OK.replace("secrets.CONAN_3_PASSWORD", "secrets.CONAN_PASSWORD")))
+check("an unaccepted source fails", code, 1)
+check("the accepted sources are stated", "accepted sources are exactly" in out, True)
+
+# 9. The PAT must travel as a workflow_call secret. `with:` inputs are not
+#    redacted in logs the way secrets are.
+code, out = run(tree(
+    reusable=CALLEE_OK,
+    main=CALLER_OK.replace("      conan-remote: kth\n",
+                           "      conan-remote: kth\n"
+                           "      conan-password: ${{ secrets.CONAN_3_PASSWORD }}\n")))
+check("a credential passed under with: fails", code, 1)
+check("it says with: is not redacted", "which is redacted" in out, True)
+
+# 10. Same rule read from the callee's side.
+code, out = run(tree(
+    reusable=CALLEE_OK.replace("      conan-remote:\n        required: true\n        type: string\n",
+                               "      conan-remote:\n        required: true\n        type: string\n"
+                               "      conan-user:\n        required: true\n        type: string\n"),
+    main=CALLER_OK))
+check("a credential declared as an input fails", code, 1)
+check("it says inputs are not redacted", "not redacted in logs" in out, True)
+
+# 11. THE OVER-MATCHING CONTROL. `conan-remote` is a setting, not a credential.
+#     A check that treats every conan-ish input as a secret would fail case 1
+#     and every real build with it.
+code, out = run(tree(reusable=CALLEE_OK, main=CALLER_OK))
+check("an ordinary conan-remote input is not a credential", code, 0)
+
+# 12. THE EMPTY CONTROL. Nothing to examine must never be silence.
+code, out = run(tree())
+check("an empty workflow directory fails", code, 1)
+check("it says nothing was examined", "nothing was examined" in out, True)
+
+code, out = run(pathlib.Path(tempfile.mkdtemp()))
+check("a missing workflow directory fails", code, 1)
+
+code, out = run(tree(unrelated=NO_CONAN_AT_ALL))
+check("a tree with no call carrying credentials fails", code, 1)
+check("it says it examined nothing", "examined nothing" in out, True)
+
+code, out = run(tree(reusable=CALLEE_OK))
+check("a callee with no caller at all fails", code, 1)
+
+# 13. Not a blanket refusal: the passing case still passes beside unrelated
+#     workflows, and with more than one call.
+code, out = run(tree(
+    reusable=CALLEE_OK, main=CALLER_OK, unrelated=NO_CONAN_AT_ALL))
+check("unrelated workflows do not break the check", code, 0)
+
+code, out = run(tree(
+    reusable=CALLEE_OK,
+    main=CALLER_OK + CALLER_OK.split("jobs:\n", 1)[1].replace("  build:", "  build2:")))
+check("two calls both pass and are counted", code, 0)
+check("both calls are counted", "2 call(s) mapping them" in out, True)
+
+# 14. A caller pointing at a workflow that is not there is "could not check",
+#     never "checked and fine".
+code, out = run(tree(
+    reusable=CALLEE_OK,
+    main=CALLER_OK.replace("./.github/workflows/reusable.yml",
+                           "./.github/workflows/absent.yml")))
+check("a missing callee fails", code, 1)
+check("it says it could not be checked", "could not be checked" in out, True)
+
+# 15. No value ever reaches the output. The literal below is not a credential,
+#     it is bait: if the reporting ever echoes what it read instead of what it
+#     was called, this catches it.
+BAIT = "s3cr3t-bait-value-not-a-real-password"
+code, out = run(tree(
+    reusable=CALLEE_OK.replace("secrets.conan_remote_password",
+                               "secrets.CONAN_PASSWORD"),
+    main=CALLER_OK.replace("${{ secrets.CONAN_3_PASSWORD }}", BAIT)))
+check("the bait case does fail", code, 1)
+check("no value is printed", BAIT in out, False)
+
+# 16. Inert copies elsewhere in the tree are reported, not enforced — and the
+#     report has to be complete. The two shapes differ: a vendored workflow
+#     READS `${{ secrets.conan-password }}`, while the per-component leftovers
+#     only HAND OVER a value under a retired key. A scan that looked for reads
+#     alone would list the first and quietly miss the second.
+root = tree(reusable=CALLEE_OK, main=CALLER_OK)
+for where, text in (
+    ("vendored", "run: conan remote login -p ${{ secrets.conan-password }} kth\n"),
+    ("src/component", "secrets:\n  conan-user: ${{ secrets.CONAN_LOGIN_USERNAME }}\n"),
+):
+    d = root / where / ".github" / "workflows"
+    d.mkdir(parents=True)
+    (d / "old.yml").write_text(text)
+code, out = run(root)
+check("inert copies do not fail the check", code, 0)
+check("a read of a retired name is listed",
+      "vendored/.github/workflows/old.yml" in out, True)
+check("a retired name used only as a key is listed too",
+      "src/component/.github/workflows/old.yml" in out, True)
+check("the report says it is not enforced", "not enforced" in out, True)
+
+if FAILURES:
+    print(f"check-conan-credentials-selftest: {len(FAILURES)} failure(s): "
+          + ", ".join(FAILURES))
+    sys.exit(1)
+print("check-conan-credentials-selftest: all checks passed")

--- a/.github/scripts/check-conan-credentials.py
+++ b/.github/scripts/check-conan-credentials.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Fail when the Conan credentials cross the boundary they are supposed to keep.
+
+There are two vocabularies here, and mixing them is the defect this guards.
+
+  * The repository's PHYSICAL secrets — `CONAN_LOGIN_USERNAME` and
+    `CONAN_3_PASSWORD` — are facts about this GitHub repository. They belong to
+    exactly one file, `main.yml`, which is where the outside world is bound to
+    the inside.
+  * The reusable workflows speak an INTERFACE: `conan_remote_username` and
+    `conan_remote_password`, declared as `workflow_call` secrets. A reusable
+    workflow that names a physical secret is coupled to the repository it
+    happens to live in today, which is the opposite of what "reusable" means.
+
+The repository reached this rule the long way. One pair of credentials had
+grown three names — `conan-user`/`conan-password` in four workflows,
+`CONAN_LOGIN_USERNAME`/`CONAN_PASSWORD` in two more, and the physical pair at
+the top — where every hop was a correct rename in isolation and the only thing
+holding the chain together was that someone had once got all six right at the
+same time. Unifying the names fixed the symptom; moving the physical names into
+one layer fixes the coupling.
+
+What makes this worth a script rather than a convention: passing a name the
+callee does not declare is valid YAML, says nothing to actionlint, and fails
+when a job *starts* — as a message about a secret rather than about the edit
+that caused it. So this reads the wiring:
+
+  * a reusable workflow declares exactly the two interface names, and mentions
+    no physical or retired name anywhere;
+  * a root workflow may read the physical names and nothing else;
+  * every call maps both interface names, each from its own physical source and
+    not crossed — a swapped pair would try to authenticate with the password as
+    the username;
+  * the credentials travel as `workflow_call` secrets, never as ordinary `with:`
+    inputs, which are not redacted the way secrets are;
+  * and if this ever examines no caller/callee pair at all, it fails. A green
+    tick from a checker that stopped looking is worse than no checker.
+
+No secret VALUE is ever read: the inputs are workflow files on disk, which hold
+`${{ secrets.NAME }}` expressions and never their contents. Output is limited to
+names, paths and line numbers.
+
+Usage: check-conan-credentials.py [--root DIR]
+"""
+
+import pathlib
+import re
+import sys
+
+INTERFACE_USERNAME = "conan_remote_username"
+INTERFACE_PASSWORD = "conan_remote_password"
+INTERFACE = {INTERFACE_USERNAME, INTERFACE_PASSWORD}
+
+PHYSICAL_USERNAME = "CONAN_LOGIN_USERNAME"
+PHYSICAL_PASSWORD = "CONAN_3_PASSWORD"
+PHYSICAL = {PHYSICAL_USERNAME, PHYSICAL_PASSWORD}
+
+# Which physical secret each interface name is allowed to come from. Crossing
+# them is valid YAML and authenticates with the password as the username.
+SOURCE_OF = {INTERFACE_USERNAME: PHYSICAL_USERNAME,
+             INTERFACE_PASSWORD: PHYSICAL_PASSWORD}
+
+# Names this repository actually used before the unification, kept only so the
+# error can say "retired" instead of "unexpected". The rule that does the work
+# is that a name must be interface-or-physical for where it appears.
+RETIRED = {
+    "CONAN_PASSWORD": "the reusable build workflows",
+    "conan-password": "the deps and calc-deps workflows",
+    "conan-user": "the deps and calc-deps workflows",
+}
+
+# Anything that looks like it names a Conan credential — deliberately loose, to
+# catch the alias nobody has invented yet.
+LOOKS_LIKE_CONAN = re.compile(r"conan", re.IGNORECASE)
+# Narrower: a Conan input that is a CREDENTIAL rather than a setting. Needed
+# because `conan-remote` is a perfectly good ordinary input and must not be
+# confused with something that has to travel as a secret.
+LOOKS_LIKE_CREDENTIAL = re.compile(
+    r"conan.*(password|passwd|pwd|secret|token|credential|user|login)"
+    r"|(password|passwd|pwd|secret|token|credential|user|login).*conan",
+    re.IGNORECASE)
+SECRET_REFERENCE = re.compile(r"secrets\.([A-Za-z_][A-Za-z0-9_-]*)")
+BLOCK_SCALAR = re.compile(r"^[|>][-+0-9]*$")
+KEY = re.compile(r"([A-Za-z0-9_.\-\"']+)\s*:(\s|$)")
+
+
+def mapping_keys(text):
+    """Every mapping key in a workflow, with the path of keys above it.
+
+    A hand-rolled reader of the YAML subset these files use, rather than a
+    dependency: this has to run inside the gcc build containers, where a pip
+    install is not guaranteed and a check that cannot run is a check that does
+    not run. It is narrow on purpose, and the selftest feeds it the shapes that
+    matter — sequences, block scalars, comments — because a parser nobody tested
+    fails by finding nothing, which is the one failure this script exists to
+    prevent.
+    """
+    entries = []
+    stack = []          # [(indent, key)] of the mapping keys currently open
+    skip_deeper_than = None
+
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+
+        # Inside a `run: |` block the content is shell, not YAML, and reading it
+        # as YAML is how a parser invents keys that were never there.
+        if skip_deeper_than is not None:
+            if indent > skip_deeper_than:
+                continue
+            skip_deeper_than = None
+
+        body = line.lstrip(" ")
+        if body.startswith("#"):
+            continue
+
+        if body == "-" or body.startswith("- "):
+            # A sequence item. Recording it keeps a step's `uses:` from being
+            # read as a job's `uses:` — they differ only by being inside this.
+            while stack and stack[-1][0] >= indent:
+                stack.pop()
+            stack.append((indent, "[]"))
+            if body == "-":
+                continue
+            indent += 2
+            body = body[2:]
+
+        match = KEY.match(body)
+        if match is None:
+            continue
+
+        key = match.group(1).strip("\"'")
+        value = body[match.end(1) + 1:].strip()
+
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+
+        entries.append((tuple(k for _, k in stack), key, value, lineno))
+        stack.append((indent, key))
+
+        if BLOCK_SCALAR.match(value):
+            skip_deeper_than = indent
+
+    return entries
+
+
+def is_reusable(entries):
+    return any(path == ("on",) and key == "workflow_call" for path, key, _v, _l in entries)
+
+
+def declared_secrets(entries):
+    return {key: lineno for path, key, _v, lineno in entries
+            if path == ("on", "workflow_call", "secrets")}
+
+
+def declared_inputs(entries):
+    return {key: lineno for path, key, _v, lineno in entries
+            if path == ("on", "workflow_call", "inputs")}
+
+
+def caller_jobs(entries):
+    """Jobs that call another workflow: the target, the secrets and the inputs."""
+    targets, secrets, withs = {}, {}, {}
+    for path, key, value, lineno in entries:
+        if len(path) == 2 and path[0] == "jobs" and key == "uses":
+            targets[path[1]] = (re.sub(r"\s+#.*$", "", value).strip(), lineno)
+        elif len(path) == 3 and path[0] == "jobs" and path[2] == "secrets":
+            secrets.setdefault(path[1], {})[key] = (value, lineno)
+        elif len(path) == 3 and path[0] == "jobs" and path[2] == "with":
+            withs.setdefault(path[1], {})[key] = (value, lineno)
+    return {job: (targets[job][0], targets[job][1],
+                  secrets.get(job, {}), withs.get(job, {}))
+            for job in targets}
+
+
+def secret_references(text):
+    """Every `${{ secrets.NAME }}` in the file, with its line."""
+    out = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for name in SECRET_REFERENCE.findall(line):
+            out.append((name, lineno))
+    return out
+
+
+def retired_note(name):
+    if name in RETIRED:
+        return (f"`{name}` was retired when the credentials were unified "
+                f"(it used to be {RETIRED[name]}). ")
+    return ""
+
+
+def main() -> int:
+    root = pathlib.Path(".")
+    argv = sys.argv[1:]
+    if argv[:1] == ["--root"]:
+        if len(argv) < 2:
+            print("::error::check-conan-credentials: --root needs a directory",
+                  file=sys.stderr)
+            return 1
+        root = pathlib.Path(argv[1])
+
+    workflow_dir = root / ".github" / "workflows"
+    if not workflow_dir.is_dir():
+        print(f"::error::check-conan-credentials: {workflow_dir} does not exist; "
+              "no workflow was examined", file=sys.stderr)
+        return 1
+
+    workflows = sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml"))
+    if not workflows:
+        print(f"::error::check-conan-credentials: no workflow file exists under "
+              f"{workflow_dir}; nothing was examined", file=sys.stderr)
+        return 1
+
+    errors = []
+    parsed, texts, reusable = {}, {}, {}
+
+    for path in workflows:
+        where = path.relative_to(root).as_posix()
+        texts[where] = path.read_text()
+        parsed[where] = mapping_keys(texts[where])
+        reusable[where] = is_reusable(parsed[where])
+
+    # ------------------------------------------------------------------
+    # Each file may speak only its own vocabulary.
+    # ------------------------------------------------------------------
+    for where, entries in parsed.items():
+        if reusable[where]:
+            declared = {k: l for k, l in declared_secrets(entries).items()
+                        if LOOKS_LIKE_CONAN.search(k)}
+            references = [(n, l) for n, l in secret_references(texts[where])
+                          if LOOKS_LIKE_CONAN.search(n)]
+
+            if declared or references:
+                if set(declared) != INTERFACE:
+                    errors.append(
+                        f"::error file={where}::check-conan-credentials: this "
+                        f"reusable workflow declares "
+                        f"{sorted(declared) or 'no Conan secret'} under "
+                        f"workflow_call, but the interface is exactly "
+                        f"{sorted(INTERFACE)}")
+
+            for name, lineno in references:
+                if name in INTERFACE:
+                    continue
+                extra = ("A reusable workflow must not name a physical "
+                         "repository secret: that couples it to this "
+                         "repository. Take it as "
+                         f"`{INTERFACE_USERNAME}` / `{INTERFACE_PASSWORD}` "
+                         "and let main.yml do the mapping."
+                         if name in PHYSICAL else
+                         f"{retired_note(name)}Use `{INTERFACE_USERNAME}` / "
+                         f"`{INTERFACE_PASSWORD}`.")
+                errors.append(
+                    f"::error file={where},line={lineno}::"
+                    f"check-conan-credentials: this reusable workflow reads "
+                    f"`{name}`. {extra}")
+
+            for name, lineno in declared_inputs(entries).items():
+                if LOOKS_LIKE_CREDENTIAL.search(name):
+                    errors.append(
+                        f"::error file={where},line={lineno}::"
+                        f"check-conan-credentials: `{name}` is declared as an "
+                        "ordinary workflow_call input. A credential must be a "
+                        "`secrets:` entry — inputs are not redacted in logs")
+        else:
+            for name, lineno in secret_references(texts[where]):
+                if not LOOKS_LIKE_CONAN.search(name) or name in PHYSICAL:
+                    continue
+                extra = ("That is the reusable workflows' interface name, not a "
+                         "repository secret; a root workflow reads the physical "
+                         "one."
+                         if name in INTERFACE else
+                         f"{retired_note(name)}The only Conan secrets this "
+                         f"repository has are {sorted(PHYSICAL)}.")
+                errors.append(
+                    f"::error file={where},line={lineno}::"
+                    f"check-conan-credentials: `{name}` is read here. {extra}")
+
+    # ------------------------------------------------------------------
+    # Every call maps both interface names, from the right physical source.
+    # ------------------------------------------------------------------
+    pairs = 0
+    for where, entries in parsed.items():
+        for job, (target, uses_line, handed, withs) in caller_jobs(entries).items():
+            if not target.startswith("./.github/workflows/"):
+                continue
+            callee = target[len("./"):]
+            if callee not in parsed:
+                errors.append(
+                    f"::error file={where},line={uses_line}::"
+                    f"check-conan-credentials: job `{job}` calls `{target}`, "
+                    "which was not found; the credentials it needs could not be "
+                    "checked")
+                continue
+
+            declared = {k for k in declared_secrets(parsed[callee])
+                        if LOOKS_LIKE_CONAN.search(k)}
+            passed = {k: v for k, v in handed.items() if LOOKS_LIKE_CONAN.search(k)}
+            if not declared and not passed:
+                continue
+            pairs += 1
+
+            for name, (value, lineno) in withs.items():
+                if LOOKS_LIKE_CREDENTIAL.search(name):
+                    errors.append(
+                        f"::error file={where},line={lineno}::"
+                        f"check-conan-credentials: job `{job}` passes `{name}` "
+                        "under `with:`. A credential must go through "
+                        "`secrets:`, which is redacted; `with:` is not")
+
+            for name in sorted(INTERFACE - set(passed)):
+                errors.append(
+                    f"::error file={where},line={uses_line}::"
+                    f"check-conan-credentials: job `{job}` calls `{target}` "
+                    f"without mapping `{name}`")
+            for name in sorted(set(passed) - INTERFACE):
+                errors.append(
+                    f"::error file={where},line={passed[name][1]}::"
+                    f"check-conan-credentials: job `{job}` maps `{name}`, which "
+                    f"is not part of the interface {sorted(INTERFACE)}")
+
+            for name, (value, lineno) in sorted(passed.items()):
+                if name not in SOURCE_OF:
+                    continue
+                sources = [n for n in SECRET_REFERENCE.findall(value)]
+                if not sources:
+                    errors.append(
+                        f"::error file={where},line={lineno}::"
+                        f"check-conan-credentials: `{name}` is mapped from "
+                        "something that is not a repository secret")
+                    continue
+                for source in sources:
+                    if source == SOURCE_OF[name]:
+                        continue
+                    if source in PHYSICAL:
+                        errors.append(
+                            f"::error file={where},line={lineno}::"
+                            f"check-conan-credentials: `{name}` is mapped from "
+                            f"`{source}`; the pair is crossed, and the login "
+                            "would send the password as the username")
+                    else:
+                        errors.append(
+                            f"::error file={where},line={lineno}::"
+                            f"check-conan-credentials: `{name}` is mapped from "
+                            f"`{source}`. {retired_note(source)}The accepted "
+                            f"sources are exactly {sorted(PHYSICAL)}")
+
+    # Concrete errors come first. "Examined nothing" is the fallback for a tree
+    # that had nothing to say, not a summary that should swallow a specific
+    # complaint — a caller pointing at a workflow that does not exist produces
+    # both conditions, and the useful one is the missing file.
+    if errors:
+        for line in errors:
+            print(line, file=sys.stderr)
+        return 1
+
+    if pairs == 0:
+        print("::error::check-conan-credentials: no call from a workflow to a "
+              "reusable workflow carrying Conan credentials was found; this "
+              "check examined nothing, which it must never do quietly",
+              file=sys.stderr)
+        return 1
+
+    n_reusable = sum(1 for w in reusable if reusable[w])
+    print(f"check-conan-credentials: {len(workflows)} workflow(s) examined, "
+          f"{n_reusable} reusable taking {INTERFACE_USERNAME} / "
+          f"{INTERFACE_PASSWORD}, {pairs} call(s) mapping them from "
+          f"{PHYSICAL_USERNAME} / {PHYSICAL_PASSWORD}")
+
+    # What this check does NOT enforce, said out loud. GitHub only executes
+    # workflows in the repository-root `.github/workflows`; this tree also
+    # carries inert copies — the vendored `ci_utils/` workflows and the
+    # per-component `knuth.yml` files left over from before the monorepo —
+    # which still spell the retired names. Renaming credentials in files that
+    # never run would be churn that hides the real answer, which is that they
+    # should not be in the tree at all. So they are listed rather than fixed or
+    # ignored: a bounded check that never says where its boundary is reads as
+    # "the repository is clean" when it only ever looked at part of it.
+    inert = []
+    for path in sorted(root.glob("*/**/.github/workflows/*.yml")):
+        try:
+            text = path.read_text()
+        except (UnicodeDecodeError, OSError):
+            continue
+        names = sorted({n for n, _l in secret_references(text)
+                        if LOOKS_LIKE_CONAN.search(n)
+                        and n not in INTERFACE and n not in PHYSICAL}
+                       | {n for n in RETIRED
+                          if re.search(rf"(?<![\w-]){re.escape(n)}(?![\w-])", text)})
+        if names:
+            inert.append((path.relative_to(root).as_posix(), names))
+
+    if inert:
+        print(f"check-conan-credentials: not enforced — {len(inert)} file(s) "
+              "outside .github/workflows still spell a retired name. GitHub "
+              "never runs them; they are dead copies and should be deleted "
+              "rather than renamed:")
+        for where, names in inert:
+            print(f"  {where}: {', '.join(names)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build-deps-with-container.yml
+++ b/.github/workflows/build-deps-with-container.yml
@@ -22,9 +22,9 @@ on:
         required: true
         type: string
     secrets:
-      conan-user:
+      conan_remote_username:
         required: true
-      conan-password:
+      conan_remote_password:
         required: true
 jobs:
   reusable-build-deps-with-container:
@@ -60,7 +60,7 @@ jobs:
         uses: ./ci_utils/.github/actions/setup-kthbuild
       - name: 🔐 Conan login
         if: ${{ inputs.reference != 'null' }}
-        run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
+        run: conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
       - name: 📥 Download artifact
         if: ${{ inputs.reference != 'null' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/build-deps-without-container.yml
+++ b/.github/workflows/build-deps-without-container.yml
@@ -19,9 +19,9 @@ on:
         required: true
         type: string
     secrets:
-      conan-user:
+      conan_remote_username:
         required: true
-      conan-password:
+      conan_remote_password:
         required: true
 jobs:
   reusable-build-deps-without-container:
@@ -70,7 +70,7 @@ jobs:
         uses: ./ci_utils/.github/actions/setup-kthbuild
       - name: 🔐 Conan login
         if: ${{ inputs.reference != 'null' }}
-        run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
+        run: conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
       - name: 📥 Download artifact
         if: ${{ inputs.reference != 'null' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/build-with-container.yml
+++ b/.github/workflows/build-with-container.yml
@@ -63,9 +63,9 @@ on:
         type: boolean
         default: false
     secrets:
-      CONAN_LOGIN_USERNAME:
+      conan_remote_username:
         required: true
-      CONAN_PASSWORD:
+      conan_remote_password:
         required: true
 jobs:
   reusable-build-with-container:
@@ -153,6 +153,10 @@ jobs:
       # job worked. The self-test now exercises the API path against a stubbed
       # curl here as well as on macOS, so a tool this image lacks is found by a
       # check rather than by an inventory that quietly keeps growing.
+      # The credentials check joined them for the same reason read from
+      # the other end: the Conan secrets had three different names
+      # across six workflows, and half a rename is valid YAML that
+      # fails when a job starts rather than when the file is edited.
       - name: 🧪 CI script checks
         if: ${{ inputs.upload != true }}
         shell: bash
@@ -160,6 +164,8 @@ jobs:
           python3 "${GITHUB_WORKSPACE}/.github/scripts/check-cache-keys.py"
           "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-selftest.sh"
           "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-closed-prs-selftest.sh"
+          python3 "${GITHUB_WORKSPACE}/.github/scripts/check-conan-credentials.py"
+          python3 "${GITHUB_WORKSPACE}/.github/scripts/check-conan-credentials-selftest.py"
 
       - name: 🗄️ Setup ccache
         if: ${{ inputs.upload != true }}
@@ -275,7 +281,7 @@ jobs:
           # Choose build strategy based on whether we need to upload
           if [ "${{ inputs.upload }}" = "true" ]; then
             echo "🚀 Release build - using conan create (includes package validation)"
-            conan remote login -p ${{ secrets.CONAN_PASSWORD }} ${{ inputs.conan-remote }} ${{ secrets.CONAN_LOGIN_USERNAME }}
+            conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
             conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd -o march_id=ZLm9Pjh $EXTRA_CONAN_OPTS
             conan create conanfile.py --version ${{ inputs.build-version }} --lockfile=build/conan.lock -pr:b linux-ci-cd -pr:h linux-ci-cd --build=missing -o march_id=ZLm9Pjh -o tests=False $EXTRA_CONAN_OPTS
           else
@@ -672,5 +678,5 @@ jobs:
         # if: github.event_name == 'push' && needs.check.outputs.permitted == 'true'
         if: ${{ inputs.upload }}
         run: |
-          conan remote login -p ${{ secrets.CONAN_PASSWORD }} ${{ inputs.conan-remote }} ${{ secrets.CONAN_LOGIN_USERNAME }}
+          conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
           conan upload ${{ inputs.recipe-name }}/${{ inputs.build-version }}@ -r ${{ inputs.conan-remote }} # --all

--- a/.github/workflows/build-without-container.yml
+++ b/.github/workflows/build-without-container.yml
@@ -48,9 +48,9 @@ on:
         type: boolean
         default: true
     secrets:
-      CONAN_LOGIN_USERNAME:
+      conan_remote_username:
         required: true
-      CONAN_PASSWORD:
+      conan_remote_password:
         required: true
 jobs:
   reusable-build-without-container:
@@ -126,6 +126,10 @@ jobs:
       # And the key check exists because an edit once moved a `restore-keys`
       # line into a neighbouring step's `run:` block: valid YAML, nothing for
       # actionlint to say, and every container build silently cold.
+      # The credentials check joined them for the same reason read from
+      # the other end: the Conan secrets had three different names
+      # across six workflows, and half a rename is valid YAML that
+      # fails when a job starts rather than when the file is edited.
       - name: 🧪 CI script checks
         if: ${{ inputs.upload != true }}
         shell: /bin/bash -e {0}
@@ -133,6 +137,8 @@ jobs:
           python3 "${GITHUB_WORKSPACE}/.github/scripts/check-cache-keys.py"
           "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-selftest.sh"
           "${GITHUB_WORKSPACE}/.github/scripts/ccache-prune-closed-prs-selftest.sh"
+          python3 "${GITHUB_WORKSPACE}/.github/scripts/check-conan-credentials.py"
+          python3 "${GITHUB_WORKSPACE}/.github/scripts/check-conan-credentials-selftest.py"
 
       - name: 🗄️ Setup ccache
         if: ${{ inputs.upload != true }}
@@ -228,7 +234,7 @@ jobs:
           # Choose build strategy based on whether we need to upload
           if [ "${{ inputs.upload }}" = "true" ]; then
             echo "🚀 Release build - using conan create (includes package validation)"
-            conan remote login -p ${{ secrets.CONAN_PASSWORD }} ${{ inputs.conan-remote }} ${{ secrets.CONAN_LOGIN_USERNAME }}
+            conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
             conan lock create conanfile.py --version ${{ inputs.build-version }} --lockfile=conan.lock --lockfile-out=build/conan.lock -pr:b general-ci-cd -pr:h general-ci-cd
             conan create conanfile.py --version ${{ inputs.build-version }} --lockfile=build/conan.lock -pr:b general-ci-cd -pr:h general-ci-cd --build=missing -o tests=False
           else
@@ -487,5 +493,5 @@ jobs:
         # if: github.event_name == 'push' && needs.check.outputs.permitted == 'true'
         if: ${{ inputs.upload }}
         run: |
-          conan remote login -p ${{ secrets.CONAN_PASSWORD }} ${{ inputs.conan-remote }} ${{ secrets.CONAN_LOGIN_USERNAME }}
+          conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
           conan upload ${{ inputs.recipe-name }}/${{ inputs.build-version }}@ -r ${{ inputs.conan-remote }} # --all

--- a/.github/workflows/calc-deps-with-container.yml
+++ b/.github/workflows/calc-deps-with-container.yml
@@ -18,9 +18,9 @@ on:
         required: true
         type: string
     secrets:
-      conan-user:
+      conan_remote_username:
         required: true
-      conan-password:
+      conan_remote_password:
         required: true
     outputs:
       matrix:
@@ -57,7 +57,7 @@ jobs:
       - name: 🔧 Setup kthbuild
         uses: ./ci_utils/.github/actions/setup-kthbuild
       - name: 🔐 Conan login
-        run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
+        run: conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
 
       - name: 📋 Calculate build order
         working-directory: .

--- a/.github/workflows/calc-deps-without-container.yml
+++ b/.github/workflows/calc-deps-without-container.yml
@@ -15,9 +15,9 @@ on:
         required: true
         type: string
     secrets:
-      conan-user:
+      conan_remote_username:
         required: true
-      conan-password:
+      conan_remote_password:
         required: true
     outputs:
       matrix:
@@ -53,7 +53,7 @@ jobs:
       - name: 🔧 Setup kthbuild
         uses: ./ci_utils/.github/actions/setup-kthbuild
       - name: 🔑 Conan login
-        run: conan remote login -p ${{ secrets.conan-password }} ${{ inputs.conan-remote }} ${{ secrets.conan-user }}
+        run: conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
 
       - name: 📋 Build order
         working-directory: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,8 +226,8 @@ jobs:
       conan-remote: "kth"
       build-version: ${{ needs.setup.outputs.build-version }}
     secrets:
-      conan-user: ${{ secrets.CONAN_LOGIN_USERNAME }}
-      conan-password: ${{ secrets.CONAN_3_PASSWORD }}
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
 
   calc-deps-without-container:
     needs: [setup, generate-matrix]
@@ -241,8 +241,8 @@ jobs:
       conan-remote: "kth"
       build-version: ${{ needs.setup.outputs.build-version }}
     secrets:
-      conan-user: ${{ secrets.CONAN_LOGIN_USERNAME }}
-      conan-password: ${{ secrets.CONAN_3_PASSWORD }}
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
 
   build-deps-with-container:
     needs: [calc-deps-with-container]
@@ -258,8 +258,8 @@ jobs:
       context: ${{ matrix.config.context }}
       conan-remote: "kth"
     secrets:
-      conan-user: ${{ secrets.CONAN_LOGIN_USERNAME }}
-      conan-password: ${{ secrets.CONAN_3_PASSWORD }}
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
 
   build-deps-without-container:
     needs: [calc-deps-without-container]
@@ -274,8 +274,8 @@ jobs:
       context: ${{ matrix.config.context }}
       conan-remote: "kth"
     secrets:
-      conan-user: ${{ secrets.CONAN_LOGIN_USERNAME }}
-      conan-password: ${{ secrets.CONAN_3_PASSWORD }}
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
 
   build-with-container:
     # Wait for the deps job to push prebuilt packages to the conan remote.
@@ -303,8 +303,8 @@ jobs:
       enable-tsan: false
       skip-tests: false
     secrets:
-      CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
-      CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
 
   # Sanitizers only run on push (master / release / hotfix /
   # dev-publish / tags), NOT on `pull_request`. Rationale:
@@ -353,8 +353,8 @@ jobs:
       skip-tests: false
       advisory: false
     secrets:
-      CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
-      CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
 
   build-without-container:
     # Wait for the macOS deps build to populate the conan remote. Hosted
@@ -380,8 +380,8 @@ jobs:
       enable-tsan: false  # Disabled due to secp256k1 inline assembly conflicts
       skip-tests: false
     secrets:
-      CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
-      CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
 
   build-with-container-release:
     needs: [setup, generate-matrix]
@@ -407,8 +407,8 @@ jobs:
       enable-tsan: false  # Disabled for clean release builds
       skip-tests: false  # Skip tests for clean release builds
     secrets:
-      CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
-      CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
 
   build-without-container-release:
     needs: [setup, generate-matrix]
@@ -433,8 +433,8 @@ jobs:
       enable-tsan: false  # Disabled for clean release builds
       skip-tests: false
     secrets:
-      CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_LOGIN_USERNAME }}
-      CONAN_PASSWORD: ${{ secrets.CONAN_3_PASSWORD }}
+      conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
+      conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
 
   static-checks:
     name: 🔍 Static analysis


### PR DESCRIPTION
One pair of Conan credentials had three names on the way down: `conan-user` /
`conan-password` in four reusable workflows, `CONAN_LOGIN_USERNAME` /
`CONAN_PASSWORD` in two more, and the repository's own pair at the top. Every hop
was a correct rename in isolation, and the only thing holding the chain together
was that someone had once got all six right at the same time.

Unifying the spelling would have fixed the symptom. The cause is that the
reusable workflows knew the names of *this* repository's secrets at all — a
workflow that reads `CONAN_3_PASSWORD` can only be reused somewhere that happens
to spell its secrets the same way, which is the opposite of what reusable means.

## Two vocabularies, one translation point

| Layer | Names | Who may say them |
| --- | --- | --- |
| Repository secrets | `CONAN_LOGIN_USERNAME`, `CONAN_3_PASSWORD` | `main.yml` (and `build-wasm.yml`, a root workflow) — nobody else |
| Reusable-workflow interface | `conan_remote_username`, `conan_remote_password` | the six reusable workflows — and nothing else |

The six reusable workflows declare the interface as `workflow_call` secrets and
consume only those:

```yaml
on:
  workflow_call:
    secrets:
      conan_remote_username:
        required: true
      conan_remote_password:
        required: true
```

```yaml
run: conan remote login -p "${{ secrets.conan_remote_password }}" "${{ inputs.conan-remote }}" "${{ secrets.conan_remote_username }}"
```

`main.yml` is the only file that binds the outside to the inside, at each of its
nine calls:

```yaml
secrets:
  conan_remote_username: ${{ secrets.CONAN_LOGIN_USERNAME }}
  conan_remote_password: ${{ secrets.CONAN_3_PASSWORD }}
```

The credentials stay `secrets:` rather than becoming `with:` inputs — inputs are
not redacted in logs — and both are quoted at the login, so a value containing
shell metacharacters cannot be re-parsed after interpolation.

**No secret is added, changed or removed.** `CONAN_3_PASSWORD` already exists and
is what every caller was already passing. Nothing needs touching in the
repository settings before or after this merges.

## The check keeps the boundary

Passing a name the callee does not declare is valid YAML, says nothing to
`actionlint`, and fails when a job *starts* — as a message about a secret rather
than about the edit that caused it. `.github/scripts/check-conan-credentials.py`
reads the wiring:

- a **reusable workflow** must declare exactly the two interface names and
  mention no physical or retired one. Coupling one back to a repository secret is
  rejected with the reason:

  ```
  ::error file=.github/workflows/calc-deps-with-container.yml,line=60:: this reusable
    workflow reads `CONAN_3_PASSWORD`. A reusable workflow must not name a physical
    repository secret: that couples it to this repository. Take it as
    `conan_remote_username` / `conan_remote_password` and let main.yml do the mapping.
  ```

- a **root workflow** may read the physical names and nothing else. Reading an
  interface name there yields an empty string and a login that fails much later.
- **every call maps both**, each from its own source and **not crossed** — a
  swapped pair is valid YAML that authenticates with the password as the
  username:

  ```
  ::error file=.github/workflows/main.yml,line=229:: `conan_remote_username` is mapped
    from `CONAN_3_PASSWORD`; the pair is crossed, and the login would send the
    password as the username
  ```

- **credentials travel as secrets**, never as `with:` inputs, checked from both
  the caller's and the callee's side.
- **it fails when it examined nothing**: no workflow directory, no workflow file,
  or no caller/callee pair carrying credentials are each an error. A concrete
  complaint always wins over that fallback — a caller pointing at a workflow that
  does not exist reports the missing file, not "examined nothing".
- **no secret value is ever read or printed.** The inputs are workflow files on
  disk, which hold `${{ secrets.NAME }}` expressions and never their contents;
  output is names, paths and line numbers.

The parser is hand-rolled rather than PyYAML, because this runs inside the gcc
build containers where a pip install is not guaranteed, and a check that cannot
run is a check that does not run. Its selftest feeds it the shapes that would
make it silently find nothing — sequences (a step's `uses:` is not a job's),
block scalars holding shell that looks like YAML, comments — carries controls
against **both** a blanket refusal and a blanket pass, keeps an ordinary
`conan-remote` input from being mistaken for a credential, and puts a
password-shaped literal into a workflow to assert it never reaches the output.

```
check-conan-credentials-selftest: all checks passed          (38 checks)
check-conan-credentials: 13 workflow(s) examined, 6 reusable taking
  conan_remote_username / conan_remote_password, 9 call(s) mapping them from
  CONAN_LOGIN_USERNAME / CONAN_3_PASSWORD
```

It runs in the existing `🧪 CI script checks` step of both build workflows,
alongside the cache-key check and the two prune selftests.

## What this does not enforce, stated rather than hidden

GitHub only executes workflows in the repository-root `.github/workflows`. This
tree also carries fourteen inert copies that still spell the retired names — the
vendored `ci_utils/` workflows and the per-component `knuth.yml` files left over
from before the monorepo. Renaming credentials in files that never run would be
churn that hides the real answer, which is that they should not be in the tree at
all. So the check lists them on every run instead:

```
check-conan-credentials: not enforced — 14 file(s) outside .github/workflows
  still spell a retired name. GitHub never runs them; they are dead copies and
  should be deleted rather than renamed:
  ci_utils/.github/workflows/build-with-container.yml: CONAN_PASSWORD
  src/domain/.github/workflows/knuth.yml: CONAN_PASSWORD, conan-password, conan-user
  …
```

Deleting them is a separate, mechanical cleanup.

## Verification

- The selftest's 38 checks.
- The check run against this tree, and against three deliberately broken
  variants of the **real** files — a reusable workflow coupled back to
  `CONAN_3_PASSWORD`, a crossed mapping in `main.yml`, and a half-applied rename
  — each rejected with the errors quoted above, and each restored afterwards.
- All 13 workflows still parse as YAML.
- `ci_utils/.github/actions/*` — the actions this repo actually calls — never see
  a Conan credential.
- No repository outside this one calls these reusable workflows (`org:k-nuth`
  search for `k-nuth/kth/.github/workflows`: 0 results), so the renamed interface
  has no external callers.
- `main.yml` has no `paths` filter, so this PR's own CI performs a **real Conan
  login through the new interface** on every deps leg. The release-only upload
  path uses the same interface but runs only on release branches.
