### PR TITLE
deps: move to UTXO-Z 0.9.1, and to the contracts it changed underneath

### DIFF
--- a/conan.lock
+++ b/conan.lock
@@ -2,7 +2,7 @@
     "version": "0.5",
     "requires": [
         "zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb%1777558780.503",
-        "utxoz/0.8.0#544d3847f25a1b54b0fa518f1656381c%1781621955.652",
+        "utxoz/0.9.1#cf72ca058a4808769921fffccd4ee5f0%1786378940.406",
         "tiny-aes-c/1.0.0#0f0a930c53a0d33d5a91a4c930f836ab%1743667795.615",
         "spdlog/1.17.0#bcbaaf7147bda6ad24ffbd1ac3d7142c%1767636069.964",
         "simdutf/9.0.0#b9af8a9a869a7fef21a9374d4335cf22%1779790472.899",

--- a/conanfile.py
+++ b/conanfile.py
@@ -75,7 +75,7 @@ class KthRecipe(KnuthConanFileV2):
         "with_stats": [True, False],
         "rpc": [True, False],
         "embed_utxo_bloom": [True, False],
-        "utxoz_compact": [True, False],
+        "utxoz_reference": [True, False],
         "asio_standalone": [True, False],
 
         # secp256k1 options
@@ -127,7 +127,7 @@ class KthRecipe(KnuthConanFileV2):
         "with_stats": False,
         "rpc": True,
         "embed_utxo_bloom": False,
-        "utxoz_compact": False,
+        "utxoz_reference": False,
         "asio_standalone": True,
 
         # secp256k1 options
@@ -177,7 +177,7 @@ class KthRecipe(KnuthConanFileV2):
         self.requires("fmt/12.1.0", transitive_headers=True, transitive_libs=True)
         self.requires("spdlog/1.17.0", transitive_headers=True, transitive_libs=True)
         self.requires("lmdb/0.9.32", transitive_headers=True, transitive_libs=True)
-        self.requires("utxoz/0.8.0", transitive_headers=True, transitive_libs=True)
+        self.requires("utxoz/0.9.1", transitive_headers=True, transitive_libs=True)
 
         # GMP is required for BigInt support in the native interpreter.
         self.requires("gmp/6.3.0", transitive_headers=True, transitive_libs=True)
@@ -309,7 +309,7 @@ class KthRecipe(KnuthConanFileV2):
         tc.variables["KTH_WITH_STATS"] = option_on_off(self.options.with_stats)
         tc.variables["KTH_WITH_RPC"] = option_on_off(self.options.rpc)
         tc.variables["KTH_EMBED_UTXO_BLOOM"] = option_on_off(self.options.embed_utxo_bloom)
-        tc.variables["KTH_UTXOZ_COMPACT_MODE"] = option_on_off(self.options.utxoz_compact)
+        tc.variables["KTH_UTXOZ_REFERENCE_MODE"] = option_on_off(self.options.utxoz_reference)
         tc.variables["KTH_ASIO_STANDALONE"] = option_on_off(self.options.asio_standalone)
 
         # Secp256k1 --------------------------------------------

--- a/docs/utxo-store-api-requirements.md
+++ b/docs/utxo-store-api-requirements.md
@@ -87,12 +87,12 @@ probe(request, buffer_provider)
 buffer_provider(required_size) -> span<uint8_t>
 ```
 
-**Compact mode** — the entry is a small POD the store holds by value, so there is
+**Reference mode** — the entry is a small POD the store holds by value, so there is
 nothing to lend:
 
 ```
 probe(request)
-    -> found(compact_find_result)
+    -> found(reference_find_result)
      | absent
      | needs_resolution
      | error
@@ -323,14 +323,14 @@ node with the single one it needs.
   phase discipline and the one-handle-per-executor rule. Calling back in would
   break both.
 - **the sink copies into caller-owned state and returns. That is all it does.**
-  No I/O, no materializing a compact reference, no parsing, no blocking work.
+  No I/O, no materializing a reference, no parsing, no blocking work.
   The node materializes and parses **after the handle is released**, in both
-  modes — a compact reference costs a block-file read and a whole transaction
+  modes — a reference costs a block-file read and a whole transaction
   parse to materialize, and doing that inside the callback would hold a version
   mapping across I/O that has nothing to do with it. Full mode defers its parse
   for the same reason, minus the I/O: the lease stays short.
 
-  **Deferring also fixes something, and that is worth keeping.** Today a compact
+  **Deferring also fixes something, and that is worth keeping.** Today a reference
   materialization that fails — an unreadable block file, an unparseable
   transaction — puts the key in the failed set, where the caller reads it as a
   missing prevout and therefore as an invalid block: a local I/O fault dressed up
@@ -413,11 +413,11 @@ the original creation height
 **And nothing else.** An earlier draft asked for a coinbase flag; that was the
 node asking for something it already has, and it is withdrawn. In full mode the
 node writes the coinbase byte and the median time past *inside the value*, so the
-payload carries them and the store stays agnostic to the content. In compact mode
+payload carries them and the store stays agnostic to the content. In reference mode
 the node derives them while materializing the transaction it must parse anyway.
 Neither needs a format change nor a bit stolen from the height.
 
-**The payload's shape follows the storage mode, and that is fine.** In compact
+**The payload's shape follows the storage mode, and that is fine.** In reference
 mode it is the small POD reference the store holds — the store does not have the
 output's bytes and cannot materialize it. In full mode it is the stored value.
 One shape does not have to serve both.
@@ -951,7 +951,7 @@ Both interfaces will exist for a while. What the node needs during that:
 | authoritative absence | not expressible at all | from the resolution; from the probe only if the capability is taken up |
 | read failure | indistinguishable from absence | its own answer |
 | pending lookups | a queue inside the store | a list the caller owns |
-| results | may reference mapped memory | delivered to a sink, valid for that invocation; probe writes into caller storage in full mode, returns a POD in compact |
+| results | may reference mapped memory | delivered to a sink, valid for that invocation; probe writes into caller storage in full mode, returns a POD in reference |
 | probe concurrency | limited by a shared statistics vector | any number of threads |
 | erase | searches cached files inline | active map only |
 | resolution | one executor, by construction | **concurrent** — the central requirement |

--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -75,13 +75,13 @@ endif()
 message(STATUS "Knuth: Header index capacity: ${KTH_HEADER_INDEX_CAPACITY}")
 add_definitions(-DKTH_HEADER_INDEX_CAPACITY=${KTH_HEADER_INDEX_CAPACITY})
 
-# UTXO-Z compact storage mode (8-byte refs instead of full output data).
-# The real default comes from Conan (conanfile.py: utxoz_compact=False); this
+# UTXO-Z reference storage mode (8-byte refs instead of full output data).
+# The real default comes from Conan (conanfile.py: utxoz_reference=False); this
 # option only applies to standalone builds. It MUST agree with the value used by
 # the other modules — the write path (utxo_builder) and the storage layer
 # (utxoz_database) branch on this same macro, so a mismatch makes them disagree
 # on the stored value layout.
-option(KTH_UTXOZ_COMPACT_MODE "Use UTXO-Z compact storage mode" OFF)
+option(KTH_UTXOZ_REFERENCE_MODE "Use UTXO-Z reference storage mode" OFF)
 
 # Embedded UTXO bloom filter — .incbin via assembly
 option(KTH_EMBED_UTXO_BLOOM "Embed UTXO bloom filter in the executable for faster IBD" ON)
@@ -256,9 +256,9 @@ if(KTH_HAS_EMBEDDED_BLOOM)
     message(STATUS "Knuth: Bloom filter will be embedded in the executable")
 endif()
 
-if(KTH_UTXOZ_COMPACT_MODE)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC KTH_UTXOZ_COMPACT_MODE)
-    message(STATUS "Knuth: UTXO-Z compact storage mode enabled")
+if(KTH_UTXOZ_REFERENCE_MODE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC KTH_UTXOZ_REFERENCE_MODE)
+    message(STATUS "Knuth: UTXO-Z reference storage mode enabled")
 endif()
 
 if (ENABLE_POSITION_INDEPENDENT_CODE)
@@ -311,6 +311,7 @@ if (ENABLE_TEST)
         test/mempool_persistence_test.cpp
         test/block_template_test.cpp
         test/utxoz_roundtrip.cpp
+        test/utxoz_contract.cpp
         test/verify_script_context.cpp
         test/batch_sigchecks.cpp
         test/finalization.cpp

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -169,8 +169,8 @@ struct KB_API block_chain {
     [[nodiscard]] code push_sync(transaction_const_ptr tx);
     [[nodiscard]] bool insert(block_const_ptr block, size_t height);
 
-#ifndef KTH_UTXOZ_COMPACT_MODE
-    // Apply a batch of UTXO changes (full mode only — compact mode uses apply_utxo_delta_raw)
+#ifndef KTH_UTXOZ_REFERENCE_MODE
+    // Apply a batch of UTXO changes (full mode only — reference mode uses apply_utxo_delta_raw)
     template <database::utxo_insert_range Inserts, database::utxo_delete_range Deletes>
     [[nodiscard]]
     database::result_code apply_utxo_delta(Inserts const& inserts, Deletes const& deletes) {
@@ -201,7 +201,8 @@ struct KB_API block_chain {
     size_t utxo_deferred_deletions_size() const;
 
     [[nodiscard]]
-    std::pair<size_t, std::vector<utxoz::deferred_deletion_entry>> utxo_process_pending_deletions();
+    std::expected<std::pair<size_t, std::vector<utxoz::deferred_deletion_entry>>, database::result_code>
+    utxo_process_pending_deletions();
 
     [[nodiscard]]
     size_t utxo_deferred_lookups_size() const;
@@ -210,7 +211,8 @@ struct KB_API block_chain {
     // returned key_not_found (queued, not authoritative) by sweeping older file
     // versions. Returns {resolved by outpoint, keys that truly don't exist}.
     [[nodiscard]]
-    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxo_entry>, std::vector<utxoz::raw_outpoint>>
+    std::expected<std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxo_entry>,
+                            std::vector<utxoz::raw_outpoint>>, database::result_code>
     utxo_process_pending_lookups();
 
     // =========================================================================
@@ -227,8 +229,8 @@ struct KB_API block_chain {
     // Raw counterpart of utxo_process_pending_lookups(): resolves the deferred
     // queue without reconstructing utxo_entry objects.
     [[nodiscard]]
-    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxoz_database::raw_stored>,
-              std::vector<utxoz::raw_outpoint>>
+    std::expected<std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxoz_database::raw_stored>,
+                            std::vector<utxoz::raw_outpoint>>, database::result_code>
     utxo_process_pending_lookups_raw();
 
 #if ! defined(KTH_DB_READONLY)
@@ -362,7 +364,11 @@ struct KB_API block_chain {
         return reorg_parked_.load(std::memory_order_seq_cst) >= registered;
     }
 
-    void utxo_compact();
+    /// Compact the UTXO store.
+    /// @return true if compaction ran and succeeded. A caller that ignores this
+    ///         is back to the 0.8.0 contract, where compaction could not fail.
+    [[nodiscard]]
+    bool utxo_compact();
     void utxo_print_statistics();
     void utxo_print_sizing_report();
     void utxo_print_height_range_stats();

--- a/src/blockchain/include/kth/blockchain/populate/populate_base.hpp
+++ b/src/blockchain/include/kth/blockchain/populate/populate_base.hpp
@@ -30,7 +30,17 @@ protected:
     void populate_pooled(domain::chain::transaction const& tx, uint32_t height) const;
     // median_time_past (tip's MTP) is used only for a prevout resolved from the
     // mempool. Block validation (require_confirmed) never consults the mempool.
-    void populate_prevout(size_t maximum_height, domain::chain::output_point const& outpoint, bool require_confirmed, uint32_t median_time_past) const;
+    /// Populate one input's prevout from the UTXO set, or from the mempool when
+    /// unconfirmed parents are allowed.
+    ///
+    /// @return error::success when the prevout was populated AND when it is
+    ///         genuinely absent — absence is a verdict about the transaction and
+    ///         is decided later, by the prevout cache being invalid. Any other
+    ///         result_code from the store is an operational failure of THIS node
+    ///         and is returned, because "could not read" must never reach that
+    ///         verdict wearing the same face as "does not exist".
+    [[nodiscard]]
+    code populate_prevout(size_t maximum_height, domain::chain::output_point const& outpoint, bool require_confirmed, uint32_t median_time_past) const;
 
     // Thread pool executor for parallel operations
     executor_type executor_;

--- a/src/blockchain/include/kth/blockchain/utxo_builder.hpp
+++ b/src/blockchain/include/kth/blockchain/utxo_builder.hpp
@@ -56,20 +56,20 @@ struct block_chain;
 // Inputs store only the outpoint being spent.
 // =============================================================================
 
-/// Compact UTXO reference: points to the transaction in blk*.dat flat files.
-/// In compact mode, this 8-byte value replaces the full serialized output data.
-struct compact_utxo_ref {
+/// UTXO storage reference: points to the transaction in blk*.dat flat files.
+/// In reference mode, this 8-byte value replaces the full serialized output data.
+struct reference_utxo_ref {
     uint32_t file_number;   // blk*.dat file number
     uint32_t tx_offset;     // absolute byte offset of the tx within that file
 };
-static_assert(sizeof(compact_utxo_ref) == 8);
+static_assert(sizeof(reference_utxo_ref) == 8);
 
 struct utxo_compact_block {
     struct output_entry {
         utxoz::raw_outpoint key;        // txid(32) + index(4) — UTXO-Z native key
         std::span<uint8_t const> raw;   // raw output bytes (value + script), points into source buffer
         bool coinbase;
-        uint32_t tx_start{0};           // offset of tx within the raw block (for compact mode)
+        uint32_t tx_start{0};           // offset of tx within the raw block (for reference mode)
     };
 
     struct input_entry {
@@ -145,12 +145,20 @@ struct KB_API utxo_raw_delta {
 // Process a compact block into a raw delta (zero-copy path).
 // Raw output bytes are serialized directly into UTXO-Z storage format.
 // When bloom is provided, outputs/inputs not in the filter are skipped.
-// In compact mode, file_number and block_data_pos are used to build compact refs.
+// In reference mode, file_number and block_data_pos are used to build reference refs.
 // NOTE: file_number is int16_t (matching header_index::get_file_number()) which limits
 // to 32767 blk*.dat files (~4 TB at 134 MB/file). Sufficient for current chain sizes.
 // If BCH grows past this, widen to int32_t in both header_index and here.
 [[nodiscard]]
-KB_API utxo_raw_delta process_compact_block_utxos(
+/// @return the block's delta, or an error if the block cannot be referenced.
+///         A negative `file_number` means the header index has no data for a
+///         block whose UTXOs are being built — the index and the block store
+///         disagree, which a crash can produce. It is NOT an impossible
+///         precondition, so it does not get an assertion that evaporates in
+///         Release: there, -1 would become UINT32_MAX and every reference in
+///         this block would point at a file that will never exist.
+[[nodiscard]]
+KB_API expect<utxo_raw_delta> process_compact_block_utxos(
     utxo_compact_block const& block,
     uint32_t height,
     uint32_t median_time_past,
@@ -233,7 +241,16 @@ std::expected<database::block_undo, database::result_code> capture_block_undo(
     }
 
     if ( ! deferred.empty()) {
-        auto [resolved, missing] = source.utxo_process_pending_lookups_raw();
+        auto drained = source.utxo_process_pending_lookups_raw();
+        if ( ! drained) {
+            // The sweep did not run, so nothing below can distinguish "spent
+            // output absent" from "never looked". Capturing an undo record on
+            // that basis would write a reorg record that cannot be trusted.
+            spdlog::error("[utxo_builder] capture_block_undo: the deferred lookup sweep "
+                "could not run at height {}; no undo record is captured", height);
+            return std::unexpected(drained.error());
+        }
+        auto& [resolved, missing] = *drained;
 
         for (auto const& key : deferred) {
             auto it = resolved.find(key);

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -144,8 +144,8 @@ bool block_chain::start(uint32_t disk_magic) {
     }
     spdlog::info("[blockchain] UTXO-Z database opened at {}", utxoz_path.string());
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-    // Compact mode find resolution requires block_store and header_index.
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    // Reference mode find resolution requires block_store and header_index.
     // block_store_ is not yet initialized here — we wire it below after initialization.
 #endif
 
@@ -394,11 +394,11 @@ bool block_chain::start(uint32_t disk_magic) {
             scanned, restored, scan_ms);
     }
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-    // Wire block_store and header_index to UTXO-Z for compact mode find resolution
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    // Wire block_store and header_index to UTXO-Z for reference mode find resolution
     utxoz_db_.set_block_store(block_store_.get());
     utxoz_db_.set_header_index(&header_index_);
-    spdlog::info("[blockchain] UTXO-Z compact mode: block_store and header_index wired for find resolution");
+    spdlog::info("[blockchain] UTXO-Z reference mode: block_store and header_index wired for find resolution");
 #endif
 
     return true;
@@ -805,15 +805,22 @@ size_t block_chain::utxo_deferred_deletions_size() const {
     return utxoz_db_.deferred_deletions_size();
 }
 
-std::pair<size_t, std::vector<utxoz::deferred_deletion_entry>> block_chain::utxo_process_pending_deletions() {
-    return utxoz_db_.process_pending_deletions();
+std::expected<std::pair<size_t, std::vector<utxoz::deferred_deletion_entry>>, database::result_code>
+block_chain::utxo_process_pending_deletions() {
+    auto drained = utxoz_db_.process_pending_deletions();
+    if ( ! drained) {
+        return std::unexpected(drained.error());
+    }
+    return std::pair<size_t, std::vector<utxoz::deferred_deletion_entry>>{
+        drained->first, std::move(drained->second)};
 }
 
 size_t block_chain::utxo_deferred_lookups_size() const {
     return utxoz_db_.deferred_lookups_size();
 }
 
-std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxo_entry>, std::vector<utxoz::raw_outpoint>>
+std::expected<std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxo_entry>,
+                        std::vector<utxoz::raw_outpoint>>, database::result_code>
 block_chain::utxo_process_pending_lookups() {
     return utxoz_db_.process_pending_lookups();
 }
@@ -827,8 +834,8 @@ block_chain::find_utxo_raw(utxoz::raw_outpoint const& key, uint32_t height) cons
     return utxoz_db_.find_raw(key, height);
 }
 
-std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxoz_database::raw_stored>,
-          std::vector<utxoz::raw_outpoint>>
+std::expected<std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, database::utxoz_database::raw_stored>,
+                        std::vector<utxoz::raw_outpoint>>, database::result_code>
 block_chain::utxo_process_pending_lookups_raw() {
     return utxoz_db_.process_pending_lookups_raw();
 }
@@ -1101,8 +1108,8 @@ block_chain::switch_result block_chain::switch_to_branch(
     co_return result;
 }
 
-void block_chain::utxo_compact() {
-    utxoz_db_.compact();
+bool block_chain::utxo_compact() {
+    return utxoz_db_.compact();
 }
 
 void block_chain::utxo_print_statistics() {

--- a/src/blockchain/src/populate/populate_base.cpp
+++ b/src/blockchain/src/populate/populate_base.cpp
@@ -48,7 +48,7 @@ void populate_base::populate_pooled(domain::chain::transaction const& tx, uint32
 // Unspent outputs are cached by the store. If the cache is large enough this
 // may never hit the file system. However on high RAM systems the file system
 // is faster than the cache due to reduced paging of the memory-mapped file.
-void populate_base::populate_prevout(size_t branch_height, output_point const& outpoint, bool require_confirmed, uint32_t median_time_past) const {
+code populate_base::populate_prevout(size_t branch_height, output_point const& outpoint, bool require_confirmed, uint32_t median_time_past) const {
     // The previous output will be cached on the input's outpoint.
     auto& prevout = outpoint.validation;
 
@@ -59,7 +59,7 @@ void populate_base::populate_prevout(size_t branch_height, output_point const& o
 
     // If the input is a coinbase there is no prevout to populate.
     if (outpoint.is_null()) {
-        return;
+        return error::success;
     }
 
     // branch_height is the validation height; get_utxo bounds the prevout to one
@@ -67,6 +67,17 @@ void populate_base::populate_prevout(size_t branch_height, output_point const& o
     // = confirmed-only (blocks) vs also-mempool (tx, handled in the miss branch).
     auto const utxo = chain_.get_utxo(outpoint, branch_height);
     if ( ! utxo) {
+        // Only key_not_found means the output is not there. Every other code is
+        // this node failing to read its own storage, and probing the mempool on
+        // that basis would answer a question nobody could answer: a miss would
+        // then look exactly like a prevout that does not exist, and the block
+        // would be rejected over a disk that did not respond.
+        if (utxo.error() != database::result_code::key_not_found) {
+            spdlog::error("[populate] the UTXO store failed while reading {}:{}; "
+                "refusing to treat an unreadable store as a missing prevout",
+                encode_hash(outpoint.hash()), outpoint.index());
+            return error::operation_failed;
+        }
         // Chained tx: the prevout may be an unconfirmed parent's output in the
         // mempool (tx-validation path only). Model the mempool coin as "confirms
         // next block" (BCHN MEMPOOL_HEIGHT): height = branch_height + 1 and the
@@ -81,7 +92,7 @@ void populate_base::populate_prevout(size_t branch_height, output_point const& o
                 prevout.from_mempool = true;
             }
         }
-        return;
+        return error::success;
     }
     prevout.cache = utxo->output;
     prevout.height = utxo->height;
@@ -99,6 +110,8 @@ void populate_base::populate_prevout(size_t branch_height, output_point const& o
         prevout.confirmed = true;
         prevout.cache = domain::chain::output{};
     }
+
+    return error::success;
 }
 
 } // namespace kth::blockchain

--- a/src/blockchain/src/populate/populate_transaction.cpp
+++ b/src/blockchain/src/populate/populate_transaction.cpp
@@ -106,9 +106,12 @@ code populate_transaction::populate_inputs_sync(transaction_const_ptr tx, size_t
         auto const& input = inputs[input_index];
         auto const& prevout = input.previous_output();
         // Tx-validation path: allow unconfirmed (mempool) parents.
-        populate_prevout(chain_height, prevout, false, median_time_past);
-
-
+        if (auto const ec = populate_prevout(chain_height, prevout, false, median_time_past)) {
+            // A store that did not answer. Returning success here and letting the
+            // empty prevout cache speak would hand the validator a verdict about
+            // the transaction built from a failure of this node.
+            return ec;
+        }
     }
 
     return error::success;

--- a/src/blockchain/src/utxo_builder.cpp
+++ b/src/blockchain/src/utxo_builder.cpp
@@ -227,7 +227,7 @@ bool utxo_raw_delta::empty() const {
 // Compact block processing (zero-copy path)
 // =============================================================================
 
-utxo_raw_delta process_compact_block_utxos(
+expect<utxo_raw_delta> process_compact_block_utxos(
     utxo_compact_block const& block,
     uint32_t height,
     uint32_t median_time_past,
@@ -235,6 +235,19 @@ utxo_raw_delta process_compact_block_utxos(
     uint32_t block_data_pos,
     database::utxo_bloom_filter const* bloom
 ) {
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    // Checked once, before anything is built. Gated on the mode because this is
+    // the only mode that stores the file number: full mode keeps the whole
+    // output and never reads this parameter, so rejecting a block there would
+    // refuse work over a field nothing uses.
+    if (file_number < 0) {
+        spdlog::error("[utxo_builder] block at height {} has no file number in the header "
+            "index (-1); the index and the block store disagree, and building references "
+            "against it would write UINT32_MAX into every entry", height);
+        return std::unexpected(error::operation_failed);
+    }
+#endif
+
     utxo_raw_delta delta;
 
     // 1. Process all outputs (inserts)
@@ -245,10 +258,9 @@ utxo_raw_delta process_compact_block_utxos(
             continue;
         }
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-        // Compact: 8-byte ref = {file_number, data_pos + tx_start}
-        KTH_ASSERT(file_number >= 0);  // -1 means "no data" — should never happen for stored blocks
-        compact_utxo_ref ref{
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+        // Reference: 8-byte ref = {file_number, data_pos + tx_start}
+        reference_utxo_ref ref{
             static_cast<uint32_t>(file_number),
             block_data_pos + out.tx_start
         };
@@ -526,7 +538,16 @@ database::result_code process_deferred_deletions(block_chain& chain) {
     auto deferred = chain.utxo_deferred_deletions_size();
     if (deferred > 0) {
         spdlog::debug("[utxo_builder] Processing {} pending deletions...", deferred);
-        auto [deleted, failed] = chain.utxo_process_pending_deletions();
+        auto drained = chain.utxo_process_pending_deletions();
+        if ( ! drained) {
+            // No deletion was applied, and the queue is still full. Returning
+            // success here would let the build advance over a UTXO set that
+            // still holds spent outputs.
+            spdlog::error("[utxo_builder] FATAL: the deferred deletion queue could not be "
+                "drained; {} deletions remain unapplied", deferred);
+            return database::result_code::other;
+        }
+        auto& [deleted, failed] = *drained;
         if ( ! failed.empty()) {
             spdlog::error("[utxo_builder] FATAL: Deferred deletions failed: {} deleted, {} failed",
                 deleted, failed.size());
@@ -794,9 +815,9 @@ uint32_t embedded_bloom_checkpoint_height() {
 
     // ==========================================================================
     // Strategy: sequential_direct - process 1 block at a time, apply directly
-    // (Not available in compact mode — uses domain-object insert path)
+    // (Not available in reference mode — uses domain-object insert path)
     // ==========================================================================
-#ifndef KTH_UTXOZ_COMPACT_MODE
+#ifndef KTH_UTXOZ_REFERENCE_MODE
     if (strategy == utxo_build_strategy::sequential_direct) {
         for (uint32_t h = actual_start; h <= end_height; ++h) {
             auto block_result = co_await chain.fetch_block(h);
@@ -897,16 +918,31 @@ uint32_t embedded_bloom_checkpoint_height() {
                 uint32_t h = batch_start + static_cast<uint32_t>(i);
                 uint32_t mtp = calculate_mtp(timestamp_window);
 
-                // Get block position from header_index for compact mode. Resolved
+                // Get block position from header_index for reference mode. Resolved
                 // through the active chain: the index also holds side branches,
                 // numbered in arrival order, so an entry's index is not its height.
                 auto const idx = chain.headers().active_at(static_cast<int32_t>(h));
-                KTH_ASSERT(idx != header_index::null_index);
+                if (idx == header_index::null_index) {
+                    // KTH_ASSERT is compiled out in Release, where this would go
+                    // on to read file number and data position from a null index
+                    // entry. block_tasks already refuses here; this is the same
+                    // fork and it was the only one still trusting the assertion.
+                    spdlog::critical("[utxo_builder] no active header at height {}; "
+                        "the index cannot place this block", h);
+                    co_return database::result_code::other;
+                }
                 KTH_ASSERT(chain.headers().get_height(idx) == static_cast<int32_t>(h));
                 auto const file_num = chain.headers().get_file_number(idx);
                 auto const data_pos = chain.headers().get_data_pos(idx);
 
-                auto block_delta = process_compact_block_utxos(compact_blocks[i], h, mtp, file_num, data_pos, bloom_ptr);
+                auto block_delta_result = process_compact_block_utxos(compact_blocks[i], h, mtp, file_num, data_pos, bloom_ptr);
+                if ( ! block_delta_result) {
+                    spdlog::critical("[utxo_builder] cannot build UTXO references for the block "
+                        "at height {}; stopping the batch rather than storing entries that "
+                        "point nowhere", h);
+                    co_return database::result_code::other;
+                }
+                auto block_delta = std::move(*block_delta_result);
                 if (i == 0) {
                     delta = std::move(block_delta);
                 } else {

--- a/src/blockchain/src/validate/batch_validate.cpp
+++ b/src/blockchain/src/validate/batch_validate.cpp
@@ -217,7 +217,20 @@ code validate_block_batch(
     // absent here truly do not exist.
     // -----------------------------------------------------------------------
     {
-        auto [found, failed] = chain.utxo_process_pending_lookups();
+        auto drained = chain.utxo_process_pending_lookups();
+        if ( ! drained) {
+            // The sweep could not run. That is a LOCAL failure of this node's
+            // storage, and it must not be reported as a consensus verdict:
+            // missing_previous_output says the block spends something that does
+            // not exist, which would reject a block that may be perfectly valid
+            // and, worse, is the kind of answer that gets cached.
+            spdlog::error("[batch_validate] the deferred lookup sweep could not run "
+                "(batch {}-{}); refusing to judge these blocks rather than calling "
+                "unresolved prevouts missing",
+                start_height, start_height + blocks.size() - 1);
+            return error::operation_failed;
+        }
+        auto& [found, failed] = *drained;
         for (auto const& [rk, entry] : found) {
             bv_outpoint key;
             std::memcpy(key.hash.data(), rk.data(), key.hash.size());

--- a/src/blockchain/test/block_undo.cpp
+++ b/src/blockchain/test/block_undo.cpp
@@ -19,7 +19,7 @@ utxoz::raw_outpoint make_key(uint8_t seed) {
     return key;
 }
 
-// A compact-mode payload: {file_number(4 LE), tx_offset(4 LE)}.
+// A reference-mode payload: {file_number(4 LE), tx_offset(4 LE)}.
 std::vector<uint8_t> make_compact_value(uint32_t file_number, uint32_t offset) {
     std::vector<uint8_t> value(8);
     std::memcpy(value.data(), &file_number, 4);

--- a/src/blockchain/test/reorg_undo_roundtrip.cpp
+++ b/src/blockchain/test/reorg_undo_roundtrip.cpp
@@ -36,9 +36,9 @@ utxoz::raw_outpoint make_outpoint(uint8_t seed, uint32_t index) {
 }
 
 // The storage-native payload for one UTXO, matching what utxo_build produces:
-// 8 bytes {file_number, tx_offset} in compact mode, a serialized entry otherwise.
+// 8 bytes {file_number, tx_offset} in reference mode, a serialized entry otherwise.
 std::vector<uint8_t> make_payload(uint32_t file_number, uint32_t tx_offset) {
-#ifdef KTH_UTXOZ_COMPACT_MODE
+#ifdef KTH_UTXOZ_REFERENCE_MODE
     std::vector<uint8_t> value(8);
     std::memcpy(value.data(), &file_number, 4);
     std::memcpy(value.data() + 4, &tx_offset, 4);
@@ -82,11 +82,11 @@ struct failing_source {
         return std::unexpected(error);
     }
 
-    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxoz_database::raw_stored>,
-              std::vector<utxoz::raw_outpoint>>
+    std::expected<std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxoz_database::raw_stored>,
+                            std::vector<utxoz::raw_outpoint>>, result_code>
     utxo_process_pending_lookups_raw() {
         ++sweeps;
-        return {};
+        return std::unexpected(error);
     }
 };
 
@@ -99,7 +99,7 @@ struct failing_source {
 // The correctness claim behind the undo record is that a spent output can be put
 // back EXACTLY as it was: same storage payload and, critically, the same ORIGINAL
 // creation height. Restoring with the spending block's height instead would
-// corrupt both coinbase maturity and (in compact mode) the median-time-past
+// corrupt both coinbase maturity and (in reference mode) the median-time-past
 // window used when the UTXO is later resolved — silently, and only for outputs
 // that a reorg touched.
 //
@@ -200,8 +200,10 @@ TEST_CASE("outputs created and spent in the same block need no undo entry", "[re
                              /*coinbase*/ false, /*tx_start*/ 0u});
     block.inputs.push_back({internal});   // spent by a later tx in the same block
 
-    auto delta = process_compact_block_utxos(block, /*height*/ 700u, /*mtp*/ 12u,
+    auto delta_result = process_compact_block_utxos(block, /*height*/ 700u, /*mtp*/ 12u,
                                              /*file*/ 0, /*data_pos*/ 0u, nullptr);
+    REQUIRE(delta_result.has_value());
+    auto& delta = *delta_result;
 
     // The producer cancels the pair: nothing to insert, and nothing to delete —
     // which is what keeps the output out of the undo record.

--- a/src/blockchain/test/utxoz_contract.cpp
+++ b/src/blockchain/test/utxoz_contract.cpp
@@ -1,0 +1,485 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Negative controls for the UTXO-Z 0.9.0 migration.
+//
+// Renaming `compact` to `reference` is the visible half of that bump and the
+// harmless one: get it wrong and nothing compiles. The dangerous half is the
+// set of functions that changed what they RETURN. Four of them started
+// returning `result<>`, three of those broke the build and were therefore
+// found, and one — `compact_all()`, which used to return void — did not. A
+// caller that kept invoking it as a statement compiled exactly as before and
+// silently discarded every failure.
+//
+// That is the failure this file exists to prevent, so the tests below assert
+// the SHAPE of the contract rather than the behaviour of a database. They are
+// static assertions on purpose: a runtime test can only fail once the wrong
+// call has already been written and executed, whereas these fail while the
+// wrong call is being written.
+
+#include <filesystem>
+#include <string>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+#include <type_traits>
+#include <utility>
+
+#include <test_helpers.hpp>
+
+#include <expected>
+
+#include <kth/blockchain/interface/block_chain.hpp>
+#include <kth/blockchain/utxo_builder.hpp>
+#include <kth/database/databases/utxoz_database.hpp>
+
+using namespace kth;
+using namespace kth::database;
+using namespace kth::blockchain;
+
+namespace {
+
+// `std::expected<T, E>` detector. Written out rather than assumed, because the
+// whole point of these assertions is that "returns a value" and "returns a
+// value or an error" are different contracts.
+template <typename T> struct is_expected : std::false_type {};
+template <typename T, typename E> struct is_expected<std::expected<T, E>> : std::true_type {};
+// A REQUIRE that fails throws, so anything after it never runs. These tests open
+// databases and create directories; without this the first failure would leak an
+// open handle and leave a temporary tree behind, and the NEXT run would then fail
+// for a different reason than the one being investigated.
+struct scoped_temp_dir {
+    std::filesystem::path path;
+    explicit scoped_temp_dir(std::string_view tag)
+        : path(std::filesystem::temp_directory_path() / std::string(tag)) {
+        std::filesystem::remove_all(path);
+        std::filesystem::create_directories(path);
+    }
+    ~scoped_temp_dir() {
+        std::error_code ignored;
+        std::filesystem::remove_all(path, ignored);
+    }
+    scoped_temp_dir(scoped_temp_dir const&) = delete;
+    scoped_temp_dir& operator=(scoped_temp_dir const&) = delete;
+};
+
+struct scoped_open_db {
+    utxoz_database& db;
+    ~scoped_open_db() { db.close(); }
+};
+
+inline int current_process_id() {
+#if defined(_WIN32)
+    return ::_getpid();
+#else
+    return static_cast<int>(::getpid());
+#endif
+}
+
+template <typename T> inline constexpr bool is_expected_v = is_expected<std::remove_cvref_t<T>>::value;
+
+
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+using utxoz_db = utxoz::reference_db;
+#else
+using utxoz_db = utxoz::full_db;
+#endif
+
+// The mode this build selected must be the mode the wrapper reports. These are
+// set in two CMake lists and read in a third place, so they can disagree.
+static_assert(
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    std::is_same_v<utxoz_db, utxoz::reference_db>,
+#else
+    std::is_same_v<utxoz_db, utxoz::full_db>,
+#endif
+    "the storage mode selected by the build is not the one this translation unit sees");
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// The contract changes that do NOT break a naive migration.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("utxoz contract: compact_all reports failure instead of returning void", "[utxoz][contract]") {
+    // THE CONTROL. In 0.8.0 this was `void compact_all()`. Had the migration
+    // kept calling it as a bare statement, everything would have compiled and
+    // every compaction failure would have been discarded. If a future version
+    // makes it void again — or if someone "simplifies" the wrapper back — this
+    // assertion is what notices.
+    using compact_result = decltype(std::declval<utxoz_db&>().compact_all());
+    static_assert( ! std::is_void_v<compact_result>,
+        "compact_all() returns void again: a failure would now be discarded silently");
+    static_assert(std::is_same_v<compact_result, utxoz::result<>>,
+        "compact_all() no longer returns result<>; the wrapper's error handling is dead code");
+
+    // And the wrapper must pass that answer on rather than swallowing it.
+    static_assert(std::is_same_v<decltype(std::declval<utxoz_database&>().compact()), bool>,
+        "utxoz_database::compact() must report whether compaction happened");
+
+    // ...and the report has to survive the trip up. A bool at the wrapper with a
+    // void above it is the same defect one layer higher: every caller of
+    // block_chain::utxo_compact() would be back to the 0.8.0 contract, in which
+    // compaction could not fail.
+    static_assert(std::is_same_v<decltype(std::declval<blockchain::block_chain&>().utxo_compact()), bool>,
+        "block_chain::utxo_compact() returns void: the failure dies between the "
+        "wrapper and every caller");
+}
+
+TEST_CASE("utxoz contract: erase distinguishes failure from absence", "[utxoz][contract]") {
+    // `erase()` went from size_t to result<size_t>. The tempting migration is
+    // `*erased > 0 ? success : key_not_found`, which quietly turns "the erase
+    // failed" into "the key was not there" — and the entry may well still exist
+    // and still be spendable.
+    using erase_result = decltype(std::declval<utxoz_db&>().erase(
+        std::declval<utxoz::raw_outpoint const&>(), uint32_t{}));
+    static_assert(std::is_same_v<erase_result, utxoz::result<size_t>>,
+        "erase() no longer returns result<size_t>; revisit the failure-vs-absence split");
+    static_assert( ! std::is_integral_v<erase_result>,
+        "erase() returns a bare count again: a failure would read as a missing key");
+}
+
+TEST_CASE("utxoz contract: draining a queue can fail as a whole", "[utxoz][contract]") {
+    // Both drains are result<>-wrapped since 0.9.0. An empty result has to keep
+    // meaning "nothing was pending"; a drain that could not run must not borrow
+    // that meaning, because every caller upstream reads absence as "spent".
+    //
+    // The library's own types are the easy half. What matters is that KNUTH
+    // does not unwrap them back into a sentinel on the way up, so each layer is
+    // pinned below — utxoz_database, block_chain, and the shape the builder
+    // template requires of whatever it is given.
+    using lib_lookups = decltype(std::declval<utxoz_db&>().process_pending_lookups());
+    using lib_deletions = decltype(std::declval<utxoz_db&>().process_pending_deletions());
+    static_assert(is_expected_v<lib_lookups>,
+        "UTXO-Z's process_pending_lookups() no longer reports failure");
+    static_assert(is_expected_v<lib_deletions>,
+        "UTXO-Z's process_pending_deletions() no longer reports failure");
+}
+
+TEST_CASE("utxoz contract: knuth does not unwrap the drains into sentinels", "[utxoz][contract]") {
+    // THE BLOCKER THIS FILE MISSED THE FIRST TIME. Every one of these compiled
+    // happily while the wrapper logged the error and returned an empty pair,
+    // which is precisely "could not drain" reported as "there was nothing".
+
+    // Layer 1: the database wrapper.
+    using db_lookups = decltype(std::declval<utxoz_database&>().process_pending_lookups());
+    using db_lookups_raw = decltype(std::declval<utxoz_database&>().process_pending_lookups_raw());
+    using db_deletions = decltype(std::declval<utxoz_database&>().process_pending_deletions());
+    static_assert(is_expected_v<db_lookups>,
+        "utxoz_database::process_pending_lookups() returns a bare pair: a failed drain "
+        "is indistinguishable from an empty queue");
+    static_assert(is_expected_v<db_lookups_raw>,
+        "utxoz_database::process_pending_lookups_raw() returns a bare pair");
+    static_assert(is_expected_v<db_deletions>,
+        "utxoz_database::process_pending_deletions() returns a bare pair");
+
+    // Layer 2: the chain interface every consumer actually calls.
+    using chain_lookups = decltype(std::declval<blockchain::block_chain&>().utxo_process_pending_lookups());
+    using chain_lookups_raw = decltype(std::declval<blockchain::block_chain&>().utxo_process_pending_lookups_raw());
+    using chain_deletions = decltype(std::declval<blockchain::block_chain&>().utxo_process_pending_deletions());
+    static_assert(is_expected_v<chain_lookups>,
+        "block_chain::utxo_process_pending_lookups() drops the failure on the way up");
+    static_assert(is_expected_v<chain_lookups_raw>,
+        "block_chain::utxo_process_pending_lookups_raw() drops the failure on the way up");
+    static_assert(is_expected_v<chain_deletions>,
+        "block_chain::utxo_process_pending_deletions() drops the failure on the way up");
+
+    // ...and the payload each one carries is mode-dependent, so a check written
+    // for full mode cannot pass vacuously in reference mode or the reverse.
+    using resolved_map = boost::unordered_flat_map<utxoz::raw_outpoint, database::utxo_entry>;
+    static_assert(std::is_same_v<typename chain_lookups::value_type,
+                                 std::pair<resolved_map, std::vector<utxoz::raw_outpoint>>>,
+        "the resolved-lookup payload changed shape");
+}
+
+TEST_CASE("utxoz contract: this target and the database agree on the mode", "[utxoz][contract]") {
+    // The first version of this test asked the macro what the macro said. The
+    // alias below and any static_assert about it both come from
+    // KTH_UTXOZ_REFERENCE_MODE as seen HERE, so they agree by construction and
+    // could never catch the thing worth catching: the option is declared in two
+    // CMake lists, and a build can end up with the database library compiled one
+    // way and blockchain the other. That produces a wrapper whose db_ member is
+    // one type on one side of the ABI and another on the other.
+    //
+    // utxoz_reference_mode() is compiled INTO the database library, so asking it
+    // at runtime compares two independently compiled answers.
+    bool const database_says = utxoz_reference_mode();
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    bool const this_target_says = true;
+#else
+    bool const this_target_says = false;
+#endif
+    INFO("database library reports " << (database_says ? "reference" : "full")
+         << ", this target was compiled as " << (this_target_says ? "reference" : "full"));
+    REQUIRE(database_says == this_target_says);
+
+    // Given they agree, the selected mode must also be the one whose find()
+    // shape is compiled in — this part is a type check, and it is only
+    // meaningful because the runtime comparison above passed.
+    using found_type = typename decltype(std::declval<utxoz_db&>().find(
+        std::declval<utxoz::raw_outpoint const&>(), uint32_t{}))::value_type;
+    if (this_target_says) {
+        REQUIRE(std::is_same_v<found_type, utxoz::reference_find_result>);
+    } else {
+        REQUIRE(std::is_same_v<found_type, utxoz::full_find_result>);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The durability contract, which is new rather than changed.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("utxoz contract: sync is a separate act from close", "[utxoz][contract]") {
+    // close() does not sync. If a future version made close() durable, the
+    // wrappers that call sync() first would become redundant — and, more to the
+    // point, code that forgot to would start working by accident, which is the
+    // kind of thing that should be noticed deliberately.
+    static_assert(std::is_same_v<decltype(std::declval<utxoz_db&>().sync()), utxoz::result<>>,
+        "sync() must report what it achieved; a void sync promises what it cannot");
+    static_assert(std::is_same_v<decltype(std::declval<utxoz_database&>().sync()), bool>,
+        "the wrapper must report whether a barrier was actually reached");
+}
+
+TEST_CASE("utxoz contract: platform durability is askable, not assumed", "[utxoz][contract]") {
+    static_assert(std::is_same_v<decltype(utxoz::platform_durability()), utxoz::durability_level>,
+        "platform_durability() no longer answers with a durability_level");
+
+    // Three distinct answers, and the middle one is the trap: under
+    // contents_only a successful sync() means the entries reached the disk and
+    // the directory entries naming them did not.
+    auto const level = utxoz_platform_durability();
+    bool const known = level == utxoz::durability_level::full
+                    || level == utxoz::durability_level::contents_only
+                    || level == utxoz::durability_level::none;
+    REQUIRE(known);
+
+    // Not a tautology: on the platforms KTH ships, a barrier exists. If this
+    // ever reports `none` on a real build, every durability claim above it is
+    // worth nothing and we want to hear about it here rather than after a crash.
+#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+    REQUIRE(level != utxoz::durability_level::none);
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// The exclusive claim, which is new behaviour at open().
+// ---------------------------------------------------------------------------
+
+TEST_CASE("utxoz contract: a second opener is refused, and says which refusal it is", "[utxoz][contract]") {
+    // 0.9.0 claims the database exclusively. Two error codes cover it and they
+    // are NOT interchangeable: `database_in_use` means someone else holds it,
+    // `database_lock_unavailable` means the claim could not be attempted at
+    // all. Collapsing them sends an operator to the wrong place.
+    static_assert(static_cast<int>(utxoz::error_code::database_in_use)
+               != static_cast<int>(utxoz::error_code::database_lock_unavailable),
+        "the two claim failures must stay distinct");
+
+    scoped_temp_dir const dir{"kth_utxoz_claim_" + std::to_string(current_process_id())};
+
+    auto first = utxoz_db::open_for_testing(dir.path.string(), true);
+    REQUIRE(first.has_value());
+
+    // The claim is held. A second open of the same path must fail rather than
+    // hand out a second writer — the whole reason KTH can stop policing this
+    // itself is that the library now does.
+    auto second = utxoz_db::open_for_testing(dir.path.string(), false);
+    REQUIRE_FALSE(second.has_value());
+    REQUIRE(second.error() == utxoz::error_code::database_in_use);
+
+    first->close();
+
+    // ...and once released, the path opens again. Without this half, a library
+    // that refused every open would pass the assertion above.
+    auto third = utxoz_db::open_for_testing(dir.path.string(), false);
+    REQUIRE(third.has_value());
+    third->close();
+}
+
+// ---------------------------------------------------------------------------
+// Behavioural controls. The assertions above pin the SHAPE of the contracts;
+// these exercise the branch and check what actually happens, which is the only
+// way to catch a signature that is right and a body that is wrong.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("utxoz behaviour: a negative file number fails in reference mode only", "[utxoz][contract]") {
+    // The field exists to build an 8-byte reference, and only reference mode
+    // builds one. A check that fired in both modes would refuse perfectly good
+    // full-mode work over a parameter that mode never reads; a check that fired
+    // in neither would write UINT32_MAX into every reference of the block.
+    utxo_compact_block block;
+    block.outputs.push_back({});
+
+    auto const negative = process_compact_block_utxos(
+        block, /*height*/ 500u, /*mtp*/ 10u, /*file*/ int16_t{-1}, /*data_pos*/ 0u, nullptr);
+
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    REQUIRE_FALSE(negative.has_value());
+#else
+    // Full mode stores the whole output; the file number is never read, so the
+    // block is buildable and refusing it would be inventing a failure.
+    REQUIRE(negative.has_value());
+#endif
+
+    // The control that keeps the above from passing by always failing: a valid
+    // file number builds in both modes.
+    auto const valid = process_compact_block_utxos(
+        block, /*height*/ 500u, /*mtp*/ 10u, /*file*/ int16_t{0}, /*data_pos*/ 0u, nullptr);
+    REQUIRE(valid.has_value());
+}
+
+TEST_CASE("utxoz behaviour: find() failing for a reason other than absence is not absence",
+          "[utxoz][contract]") {
+    // The distinction that matters upstream: key_not_found lets populate_prevout
+    // fall back to the mempool, and every other code must not. A closed database
+    // is the cheapest real producer of "not key_not_found".
+    utxoz_database db;
+    auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{
+        std::vector<uint8_t>(32, 7).data(), 32}, 0);
+
+    // NEGATION: closed, so the read never happened.
+    auto const closed = db.find_raw(key, 0);
+    REQUIRE_FALSE(closed.has_value());
+    REQUIRE(closed.error() != result_code::key_not_found);
+
+    // POSITIVE: opened and empty, the same key is genuinely absent, and THAT is
+    // key_not_found. Without this half, an implementation that returned `other`
+    // for everything would pass the negation and destroy the fallback.
+    scoped_temp_dir const dir{"kth_utxoz_find_" + std::to_string(current_process_id())};
+    REQUIRE(db.open(dir.path, true));
+    scoped_open_db const guard{db};
+    auto const absent = db.find_raw(key, 0);
+    REQUIRE_FALSE(absent.has_value());
+    REQUIRE(absent.error() == result_code::key_not_found);
+}
+
+TEST_CASE("utxoz behaviour: an entry that cannot be materialised is not absent",
+          "[utxoz][contract]") {
+    // Reference mode resolves a stored reference by reading the block file. If
+    // that read fails, the entry EXISTS and could not be read — reporting it as
+    // missing would tell the validator a live UTXO was spent.
+    //
+    // Full mode reaches the same fork through decoding: bytes that will not
+    // parse are corruption, not absence, and must not be silently skipped.
+    scoped_temp_dir const dir{"kth_utxoz_mat_" + std::to_string(current_process_id())};
+
+    utxoz_database db;
+    REQUIRE(db.open(dir.path, true));
+    scoped_open_db const guard{db};
+
+    auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{
+        std::vector<uint8_t>(32, 9).data(), 32}, 0);
+
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    // A reference pointing at a block file that no store can serve: the resolver
+    // has no block_store wired, so materialising must fail.
+    std::vector<uint8_t> ref(8, 0);
+    struct raw_in { std::vector<uint8_t> data; uint32_t height; };
+    std::vector<std::pair<utxoz::raw_outpoint, raw_in>> inserts{{key, {ref, 100u}}};
+#else
+    // Bytes that are not a serialised utxo_entry.
+    std::vector<uint8_t> junk{0xff, 0xff, 0xff};
+    struct raw_in { std::vector<uint8_t> data; uint32_t height; };
+    std::vector<std::pair<utxoz::raw_outpoint, raw_in>> inserts{{key, {junk, 100u}}};
+#endif
+    std::vector<std::pair<utxoz::raw_outpoint, uint32_t>> const no_deletes;
+    REQUIRE(db.apply_delta_raw(inserts, no_deletes) == result_code::success);
+
+    // NEGATION. This MUST fail in both modes, for the reason each mode has:
+    // in reference the stored reference points at a block file no store can
+    // serve and no block_store is wired, so materialising it fails; in full the
+    // stored bytes are not a serialised entry, so decoding fails. Either way the
+    // failure must not be reported as the key being absent — the entry is there.
+    //
+    // An earlier version wrote this as `if ( ! found)`, which let a fabricated
+    // success pass: the one outcome meaning the resolver invented an entry.
+    auto const point = utxoz_database::key_to_point(key);
+    auto const found = db.find(point, 0);
+    REQUIRE_FALSE(found.has_value());
+    REQUIRE(found.error() != result_code::key_not_found);
+
+    // POSITIVE: the raw payload is there, so the entry is genuinely stored —
+    // this is what makes the negation above about materialisation and not about
+    // an empty database.
+    auto const raw = db.find_raw(key, 0);
+    REQUIRE(raw.has_value());
+}
+
+TEST_CASE("utxoz behaviour: a reference payload that is not eight bytes is refused",
+          "[utxoz][contract]") {
+    // apply_delta_raw reads the reference with two memcpys off a caller-supplied
+    // buffer. A short payload would read past its end, and a long one would be
+    // silently truncated into a reference pointing somewhere else — both write a
+    // UTXO that resolves to the wrong bytes, or to none.
+    scoped_temp_dir const dir{"kth_utxoz_len_" + std::to_string(current_process_id())};
+    utxoz_database db;
+    REQUIRE(db.open(dir.path, true));
+    scoped_open_db const guard{db};
+
+    struct raw_in { std::vector<uint8_t> data; uint32_t height; };
+    std::vector<std::pair<utxoz::raw_outpoint, uint32_t>> const no_deletes;
+
+    auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{
+        std::vector<uint8_t>(32, 3).data(), 32}, 0);
+
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    // NEGATION: seven bytes is not a reference, and must be refused BEFORE the
+    // reads rather than producing a stored entry.
+    std::vector<std::pair<utxoz::raw_outpoint, raw_in>> short_payload{
+        {key, {std::vector<uint8_t>(7, 0), 10u}}};
+    REQUIRE(db.apply_delta_raw(short_payload, no_deletes) != result_code::success);
+    REQUIRE_FALSE(db.find_raw(key, 0).has_value());
+
+    // ...and nine bytes, which would otherwise be accepted by silent truncation.
+    std::vector<std::pair<utxoz::raw_outpoint, raw_in>> long_payload{
+        {key, {std::vector<uint8_t>(9, 0), 10u}}};
+    REQUIRE(db.apply_delta_raw(long_payload, no_deletes) != result_code::success);
+#endif
+
+    // POSITIVE, in both modes: a well-formed payload is accepted and stored, so
+    // the refusals above are about the length and not about the call failing
+    // unconditionally.
+    std::vector<std::pair<utxoz::raw_outpoint, raw_in>> good{
+        {key, {std::vector<uint8_t>(8, 0), 10u}}};
+    REQUIRE(db.apply_delta_raw(good, no_deletes) == result_code::success);
+    REQUIRE(db.find_raw(key, 0).has_value());
+}
+
+TEST_CASE("utxoz behaviour: a delete on a closed store is not success",
+          "[utxoz][contract]") {
+    // apply_delta/apply_delta_raw used to discard db_->erase(), so a storage
+    // failure ended in result_code::success and the caller recorded the batch as
+    // applied while the outputs it spent were still in the set. That discard is
+    // fixed in the code.
+    //
+    // HONEST LIMIT OF THIS TEST. It does NOT exercise that branch. A closed store
+    // returns from the is_open() guard before the delete loop is reached, so
+    // reverting the erase propagation still passes here — checked by reverting it,
+    // and this test did not notice. Making db_->erase() fail on an OPEN store
+    // needs a fault-injection seam the wrapper does not have.
+    //
+    // What it does pin, and both are worth pinning: the closed-store guard, and
+    // that not_found stays TOLERATED — without the second half, propagating every
+    // erase error would fail any batch carrying an already-pruned output.
+    utxoz_database db;
+    auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{
+        std::vector<uint8_t>(32, 4).data(), 32}, 0);
+
+    struct raw_in { std::vector<uint8_t> data; uint32_t height; };
+    std::vector<std::pair<utxoz::raw_outpoint, raw_in>> const no_inserts;
+    std::vector<std::pair<utxoz::raw_outpoint, uint32_t>> deletes{{key, 10u}};
+
+    // NEGATION: closed store, the erase cannot have happened.
+    REQUIRE(db.apply_delta_raw(no_inserts, deletes) != result_code::success);
+
+    // POSITIVE: open store, and deleting a key that was never there is NOT a
+    // storage failure — not_found must stay tolerated, or every delta carrying a
+    // pruned output would fail the batch.
+    scoped_temp_dir const dir{"kth_utxoz_del_" + std::to_string(current_process_id())};
+    REQUIRE(db.open(dir.path, true));
+    scoped_open_db const guard{db};
+    REQUIRE(db.apply_delta_raw(no_inserts, deletes) == result_code::success);
+}

--- a/src/blockchain/test/utxoz_roundtrip.cpp
+++ b/src/blockchain/test/utxoz_roundtrip.cpp
@@ -48,7 +48,7 @@ std::filesystem::path fresh_utxoz_dir() {
 //      reader deserialized the output in non-wire form.
 // Both are invisible until something reads UTXO-Z (IBD is merkle-only and never
 // calls get_utxo), so it stayed latent.
-#ifndef KTH_UTXOZ_COMPACT_MODE
+#ifndef KTH_UTXOZ_REFERENCE_MODE
 TEST_CASE("utxoz full-mode value round-trips write path -> find", "[utxoz][regression]") {
     utxoz_database db;
     REQUIRE(db.open(fresh_utxoz_dir(), true));
@@ -80,8 +80,10 @@ TEST_CASE("utxoz full-mode value round-trips write path -> find", "[utxoz][regre
     block.outputs.push_back(oe);
 
     // Write path (blockchain): serialize + insert.
-    auto delta = process_compact_block_utxos(
+    auto delta_result = process_compact_block_utxos(
         block, /*height*/ 100u, /*mtp*/ 111u, /*file*/ 0, /*data_pos*/ 0u, nullptr);
+    REQUIRE(delta_result.has_value());
+    auto& delta = *delta_result;
     REQUIRE(db.apply_delta_raw(delta.inserts, delta.deletes) == result_code::success);
 
     // Read path (database), the same one get_utxo uses. Look the prevout up at a
@@ -93,4 +95,4 @@ TEST_CASE("utxoz full-mode value round-trips write path -> find", "[utxoz][regre
     CHECK(found->median_time_past() == 111u);
     CHECK(found->coinbase() == false);
 }
-#endif // KTH_UTXOZ_COMPACT_MODE
+#endif // KTH_UTXOZ_REFERENCE_MODE

--- a/src/c-api/include/kth/capi/node_info.h
+++ b/src/c-api/include/kth/capi/node_info.h
@@ -50,9 +50,9 @@ uint32_t kth_node_cppapi_build_timestamp(void);
 
 // Build configuration of the UTXO storage / IBD optimizations.
 
-// Whether UTXO-Z was built in compact mode (KTH_UTXOZ_COMPACT_MODE) vs full mode.
+// Whether UTXO-Z was built in reference mode (KTH_UTXOZ_REFERENCE_MODE) vs full mode.
 KTH_EXPORT
-kth_bool_t kth_node_utxoz_compact_mode(void);
+kth_bool_t kth_node_utxoz_reference_mode(void);
 
 // Whether this build embeds a UTXO bloom filter (KTH_HAS_EMBEDDED_BLOOM).
 KTH_EXPORT

--- a/src/c-api/src/node_info.cpp
+++ b/src/c-api/src/node_info.cpp
@@ -88,8 +88,8 @@ uint32_t kth_node_cppapi_build_timestamp() {
 // #endif
 }
 
-kth_bool_t kth_node_utxoz_compact_mode() {
-    return kth::database::utxoz_compact_mode() ? 1 : 0;
+kth_bool_t kth_node_utxoz_reference_mode() {
+    return kth::database::utxoz_reference_mode() ? 1 : 0;
 }
 
 kth_bool_t kth_node_embedded_bloom_available() {

--- a/src/database/CMakeLists.txt
+++ b/src/database/CMakeLists.txt
@@ -55,13 +55,13 @@ if (NOT GLOBAL_BUILD)
   find_package(domain REQUIRED)
 endif()
 
-# UTXO-Z compact storage mode (8-byte refs instead of full output data).
-# The real default comes from Conan (conanfile.py: utxoz_compact=False); this
+# UTXO-Z reference storage mode (8-byte refs instead of full output data).
+# The real default comes from Conan (conanfile.py: utxoz_reference=False); this
 # option only applies to standalone builds. It MUST agree with the value used by
 # the other modules — the write path (utxo_builder) and the storage layer
 # (utxoz_database) branch on this same macro, so a mismatch makes them disagree
 # on the stored value layout.
-option(KTH_UTXOZ_COMPACT_MODE "Use UTXO-Z compact storage mode" OFF)
+option(KTH_UTXOZ_REFERENCE_MODE "Use UTXO-Z reference storage mode" OFF)
 
 find_package(lmdb 0.9.29 REQUIRED)
 find_package(utxoz REQUIRED)
@@ -193,9 +193,9 @@ target_link_libraries(${PROJECT_NAME} PUBLIC domain::domain)
 target_link_libraries(${PROJECT_NAME} PUBLIC lmdb::lmdb)
 target_link_libraries(${PROJECT_NAME} PUBLIC utxoz::utxoz)
 
-if(KTH_UTXOZ_COMPACT_MODE)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC KTH_UTXOZ_COMPACT_MODE)
-    message(STATUS "Knuth: UTXO-Z compact storage mode enabled (database)")
+if(KTH_UTXOZ_REFERENCE_MODE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC KTH_UTXOZ_REFERENCE_MODE)
+    message(STATUS "Knuth: UTXO-Z reference storage mode enabled (database)")
 endif()
 
 if (MINGW)

--- a/src/database/include/kth/database/block_undo.hpp
+++ b/src/database/include/kth/database/block_undo.hpp
@@ -19,15 +19,15 @@ namespace kth::database {
 
 /// One output spent by a block, recorded so the block can be disconnected.
 ///
-/// `value` is the UTXO storage payload verbatim — in compact mode the 8-byte
+/// `value` is the UTXO storage payload verbatim — in reference mode the 8-byte
 /// {file_number, tx_offset} reference, in full mode the serialized entry — which
 /// is exactly the shape apply_delta_raw's insert range consumes. Restoring a
 /// spent output is therefore just re-inserting this record; no reconstruction of
-/// the output is needed, and none is possible in compact mode (the storage holds
+/// the output is needed, and none is possible in reference mode (the storage holds
 /// a reference into the block files, not the output bytes).
 ///
 /// `height` is the output's ORIGINAL creation height, not the height of the block
-/// that spent it. It must round-trip exactly: in compact mode the height also
+/// that spent it. It must round-trip exactly: in reference mode the height also
 /// drives the median-time-past window used when the UTXO is later resolved.
 struct KD_API spent_output {
     utxoz::raw_outpoint key{};

--- a/src/database/include/kth/database/databases/utxoz_database.hpp
+++ b/src/database/include/kth/database/databases/utxoz_database.hpp
@@ -27,16 +27,25 @@
 #include <kth/domain/chain/point.hpp>
 #include <kth/infrastructure/formats/base_16.hpp>
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
+#ifdef KTH_UTXOZ_REFERENCE_MODE
 #include <kth/database/flat_file_pos.hpp>
 #include <kth/database/header_index.hpp>
 #endif
 
 namespace kth::database {
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
+#ifdef KTH_UTXOZ_REFERENCE_MODE
 struct block_store;
 #endif
+
+/// What a successful sync() is worth on this platform.
+///
+/// New in UTXO-Z 0.9.0, and worth asking rather than assuming: under
+/// `contents_only` the file contents reach the disk and the directory entries
+/// naming them do not, so a checkpoint recorded on the strength of a successful
+/// sync is weaker than it looks. Constant for the build, and safe to branch on.
+[[nodiscard]]
+KD_API utxoz::durability_level utxoz_platform_durability();
 
 // Bloom filter type for UTXO skip-insert optimization.
 // K=7 hash functions, default subfilter/stride, uses std::hash<raw_outpoint>.
@@ -100,8 +109,8 @@ struct KD_API utxoz_database {
     [[nodiscard]]
     size_t size() const;
 
-#ifndef KTH_UTXOZ_COMPACT_MODE
-    /// Insert a UTXO (full mode only — compact mode uses apply_delta_raw)
+#ifndef KTH_UTXOZ_REFERENCE_MODE
+    /// Insert a UTXO (full mode only — reference mode uses apply_delta_raw)
     /// @param point Output point (txid + index)
     /// @param entry UTXO entry data
     /// @return result_code::success on success
@@ -128,7 +137,7 @@ struct KD_API utxoz_database {
     // =============================================================================
 
     /// A UTXO exactly as stored, without resolving it into a utxo_entry.
-    /// `value` is the storage-native payload — in compact mode the 8-byte
+    /// `value` is the storage-native payload — in reference mode the 8-byte
     /// {file_number, tx_offset} reference, in full mode the serialized entry — so
     /// it can be fed straight back into apply_delta_raw's insert range. `height` is
     /// the entry's ORIGINAL creation height, which restoring must preserve.
@@ -137,7 +146,7 @@ struct KD_API utxoz_database {
         uint32_t height;
     };
 
-    /// Read a UTXO's stored payload without resolving it (compact mode does not
+    /// Read a UTXO's stored payload without resolving it (reference mode does not
     /// touch the flat block files here; only resolve/find does).
     ///
     /// Two-phase contract, same as find(): a key_not_found result only means "not
@@ -153,17 +162,21 @@ struct KD_API utxoz_database {
     /// Resolve the deferred-lookup queue, returning payloads verbatim (no
     /// utxo_entry reconstruction — the cheap counterpart of
     /// process_pending_lookups()).
-    /// @return pair of (resolved entries keyed by outpoint, keys that truly don't exist)
+    /// @return on success, (resolved entries keyed by outpoint, keys PROVEN
+    ///         absent — see process_pending_lookups()). On failure, the error: a
+    ///         queue that could not be drained is NOT a queue that resolved to
+    ///         nothing, and callers read "not resolved" as "this UTXO is spent".
     [[nodiscard]]
-    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, raw_stored>, std::vector<utxoz::raw_outpoint>>
+    std::expected<std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, raw_stored>,
+                            std::vector<utxoz::raw_outpoint>>, result_code>
     process_pending_lookups_raw();
 
     // =============================================================================
     // Batch Operations (for UTXO set building)
     // =============================================================================
 
-#ifndef KTH_UTXOZ_COMPACT_MODE
-    /// Apply a batch of UTXO changes (full mode only — compact mode uses apply_delta_raw)
+#ifndef KTH_UTXOZ_REFERENCE_MODE
+    /// Apply a batch of UTXO changes (full mode only — reference mode uses apply_delta_raw)
     /// @param inserts UTXOs to add (point -> utxo_entry, entry contains height)
     /// @param deletes UTXOs to remove (point -> height for traceability)
     /// @return result_code::success on success
@@ -187,7 +200,16 @@ struct KD_API utxoz_database {
 
         for (auto const& [point, height] : deletes) {
             auto key = point_to_key(point);
-            std::ignore = db_->erase(key, height);
+            auto const erased = db_->erase(key, height);
+            if ( ! erased && erased.error() != utxoz::error_code::not_found) {
+                // A delete that failed leaves a spent output in the set. Ignoring
+                // it and returning success let a batch be recorded as applied
+                // while the UTXO it spent is still there. not_found is different:
+                // the key was not present, which a delta can legitimately hit.
+                spdlog::error("[utxoz_database] Failed to erase UTXO from block {} - {}:{}",
+                    height, encode_hash(point.hash()), point.index());
+                return result_code::other;
+            }
         }
 
         return result_code::success;
@@ -206,8 +228,17 @@ struct KD_API utxoz_database {
         }
 
         for (auto const& [key, raw] : inserts) {
-#ifdef KTH_UTXOZ_COMPACT_MODE
-            // Compact mode: deserialize 8-byte compact_utxo_ref into typed fields
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+            // Reference mode: deserialize the 8-byte reference into typed fields.
+            // Checked first: these are two reads off a caller-supplied buffer,
+            // and a short payload would read past its end. A payload that is not
+            // exactly eight bytes is not a reference at all, whatever it is.
+            if (raw.data.size() != 8) {
+                spdlog::error("[utxoz_database] reference payload for {} is {} byte(s), "
+                    "not 8; refusing to read it as a reference",
+                    utxoz::outpoint_to_string(key), raw.data.size());
+                return result_code::other;
+            }
             uint32_t file_number, tx_offset;
             std::memcpy(&file_number, raw.data.data(), 4);
             std::memcpy(&tx_offset, raw.data.data() + 4, 4);
@@ -228,7 +259,12 @@ struct KD_API utxoz_database {
         }
 
         for (auto const& [key, height] : deletes) {
-            std::ignore = db_->erase(key, height);
+            auto const erased = db_->erase(key, height);
+            if ( ! erased && erased.error() != utxoz::error_code::not_found) {
+                spdlog::error("[utxoz_database] Failed to erase {} at block {}",
+                    utxoz::outpoint_to_string(key), height);
+                return result_code::other;
+            }
         }
 
         return result_code::success;
@@ -254,11 +290,11 @@ struct KD_API utxoz_database {
         utxo_bloom_.reset();
     }
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-    /// Set the block store for compact mode find resolution.
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    /// Set the block store for reference mode find resolution.
     void set_block_store(block_store const* store) { block_store_ = store; }
 
-    /// Set the header index for compact mode find resolution (MTP calculation).
+    /// Set the header index for reference mode find resolution (MTP calculation).
     void set_header_index(header_index const* idx) { header_index_ = idx; }
 #endif
 
@@ -276,9 +312,12 @@ struct KD_API utxoz_database {
     size_t deferred_deletions_size() const;
 
     /// Process pending deferred deletions
-    /// @return pair of (successful deletions, failed entries with key and height)
+    /// @return on success, (successful deletions, failed entries with key and
+    ///         height). On failure, the error: no deletion was applied, which is
+    ///         not the same as there having been none to apply.
     [[nodiscard]]
-    std::pair<uint32_t, std::vector<utxoz::deferred_deletion_entry>> process_pending_deletions();
+    std::expected<std::pair<uint32_t, std::vector<utxoz::deferred_deletion_entry>>, result_code>
+    process_pending_deletions();
 
     /// Get the number of pending deferred lookups
     [[nodiscard]]
@@ -288,13 +327,38 @@ struct KD_API utxoz_database {
     /// find() is a two-phase contract: its key_not_found only means "not in the
     /// active file, queued". This resolves the queue. Call once per batch, BEFORE
     /// process_pending_deletions().
-    /// @return pair of (resolved entries keyed by outpoint, keys that truly don't exist)
+    /// @return on success, (resolved entries keyed by outpoint, keys PROVEN
+    ///         absent). Since UTXO-Z 0.9.1 the second list means exactly that:
+    ///         a version file that could not be read makes the whole sweep fail
+    ///         with version_unreadable instead of dropping its keys in there. On
+    ///         failure, the error — absence is read upstream as "spent".
     [[nodiscard]]
-    std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxo_entry>, std::vector<utxoz::raw_outpoint>>
+    std::expected<std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxo_entry>,
+                            std::vector<utxoz::raw_outpoint>>, result_code>
     process_pending_lookups();
 
-    /// Compact the database
-    void compact();
+    /// Compact the database.
+    ///
+    /// The name is the compaction OPERATION and did not change when UTXO-Z
+    /// renamed its storage mode; what changed is the contract. In 0.8.0
+    /// `compact_all()` returned void, so there was nothing to ignore. In 0.9.0
+    /// it returns `result<>`, and a caller that keeps calling it as a statement
+    /// still compiles while dropping every failure on the floor — which is why
+    /// this reports rather than returns void.
+    /// @return true if the database compacted, false if it is closed or the
+    ///         operation failed (the reason is logged).
+    bool compact();
+
+    /// Ask for the data written so far to reach stable storage.
+    ///
+    /// New in UTXO-Z 0.9.0. Closing does NOT sync: `close()` releases the
+    /// mapping and stops, so a caller that wants the guarantee has to ask for
+    /// it here first. What the answer is worth depends on the platform —
+    /// see platform_durability().
+    /// @return true if a barrier was reached; false if the database is closed,
+    ///         the platform has none, or the barrier failed (each is logged as
+    ///         the distinct thing it is).
+    bool sync();
 
     /// Print statistics to log
     void print_statistics();
@@ -322,24 +386,24 @@ private:
     [[nodiscard]]
     static std::expected<utxo_entry, result_code> bytes_to_entry(std::span<uint8_t const> bytes);
 
-    // Resolve a compact find result to a full utxo_entry.
-    // Used in compact mode find path.
-#ifdef KTH_UTXOZ_COMPACT_MODE
+    // Resolve a reference find result to a full utxo_entry.
+    // Used in reference mode find path.
+#ifdef KTH_UTXOZ_REFERENCE_MODE
     [[nodiscard]]
-    std::expected<utxo_entry, result_code> resolve_compact_ref(
-        utxoz::compact_find_result const& ref,
+    std::expected<utxo_entry, result_code> resolve_reference_ref(
+        utxoz::reference_find_result const& ref,
         uint32_t output_index) const;
 #endif
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-    std::optional<utxoz::compact_db> db_;
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    std::optional<utxoz::reference_db> db_;
 #else
     std::optional<utxoz::full_db> db_;
 #endif
     bool is_open_ = false;
     std::shared_ptr<utxo_bloom_filter const> utxo_bloom_;  // optional bloom filter for skip-insert optimization
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
+#ifdef KTH_UTXOZ_REFERENCE_MODE
     block_store const* block_store_ = nullptr;
     header_index const* header_index_ = nullptr;
 #endif

--- a/src/database/include/kth/database/define.hpp
+++ b/src/database/include/kth/database/define.hpp
@@ -37,11 +37,11 @@ namespace kth::database {
 using array_index = uint32_t;
 using file_offset = uint64_t;
 
-/// True if this database library was compiled with UTXO-Z compact storage mode
-/// (KTH_UTXOZ_COMPACT_MODE). Reported for build diagnostics: the option is
+/// True if this database library was compiled with UTXO-Z reference storage mode
+/// (KTH_UTXOZ_REFERENCE_MODE). Reported for build diagnostics: the option is
 /// declared in more than one CMake list, so a build can end up with the database
 /// and blockchain modules disagreeing — this exposes each module's actual value.
-KD_API bool utxoz_compact_mode();
+KD_API bool utxoz_reference_mode();
 
 } // namespace kth::database
 

--- a/src/database/src/databases/utxoz_database.cpp
+++ b/src/database/src/databases/utxoz_database.cpp
@@ -9,19 +9,87 @@
 
 #include <kth/infrastructure/utility/byte_reader.hpp>
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
+#ifdef KTH_UTXOZ_REFERENCE_MODE
 #include <kth/database/block_store.hpp>
 #include <kth/database/header_index.hpp>
 #endif
 
 namespace kth::database {
 
-bool utxoz_compact_mode() {
-#ifdef KTH_UTXOZ_COMPACT_MODE
+bool utxoz_reference_mode() {
+#ifdef KTH_UTXOZ_REFERENCE_MODE
     return true;
 #else
     return false;
 #endif
+}
+
+namespace {
+
+// UTXO-Z 0.9.0 grew its error enum from five values to twenty-one. Logging the
+// integer, as this used to, turns a diagnosis into a lookup against whichever
+// header version the reader happens to open — and the numbers moved, so an old
+// note now names a different fault. Naming them here costs one switch and keeps
+// the log readable on its own.
+//
+// The switch lists every code and has no `default`. That asks for a -Wswitch
+// warning when UTXO-Z adds one, but this is a warning, not an error, and only
+// where it is enabled and promoted — when 0.9.1 added version_unreadable, this
+// file compiled clean and the new code would have printed "unrecognised". So the
+// trailing return is the defence, and adding a case is a manual step on every
+// UTXO-Z bump, not something the build will remind anyone about.
+char const* utxoz_error_name(utxoz::error_code code) {
+    switch (code) {
+        case utxoz::error_code::not_found:              return "not_found";
+        case utxoz::error_code::closed:                 return "closed";
+        case utxoz::error_code::storage_mode_mismatch:  return "storage_mode_mismatch";
+        case utxoz::error_code::config_file_corrupt:    return "config_file_corrupt";
+        case utxoz::error_code::value_too_large:        return "value_too_large";
+        case utxoz::error_code::duplicate_key:          return "duplicate_key";
+        case utxoz::error_code::catalog_unreadable:     return "catalog_unreadable";
+        case utxoz::error_code::version_unreadable:     return "version_unreadable";
+        case utxoz::error_code::removal_failed:         return "removal_failed";
+        case utxoz::error_code::sync_unsupported:       return "sync_unsupported";
+        case utxoz::error_code::sync_failed:            return "sync_failed";
+        case utxoz::error_code::rename_failed:          return "rename_failed";
+        case utxoz::error_code::database_in_use:        return "database_in_use";
+        case utxoz::error_code::database_lock_unavailable: return "database_lock_unavailable";
+        case utxoz::error_code::entropy_unavailable:    return "entropy_unavailable";
+        case utxoz::error_code::file_open_failed:       return "file_open_failed";
+        case utxoz::error_code::identity_collision:     return "identity_collision";
+        case utxoz::error_code::insufficient_space:     return "insufficient_space";
+        case utxoz::error_code::recovery_required:      return "recovery_required";
+        case utxoz::error_code::recovery_failed:        return "recovery_failed";
+        case utxoz::error_code::metadata_write_failed:  return "metadata_write_failed";
+    }
+    return "unrecognised";
+}
+
+// UTXO-Z's find() can now fail for reasons that are not absence: the database
+// is closed, the catalogue could not be read, recovery is required. Folding all
+// of them into key_not_found is the sentinel conversion this migration exists
+// to avoid — upstream reads key_not_found as "queued, sweep it", and a sweep
+// over a database that cannot be read answers "absent", which the validator
+// reads as "spent".
+result_code find_failure_to_result_code(utxoz::error_code code) {
+    return code == utxoz::error_code::not_found
+         ? result_code::key_not_found
+         : result_code::other;
+}
+
+char const* to_string(utxoz::durability_level level) {
+    switch (level) {
+        case utxoz::durability_level::full:          return "full";
+        case utxoz::durability_level::contents_only: return "contents_only";
+        case utxoz::durability_level::none:          return "none";
+    }
+    return "unrecognised";
+}
+
+} // namespace
+
+utxoz::durability_level utxoz_platform_durability() {
+    return utxoz::platform_durability();
 }
 
 
@@ -35,13 +103,43 @@ bool utxoz_database::open(std::filesystem::path const& path, bool remove_existin
         return true;
     }
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-    auto result = utxoz::compact_db::open(path.string(), remove_existing);
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    auto result = utxoz::reference_db::open(path.string(), remove_existing);
 #else
     auto result = utxoz::full_db::open(path.string(), remove_existing);
 #endif
     if ( ! result) {
-        spdlog::error("[utxoz_database] Failed to open database: {}", static_cast<int>(result.error()));
+        // UTXO-Z 0.9.0 claims the database exclusively. Four of the ways an open
+        // can now fail are operational facts an operator can act on, and each
+        // sends them somewhere different, so none of them may arrive as a bare
+        // number.
+        switch (result.error()) {
+            case utxoz::error_code::database_in_use:
+                spdlog::error("[utxoz_database] Another instance already holds {} — "
+                    "UTXO-Z takes an exclusive claim, so a second node cannot open it",
+                    path.string());
+                break;
+            case utxoz::error_code::database_lock_unavailable:
+                spdlog::error("[utxoz_database] The claim on {} could not be attempted at all: "
+                    "no permission, a filesystem without locking, or a lock file that is not "
+                    "a regular file. This is NOT 'someone else has it'", path.string());
+                break;
+            case utxoz::error_code::recovery_required:
+            case utxoz::error_code::recovery_failed:
+                spdlog::error("[utxoz_database] {} did not open: {}. Recovery found an "
+                    "interrupted operation it will not guess at; the database is left alone",
+                    path.string(), utxoz_error_name(result.error()));
+                break;
+            case utxoz::error_code::storage_mode_mismatch:
+                spdlog::error("[utxoz_database] {} was created in the other storage mode. "
+                    "This build is {} mode; the files on disk are not", path.string(),
+                    utxoz_reference_mode() ? "reference" : "full");
+                break;
+            default:
+                spdlog::error("[utxoz_database] Failed to open database: {}",
+                    utxoz_error_name(result.error()));
+                break;
+        }
         return false;
     }
     db_.emplace(std::move(*result));
@@ -70,7 +168,7 @@ size_t utxoz_database::size() const {
     return db_->size();
 }
 
-#ifndef KTH_UTXOZ_COMPACT_MODE
+#ifndef KTH_UTXOZ_REFERENCE_MODE
 result_code utxoz_database::insert(domain::chain::point const& point, utxo_entry const& entry) {
     if ( ! is_open()) {
         return result_code::other;
@@ -94,16 +192,24 @@ std::expected<utxo_entry, result_code> utxoz_database::find(domain::chain::point
 
     auto key = point_to_key(point);
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
+#ifdef KTH_UTXOZ_REFERENCE_MODE
     auto result = db_->find(key, height);
     if ( ! result) {
-        return std::unexpected(result_code::key_not_found);
+        if (result.error() != utxoz::error_code::not_found) {
+            spdlog::error("[utxoz_database] find() failed for {}: {}; this is not absence",
+                utxoz::outpoint_to_string(key), utxoz_error_name(result.error()));
+        }
+        return std::unexpected(find_failure_to_result_code(result.error()));
     }
-    return resolve_compact_ref(*result, point.index());
+    return resolve_reference_ref(*result, point.index());
 #else
     auto result = db_->find(key, height);
     if ( ! result) {
-        return std::unexpected(result_code::key_not_found);
+        if (result.error() != utxoz::error_code::not_found) {
+            spdlog::error("[utxoz_database] find() failed for {}: {}; this is not absence",
+                utxoz::outpoint_to_string(key), utxoz_error_name(result.error()));
+        }
+        return std::unexpected(find_failure_to_result_code(result.error()));
     }
     return bytes_to_entry(result->data);
 #endif
@@ -115,17 +221,29 @@ result_code utxoz_database::erase(domain::chain::point const& point, uint32_t he
     }
 
     auto key = point_to_key(point);
-    auto erased = db_->erase(key, height);
 
-    return erased > 0 ? result_code::success : result_code::key_not_found;
+    // 0.9.0 wraps the count in result<>. The old `erased > 0` no longer
+    // compiles, which is the lucky half of this change: the dangerous reading
+    // is that a failed erase looks like a key that was not there. It is not —
+    // the entry may well exist and still be spendable — so a failure reports
+    // itself rather than being folded into key_not_found.
+    auto const erased = db_->erase(key, height);
+    if ( ! erased) {
+        spdlog::error("[utxoz_database] Erase failed for {}: {}; this is NOT "
+            "the key being absent", utxoz::outpoint_to_string(key),
+            utxoz_error_name(erased.error()));
+        return result_code::other;
+    }
+
+    return *erased > 0 ? result_code::success : result_code::key_not_found;
 }
 
 namespace {
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-// Pack a compact reference the way apply_delta_raw expects it to arrive:
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+// Pack a reference the way apply_delta_raw expects it to arrive:
 // {file_number(4 LE), tx_offset(4 LE)}.
-std::vector<uint8_t> pack_compact_ref(uint32_t file_number, uint32_t offset) {
+std::vector<uint8_t> pack_reference_ref(uint32_t file_number, uint32_t offset) {
     std::vector<uint8_t> value(8);
     std::memcpy(value.data(), &file_number, 4);
     std::memcpy(value.data() + 4, &offset, 4);
@@ -143,32 +261,51 @@ utxoz_database::find_raw(utxoz::raw_outpoint const& key, uint32_t height) const 
 
     auto result = db_->find(key, height);
     if ( ! result) {
-        // Not in the active version file. May still be resolved by the deferred
-        // sweep — the caller must not treat this as absence.
-        return std::unexpected(result_code::key_not_found);
+        // not_found means "not in the active version file"; it may still be
+        // resolved by the deferred sweep, and the caller must not treat it as
+        // absence. Any OTHER error is a read that failed, and must not be
+        // dressed up as the two-phase contract.
+        if (result.error() != utxoz::error_code::not_found) {
+            spdlog::error("[utxoz_database] find_raw() failed for {}: {}; this is not "
+                "a deferred lookup", utxoz::outpoint_to_string(key),
+                utxoz_error_name(result.error()));
+        }
+        return std::unexpected(find_failure_to_result_code(result.error()));
     }
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-    return raw_stored{pack_compact_ref(result->file_number, result->offset), result->block_height};
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    return raw_stored{pack_reference_ref(result->file_number, result->offset), result->block_height};
 #else
     return raw_stored{result->data, result->block_height};
 #endif
 }
 
-std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxoz_database::raw_stored>, std::vector<utxoz::raw_outpoint>>
+std::expected<std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxoz_database::raw_stored>,
+                        std::vector<utxoz::raw_outpoint>>, result_code>
 utxoz_database::process_pending_lookups_raw() {
     boost::unordered_flat_map<utxoz::raw_outpoint, raw_stored> resolved;
     std::vector<utxoz::raw_outpoint> failed;
 
     if ( ! is_open()) {
-        return {std::move(resolved), std::move(failed)};
+        return std::unexpected(result_code::other);
     }
 
-    auto [found, fail] = db_->process_pending_lookups();
+    // 0.9.0 wraps this in result<>: draining the queue can now fail as a whole
+    // (an unreadable catalogue is not an empty one), and that is a different
+    // answer from "these keys do not exist". Reporting the failure as an empty
+    // resolution would turn a read error into a UTXO that is absent.
+    auto drained = db_->process_pending_lookups();
+    if ( ! drained) {
+        spdlog::error("[utxoz_database] Draining the deferred lookup queue failed: {}; "
+            "this is not the same as the keys being absent",
+            utxoz_error_name(drained.error()));
+        return std::unexpected(result_code::other);
+    }
+    auto& [found, fail] = *drained;
     resolved.reserve(found.size());
     for (auto const& [key, res] : found) {
-#ifdef KTH_UTXOZ_COMPACT_MODE
-        resolved.emplace(key, raw_stored{pack_compact_ref(res.file_number, res.offset), res.block_height});
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+        resolved.emplace(key, raw_stored{pack_reference_ref(res.file_number, res.offset), res.block_height});
 #else
         resolved.emplace(key, raw_stored{res.data, res.block_height});
 #endif
@@ -179,7 +316,7 @@ utxoz_database::process_pending_lookups_raw() {
         failed.push_back(e.key);
     }
 
-    return {std::move(resolved), std::move(failed)};
+    return std::pair{std::move(resolved), std::move(failed)};
 }
 
 result_code utxoz_database::clear() {
@@ -200,11 +337,22 @@ size_t utxoz_database::deferred_deletions_size() const {
     return db_->deferred_deletions_size();
 }
 
-std::pair<uint32_t, std::vector<utxoz::deferred_deletion_entry>> utxoz_database::process_pending_deletions() {
+std::expected<std::pair<uint32_t, std::vector<utxoz::deferred_deletion_entry>>, result_code>
+utxoz_database::process_pending_deletions() {
     if ( ! is_open()) {
-        return {0, {}};
+        return std::unexpected(result_code::other);
     }
-    return db_->process_pending_deletions();
+
+    // Also result<>-wrapped since 0.9.0. An empty return has to mean "nothing
+    // was pending", so a drain that could not run says so instead of borrowing
+    // that meaning.
+    auto drained = db_->process_pending_deletions();
+    if ( ! drained) {
+        spdlog::error("[utxoz_database] Draining the deferred deletion queue failed: {}; "
+            "no deletion was applied", utxoz_error_name(drained.error()));
+        return std::unexpected(result_code::other);
+    }
+    return std::move(*drained);
 }
 
 size_t utxoz_database::deferred_lookups_size() const {
@@ -214,51 +362,124 @@ size_t utxoz_database::deferred_lookups_size() const {
     return db_->deferred_lookups_size();
 }
 
-std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxo_entry>, std::vector<utxoz::raw_outpoint>>
+std::expected<std::pair<boost::unordered_flat_map<utxoz::raw_outpoint, utxo_entry>,
+                        std::vector<utxoz::raw_outpoint>>, result_code>
 utxoz_database::process_pending_lookups() {
     boost::unordered_flat_map<utxoz::raw_outpoint, utxo_entry> resolved;
     std::vector<utxoz::raw_outpoint> failed;
     if ( ! is_open()) {
-        return {std::move(resolved), std::move(failed)};
+        return std::unexpected(result_code::other);
     }
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-    auto [found, fail] = db_->process_pending_lookups();
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+    // 0.9.0 wraps this in result<>: draining the queue can now fail as a whole
+    // (an unreadable catalogue is not an empty one), and that is a different
+    // answer from "these keys do not exist". Reporting the failure as an empty
+    // resolution would turn a read error into a UTXO that is absent.
+    auto drained = db_->process_pending_lookups();
+    if ( ! drained) {
+        spdlog::error("[utxoz_database] Draining the deferred lookup queue failed: {}; "
+            "this is not the same as the keys being absent",
+            utxoz_error_name(drained.error()));
+        return std::unexpected(result_code::other);
+    }
+    auto& [found, fail] = *drained;
     resolved.reserve(found.size());
     for (auto const& [key, ref] : found) {
         uint32_t index;
         std::memcpy(&index, key.data() + 32, sizeof(index));   // outpoint index (LE)
-        auto entry = resolve_compact_ref(ref, index);
-        if (entry) {
-            resolved.emplace(key, std::move(*entry));
-        } else {
-            failed.push_back(key);   // conversion failure -> treat as missing
+        auto entry = resolve_reference_ref(ref, index);
+        if ( ! entry) {
+            // The sweep FOUND this key; materialising the reference is a read of
+            // the block file, and that read failed. Pushing it onto `failed`
+            // would report a UTXO that demonstrably exists as one that does not.
+            spdlog::error("[utxoz_database] resolving a reference for a key the sweep "
+                "found failed: {}; the entry exists and could not be read",
+                utxoz::outpoint_to_string(key));
+            return std::unexpected(entry.error());
         }
+        resolved.emplace(key, std::move(*entry));
     }
     for (auto const& e : fail) {
         failed.push_back(e.key);
     }
 #else
-    auto [found, fail] = db_->process_pending_lookups();
+    // 0.9.0 wraps this in result<>: draining the queue can now fail as a whole
+    // (an unreadable catalogue is not an empty one), and that is a different
+    // answer from "these keys do not exist". Reporting the failure as an empty
+    // resolution would turn a read error into a UTXO that is absent.
+    auto drained = db_->process_pending_lookups();
+    if ( ! drained) {
+        spdlog::error("[utxoz_database] Draining the deferred lookup queue failed: {}; "
+            "this is not the same as the keys being absent",
+            utxoz_error_name(drained.error()));
+        return std::unexpected(result_code::other);
+    }
+    auto& [found, fail] = *drained;
     resolved.reserve(found.size());
     for (auto const& [key, res] : found) {
         auto entry = bytes_to_entry(res.data);
-        if (entry) {
-            resolved.emplace(key, std::move(*entry));
+        if ( ! entry) {
+            // Stored bytes that will not decode are corruption. Skipping the
+            // entry silently drops it from `resolved` without putting it in
+            // `failed` either, so the caller sees neither the UTXO nor a problem.
+            spdlog::error("[utxoz_database] stored bytes for {} could not be decoded; "
+                "the entry exists and is unreadable",
+                utxoz::outpoint_to_string(key));
+            return std::unexpected(entry.error());
         }
+        resolved.emplace(key, std::move(*entry));
     }
     failed.reserve(fail.size());
     for (auto const& e : fail) {
         failed.push_back(e.key);
     }
 #endif
-    return {std::move(resolved), std::move(failed)};
+    return std::pair{std::move(resolved), std::move(failed)};
 }
 
-void utxoz_database::compact() {
-    if (is_open()) {
-        db_->compact_all();
+bool utxoz_database::compact() {
+    if ( ! is_open()) {
+        return false;
     }
+    auto const compacted = db_->compact_all();
+    if ( ! compacted) {
+        spdlog::error("[utxoz_database] Compaction failed: {}",
+            utxoz_error_name(compacted.error()));
+        return false;
+    }
+    return true;
+}
+
+bool utxoz_database::sync() {
+    if ( ! is_open()) {
+        spdlog::warn("[utxoz_database] sync() on a closed database; nothing was written");
+        return false;
+    }
+
+    auto const synced = db_->sync();
+    if (synced) {
+        return true;
+    }
+
+    // These are three different facts about the machine, and collapsing them
+    // into "sync failed" would send an operator looking in the wrong place.
+    switch (synced.error()) {
+        case utxoz::error_code::sync_unsupported:
+            spdlog::warn("[utxoz_database] This platform exposes no durability "
+                "barrier ({}); nothing was promised",
+                to_string(utxoz::platform_durability()));
+            break;
+        case utxoz::error_code::sync_failed:
+            spdlog::error("[utxoz_database] A durability barrier was attempted "
+                "and failed; the data written so far is not known to be durable");
+            break;
+        default:
+            spdlog::error("[utxoz_database] sync() failed: {}",
+                utxoz_error_name(synced.error()));
+            break;
+    }
+    return false;
 }
 
 void utxoz_database::print_statistics() {
@@ -279,21 +500,21 @@ void utxoz_database::print_height_range_stats() {
     }
 }
 
-#ifdef KTH_UTXOZ_COMPACT_MODE
-std::expected<utxo_entry, result_code> utxoz_database::resolve_compact_ref(
-    utxoz::compact_find_result const& ref,
+#ifdef KTH_UTXOZ_REFERENCE_MODE
+std::expected<utxo_entry, result_code> utxoz_database::resolve_reference_ref(
+    utxoz::reference_find_result const& ref,
     uint32_t output_index) const
 {
     if ( ! block_store_ || ! header_index_) {
-        spdlog::error("[utxoz_database] resolve_compact_ref: block_store or header_index not set");
+        spdlog::error("[utxoz_database] resolve_reference_ref: block_store or header_index not set");
         return std::unexpected(result_code::other);
     }
 
-    // Read raw transaction from flat file using typed fields from compact_find_result
+    // Read raw transaction from flat file using typed fields from reference_find_result
     flat_file_pos pos{static_cast<int32_t>(ref.file_number), ref.offset};
     auto raw_tx = block_store_->read_tx_raw(pos);
     if ( ! raw_tx) {
-        spdlog::error("[utxoz_database] resolve_compact_ref: failed to read tx at file={} offset={}",
+        spdlog::error("[utxoz_database] resolve_reference_ref: failed to read tx at file={} offset={}",
             ref.file_number, ref.offset);
         return std::unexpected(result_code::other);
     }
@@ -301,13 +522,13 @@ std::expected<utxo_entry, result_code> utxoz_database::resolve_compact_ref(
     // Parse the transaction
     auto tx = kth::from_data_chunk<domain::chain::transaction>(*raw_tx, true);  // wire=true
     if ( ! tx) {
-        spdlog::error("[utxoz_database] resolve_compact_ref: failed to parse tx at file={} offset={}",
+        spdlog::error("[utxoz_database] resolve_reference_ref: failed to parse tx at file={} offset={}",
             ref.file_number, ref.offset);
         return std::unexpected(result_code::other);
     }
 
     if (output_index >= tx->outputs().size()) {
-        spdlog::error("[utxoz_database] resolve_compact_ref: output_index {} >= tx outputs size {}",
+        spdlog::error("[utxoz_database] resolve_reference_ref: output_index {} >= tx outputs size {}",
             output_index, tx->outputs().size());
         return std::unexpected(result_code::other);
     }

--- a/src/node/src/executor/executor.cpp
+++ b/src/node/src/executor/executor.cpp
@@ -544,7 +544,7 @@ void executor::print_version(std::string_view extra) {
 #endif
     // UTXO-Z storage mode (single source of truth).
     std::println("  UTXO-Z mode: {}",
-        kth::database::utxoz_compact_mode() ? "compact" : "full");
+        kth::database::utxoz_reference_mode() ? "reference" : "full");
     // Embedded UTXO bloom filter (single source of truth).
     if (kth::blockchain::embedded_bloom_available()) {
         std::println("  UTXO bloom: embedded (checkpoint height {})",

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -2046,11 +2046,22 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             // Prune with the bloom only up to the checkpoint; above it keep every
             // output (live UTXO set) so full validation can resolve prevouts.
             auto const* block_bloom = (h <= checkpoint_height) ? bloom_ptr : nullptr;
-            auto block_delta = blockchain::process_compact_block_utxos(
+            auto block_delta_result = blockchain::process_compact_block_utxos(
                 *parsed, h, mtp,
                 chain.headers().get_file_number(idx),
                 chain.headers().get_data_pos(idx),
                 block_bloom);
+            if ( ! block_delta_result) {
+                // The header index has no file number for this block. Storing
+                // references built from it would put UINT32_MAX in every entry,
+                // so the batch stops here rather than writing entries that can
+                // never be resolved.
+                spdlog::critical("[utxo_build] cannot reference the block at height {}: "
+                    "the header index and the block store disagree", h);
+                on_fatal("the header index has no data for a block being built");
+                co_return;
+            }
+            auto block_delta = std::move(*block_delta_result);
 
             // Capture undo data so this block can be disconnected on a reorg.
             // Only above the checkpoint: below it the bloom prunes the delta, so
@@ -2133,6 +2144,52 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
             }
         }
 
+        // The deletions the store deferred are part of this batch's delta, not
+        // work that follows it: until they run, outputs these blocks spent are
+        // still in the set. So they come before the state is published, and a
+        // failure is fatal rather than logged — a spent output left behind is a
+        // double spend the node would accept.
+        //
+        // ORDER MATTERS, and it used to be wrong: the height marker was persisted
+        // first and the queue drained afterwards. A crash between the two left a
+        // marker saying the batch was complete over a set that still held every
+        // output these blocks spent, and the restart trusted the marker and never
+        // drained again — a double spend the node would accept, reachable without
+        // any storage failure at all, just bad luck with the timing.
+        //
+        // Draining first closes that window in one direction only: a crash after
+        // the drain and before the marker replays the batch, which is safe
+        // because applying a delta twice is idempotent for the marker's purpose
+        // (resume rebuilds from the recorded height). The other direction is what
+        // #600 specifies and #602 implements: a durable record that says which of
+        // the two happened, so recovery does not have to infer it. This PR gets
+        // the order right and refuses to continue past a failure; it does not
+        // make the window crash-safe, and the two must not be confused.
+        auto const deferred = chain.utxo_deferred_deletions_size();
+        if (deferred > 0) {
+            auto drained = chain.utxo_process_pending_deletions();
+            if ( ! drained) {
+                // Asked again rather than reusing the count taken before the
+                // call: the drain may have applied some deletions before it
+                // failed, and reporting the pre-drain figure would overstate
+                // what is still outstanding.
+                spdlog::critical("[utxo_build] the deferred deletion queue could not be "
+                    "drained at batch {}-{}: {} deletion(s) remain unapplied, so the UTXO "
+                    "set still holds outputs these blocks spent", batch_start, batch_end,
+                    chain.utxo_deferred_deletions_size());
+                on_fatal("the deferred deletion queue could not be drained");
+                co_return;
+            }
+            auto const& failed = drained->second;
+            if ( ! failed.empty()) {
+                spdlog::critical("[utxo_build] {} deferred deletion(s) failed at batch {}-{}: the "
+                    "UTXO set still holds outputs these blocks spent", failed.size(),
+                    batch_start, batch_end);
+                on_fatal("a batch left spent outputs in the UTXO set");
+                co_return;
+            }
+        }
+
         utxo_built_height = batch_end;
 
         // Save progress. Not ignorable: everything below treats these blocks as
@@ -2173,28 +2230,6 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
                 co_return;
             }
         }
-        // The deletions the store deferred are part of this batch's delta, not
-        // work that follows it: until they run, outputs these blocks spent are
-        // still in the set. So they come before the state is published, and a
-        // failure is fatal rather than logged — a spent output left behind is a
-        // double spend the node would accept.
-        //
-        // The marker at which this becomes recoverable rather than merely fatal
-        // is #600, and #602 is the change that adds it. This orders the work
-        // correctly and refuses to continue past a failure; it does not make the
-        // window crash-safe, and the two must not be confused.
-        auto const deferred = chain.utxo_deferred_deletions_size();
-        if (deferred > 0) {
-            auto [deleted, failed] = chain.utxo_process_pending_deletions();
-            if ( ! failed.empty()) {
-                spdlog::critical("[utxo_build] {} deferred deletion(s) failed at batch {}-{}: the "
-                    "UTXO set still holds outputs these blocks spent", failed.size(),
-                    batch_start, batch_end);
-                on_fatal("a batch left spent outputs in the UTXO set");
-                co_return;
-            }
-        }
-
         // Now the batch is closed: the delta is applied in full, the undo records
         // are written, the height marker has moved and the mempool no longer
         // holds what these blocks confirmed. Only now does a coherent state exist
@@ -2223,7 +2258,13 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
 
     // Final compaction
     spdlog::info("[utxo_build] Running final compaction...");
-    chain.utxo_compact();
+    if ( ! chain.utxo_compact()) {
+        // Not fatal: compaction reclaims space, it does not decide correctness,
+        // and the set is coherent either way. But it is not nothing, and the old
+        // void signature meant nobody could tell it had happened.
+        spdlog::error("[utxo_build] final compaction failed; the UTXO set is intact "
+            "but was not compacted");
+    }
     chain.utxo_print_statistics();
     chain.utxo_print_sizing_report();
     chain.utxo_print_height_range_stats();

--- a/src/node/test/sync_harness.hpp
+++ b/src/node/test/sync_harness.hpp
@@ -168,12 +168,26 @@ inline header_persister real_persister(blockchain::block_chain& chain) {
 // whatever the sweep had not reached yet.
 inline bool utxo_present(blockchain::block_chain& chain, hash_digest const& txid, uint32_t index,
                   uint32_t at_height) {
-    if (chain.get_utxo(domain::chain::output_point{txid, index}, at_height)) {
+    auto const direct = chain.get_utxo(domain::chain::output_point{txid, index}, at_height);
+    if (direct) {
         return true;
     }
+    if (direct.error() != database::result_code::key_not_found) {
+        // Only "not in the active file, queued" is a reason to sweep. Any other
+        // code is the store failing, and sweeping on it would answer a question
+        // the store just refused.
+        throw std::runtime_error(
+            "utxo_present: the UTXO store failed; presence is unknown");
+    }
     auto const key = utxoz::make_outpoint(std::span<uint8_t const, 32>{txid.data(), 32}, index);
-    auto const [found, missing] = chain.utxo_process_pending_lookups();
-    return found.contains(key);
+    auto const drained = chain.utxo_process_pending_lookups();
+    if ( ! drained) {
+        // "Could not look" is not "not there". Returning false here would make
+        // every assertion built on this helper pass or fail for the wrong reason.
+        throw std::runtime_error(
+            "utxo_present: the deferred lookup sweep could not run; presence is unknown");
+    }
+    return drained->first.contains(key);
 }
 
 


### PR DESCRIPTION
Moves Knuth from `utxoz/0.8.0` to `utxoz/0.9.0`, with `conan.lock` regenerated
from scratch rather than patched.

The visible half of this bump is a rename. The half that matters is what four
functions now return.

## The rename: `compact` → `reference`, for the MODE only

| UTXO-Z 0.8.0 | UTXO-Z 0.9.0 |
| --- | --- |
| `compact_db` | `reference_db` |
| `compact_find_result` | `reference_find_result` |
| `storage_mode::compact` | `storage_mode::reference` |
| `compact_file_size`, `compact_test_file_size` | `reference_*` |

Knuth follows: option `utxoz_compact` → `utxoz_reference`, macro
`KTH_UTXOZ_COMPACT_MODE` → `KTH_UTXOZ_REFERENCE_MODE`,
`database::utxoz_compact_mode()` → `utxoz_reference_mode()`, C-API
`kth_node_utxoz_compact_mode` → `kth_node_utxoz_reference_mode`, and the
internal `compact_utxo_ref` / `pack_compact_ref` that name the reference-mode
payload. 70 identifiers in all.

**What deliberately keeps the word**, because it is the compaction *operation*
or something else entirely: `utxoz_database::compact()` and UTXO-Z's
`compact_all()`; `block_chain::utxo_compact()`; BIP152 `compact_block` and
`send_compact`; `history_compact` and `stealth_compact`; `chain::compact` (the
difficulty-bits encoding); `CompactSize` in the consensus serialisers;
secp256k1's compact signature format; and `utxo_compact_block`, the UTXO
builder's small parsed-block view, which is used in **both** modes and is not
the storage mode at all.

Each rename rule names an exact identifier rather than the substring `compact`,
so none of the above could be caught by accident.

## The contracts that changed underneath

| Function | 0.8.0 | 0.9.0 | Breaks the build? |
| --- | --- | --- | --- |
| `compact_all()` | `void` | `result<>` | **No** |
| `process_pending_lookups()` | `pair<…>` | `result<pair<…>>` | Yes (×3) |
| `process_pending_deletions()` | `pair<…>` | `result<pair<…>>` | Yes |
| `erase()` | `size_t` | `result<size_t>` | Yes |

`compact_all()` is why this is not a version-number change: it used to return
`void`, so a caller that kept invoking it as a bare statement compiled exactly
as before while discarding every failure.

`erase()` is worth reading twice. It returned a count, and the natural migration
writes `*erased > 0 ? success : key_not_found` — which turns *the erase failed*
into *the key was not there*, about an entry that may still exist and still be
spendable. Both drains have the same shape: an unreadable catalogue is not an
empty queue, and the caller upstream reads absence as spent. All three now
report failure as failure.

## What is new rather than changed

- **`sync()`**, and `close()` does not do it for you. Wrapped as
  `utxoz_database::sync()`.
- **`platform_durability()` / `durability_level`**, which say what a successful
  sync is *worth*: under `contents_only` the file contents reach the disk and
  the directory entries naming them do not. Exposed as
  `utxoz_platform_durability()` rather than assumed.
- **The exclusive claim.** `open()` now distinguishes `database_in_use` (another
  instance holds it) from `database_lock_unavailable` (the claim could not be
  attempted at all — no permission, a filesystem without locking, a lock file
  that is not a regular file). UTXO-Z's own header notes these send an operator
  looking in different places, so they are logged as different things, alongside
  `recovery_required` / `recovery_failed` and a storage-mode mismatch.
- **The error enum grew from 5 values to 21.** Failures are now logged by name:
  the numbers moved, so an old note that said `error 3` names a different fault
  today. The naming switch is exhaustive with no `default`, so code 22 will stop
  the build rather than print "unknown".

## Negative controls

`src/blockchain/test/utxoz_contract.cpp` asserts the *shape* of these contracts,
mostly at compile time — a runtime test can only fail once the wrong call has
already been written and executed.

Proven non-vacuous by breaking it on purpose: reverting `compact()` to its
0.8.0 form fails the build with

```
utxoz_contract.cpp:72:24: error: static assertion failed:
  utxoz_database::compact() must report whether compaction happened
```

and the restored tree builds clean again. The exclusive-claim test has both
halves — a second `open()` is refused with `database_in_use`, **and** the path
opens again once released, so a library that refused every open would not pass.

## Verification

| Check | Result |
| --- | --- |
| `conan lock create` from scratch | `utxoz/0.9.0#1641e774…`, RC=0 |
| `conan install` (tests, rpc, C++23) | RC=0 |
| Full cold build, **full mode**, RPC on | 100%, RC=0 |
| Full build, **reference mode** | 100%, RC=0 |
| `kth_infrastructure_test` | 130992 assertions / 456 cases |
| `kth_domain_test` | 1008358 / 3823 |
| `kth_blockchain_test` (full mode) | 3802 / 221 |
| `kth_blockchain_test` (reference mode) | 3791 / 220 |
| `kth_blockchain_vmlimits_test` | 4732 / 21 |
| `kth_network_test` | 1440 / 85 |
| `kth_node_test` | 3318 / 169 |
| `kth_capi_test` | 2790 / 735 |

**Full mode remains the default** — in the recipe and in both CMake lists.
Reference mode is built and tested here as a *check*: it is the half of the
`#ifdef` that nothing in CI compiles, so a rename that broke it would go
unnoticed until someone turned the flag on. Doing that found a real defect this
PR fixes: the executor still printed `UTXO-Z mode: compact` for reference mode,
because the identifier was renamed and the string beside it was not.

`#602` is deliberately **not** included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added UTXO-Z reference-mode support across storage, blockchain processing, diagnostics, and version reporting.
  - Added database synchronization and durability-status reporting.
  - Compaction now reports whether it completed successfully.
  - Added exclusive database access handling and clearer reopening behavior.

- **API Updates**
  - Renamed compact-mode diagnostics and configuration options to reference-mode terminology.

- **Bug Fixes**
  - Improved handling of storage failures, invalid references, pending queues, lookup errors, and lock conflicts.
  - Prevented validation and synchronization from continuing after critical UTXO processing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->