### PR TITLE
blockchain: give the UTXO store the exclusion window its deletions require

### DIFF
--- a/src/blockchain/CMakeLists.txt
+++ b/src/blockchain/CMakeLists.txt
@@ -312,7 +312,9 @@ if (ENABLE_TEST)
         test/mempool_persistence_test.cpp
         test/block_template_test.cpp
         test/utxoz_roundtrip.cpp
-        test/utxoz_contract.cpp
+        test/utxo_gate.cpp
+          test/utxo_gate_bench.cpp
+          test/utxoz_contract.cpp
         test/verify_script_context.cpp
         test/batch_sigchecks.cpp
         test/finalization.cpp

--- a/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
+++ b/src/blockchain/include/kth/blockchain/interface/block_chain.hpp
@@ -34,6 +34,7 @@
 
 #include <kth/blockchain/define.hpp>
 #include <kth/blockchain/header_index.hpp>
+#include <kth/blockchain/utxo_gate.hpp>
 #include <kth/blockchain/pools/block_organizer.hpp>
 #include <kth/blockchain/pools/branch.hpp>
 #include <kth/blockchain/pools/capture_gate.hpp>
@@ -163,6 +164,19 @@ struct KB_API block_chain {
     code replace_headers_from(domain::chain::header::list const& headers, size_t start_height);
 #endif // ! defined(KTH_DB_READONLY)
 
+    /// Open the exclusive window over the UTXO store, for ONE logical operation.
+    ///
+    /// Held from before the first mutation until the set is coherent again — a
+    /// connect batch's inserts through its deletions, a rewind's restorations
+    /// through its final sweep. Per call would keep readers out of the mappings
+    /// and still admit one between the inserts and the deletions, where the set
+    /// holds outputs the blocks spent.
+    ///
+    /// Blocks until every admitted reader has left. Never held across a
+    /// suspension point: the mutating stretches it guards are synchronous.
+    [[nodiscard]]
+    utxo_write_window begin_utxo_write() { return utxo_gate_.write(); }
+
     /// What the persisted transition record says about the last transition
     /// (#600). Read before anything is mutated: `start()` asks it and refuses
     /// to come up on a database whose last transition did not finish.
@@ -183,16 +197,20 @@ struct KB_API block_chain {
     // Apply a batch of UTXO changes (full mode only — reference mode uses apply_utxo_delta_raw)
     template <database::utxo_insert_range Inserts>
     [[nodiscard]]
-    database::result_code apply_utxo_inserts(Inserts const& inserts) {
-        return utxoz_db_.apply_inserts(inserts);
+    database::result_code apply_utxo_inserts(
+        utxo_write_window const& window, Inserts const& inserts) {
+        return utxoz_db_.with_write(window,
+            [&](auto& db) { return db.apply_inserts(inserts); });
     }
 #endif
 
     // Apply a batch of raw UTXO changes (zero-copy path, no domain objects)
     template <typename Inserts>
     [[nodiscard]]
-    database::result_code apply_utxo_inserts_raw(Inserts const& inserts) {
-        return utxoz_db_.apply_inserts_raw(inserts);
+    database::result_code apply_utxo_inserts_raw(
+        utxo_write_window const& window, Inserts const& inserts) {
+        return utxoz_db_.with_write(window,
+            [&](auto& db) { return db.apply_inserts_raw(inserts); });
     }
 
     /// Apply a batch of deletions this caller owns. See
@@ -200,6 +218,7 @@ struct KB_API block_chain {
     /// matched back BY KEY, and only `unresolved` may be resent.
     [[nodiscard]]
     utxoz::deletion_progress utxo_apply_deletes(
+        utxo_write_window const& window,
         std::span<utxoz::deferred_deletion_entry const> requests);
 
     // Set last block height in LMDB (for fast IBD storage progress tracking)
@@ -273,9 +292,13 @@ struct KB_API block_chain {
     std::expected<void, database::block_store::undo_flush_error>
     flush_undo(std::span<int32_t const> file_numbers);
 
-    /// Step 9. UTXO-Z's own barrier, which `close()` does not run.
+    /// Step 9. UTXO-Z's own durability barrier, which `close()` does not run,
+    /// under the window of the operation it belongs to. Takes the capability
+    /// rather than opening its own: the connect batch and the rewind both call
+    /// it while still holding theirs, and this gate is deliberately not
+    /// recursive.
     [[nodiscard]]
-    database::barrier_outcome utxo_sync();
+    database::barrier_outcome utxo_sync(utxo_write_window const& window);
 
     /// What this node may claim about a published transition: the weakest of
     /// the four barriers above, not any one store's answer.
@@ -347,6 +370,7 @@ struct KB_API block_chain {
     ///        The rewind owns the batch and applies it once at the end: the
     ///        descent through the version files is paid per batch, not per key.
     database::disconnect_result disconnect_block(uint32_t height,
+        utxo_write_window const& window,
         boost::unordered_flat_map<utxoz::raw_outpoint, bool>& absence_tolerated,
         std::vector<utxoz::deferred_deletion_entry>& pending_deletes);
 
@@ -477,8 +501,12 @@ struct KB_API block_chain {
     ///         sees no difference between a complete walk and one that stopped.
     template <typename F>
     [[nodiscard]]
-    bool utxo_for_each(F&& callback) const {
-        return utxoz_db_.for_each_utxo(std::forward<F>(callback));
+    bool utxo_for_each(utxo_write_window const& window, F&& callback) const {
+        // Under the window rather than a lease: a full walk of every version is
+        // exactly the shape that must not overlap a mutation, and the bloom
+        // filter it feeds decides which keys a later delta may SKIP.
+        return utxoz_db_.with_read(window,
+            [&](auto const& db) { return db.for_each_utxo(std::forward<F>(callback)); });
     }
 
     // UTXO-Z size (number of UTXOs in the set)
@@ -890,6 +918,7 @@ private:
     ///         record then stays and the caller must treat the switch as fatal.
     [[nodiscard]]
     bool sweep_reorg_deletions(uint64_t operation_id,
+        utxo_write_window const& window,
         boost::unordered_flat_map<utxoz::raw_outpoint, bool> const& absence_tolerated,
         std::span<utxoz::deferred_deletion_entry const> pending_deletes);
 
@@ -912,6 +941,7 @@ private:
     ///         stays in place and the caller must treat the switch as fatal.
     [[nodiscard]]
     bool publish_reorg_transition(uint32_t connected_height, uint64_t operation_id,
+        utxo_write_window const& window,
         boost::unordered_flat_map<utxoz::raw_outpoint, bool> const& absence_tolerated,
         std::span<utxoz::deferred_deletion_entry const> pending_deletes);
 #endif
@@ -990,7 +1020,10 @@ private:
     std::unique_ptr<database::block_store> block_store_;
 
     // UTXO-Z high-performance UTXO database
-    database::utxoz_database utxoz_db_;
+    // The gate first: guarded_store holds a pointer to it, so it must outlive
+    // the store and therefore be declared before it.
+    mutable utxo_gate utxo_gate_;
+    guarded_store<database::utxoz_database> utxoz_db_;
 };
 
 } // namespace kth::blockchain

--- a/src/blockchain/include/kth/blockchain/utxo_gate.hpp
+++ b/src/blockchain/include/kth/blockchain/utxo_gate.hpp
@@ -1,0 +1,655 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef KTH_BLOCKCHAIN_UTXO_GATE_HPP
+#define KTH_BLOCKCHAIN_UTXO_GATE_HPP
+
+#include <chrono>
+#include <concepts>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <thread>
+#include <type_traits>
+#include <string>
+#include <utility>
+
+#include <kth/blockchain/define.hpp>
+#include <kth/infrastructure/utility/assert.hpp>
+
+namespace kth::blockchain {
+
+class utxo_gate;
+
+/// Raised when a thread that already holds the exclusive window asks for another
+/// window, or for a read lease.
+///
+/// FAIL-FAST DETECTION, never authorisation: the recorded thread id is used only
+/// to refuse, and never to grant, bypass or transfer a capability. Reentering
+/// would deadlock — the gate is deliberately not recursive — and this turns that
+/// hang into an immediate, named error at the site that caused it.
+///
+/// It exists because scope discipline alone proved insufficient: three accidental
+/// reentries occurred in one change, one of them in production (`start()` in
+/// reference mode, where a window covering the whole function met the wiring
+/// below it).
+struct KB_API utxo_reentry_error : std::logic_error {
+    using std::logic_error::logic_error;
+};
+
+/// Raised when a capability is moved or used by a thread other than the one that
+/// took it from the gate.
+///
+/// The contract IS thread-affine, and this makes that checkable instead of
+/// merely written down. The exclusion this gate sells is over a window in one
+/// thread's execution: the scope audit that justifies it is per function per
+/// thread, and the rule that no capability may live across a `co_await` exists
+/// precisely because a coroutine resumes on whichever executor thread is free —
+/// which is a thread transfer wearing a different shape.
+///
+/// A capability that authorised anywhere would also silence the reentry
+/// detection: the gate's recorded owner would still name the thread that took
+/// the window, so the thread actually holding it could ask for another one and
+/// be told to wait for itself.
+struct KB_API utxo_affinity_error : std::logic_error {
+    using std::logic_error::logic_error;
+};
+
+/// Raised when a thread holding the UTXO window reaches for a lock that the rest
+/// of the node takes BEFORE the UTXO gate.
+///
+/// The node has two locks and one order. The transaction organizer takes
+/// `validation_mutex_` and then, inside `validator_.accept()`, a UTXO read
+/// lease. A connect batch that still held the window while taking that same
+/// mutex would be acquiring them in the opposite order, and two threads doing
+/// both at once is the AB-BA deadlock — which appears as a node that stops, with
+/// no error and nothing in the log.
+///
+/// Detection, exactly like utxo_reentry_error: the recorded thread is read only
+/// to refuse. The right fix is always to end the window first — the invariant is
+/// that nothing under it may take another of the node's locks.
+struct KB_API utxo_lock_order_error : std::logic_error {
+    using std::logic_error::logic_error;
+};
+
+namespace detail {
+
+/// Shared by both capabilities: a transfer is legal only while the thread doing
+/// it is the one the gate issued to. An empty capability transfers nothing, so
+/// it moves freely.
+inline void check_capability_move(bool held, std::thread::id owner, char const* what) {
+    if (held && owner != std::this_thread::get_id()) {
+        throw utxo_affinity_error(
+            std::string("a UTXO ") + what + " was moved by a thread other than the "
+            "one that took it; capabilities are thread-affine");
+    }
+}
+
+/// The pending-writer bookkeeping of utxo_gate, extracted so its exceptional
+/// path can be exercised directly rather than argued about.
+///
+/// Writer preference means a reader waits for the pending count to reach zero.
+/// So a writer that stops waiting — by timing out, or by unwinding — owes two
+/// things and not one: the count restored AND a notification. The decrement
+/// alone changes nothing for a reader already parked in `cv.wait()`, because a
+/// condition variable re-evaluates its predicate only when it is notified. A
+/// count restored in silence leaves that reader waiting for a writer that is
+/// already gone.
+///
+/// @par The order, which is the whole of it
+/// Decrement under the mutex, release the mutex, then notify.
+///   - unguarded decrement would race the readers that read the count;
+///   - notifying while still holding the mutex is legal, but wakes readers
+///     straight into blocking on it again;
+///   - notifying before the decrement would be the premature one: the reader
+///     wakes, finds its predicate still false and parks again, having consumed
+///     the only notification it was going to get.
+class pending_writer {
+public:
+    pending_writer(size_t& count, std::condition_variable& cv,
+                   std::unique_lock<std::mutex>& lock)
+        : count_(&count), cv_(&cv), lock_(&lock) {
+        ++*count_;
+    }
+
+    pending_writer(pending_writer const&) = delete;
+    pending_writer& operator=(pending_writer const&) = delete;
+
+    /// The wait succeeded and the caller is becoming the writer: restore the
+    /// count and stand down. No notification, because the caller is about to
+    /// set writer_active_ and every reader's predicate stays false either way;
+    /// and the lock stays held, because the caller still has state to publish
+    /// under it.
+    void acquired() {
+        if (count_ == nullptr) {
+            return;
+        }
+        --*count_;
+        count_ = nullptr;
+    }
+
+    /// Gave up, or unwinding out of the wait.
+    ///
+    /// The mutex is held here: `condition_variable::wait` re-acquires it before
+    /// propagating an exception, so an unwinding writer arrives holding it just
+    /// as a timed-out one does. `owns_lock()` is checked anyway — a destructor
+    /// may not throw, and `unlock()` on a lock that is not held does.
+    ~pending_writer() {
+        if (count_ == nullptr) {
+            return;
+        }
+        --*count_;
+        if (lock_->owns_lock()) {
+            lock_->unlock();
+        }
+        cv_->notify_all();
+    }
+
+private:
+    size_t* count_;
+    std::condition_variable* cv_;
+    std::unique_lock<std::mutex>* lock_;
+};
+
+} // namespace detail
+
+
+/// Proof that the exclusive window over the UTXO store is held.
+///
+/// UTXO-Z 0.10 requires apply_deletes() to run with no find(), resolve(),
+/// insert(), compaction or close() in flight: it erases from the active
+/// containers AND writes through the file cache's mappings, and the library's
+/// own lock covers resolve-vs-resolve only. This is that window (#649).
+///
+/// It is a capability, not a convention. The store cannot be reached without one
+/// of these or a read lease — see guarded_store — so a caller that forgets is a
+/// compile error rather than a race, and a caller added later inherits the rule
+/// without knowing it exists.
+///
+/// @par It covers the OPERATION, not the call
+/// Held across the whole logical mutation: for a connect batch from before the
+/// first insert until the deletions have left the set coherent; for a
+/// reorganization the entire rewind, restorations and final sweep included. Per
+/// call would still keep readers out of the mappings, but it would let one in
+/// between the inserts and the deletions — where the set holds outputs the
+/// blocks spent, and the transition record does not protect a reader that never
+/// consults it.
+class KB_API utxo_write_window {
+public:
+    utxo_write_window(utxo_write_window const&) = delete;
+    utxo_write_window& operator=(utxo_write_window const&) = delete;
+
+    /// Movable, and DELIBERATELY not noexcept: the move is checked, because a
+    /// capability that changed threads silently would authorise a store access
+    /// from a thread the gate never admitted.
+    utxo_write_window(utxo_write_window&& other)
+        : gate_(nullptr), owner_() {
+        detail::check_capability_move(other.gate_ != nullptr, other.owner_, "write window");
+        gate_ = std::exchange(other.gate_, nullptr);
+        owner_ = std::exchange(other.owner_, std::thread::id{});
+    }
+
+    utxo_write_window& operator=(utxo_write_window&& other) {
+        if (this != &other) {
+            // Checked BEFORE releasing: a refused move must leave both sides as
+            // they were, not destroy the capability it declined to overwrite.
+            detail::check_capability_move(other.gate_ != nullptr, other.owner_, "write window");
+            release();
+            gate_ = std::exchange(other.gate_, nullptr);
+            owner_ = std::exchange(other.owner_, std::thread::id{});
+        }
+        return *this;
+    }
+
+    /// Releases on every path, including an exception or a cancellation midway.
+    /// The door must never be left shut by a failure — the failure's own
+    /// fail-closed handling refuses to publish, which is a different mechanism.
+    ///
+    /// Destruction is deliberately NOT affinity-checked. A destructor that threw
+    /// during unwinding would call std::terminate, so releasing from another
+    /// thread is defined rather than refused: it takes the gate's mutex like any
+    /// other release, opens the door and wakes whoever waits. Refusing the USE is
+    /// what protects the store; refusing the RELEASE would only strand it.
+    ~utxo_write_window() { release(); }
+
+    [[nodiscard]] bool held() const { return gate_ != nullptr; }
+
+    /// Whether this capability was issued by `gate` and is still held. A token
+    /// from another gate authorises nothing: it proves exclusion over a store
+    /// that is not the one being reached for.
+    [[nodiscard]] bool authorises(utxo_gate const& gate) const {
+        return gate_ == &gate;
+    }
+
+    /// Whether the asking thread is the one the gate issued this to. Checked at
+    /// every access, so a capability that reached another thread stops
+    /// authorising there even though it still names the right gate.
+    [[nodiscard]] bool on_issuing_thread() const {
+        return owner_ == std::this_thread::get_id();
+    }
+
+private:
+    friend class utxo_gate;
+    explicit utxo_write_window(utxo_gate& gate)
+        : gate_(&gate), owner_(std::this_thread::get_id()) {}
+    void release();
+
+    utxo_gate* gate_;
+    std::thread::id owner_;
+};
+
+/// Proof that a shared read lease is held: many of these may coexist, none of
+/// them with a write window.
+class KB_API utxo_read_lease {
+public:
+    utxo_read_lease(utxo_read_lease const&) = delete;
+    utxo_read_lease& operator=(utxo_read_lease const&) = delete;
+
+    /// Thread-affine for the same reason as the window, and it is not a weaker
+    /// case: a lease that authorised elsewhere would let a thread the gate never
+    /// counted read the store, which is exactly what the window is meant to
+    /// exclude.
+    utxo_read_lease(utxo_read_lease&& other)
+        : gate_(nullptr), owner_() {
+        detail::check_capability_move(other.gate_ != nullptr, other.owner_, "read lease");
+        gate_ = std::exchange(other.gate_, nullptr);
+        owner_ = std::exchange(other.owner_, std::thread::id{});
+    }
+
+    utxo_read_lease& operator=(utxo_read_lease&& other) {
+        if (this != &other) {
+            detail::check_capability_move(other.gate_ != nullptr, other.owner_, "read lease");
+            release();
+            gate_ = std::exchange(other.gate_, nullptr);
+            owner_ = std::exchange(other.owner_, std::thread::id{});
+        }
+        return *this;
+    }
+
+    /// Not affinity-checked, for the reason given on the window's destructor.
+    ~utxo_read_lease() { release(); }
+
+    [[nodiscard]] bool held() const { return gate_ != nullptr; }
+
+    [[nodiscard]] bool authorises(utxo_gate const& gate) const {
+        return gate_ == &gate;
+    }
+
+    [[nodiscard]] bool on_issuing_thread() const {
+        return owner_ == std::this_thread::get_id();
+    }
+
+private:
+    friend class utxo_gate;
+    explicit utxo_read_lease(utxo_gate& gate)
+        : gate_(&gate), owner_(std::this_thread::get_id()) {}
+    void release();
+
+    utxo_gate* gate_;
+    std::thread::id owner_;
+};
+
+/// Readers-or-one-writer over the UTXO store, with writer preference.
+///
+/// @par Why not the node's priority mutex
+/// It has no shared mode — it serialises everything one at a time — and it is
+/// taken across coroutine suspension points, which is undefined behaviour a
+/// reader/writer split would inherit. Nothing here is ever held across a
+/// suspension: every store operation this guards is synchronous, and the leases
+/// carry a count rather than a lock.
+///
+/// @par Not a check, a wait
+/// A writer does not ask whether readers are present and proceed. It marks
+/// itself pending — which closes the door to readers that have not entered yet,
+/// immediately — and then waits under the mutex until the reader count reaches
+/// zero. There is no instant at which the answer could go stale between the
+/// question and the mutation, which is what a "no readers right now" test would
+/// have.
+/// @par What this does NOT detect: an upgrade
+/// Nothing on utxo_read_lease yields a window — there is no upgrade operation to
+/// call — so the only way to form one is for a caller to hold a lease and then
+/// ask the gate for a window in the same scope. That WOULD self-deadlock, and
+/// this gate cannot see it coming: capabilities are values the caller holds, not
+/// context the gate can inspect, and reconstructing ownership from thread::id
+/// was rejected deliberately when capabilities were chosen over it.
+///
+/// So the honest statement is: the upgrade is REACHABLE — begin_utxo_write() can
+/// be called while a read lease is alive — but it is not supported, and the
+/// blocking variant would self-deadlock if anyone did it. What keeps it from
+/// happening is that no caller forms the pattern: audited, and every lease in
+/// block_chain dies with the single function that took it. try_write_for() below
+/// exists as a defensive bound for tests, NOT as upgrade detection.
+///
+/// @par Thread affinity, and the one case it still does not cover
+/// Capabilities are thread-affine and checked: moving one out of its issuing
+/// thread throws, and using one from another thread throws, so a window cannot
+/// quietly authorise a store access on a thread the gate never admitted (see
+/// utxo_affinity_error). Releasing from another thread stays defined, because a
+/// destructor cannot refuse.
+///
+/// What remains: an owner may still park a live capability in shared state, and
+/// a second thread that merely HOLDS it — without ever using it — can then ask
+/// for a window and wait for one nothing will release. The gate cannot tell that
+/// apart from the ordinary case of a thread legitimately waiting for a window
+/// another thread holds; the two are identical from here, and separating them
+/// needs the ownership tracking that capabilities were chosen over. Both useful
+/// shapes of the transfer are refused, this one is not, and no production path
+/// forms it: every capability is a `const` local that dies in the function that
+/// took it.
+class KB_API utxo_gate {
+public:
+    utxo_gate() = default;
+
+    /// A capability that outlived its gate would release into freed memory, and
+    /// the crash would surface far from the ordering mistake that caused it —
+    /// in a destructor, during shutdown, with nothing left to point at. Caught
+    /// here instead, where the mistake actually is.
+    ///
+    /// KTH_CONTRACT and not KTH_ASSERT: this must hold in Release, which is the
+    /// only build a node runs.
+    ~utxo_gate() {
+        std::lock_guard<std::mutex> guard(mutex_);
+        KTH_CONTRACT(readers_ == 0 && ! writer_active_ && writers_waiting_ == 0);
+    }
+
+    utxo_gate(utxo_gate const&) = delete;
+    utxo_gate& operator=(utxo_gate const&) = delete;
+
+    /// Admit a reader. Blocks while a writer holds or has asked for the window.
+    ///
+    /// @par ONE lease per thread, and it is an invariant rather than a style
+    /// A thread holding a lease and asking for a SECOND one self-deadlocks if a
+    /// writer becomes pending in between: the second request waits for
+    /// writers_waiting_ == 0, and the writer waits for readers_ == 0 — which the
+    /// first lease is holding above zero. Writer preference is what makes it a
+    /// deadlock rather than a delay.
+    ///
+    /// Not detectable here, for the same reason the read-then-write upgrade is
+    /// not: leases are values the caller holds, not context the gate can inspect,
+    /// and counting per thread was rejected with the rest of ownership tracking.
+    /// What holds it up is the audit — every lease in block_chain dies with the
+    /// single function that took it, and nothing nests — plus the bounded
+    /// regression in the suite.
+    [[nodiscard]]
+    utxo_read_lease read() {
+        std::unique_lock<std::mutex> guard(mutex_);
+        // Refused, not waited on: this thread is holding the window this lease
+        // would wait for. Detection only — a thread that does NOT hold the
+        // window is never granted anything on the strength of its id.
+        if (writer_active_ && owner_ == std::this_thread::get_id()) {
+            throw utxo_reentry_error(
+                "a read lease was requested by the thread already holding the "
+                "exclusive window; reading under the window is not supported");
+        }
+        // Writer preference, and it is the point rather than a tuning choice: a
+        // stream of readers must not be able to starve the deletion that a
+        // batch cannot publish without.
+        cv_.wait(guard, [this] { return ! writer_active_ && writers_waiting_ == 0; });
+        ++readers_;
+        return utxo_read_lease(*this);
+    }
+
+    /// Take the exclusive window. Blocks until every admitted reader has left.
+    [[nodiscard]]
+    utxo_write_window write() {
+        std::unique_lock<std::mutex> guard(mutex_);
+        if (writer_active_ && owner_ == std::this_thread::get_id()) {
+            throw utxo_reentry_error(
+                "the exclusive window was requested by the thread already holding "
+                "it; the gate is not recursive");
+        }
+        detail::pending_writer pending(writers_waiting_, cv_, guard);
+        // The only exception this call can propagate is the predicate's, and
+        // this predicate reads two members: on this implementation the guard's
+        // exceptional path is unreachable from here. It is written to be correct
+        // regardless, and tested where it lives rather than through this call.
+        cv_.wait(guard, [this] { return ! writer_active_ && readers_ == 0; });
+        pending.acquired();
+        writer_active_ = true;
+        owner_ = std::this_thread::get_id();
+        return utxo_write_window(*this);
+    }
+
+    /// Take the window, or give up. Returns nullopt rather than waiting past the
+    /// deadline.
+    ///
+    /// Not for production paths — a batch that gave up on its window would have
+    /// to decide what to do with a half-applied delta, and #602's answer is that
+    /// it must not have one. It exists so a test can assert that an exclusion
+    /// defect FAILS rather than hanging: a suite that deadlocks tells an
+    /// operator nothing except that CI timed out.
+    [[nodiscard]]
+    std::optional<utxo_write_window> try_write_for(std::chrono::milliseconds budget) {
+        std::unique_lock<std::mutex> guard(mutex_);
+        // Same refusal as write(), and for the same reason: waiting out the
+        // budget would report a programming error as contention, and hand back a
+        // nullopt that reads as "someone else had it" when nobody did.
+        if (writer_active_ && owner_ == std::this_thread::get_id()) {
+            throw utxo_reentry_error(
+                "the exclusive window was requested by the thread already holding "
+                "it; the gate is not recursive");
+        }
+        {
+            detail::pending_writer pending(writers_waiting_, cv_, guard);
+            if ( ! cv_.wait_for(guard, budget,
+                    [this] { return ! writer_active_ && readers_ == 0; })) {
+                // Restored, released and announced by ~pending_writer, in that
+                // order. Giving up in silence would leave every later reader
+                // waiting on a count nothing will lower again.
+                return std::nullopt;
+            }
+            pending.acquired();
+        }
+        writer_active_ = true;
+        owner_ = std::this_thread::get_id();
+        return utxo_write_window(*this);
+    }
+
+    /// A reader that gives up rather than waiting, for the same reason as
+    /// try_write_for: a test must be able to observe "did not acquire" as a
+    /// value instead of hanging.
+    [[nodiscard]]
+    std::optional<utxo_read_lease> try_read_for(std::chrono::milliseconds budget) {
+        std::unique_lock<std::mutex> guard(mutex_);
+        if (writer_active_ && owner_ == std::this_thread::get_id()) {
+            throw utxo_reentry_error(
+                "a read lease was requested by the thread already holding the "
+                "exclusive window; reading under the window is not supported");
+        }
+        auto const got = cv_.wait_for(guard, budget,
+            [this] { return ! writer_active_ && writers_waiting_ == 0; });
+        if ( ! got) {
+            return std::nullopt;
+        }
+        ++readers_;
+        return utxo_read_lease(*this);
+    }
+
+    /// Diagnostics for tests. Never a basis for a decision: a count read outside
+    /// the mutex is a fact about the past.
+    [[nodiscard]] size_t readers() const {
+        std::lock_guard<std::mutex> guard(mutex_);
+        return readers_;
+    }
+
+    /// How many writers are waiting for the window. Diagnostics only, and the
+    /// same caveat as readers(): a count read outside the mutex is a fact about
+    /// the past. A test uses it to know a writer has actually become pending
+    /// instead of sleeping and hoping.
+    [[nodiscard]] size_t writers_waiting() const {
+        std::lock_guard<std::mutex> guard(mutex_);
+        return writers_waiting_;
+    }
+
+    [[nodiscard]] bool writing() const {
+        std::lock_guard<std::mutex> guard(mutex_);
+        return writer_active_;
+    }
+
+    /// Whether THIS thread is the one holding the window.
+    ///
+    /// For refusing, never for granting: it is what lets a lock-order control
+    /// say "you are under the window, do not take that mutex here" at the site
+    /// rather than leaving it to be found as a hang. Unlike `writing()`, the
+    /// answer is about the caller, so it cannot be misread as permission —
+    /// with_read/with_write still ask the capability and never the thread.
+    [[nodiscard]] bool held_by_current_thread() const {
+        std::lock_guard<std::mutex> guard(mutex_);
+        return writer_active_ && owner_ == std::this_thread::get_id();
+    }
+
+private:
+    friend class utxo_write_window;
+    friend class utxo_read_lease;
+
+    void end_read() {
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
+            --readers_;
+        }
+        cv_.notify_all();
+    }
+
+    void end_write() {
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
+            writer_active_ = false;
+            // Cleared on every path, an exception included: the destructor runs
+            // during unwinding, so a stale owner cannot outlive a failed
+            // operation and refuse the next one.
+            owner_ = std::thread::id{};
+        }
+        cv_.notify_all();
+    }
+
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    size_t readers_{0};
+    size_t writers_waiting_{0};
+    bool writer_active_{false};
+
+    /// Whoever holds the window, for DETECTION only. Never read to authorise an
+    /// access: with_read/with_write ask the capability, never the thread.
+    std::thread::id owner_{};
+};
+
+inline void utxo_write_window::release() {
+    if (gate_ != nullptr) {
+        gate_->end_write();
+        gate_ = nullptr;
+    }
+}
+
+inline void utxo_read_lease::release() {
+    if (gate_ != nullptr) {
+        gate_->end_read();
+        gate_ = nullptr;
+    }
+}
+
+/// Raised when a capability does not authorise the access it was offered for.
+///
+/// A programming error, surfaced rather than left as undefined behaviour: a
+/// token from a different gate, or one already released, proves exclusion over
+/// something that is not this store — or over nothing at all.
+struct KB_API utxo_capability_error : std::logic_error {
+    using std::logic_error::logic_error;
+};
+
+
+/// A callback whose result cannot carry the store out of the scope that
+/// authorised reaching it. void and owned values pass; references and pointers
+/// do not — expressed as a constraint rather than an assertion in the body, so
+/// the ill-formed shape is DETECTABLE rather than merely fatal.
+template <typename F, typename Arg>
+concept escaping_free_result =
+    std::invocable<F, Arg> &&
+    ! std::is_reference_v<std::invoke_result_t<F, Arg>> &&
+    ! std::is_pointer_v<std::invoke_result_t<F, Arg>>;
+
+/// A value reachable only under proof that the gate authorises the access.
+///
+/// This is what makes the exclusion structural rather than a habit. There is no
+/// operator->, no getter and no way to name the value: access is handed to a
+/// callback for the duration of the call, so a method of block_chain that
+/// reaches for the store without a capability does not compile — including one
+/// written years from now by someone who never read this file.
+///
+/// @par Why a callback and not a reference
+/// A `T& under(capability)` would let the reference outlive the capability that
+/// justified it, which is exactly the guarantee being sold. Scoping the access
+/// to a call removes the ordinary way to do that by accident. A callback that
+/// deliberately stashes the reference can still escape it — no C++ API prevents
+/// that without a lifetime annotation — so this is a barrier against the
+/// mistake, not against the intent, and the difference is worth stating.
+template <typename T>
+class guarded_store {
+public:
+    explicit guarded_store(utxo_gate& gate) : gate_(&gate) {}
+
+    guarded_store(guarded_store const&) = delete;
+    guarded_store& operator=(guarded_store const&) = delete;
+
+    /// Mutating access, for the operation holding the exclusive window.
+    ///
+    /// The callback may return void or a value of its own. It may NOT return a
+    /// reference or a pointer: that is the accidental way the store escapes the
+    /// scope that justified reaching it, and it is the one worth closing. A
+    /// callback determined to stash the reference still can — see the note above
+    /// — but nothing here hands it out by return.
+    template <typename F>
+        requires escaping_free_result<F, T&>
+    decltype(auto) with_write(utxo_write_window const& window, F&& callback) {
+        authorise(window, "write");
+        return std::forward<F>(callback)(value_);
+    }
+
+    /// Reading access under a shared lease.
+    template <typename F>
+        requires escaping_free_result<F, T const&>
+    decltype(auto) with_read(utxo_read_lease const& lease, F&& callback) const {
+        authorise(lease, "read");
+        return std::forward<F>(callback)(value_);
+    }
+
+    /// Reading access from INSIDE the exclusive window, authorised by the
+    /// capability the operation already holds rather than by which thread is
+    /// asking. Undo capture reads the set in the middle of a connect batch, and
+    /// a lease there would wait on the window its own operation is holding.
+    template <typename F>
+        requires escaping_free_result<F, T const&>
+    decltype(auto) with_read(utxo_write_window const& window, F&& callback) const {
+        authorise(window, "read under the write window");
+        return std::forward<F>(callback)(value_);
+    }
+
+private:
+    /// Two independent questions, asked in this order and reported apart because
+    /// they are different mistakes: the capability must name THIS gate, and the
+    /// thread asking must be the one the gate issued it to. Naming the right gate
+    /// first matters — a released or moved-from capability has no meaningful
+    /// issuing thread, and reporting affinity for it would misname the defect.
+    template <typename Capability>
+    void authorise(Capability const& capability, char const* what) const {
+        if ( ! capability.authorises(*gate_)) {
+            throw utxo_capability_error(
+                std::string("the capability offered for ") + what +
+                " was released, default-constructed, or issued by another gate");
+        }
+        if ( ! capability.on_issuing_thread()) {
+            throw utxo_affinity_error(
+                std::string("the capability offered for ") + what +
+                " was taken by another thread; it authorises nothing here");
+        }
+    }
+
+    utxo_gate* gate_;
+    T value_;
+};
+
+} // namespace kth::blockchain
+
+#endif

--- a/src/blockchain/src/interface/block_chain.cpp
+++ b/src/blockchain/src/interface/block_chain.cpp
@@ -115,6 +115,7 @@ block_chain::block_chain(blockchain::settings const& chain_settings,
     , priority_pool_("priority", std::min(size_t(8), thread_ceiling(chain_settings.cores)))
     , transaction_organizer_(validation_mutex_, priority_pool_.get_executor(), priority_pool_.size(), priority_pool_, *this, chain_settings)
     , block_organizer_(validation_mutex_, priority_pool_.get_executor(), priority_pool_.size(), priority_pool_, *this, chain_settings, network, relay_transactions)
+    , utxoz_db_(utxo_gate_)
 {
     spdlog::debug("[blockchain] block_chain constructor completed successfully");
     spdlog::info("[blockchain] Mempool backend: {}", mempool_backend_name);
@@ -204,9 +205,17 @@ bool block_chain::start(uint32_t disk_magic) {
     // Open UTXO-Z database (in a subdirectory of the main database)
     utxoz::set_log_prefix("UTXO-Z");
     auto utxoz_path = database_.internal_db_dir.parent_path() / "utxoz";
-    if ( ! utxoz_db_.open(utxoz_path)) {
-        spdlog::error("[blockchain] Failed to open UTXO-Z database at {}", utxoz_path.string());
-        return false;
+    // Scoped to the open itself. Held for the rest of start() it would deadlock
+    // against the reference-mode wiring below, which takes a window of its own —
+    // and only in reference mode, so a full-mode build would never show it and
+    // the node would hang at startup on the other one.
+    {
+        auto const lifecycle = utxo_gate_.write();
+        if ( ! utxoz_db_.with_write(lifecycle, [&](auto& db) { return db.open(utxoz_path); })) {
+            spdlog::error("[blockchain] Failed to open UTXO-Z database at {}",
+                utxoz_path.string());
+            return false;
+        }
     }
     spdlog::info("[blockchain] UTXO-Z database opened at {}", utxoz_path.string());
 
@@ -462,8 +471,17 @@ bool block_chain::start(uint32_t disk_magic) {
 
 #ifdef KTH_UTXOZ_REFERENCE_MODE
     // Wire block_store and header_index to UTXO-Z for reference mode find resolution
-    utxoz_db_.set_block_store(block_store_.get());
-    utxoz_db_.set_header_index(&header_index_);
+    // Scoped to the wiring it authorises, and for the same reason the open above
+    // is: a window that outlived its callback once already met another one and
+    // hung the node at startup, in reference mode only. Nothing follows this here
+    // today — but the previous version of that sentence was also true.
+    {
+        auto const configure = utxo_gate_.write();
+        utxoz_db_.with_write(configure, [&](auto& db) {
+            db.set_block_store(block_store_.get());
+            db.set_header_index(&header_index_);
+        });
+    }
     spdlog::info("[blockchain] UTXO-Z reference mode: block_store and header_index wired for find resolution");
 #endif
 
@@ -487,7 +505,12 @@ bool block_chain::close() {
     // is torn down (the path is a plain sibling of the DB, still valid here).
     dump_mempool_to_disk();
     priority_pool_.join();
-    utxoz_db_.close();
+    {
+        // close() is a mutation of the store's own state; it needs the same
+        // window as any other, for its whole operation.
+        auto closing = utxo_gate_.write();
+        utxoz_db_.with_write(closing, [](auto& db) { db.close(); });
+    }
     return result && database_.close();
 }
 
@@ -897,8 +920,8 @@ block_chain::flush_undo(std::span<int32_t const> file_numbers) {
     return block_store_->flush_undo(file_numbers);
 }
 
-database::barrier_outcome block_chain::utxo_sync() {
-    return utxoz_db_.sync();
+database::barrier_outcome block_chain::utxo_sync(utxo_write_window const& window) {
+    return utxoz_db_.with_write(window, [](auto& db) { return db.sync(); });
 }
 
 database::durability_level block_chain::durability() const {
@@ -910,13 +933,15 @@ database::result_code block_chain::set_last_block_height(uint32_t height) {
 }
 
 utxoz::deletion_progress block_chain::utxo_apply_deletes(
-    std::span<utxoz::deferred_deletion_entry const> requests) {
-    return utxoz_db_.apply_deletes(requests);
+    utxo_write_window const& window, std::span<utxoz::deferred_deletion_entry const> requests) {
+    return utxoz_db_.with_write(window,
+        [&](auto& db) { return db.apply_deletes(requests); });
 }
 
 std::expected<database::utxoz_database::entry_resolution, database::result_code>
 block_chain::utxo_resolve(std::span<utxoz::lookup_request const> requests) const {
-    return utxoz_db_.resolve(requests);
+    auto lease = utxo_gate_.read();
+    return utxoz_db_.with_read(lease, [&](auto const& db) { return db.resolve(requests); });
 }
 
 // =============================================================================
@@ -925,12 +950,14 @@ block_chain::utxo_resolve(std::span<utxoz::lookup_request const> requests) const
 
 std::expected<database::utxoz_database::raw_stored, database::result_code>
 block_chain::find_utxo_raw(utxoz::raw_outpoint const& key, uint32_t height) const {
-    return utxoz_db_.find_raw(key, height);
+    auto lease = utxo_gate_.read();
+    return utxoz_db_.with_read(lease, [&](auto const& db) { return db.find_raw(key, height); });
 }
 
 std::expected<database::utxoz_database::raw_resolution, database::result_code>
 block_chain::utxo_resolve_raw(std::span<utxoz::lookup_request const> requests) const {
-    return utxoz_db_.resolve_raw(requests);
+    auto lease = utxo_gate_.read();
+    return utxoz_db_.with_read(lease, [&](auto const& db) { return db.resolve_raw(requests); });
 }
 
 #if ! defined(KTH_DB_READONLY)
@@ -981,6 +1008,7 @@ block_chain::read_block_undo(database::header_index::index_t idx, hash_digest co
 
 #if ! defined(KTH_DB_READONLY)
 database::disconnect_result block_chain::disconnect_block(uint32_t height,
+    utxo_write_window const& window,
     boost::unordered_flat_map<utxoz::raw_outpoint, bool>& absence_tolerated,
     std::vector<utxoz::deferred_deletion_entry>& pending_deletes) {
     // Genesis anchors the chain and has no parent to roll back to.
@@ -1101,7 +1129,8 @@ database::disconnect_result block_chain::disconnect_block(uint32_t height,
         fold_absence_tolerance(absence_tolerated, key, spent_here.contains(key));
     }
 
-    auto const result = utxoz_db_.apply_inserts_raw(inverse.inserts);
+    auto const result = utxoz_db_.with_write(window,
+        [&](auto& db) { return db.apply_inserts_raw(inverse.inserts); });
     if (result != database::result_code::success) {
         spdlog::error("[blockchain] disconnect_block: failed to restore spent outputs at height {}",
             height);
@@ -1208,6 +1237,13 @@ block_chain::switch_result block_chain::switch_to_branch(
     // Accumulated across every block this rewind disconnects, and consumed once
     // by the sweep below. Per-block by construction: each disconnect adds only
     // the keys ITS own inverse delta created and spent within itself.
+    // ONE window for the whole rewind: the restorations, every disconnect, and
+    // the final sweep. A reader admitted between them would see a set holding
+    // outputs of blocks this switch is abandoning, and it would not consult the
+    // transition record to know better. Synchronous throughout — nothing below
+    // suspends — so the capability never crosses a co_await (#649).
+    auto const window = utxo_gate_.write();
+
     // Per key, whether a proven absence is tolerable: true only while every
     // block that asked for this key's deletion created and spent it itself.
     boost::unordered_flat_map<utxoz::raw_outpoint, bool> absence_tolerated;
@@ -1276,7 +1312,7 @@ block_chain::switch_result block_chain::switch_to_branch(
         // Newest first: disconnecting out of order would restore outputs that a
         // later block still spends.
         for (uint32_t h = heights->block; h > fork_height; --h) {
-            auto const result = disconnect_block(h, absence_tolerated, pending_deletes);
+            auto const result = disconnect_block(h, window, absence_tolerated, pending_deletes);
 
             if (result == database::disconnect_result::unclean) {
                 // The delta was applied, so this counts as a mutation even
@@ -1315,7 +1351,7 @@ block_chain::switch_result block_chain::switch_to_branch(
                 // the next start from refusing over a database that is whole.
                 spdlog::error("[blockchain] Reorg: failed to disconnect block at height {}, "
                     "aborting the switch (validated tip is now {})", h, h);
-                if ( ! publish_reorg_transition(h, operation_id, absence_tolerated, pending_deletes)) {
+                if ( ! publish_reorg_transition(h, operation_id, window, absence_tolerated, pending_deletes)) {
                     return {false, std::nullopt, mutated, /*fatal*/ true};
                 }
                 return {false, h, mutated};
@@ -1330,7 +1366,7 @@ block_chain::switch_result block_chain::switch_to_branch(
     // disconnected: no record was written, so there is nothing to publish and
     // nothing to clear, and asking four stores for a barrier over no mutation
     // would only cost the fsyncs.
-    if (record_written && ! publish_reorg_transition(validated_tip, operation_id,
+    if (record_written && ! publish_reorg_transition(validated_tip, operation_id, window,
             absence_tolerated, pending_deletes)) {
         // The chain has moved and the transition could not be recorded as
         // finished. No tip is reported: the caller reads that as fatal, leaves
@@ -1352,6 +1388,7 @@ block_chain::switch_result block_chain::switch_to_branch(
 }
 
 bool block_chain::sweep_reorg_deletions(uint64_t operation_id,
+    utxo_write_window const& window,
     boost::unordered_flat_map<utxoz::raw_outpoint, bool> const& absence_tolerated,
     std::span<utxoz::deferred_deletion_entry const> pending_deletes) {
     // This function deliberately touches NOTHING that is shared with a reader.
@@ -1397,8 +1434,8 @@ bool block_chain::sweep_reorg_deletions(uint64_t operation_id,
     auto const outcome = run_deletion_sweep(
         std::vector<utxoz::deferred_deletion_entry>(pending_deletes.begin(), pending_deletes.end()),
         absence_tolerated,
-        [this](std::span<utxoz::deferred_deletion_entry const> batch) {
-            return utxo_apply_deletes(batch);
+        [this, &window](std::span<utxoz::deferred_deletion_entry const> batch) {
+            return utxo_apply_deletes(window, batch);
         },
         max_deletion_attempts,
         [&](int attempt, utxoz::deletion_progress const& progress) {
@@ -1445,13 +1482,14 @@ bool block_chain::sweep_reorg_deletions(uint64_t operation_id,
 }
 
 bool block_chain::publish_reorg_transition(uint32_t connected_height, uint64_t operation_id,
+    utxo_write_window const& window,
     boost::unordered_flat_map<utxoz::raw_outpoint, bool> const& absence_tolerated,
     std::span<utxoz::deferred_deletion_entry const> pending_deletes) {
     // Step 6. The deletions the rewind's inverse deltas deferred. Before the
     // barriers, because a barrier over a set that still owes them makes the
     // outputs of abandoned blocks durable instead of removing them, and before
     // the publication, because clearing the record asserts the stores agree.
-    if ( ! sweep_reorg_deletions(operation_id, absence_tolerated, pending_deletes)) {
+    if ( ! sweep_reorg_deletions(operation_id, window, absence_tolerated, pending_deletes)) {
         return false;
     }
 
@@ -1472,7 +1510,7 @@ bool block_chain::publish_reorg_transition(uint32_t connected_height, uint64_t o
 
     // Step 9. The rewind's inverse deltas live in UTXO-Z, and close() does not
     // sync.
-    switch (utxo_sync()) {
+    switch (utxo_sync(window)) {
         case database::barrier_outcome::crossed:
             break;
         case database::barrier_outcome::unsupported:
@@ -1538,31 +1576,42 @@ bool block_chain::publish_reorg_transition(uint32_t connected_height, uint64_t o
 }
 
 bool block_chain::utxo_compact() {
-    return utxoz_db_.compact();
+    auto window = utxo_gate_.write();
+    return utxoz_db_.with_write(window, [](auto& db) { return db.compact(); });
 }
 
 void block_chain::utxo_print_statistics() {
-    utxoz_db_.print_statistics();
+    // The exclusive window, and deliberately not a lease: UTXO-Z recomputes the
+    // fragmentation counters here and documents that it must not overlap a
+    // mutation nor another statistics call. The two reports below are const on
+    // both sides and are genuine observations.
+    auto window = utxo_gate_.write();
+    utxoz_db_.with_write(window, [](auto& db) { db.print_statistics(); });
 }
 
 void block_chain::utxo_print_sizing_report() {
-    utxoz_db_.print_sizing_report();
+    auto lease = utxo_gate_.read();
+    utxoz_db_.with_read(lease, [](auto const& db) { db.print_sizing_report(); });
 }
 
 void block_chain::utxo_print_height_range_stats() {
-    utxoz_db_.print_height_range_stats();
+    auto lease = utxo_gate_.read();
+    utxoz_db_.with_read(lease, [](auto const& db) { db.print_height_range_stats(); });
 }
 
 size_t block_chain::utxo_size() const {
-    return utxoz_db_.size();
+    auto lease = utxo_gate_.read();
+    return utxoz_db_.with_read(lease, [](auto const& db) { return db.size(); });
 }
 
 void block_chain::set_utxo_bloom(std::shared_ptr<database::utxo_bloom_filter const> bloom) {
-    utxoz_db_.set_utxo_bloom(std::move(bloom));
+    auto window = utxo_gate_.write();
+    utxoz_db_.with_write(window, [&](auto& db) { db.set_utxo_bloom(std::move(bloom)); });
 }
 
 void block_chain::clear_utxo_bloom() {
-    utxoz_db_.clear_utxo_bloom();
+    auto window = utxo_gate_.write();
+    utxoz_db_.with_write(window, [](auto& db) { db.clear_utxo_bloom(); });
 }
 
 #endif // ! defined(KTH_DB_READONLY)
@@ -1718,6 +1767,24 @@ private:
 } // namespace
 
 code block_chain::mempool_remove_for_block(byte_span raw) {
+    // Lock-order control (#649). The organizer takes validation_mutex_ and THEN a
+    // UTXO read lease inside validator_.accept(); arriving here still holding the
+    // UTXO window would take the same two in the opposite order, and two threads
+    // doing both at once is the AB-BA deadlock. Refused by name, at the site,
+    // rather than found later as a node that stopped for no stated reason.
+    if (utxo_gate_.held_by_current_thread()) {
+        // Logged before it is thrown, because the throw does not survive the
+        // trip: it leaves a coroutine, and what an operator ends up reading is
+        // whatever downstream notices the batch died — "two chain transitions
+        // overlapped", which names a consequence and not this cause.
+        spdlog::critical("[blockchain] The mempool update was reached while this thread still "
+            "holds the UTXO write window; the window must end after the durability barrier "
+            "and before the mempool update, or this deadlocks against transaction validation");
+        throw utxo_lock_order_error(
+            "mempool_remove_for_block was called while this thread holds the UTXO "
+            "write window; the window must end before the mempool update");
+    }
+
     validation_high_priority_lock const lock(validation_mutex_);
 
     // Under the lock, so an admission cannot land between finding the pool empty
@@ -1738,6 +1805,24 @@ code block_chain::mempool_remove_for_block(byte_span raw) {
 }
 
 void block_chain::mempool_remove_for_block(domain::chain::block const& block) {
+    // Lock-order control (#649). The organizer takes validation_mutex_ and THEN a
+    // UTXO read lease inside validator_.accept(); arriving here still holding the
+    // UTXO window would take the same two in the opposite order, and two threads
+    // doing both at once is the AB-BA deadlock. Refused by name, at the site,
+    // rather than found later as a node that stopped for no stated reason.
+    if (utxo_gate_.held_by_current_thread()) {
+        // Logged before it is thrown, because the throw does not survive the
+        // trip: it leaves a coroutine, and what an operator ends up reading is
+        // whatever downstream notices the batch died — "two chain transitions
+        // overlapped", which names a consequence and not this cause.
+        spdlog::critical("[blockchain] The mempool update was reached while this thread still "
+            "holds the UTXO write window; the window must end after the durability barrier "
+            "and before the mempool update, or this deadlocks against transaction validation");
+        throw utxo_lock_order_error(
+            "mempool_remove_for_block was called while this thread holds the UTXO "
+            "write window; the window must end before the mempool update");
+    }
+
     validation_high_priority_lock const lock(validation_mutex_);
     mempool_.remove_for_block(block);
 }
@@ -1953,7 +2038,9 @@ std::expected<block_chain::output_info, database::result_code> block_chain::get_
     domain::chain::output_point const& outpoint, size_t branch_height) const {
 
     // Use UTXO-Z high-performance database
-    auto entry = utxoz_db_.find(outpoint, static_cast<uint32_t>(branch_height));
+    auto lease = utxo_gate_.read();
+    auto entry = utxoz_db_.with_read(lease,
+        [&](auto const& db) { return db.find(outpoint, static_cast<uint32_t>(branch_height)); });
     if ( ! entry) {
         return std::unexpected(entry.error());
     }

--- a/src/blockchain/src/utxo_builder.cpp
+++ b/src/blockchain/src/utxo_builder.cpp
@@ -535,7 +535,8 @@ char const* strategy_name(utxo_build_strategy strategy) {
 // Helper to process deferred deletions and report errors
 [[nodiscard]]
 database::result_code apply_owned_deletes(
-    block_chain& chain, std::vector<utxoz::deferred_deletion_entry> owed) {
+    block_chain& chain, utxo_write_window const& window,
+    std::vector<utxoz::deferred_deletion_entry> owed) {
     if (owed.empty()) {
         return database::result_code::success;
     }
@@ -544,7 +545,7 @@ database::result_code apply_owned_deletes(
     // retired permanently even when the walk reported a fault.
     constexpr int max_deletion_attempts = 3;
     for (int attempt = 1; attempt <= max_deletion_attempts; ++attempt) {
-        auto progress = chain.utxo_apply_deletes(owed);
+        auto progress = chain.utxo_apply_deletes(window, owed);
 
         // The build nets out anything created and spent inside one batch, so no
         // deletion here is entitled to be absent: every key it asks for was in
@@ -624,7 +625,8 @@ bool save_utxo_bloom(
     auto bloom = std::make_shared<database::utxo_bloom_filter>(utxo_count, 0.01);
 
     size_t inserted = 0;
-    if ( ! chain.utxo_for_each([&](utxoz::raw_outpoint const& key) {
+    auto const window = chain.begin_utxo_write();
+    if ( ! chain.utxo_for_each(window, [&](utxoz::raw_outpoint const& key) {
             bloom->insert(key);
             ++inserted;
         })) {
@@ -852,8 +854,10 @@ uint32_t embedded_bloom_checkpoint_height() {
             // Process single block
             auto delta = process_block_utxos(*block_ptr, h, mtp);
 
-            // Apply directly to UTXO-Z
-            auto result = chain.apply_utxo_inserts(delta.inserts);
+            // Apply directly to UTXO-Z, under ONE window for the whole coherent
+            // application: the inserts and the deletions this delta owes.
+            auto const window = chain.begin_utxo_write();
+            auto result = chain.apply_utxo_inserts(window, delta.inserts);
                 if (result == database::result_code::success) {
                     std::vector<utxoz::deferred_deletion_entry> owed;
                     owed.reserve(delta.deletes.size());
@@ -863,7 +867,7 @@ uint32_t embedded_bloom_checkpoint_height() {
                             utxoz::make_outpoint(std::span<uint8_t const, 32>{ph.data(), 32},
                                                  point.index()), h);
                     }
-                    result = apply_owned_deletes(chain, std::move(owed));
+                    result = apply_owned_deletes(chain, window, std::move(owed));
                 }
             if (result != database::result_code::success) {
                 spdlog::error("[utxo_builder] Failed to apply UTXO delta at height {}", h);
@@ -991,14 +995,15 @@ uint32_t embedded_bloom_checkpoint_height() {
             // ===== TIMING: Apply to UTXO-Z =====
             auto t_apply_start = clock::now();
 
-            auto result = chain.apply_utxo_inserts_raw(delta.inserts);
+            auto const window = chain.begin_utxo_write();
+            auto result = chain.apply_utxo_inserts_raw(window, delta.inserts);
             if (result == database::result_code::success) {
                 std::vector<utxoz::deferred_deletion_entry> owed;
                 owed.reserve(delta.deletes.size());
                 for (auto const& [key, h] : delta.deletes) {
                     owed.emplace_back(key, h);
                 }
-                result = apply_owned_deletes(chain, std::move(owed));
+                result = apply_owned_deletes(chain, window, std::move(owed));
             }
             if (result != database::result_code::success) {
                 spdlog::error("[utxo_builder] Failed to apply UTXO delta at batch starting {}", batch_start);

--- a/src/blockchain/test/mempool_block_connect.cpp
+++ b/src/blockchain/test/mempool_block_connect.cpp
@@ -184,3 +184,54 @@ TEST_CASE("with a pool to update the raw form reports bytes it cannot parse", "[
     CHECK(pool.size() == 1);
     CHECK(pool.entry(pooled->hash()));
 }
+
+// =============================================================================
+// Lock order (#649)
+// =============================================================================
+//
+// The node has two locks and exactly one order. The transaction organizer takes
+// validation_mutex_ and THEN, inside validator_.accept(), a UTXO read lease. So
+// a connect batch still holding the UTXO write window when it reaches the
+// mempool update would take the same two in the opposite order, and two threads
+// doing both at once is the AB-BA deadlock: a node that stops, with no error and
+// nothing in the log.
+//
+// This is a DISCRIMINATING control, not a timeout. It fails by name, in the
+// thread that formed the pattern, and it goes red the moment the connect path
+// keeps its window past step 9 — which is precisely the defect it exists for. No
+// wall-clock is involved in reaching the verdict.
+
+TEST_CASE("the mempool update refuses to run under the UTXO window",
+          "[mempool][connect][gate]") {
+    test::chain_fixture fixture("mp_lock_order");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+    auto& pool = chain.mempool_ref();
+
+    auto const confirmed = as_ptr(make_tx({op(1, 0)}, 1, 1));
+    REQUIRE(pool.add(entry_for(confirmed, 1)));
+    auto const blk = block_with({*confirmed});
+    auto const raw = serialize(blk);
+
+    {
+        auto const window = chain.begin_utxo_write();
+
+        // Both overloads: the raw one is what the connect path calls, and the
+        // parsed one is reachable from the reorganization side.
+        CHECK_THROWS_AS(chain.mempool_remove_for_block(blk),
+                        blockchain::utxo_lock_order_error);
+        CHECK_THROWS_AS(chain.mempool_remove_for_block(byte_span{raw.data(), raw.size()}),
+                        blockchain::utxo_lock_order_error);
+
+        // Refused BEFORE doing anything: the pool is untouched, so this is a
+        // rejection rather than a half-applied update that also complained.
+        CHECK(pool.entry(confirmed->hash()));
+    }
+
+    // POSITIVE, and the half that makes the negation mean something: with the
+    // window ended — which is where the connect path now ends it — the same call
+    // does its work.
+    CHECK_FALSE(chain.mempool_remove_for_block(byte_span{raw.data(), raw.size()}));
+    CHECK_FALSE(pool.entry(confirmed->hash()));
+}

--- a/src/blockchain/test/utxo_gate.cpp
+++ b/src/blockchain/test/utxo_gate.cpp
@@ -1,0 +1,961 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <kth/blockchain/utxo_gate.hpp>
+
+using namespace kth;
+using namespace kth::blockchain;
+
+// =============================================================================
+// The exclusion window UTXO-Z 0.10 requires for apply_deletes() (#649)
+// =============================================================================
+//
+// apply_deletes() erases from the active containers and writes through the file
+// cache's mappings, so it needs a window with no find(), resolve(), insert(),
+// compaction or close() in flight. The library's own lock covers
+// resolve-vs-resolve and does not extend here.
+//
+// These tests are about the gate itself: that a writer cannot start under a
+// reader, that a reader cannot slip in once the window is asked for, that the
+// door reopens, and — the one that matters most — that the window spans the
+// whole logical mutation rather than each call, because a reader admitted
+// between the inserts and the deletions sees a set holding outputs the blocks
+// spent, and the transition record does not protect a reader that never
+// consults it.
+
+// Everything test-only in this file has internal linkage. `fake_store` and
+// `watchdog` are exactly the names another test translation unit in the same
+// binary is likely to define, and two differing definitions of either would be
+// an ODR violation the linker is free to resolve silently and wrongly.
+namespace {
+
+constexpr auto settle = std::chrono::milliseconds(120);
+
+// A stand-in for the store, so the capability rules can be tested without one.
+struct fake_store {
+    int touched = 0;
+};
+
+} // namespace
+
+TEST_CASE("a capability only opens the store of the gate that issued it",
+          "[utxo][gate]") {
+    // Two gates, two stores. A window over one proves exclusion over the other's
+    // readers of nothing at all, so offering it must be refused rather than
+    // quietly accepted — the whole guarantee is that holding a token means the
+    // readers of THIS store are out.
+    utxo_gate mine;
+    utxo_gate other;
+    guarded_store<fake_store> store(mine);
+
+    auto foreign = other.write();
+    CHECK_THROWS_AS(store.with_write(foreign, [](auto& s) { ++s.touched; }),
+                    utxo_capability_error);
+
+    // And the right one works, so the rejection is not "everything is refused".
+    auto ours = mine.write();
+    CHECK_NOTHROW(store.with_write(ours, [](auto& s) { ++s.touched; }));
+}
+
+TEST_CASE("a released or moved-from capability authorises nothing",
+          "[utxo][gate]") {
+    utxo_gate gate;
+    guarded_store<fake_store> store(gate);
+
+    SECTION("moved-from") {
+        auto window = gate.write();
+        auto moved = std::move(window);
+        // `window` is spent: it no longer names the gate, so it proves nothing.
+        CHECK_THROWS_AS(store.with_write(window, [](auto& s) { ++s.touched; }),
+                        utxo_capability_error);
+        CHECK_NOTHROW(store.with_write(moved, [](auto& s) { ++s.touched; }));
+    }
+
+    SECTION("released") {
+        utxo_write_window spent = gate.write();
+        {
+            auto taking = std::move(spent);   // released at the end of this scope
+        }
+        CHECK_THROWS_AS(store.with_write(spent, [](auto& s) { ++s.touched; }),
+                        utxo_capability_error);
+    }
+
+    SECTION("a lease that has gone out of scope cannot be reused") {
+        utxo_read_lease spent = gate.read();
+        {
+            auto taking = std::move(spent);
+        }
+        CHECK_THROWS_AS(store.with_read(spent, [](auto const& s) { return s.touched; }),
+                        utxo_capability_error);
+    }
+}
+
+namespace {
+
+// A requires-expression over a CONCRETE type is a hard error rather than a
+// substitution failure, so each impossibility is asked through a template.
+template <typename G>
+concept writes_without_capability = requires(G& g) { g.with_write([](auto&) {}); };
+template <typename G>
+concept has_getter = requires(G& g) { g.get(); };
+template <typename G>
+concept has_arrow = requires(G& g) { g.operator->(); };
+template <typename G, typename L>
+concept writes_under_read_lease = requires(G& g, L const& l) {
+    g.with_write(l, [](auto&) {});
+};
+
+template <typename G, typename Cap, typename F>
+concept accepts_callback = requires(G& g, Cap const& c, F f) { g.with_write(c, f); };
+template <typename G, typename Cap, typename F>
+concept accepts_read_callback = requires(G const& g, Cap const& c, F f) { g.with_read(c, f); };
+
+} // namespace
+
+TEST_CASE("the callback may not hand the store back out", "[utxo][gate]") {
+    // Returning a reference or a pointer is the ACCIDENTAL way the store leaves
+    // the scope that authorised reaching it — someone writes `return s.field;`
+    // against a `decltype(auto)` and the reference outlives the capability. That
+    // shape is refused. A callback determined to stash the reference in a
+    // capture still can, and the header says so rather than pretending
+    // otherwise.
+    using store_t = guarded_store<fake_store>;
+
+    // POSITIVE: void and an owned value are the shapes callers need.
+    static_assert(accepts_callback<store_t, utxo_write_window, void(*)(fake_store&)>,
+        "a void callback is refused");
+    static_assert(accepts_callback<store_t, utxo_write_window, int(*)(fake_store&)>,
+        "a callback returning a value is refused");
+    static_assert(accepts_read_callback<store_t, utxo_read_lease, int(*)(fake_store const&)>,
+        "a reading callback returning a value is refused");
+
+    // NEGATIVE: every way of handing the store itself back.
+    static_assert( ! accepts_callback<store_t, utxo_write_window, fake_store&(*)(fake_store&)>,
+        "a callback may return a mutable reference to the store");
+    static_assert( ! accepts_callback<store_t, utxo_write_window,
+                                      fake_store const&(*)(fake_store&)>,
+        "a callback may return a const reference to the store");
+    static_assert( ! accepts_callback<store_t, utxo_write_window, fake_store*(*)(fake_store&)>,
+        "a callback may return a pointer to the store");
+    static_assert( ! accepts_callback<store_t, utxo_write_window,
+                                      fake_store const*(*)(fake_store&)>,
+        "a callback may return a const pointer to the store");
+
+    // And the same on the reading side, which is the one called most.
+    static_assert( ! accepts_read_callback<store_t, utxo_read_lease,
+                                           fake_store const&(*)(fake_store const&)>,
+        "a reading callback may return a reference to the store");
+    static_assert( ! accepts_read_callback<store_t, utxo_read_lease,
+                                           fake_store const*(*)(fake_store const&)>,
+        "a reading callback may return a pointer to the store");
+
+    // A value really does come back, so the constraint is not just refusing.
+    utxo_gate gate;
+    store_t store(gate);
+    auto window = gate.write();
+    store.with_write(window, [](fake_store& s) { s.touched = 7; });
+    auto const seen = store.with_read(window, [](fake_store const& s) { return s.touched; });
+    CHECK(seen == 7);
+}
+
+TEST_CASE("the store cannot be reached without a capability", "[utxo][gate]") {
+    // The structural half, checked by the type system rather than by review.
+    using store_t = guarded_store<fake_store>;
+
+    // A mutation without a token: no overload takes only a callback.
+    static_assert( ! writes_without_capability<store_t>,
+        "guarded_store accepts a write without a capability");
+
+    // A direct access: no getter, no operator->.
+    static_assert( ! has_getter<store_t>,
+        "guarded_store grew a getter; the store is reachable without a capability");
+    static_assert( ! has_arrow<store_t>,
+        "guarded_store grew operator->; the store is reachable without a capability");
+
+    // A read lease does not authorise a mutation.
+    static_assert( ! writes_under_read_lease<store_t, utxo_read_lease>,
+        "a read lease authorises a mutation");
+
+    // POSITIVE: the authorised shapes DO compile, so the negations above are
+    // not passing because every call is ill-formed.
+    static_assert(requires(store_t& g, utxo_write_window const& w) {
+        g.with_write(w, [](auto&) {});
+    }, "the authorised write does not compile");
+    static_assert(requires(store_t const& g, utxo_read_lease const& l) {
+        g.with_read(l, [](auto const&) {});
+    }, "the authorised read does not compile");
+    static_assert(requires(store_t const& g, utxo_write_window const& w) {
+        g.with_read(w, [](auto const&) {});
+    }, "the authorised read from inside the window does not compile");
+}
+
+// Every concurrent test here runs under this. An exclusion defect must produce a
+// NAMED failure, not a suite that hangs until CI's global timeout — which tells
+// an operator nothing except that something, somewhere, stopped.
+namespace {
+
+struct watchdog {
+    std::atomic<bool> done{false};
+    std::thread barker;
+
+    watchdog(std::chrono::milliseconds budget, std::string what)
+        : barker([this, budget, what = std::move(what)] {
+              auto const deadline = std::chrono::steady_clock::now() + budget;
+              while ( ! done.load()) {
+                  if (std::chrono::steady_clock::now() > deadline) {
+                      // Abort rather than let the suite wedge: the stack of every
+                      // thread is in the core, which is the diagnosis.
+                      std::fprintf(stderr,
+                          "\n[watchdog] %s did not finish within its budget: "
+                          "treating it as an exclusion defect\n", what.c_str());
+                      std::abort();
+                  }
+                  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+              }
+          }) {}
+
+    ~watchdog() {
+        done.store(true);
+        barker.join();
+    }
+};
+
+constexpr auto watchdog_budget = std::chrono::seconds(20);
+
+} // namespace
+
+TEST_CASE("asking for the window while holding a lease does not acquire it",
+          "[utxo][gate]") {
+    // NOT a claim that an upgrade is detected — it is not, and the header says
+    // so. The pattern is REACHABLE: begin_utxo_write() can be called while a
+    // lease is alive. It is simply not supported, and the blocking variant would
+    // self-deadlock. What keeps it from happening is that no caller forms it,
+    // which is audited rather than enforced.
+    //
+    // What this pins is the defensive bound: the timed acquisition returns a
+    // VALUE the test can check instead of parking a thread, and the gate stays
+    // usable afterwards. The blocking write() in the same position WOULD wedge,
+    // which is why no production path may take a lease and then a window.
+    watchdog guard(watchdog_budget, "the upgrade attempt");
+    utxo_gate gate;
+
+    auto lease = gate.read();
+    REQUIRE(gate.readers() == 1);
+
+    auto const started = std::chrono::steady_clock::now();
+    auto refused = gate.try_write_for(std::chrono::milliseconds(150));
+    auto const waited = std::chrono::steady_clock::now() - started;
+
+    // Expired rather than acquired, and it came back — the distinction this
+    // test can actually make. It is a bounded timeout, not a detected upgrade.
+    CHECK_FALSE(refused.has_value());
+    // It really did wait its budget, with a tolerance for timer resolution:
+    // wait_for measures against the condition variable's own clock, which may
+    // return a tick or two before steady_clock agrees, and a test that fails on
+    // that is measuring the platform rather than the gate. The claim being made
+    // is "it waited", not "it waited to the millisecond".
+    CHECK(waited >= std::chrono::milliseconds(140));
+    CHECK(waited < std::chrono::seconds(5));           // and it really did return
+
+    // POSITIVE, and the reason this test is not just an assertion about failing:
+    // the gate stays usable afterwards. A refusal that left writers_waiting_
+    // raised would keep every later reader out.
+    { auto releasing = std::move(lease); }
+
+    auto after = gate.try_write_for(std::chrono::seconds(2));
+    REQUIRE(after.has_value());
+    CHECK(after->held());
+    { auto closing = std::move(*after); }
+
+    std::atomic<bool> entered{false};
+    std::thread reader([&] {
+        auto l = gate.read();
+        entered.store(true);
+    });
+    reader.join();
+    CHECK(entered.load());
+}
+
+TEST_CASE("a second lease on one thread is not safe once a writer is pending",
+          "[utxo][gate]") {
+    // The invariant the header states, pinned rather than trusted. A thread
+    // holding a lease and asking for a SECOND one is fine while nothing else
+    // wants the gate — and self-deadlocks the moment a writer becomes pending:
+    // the second request waits for writers_waiting_ == 0, and the writer waits
+    // for readers_ == 0, which the FIRST lease is holding above zero.
+    //
+    // The gate cannot detect it — leases are values the caller holds, not
+    // context the gate can inspect — so this bounds it instead of hanging, and
+    // the timed form is what makes the verdict a value.
+    watchdog guard(watchdog_budget, "the nested lease with a writer pending");
+    utxo_gate gate;
+
+    auto first = gate.read();   // not const: released explicitly at the end
+    REQUIRE(gate.readers() == 1);
+
+    // Nesting with nobody waiting: allowed, and it must stay allowed, or this
+    // test would be measuring a gate that simply refuses everything.
+    {
+        auto const nested = gate.read();
+        CHECK(gate.readers() == 2);
+    }
+    REQUIRE(gate.readers() == 1);
+
+    // Now a writer becomes pending. It cannot get in — `first` is still held —
+    // but writer preference closes the door behind it.
+    std::atomic<bool> writer_in{false};
+    std::thread writer([&] {
+        auto const window = gate.write();
+        writer_in.store(true);
+    });
+    while (gate.writers_waiting() == 0) {
+        std::this_thread::yield();
+    }
+    CHECK_FALSE(writer_in.load());
+
+    // THE PROPERTY: the second lease is refused now. The blocking read() here
+    // would wait for a writer that is waiting for this very thread.
+    auto const nested = gate.try_read_for(std::chrono::milliseconds(150));
+    CHECK_FALSE(nested.has_value());
+    CHECK_FALSE(writer_in.load());   // and the writer is still shut out by `first`
+
+    // Releasing the first lease lets the writer through, so the refusal above
+    // was the nesting and not a gate that had stopped working.
+    { auto const releasing = std::move(first); }
+    writer.join();
+    CHECK(writer_in.load());
+    CHECK_FALSE(gate.writing());
+}
+
+TEST_CASE("the timed variants refuse reentry instead of waiting it out",
+          "[utxo][gate]") {
+    // The blocking pair refuses reentry; the timed pair used to wait the whole
+    // budget and hand back a nullopt, which reads as "another thread had it"
+    // when nobody did — a programming error reported as contention, and the
+    // longer the budget the longer the lie takes to arrive.
+    watchdog guard(watchdog_budget, "reentry through the timed variants");
+    utxo_gate gate;
+
+    auto const window = gate.write();
+
+    // A budget long enough that waiting it out would be unmistakable in the
+    // elapsed time below.
+    auto const before = std::chrono::steady_clock::now();
+    CHECK_THROWS_AS(gate.try_write_for(std::chrono::seconds(3)), utxo_reentry_error);
+    CHECK_THROWS_AS(gate.try_read_for(std::chrono::seconds(3)), utxo_reentry_error);
+    auto const elapsed = std::chrono::steady_clock::now() - before;
+
+    // Refused, not waited out: neither call spent its budget.
+    CHECK(elapsed < std::chrono::milliseconds(500));
+
+    // And the refusals left the gate intact — the window still holds, and the
+    // pending-writer count was restored on the way out rather than stranded,
+    // which a later reader would be the one to pay for.
+    CHECK(window.held());
+    CHECK(gate.writing());
+}
+
+// =============================================================================
+// Giving up on the window: two DIFFERENT paths, and one does not evidence the
+// other
+// =============================================================================
+//
+// Writer preference means readers wait for the pending count to reach zero, so a
+// writer that stops waiting owes the count back AND a notification: a reader
+// already parked in cv.wait() re-evaluates its predicate only when notified.
+//
+// A timed-out wait_for is an ORDINARY RETURN. It proves the count is restored
+// and that the sequence works, and it proves nothing whatsoever about what
+// happens when the wait is left by an exception, where the notification is the
+// part that can be forgotten. The two are tested apart, below.
+
+TEST_CASE("a writer that times out restores the count and wakes the readers",
+          "[utxo][gate]") {
+    // THE NORMAL RETURN. wait_for exhausting its budget is not an error path.
+    watchdog guard(watchdog_budget, "the pending-writer count after a timeout");
+    utxo_gate gate;
+
+    // Parked BEFORE the writer gives up, so what admits it is the notification
+    // the giving-up path issues — not a fresh evaluation that happened to run
+    // after the count was already down.
+    std::atomic<bool> reader_at_gate{false};
+    std::atomic<bool> admitted{false};
+    std::thread reader;
+
+    {
+        auto const lease = gate.read();
+
+        reader = std::thread([&] {
+            reader_at_gate.store(true);
+            auto const l = gate.read();     // waits: a writer is pending
+            admitted.store(true);
+        });
+        while ( ! reader_at_gate.load()) {
+            std::this_thread::yield();
+        }
+
+        auto const refused = gate.try_write_for(std::chrono::milliseconds(60));
+        CHECK_FALSE(refused.has_value());
+    }
+
+    // The proof is a reader getting in, not a counter being inspected.
+    reader.join();
+    CHECK(admitted.load());
+    CHECK(gate.readers() == 0);
+}
+
+TEST_CASE("a writer that unwinds restores the count and wakes the readers",
+          "[utxo][gate]") {
+    // THE EXCEPTIONAL PATH, exercised where it lives.
+    //
+    // The gate's own wait cannot reach it: `wait(lock, pred)` is `while (!pred())
+    // wait(lock);`, so the only exception it can propagate is the predicate's,
+    // and the gate's predicate reads two members and cannot throw. There is no
+    // honest seam in utxo_gate — hence the extraction, and hence this test drives
+    // blockchain::detail::pending_writer directly rather than dressing a timeout
+    // up as an exception.
+    //
+    // The sequence is the one libstdc++ produces: the mutex is re-acquired
+    // before the exception propagates, so the guard is destroyed holding it.
+    watchdog guard(watchdog_budget, "the pending-writer count after an unwind");
+
+    std::mutex mutex;
+    std::condition_variable cv;
+    size_t writers_waiting = 0;
+
+    std::atomic<bool> release_writer{false};
+    std::atomic<bool> unwound{false};
+    std::atomic<bool> reader_at_gate{false};
+    std::atomic<bool> admitted{false};
+
+    std::thread writer([&] {
+        try {
+            std::unique_lock<std::mutex> lock(mutex);
+            blockchain::detail::pending_writer pending(writers_waiting, cv, lock);
+
+            // Releases the mutex the way cv.wait would, parks on something this
+            // gate's cv cannot wake — so the reader below is admitted by the
+            // guard's notification and by nothing else — and re-acquires before
+            // throwing, which is what the library does before propagating.
+            lock.unlock();
+            while ( ! release_writer.load()) {
+                std::this_thread::yield();
+            }
+            lock.lock();
+            throw std::runtime_error("the wait ended badly");
+        } catch (std::runtime_error const&) {
+            unwound.store(true);
+        }
+    });
+
+    std::thread reader([&] {
+        std::unique_lock<std::mutex> lock(mutex);
+        reader_at_gate.store(true);
+        cv.wait(lock, [&] { return writers_waiting == 0; });
+        admitted.store(true);
+    });
+
+    // Parked, provably: the flag is set while the reader holds the mutex, so
+    // acquiring it here is only possible once cv.wait has released it. Without
+    // this the reader might evaluate its predicate after the decrement and pass
+    // without the notification ever mattering.
+    while ( ! reader_at_gate.load()) {
+        std::this_thread::yield();
+    }
+    { std::lock_guard<std::mutex> parked(mutex); }
+
+    release_writer.store(true);
+
+    writer.join();
+    reader.join();
+
+    CHECK(unwound.load());
+    CHECK(admitted.load());          // woken by the guard, on the way out
+    CHECK(writers_waiting == 0u);    // and the count came back
+}
+
+TEST_CASE("reentering the window from the same thread fails immediately",
+          "[utxo][gate]") {
+    // Scope discipline alone proved insufficient: three accidental reentries in
+    // one change, one of them in production. This turns the resulting hang into
+    // a named error at the site that caused it.
+    //
+    // DETECTION, never authorisation: the recorded id only ever refuses.
+    watchdog guard(watchdog_budget, "the reentry detection");
+    utxo_gate gate;
+
+    auto window = gate.write();
+
+    // 1 & 2 — both refused, and immediately: no budget, no waiting.
+    auto const before = std::chrono::steady_clock::now();
+    CHECK_THROWS_AS(gate.write(), utxo_reentry_error);
+    CHECK_THROWS_AS(gate.read(), utxo_reentry_error);
+    auto const elapsed = std::chrono::steady_clock::now() - before;
+    CHECK(elapsed < std::chrono::milliseconds(200));
+
+    // 3 — the original window survived both refusals and still authorises.
+    CHECK(window.held());
+
+    // 6 — moving within the same thread still works.
+    auto moved = std::move(window);
+    CHECK(moved.held());
+    CHECK_THROWS_AS(gate.write(), utxo_reentry_error);   // still owned
+
+    // 4 — another thread WAITS rather than being refused: legitimate contention
+    // must not have been turned into an error.
+    std::atomic<bool> other_entered{false};
+    std::thread other([&] {
+        auto w = gate.write();
+        other_entered.store(true);
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    CHECK_FALSE(other_entered.load());
+
+    // 3 (second half) — releasing reopens the gate for everyone.
+    { auto closing = std::move(moved); }
+    other.join();
+    CHECK(other_entered.load());
+    CHECK_FALSE(gate.writing());
+
+    std::atomic<bool> reader_in{false};
+    std::thread reader([&] {
+        auto l = gate.read();
+        reader_in.store(true);
+    });
+    reader.join();
+    CHECK(reader_in.load());
+}
+
+TEST_CASE("an exception inside the window clears the owner", "[utxo][gate]") {
+    // 5 — a stale owner would refuse the NEXT operation on this thread, turning
+    // one failure into a node that cannot write again.
+    watchdog guard(watchdog_budget, "the owner after an exception");
+    utxo_gate gate;
+
+    try {
+        auto window = gate.write();
+        throw std::runtime_error("the operation failed");
+    } catch (std::runtime_error const&) {
+    }
+
+    // The same thread can take it again, which it could not if the owner had
+    // survived the unwinding.
+    auto again = gate.write();
+    CHECK(again.held());
+    { auto closing = std::move(again); }
+
+    // And a read on this thread is no longer refused either.
+    auto lease = gate.read();
+    CHECK(lease.held());
+}
+
+TEST_CASE("a writer does not start while a reader is admitted", "[utxo][gate]") {
+    utxo_gate gate;
+    watchdog guard(watchdog_budget, "the writer waiting on a reader");
+    std::atomic<bool> writing{false};
+
+    std::thread writer;
+    {
+        auto lease = gate.read();
+        REQUIRE(gate.readers() == 1);
+
+        writer = std::thread([&] {
+            auto window = gate.write();
+            writing.store(true);
+            std::this_thread::sleep_for(settle);
+        });
+
+        // The writer is waiting on a reader that has not left, so it must not
+        // have entered. Sleeping is what gives it the chance to be wrong.
+        std::this_thread::sleep_for(settle);
+        CHECK_FALSE(writing.load());
+        CHECK_FALSE(gate.writing());
+
+        // Leaving this scope releases the reader, which is what lets it through.
+    }
+
+    writer.join();
+    CHECK(writing.load());
+}
+
+TEST_CASE("a reader admitted after the window is asked for waits for it",
+          "[utxo][gate]") {
+    watchdog guard(watchdog_budget, "the reader waiting on the window");
+    // Writer preference, and it is the property rather than a tuning choice: a
+    // stream of readers must not starve the deletion a batch cannot publish
+    // without.
+    utxo_gate gate;
+    std::atomic<bool> read_entered{false};
+    std::atomic<bool> window_open{false};
+
+    auto window = gate.write();
+    window_open.store(true);
+
+    std::thread reader([&] {
+        auto lease = gate.read();
+        read_entered.store(true);
+    });
+
+    std::this_thread::sleep_for(settle);
+    CHECK_FALSE(read_entered.load());
+
+    // And the door reopens: the reader must progress once the window closes,
+    // which is what rules out an implementation that simply blocks forever.
+    { auto closing = std::move(window); }
+    reader.join();
+    CHECK(read_entered.load());
+}
+
+TEST_CASE("many readers coexist and none excludes another", "[utxo][gate]") {
+    watchdog guard(watchdog_budget, "the concurrent readers");
+    // The positive control for the shared side. Without it, a gate that made
+    // every reader exclusive would pass every exclusion test in this file.
+    utxo_gate gate;
+    constexpr int count = 8;
+    std::atomic<int> inside{0};
+    std::atomic<int> peak{0};
+    std::vector<std::thread> readers;
+
+    for (int i = 0; i < count; ++i) {
+        readers.emplace_back([&] {
+            auto lease = gate.read();
+            auto const now = inside.fetch_add(1) + 1;
+            int seen = peak.load();
+            while (now > seen && ! peak.compare_exchange_weak(seen, now)) {
+            }
+            std::this_thread::sleep_for(settle);
+            inside.fetch_sub(1);
+        });
+    }
+
+    for (auto& r : readers) {
+        r.join();
+    }
+
+    CHECK(peak.load() > 1);
+    CHECK(gate.readers() == 0);
+}
+
+TEST_CASE("a reader forced between the inserts and the deletions waits for both",
+          "[utxo][gate]") {
+    watchdog guard(watchdog_budget, "the reader forced mid-operation");
+    // THE ONE THIS EXISTS FOR. A window taken per mutating call keeps readers
+    // out of the mappings and still lets one in at the exact point where the
+    // set holds outputs the blocks spent — inserts applied, deletions not yet.
+    // The transition record does not help: a reader never consults it.
+    //
+    // The moment is FORCED, not raced for, and both directions are pinned:
+    // the operation waits until the reader has announced it is about to ask,
+    // and the reader records that the window was still open when it did. A
+    // version that only spawned the reader and slept could pass without the
+    // reader ever blocking — it would reach the gate after the window closed,
+    // observe the finished state, and look identical to the real thing.
+    utxo_gate gate;
+
+    std::atomic<bool> inserts_done{false};
+    std::atomic<bool> deletes_done{false};
+    std::atomic<bool> reader_at_gate{false};
+    std::atomic<bool> saw_window_open{false};
+    std::atomic<bool> read_saw_deletes{false};
+    std::atomic<bool> read_returned{false};
+
+    std::thread mutation([&] {
+        // ONE window for the whole logical operation.
+        auto window = gate.write();
+
+        inserts_done.store(true);              // ... inserts applied
+
+        // The incoherent interval, held open until the reader is actually at the
+        // door. Without this the sleep alone decides, and a slow thread start
+        // would let the whole mutation finish first.
+        while ( ! reader_at_gate.load()) {
+            std::this_thread::yield();
+        }
+        std::this_thread::sleep_for(settle);
+
+        deletes_done.store(true);              // ... deletions applied
+    });
+
+    // Enter exactly in that interval.
+    while ( ! inserts_done.load()) {
+        std::this_thread::yield();
+    }
+
+    std::thread reader([&] {
+        // Recorded BEFORE blocking: this is the proof that the reader arrived
+        // mid-operation rather than after it. The mutation cannot finish until
+        // the flag below is seen, so the window is necessarily still open here.
+        saw_window_open.store(gate.writing());
+        reader_at_gate.store(true);
+
+        auto lease = gate.read();
+        read_saw_deletes.store(deletes_done.load());
+        read_returned.store(true);
+    });
+
+    mutation.join();
+    reader.join();
+
+    // Arrived while the window was open...
+    CHECK(saw_window_open.load());
+    // ... waited, and by the time it was admitted the whole mutation had landed.
+    // Under a per-call window it would have been admitted mid-operation and
+    // observed the set with the deletions still outstanding.
+    CHECK(read_returned.load());
+    CHECK(read_saw_deletes.load());
+}
+
+TEST_CASE("an exception inside the window does not leave the door shut",
+          "[utxo][gate]") {
+    watchdog guard(watchdog_budget, "the door after an exception");
+    // Fail-closed is about refusing to publish, never about wedging the node.
+    utxo_gate gate;
+
+    try {
+        auto window = gate.write();
+        throw std::runtime_error("the operation failed");
+    } catch (std::runtime_error const&) {
+    }
+
+    CHECK_FALSE(gate.writing());
+
+    // Provable rather than asserted from a flag: a reader gets in.
+    std::atomic<bool> entered{false};
+    std::thread reader([&] {
+        auto lease = gate.read();
+        entered.store(true);
+    });
+    reader.join();
+    CHECK(entered.load());
+
+    // And the window can be taken again.
+    {
+        auto again = gate.write();
+        CHECK(again.held());
+    }
+    CHECK_FALSE(gate.writing());
+}
+
+TEST_CASE("a released window and lease report themselves released",
+          "[utxo][gate]") {
+    utxo_gate gate;
+
+    {
+        auto window = gate.write();
+        CHECK(window.held());
+        auto moved = std::move(window);
+        CHECK(moved.held());
+        CHECK_FALSE(window.held());   // moved from: must not release twice
+    }
+    CHECK_FALSE(gate.writing());
+
+    {
+        auto lease = gate.read();
+        CHECK(lease.held());
+        auto moved = std::move(lease);
+        CHECK(moved.held());
+        CHECK_FALSE(lease.held());
+    }
+    CHECK(gate.readers() == 0);
+}
+
+// =============================================================================
+// Thread affinity
+// =============================================================================
+//
+// A capability carries a pointer to its gate, and that alone would authorise
+// anywhere: a window taken in one thread and used in another would open the
+// store for a thread the gate never admitted, while the gate's recorded owner
+// still named the first one — so the thread actually holding the window could
+// ask for another and be told to wait for itself.
+//
+// The contract IS thread-affine: the scope audit behind it is per function per
+// thread, and the rule that nothing may live across a co_await exists because a
+// coroutine resumes on whichever executor thread is free. These make that
+// checkable. None of them depends on a global timeout to reach a verdict: each
+// failure is a value or an exception, and the watchdogs are there so a
+// regression is a named abort instead of a wedge.
+
+TEST_CASE("a capability used by another thread authorises nothing",
+          "[utxo][gate][affinity]") {
+    watchdog guard(watchdog_budget, "a cross-thread use of a capability");
+    utxo_gate gate;
+    guarded_store<fake_store> store(gate);
+
+    SECTION("a write window") {
+        auto const window = gate.write();
+        // It still names the right gate — that is the point. What disqualifies it
+        // is the thread asking, and the two are reported apart.
+        CHECK(window.authorises(gate));
+
+        std::atomic<bool> refused{false};
+        std::atomic<bool> other_error{false};
+        std::thread borrower([&] {
+            try {
+                store.with_write(window, [](auto& s) { ++s.touched; });
+            } catch (utxo_affinity_error const&) {
+                refused.store(true);
+            } catch (...) {
+                other_error.store(true);
+            }
+        });
+        borrower.join();
+
+        CHECK(refused.load());
+        CHECK_FALSE(other_error.load());
+        // Refused, and NOT by damaging the capability: the issuing thread
+        // continues to hold a window that works.
+        CHECK_NOTHROW(store.with_write(window, [](auto& s) { ++s.touched; }));
+    }
+
+    SECTION("a read lease") {
+        auto const lease = gate.read();
+
+        std::atomic<bool> refused{false};
+        std::thread borrower([&] {
+            try {
+                store.with_read(lease, [](auto const& s) { return s.touched; });
+            } catch (utxo_affinity_error const&) {
+                refused.store(true);
+            }
+        });
+        borrower.join();
+
+        CHECK(refused.load());
+        CHECK_NOTHROW(store.with_read(lease, [](auto const& s) { return s.touched; }));
+    }
+}
+
+TEST_CASE("moving a capability out of its thread is refused at the move",
+          "[utxo][gate][affinity]") {
+    // The other shape of the transfer, and the earlier one: refusing the USE
+    // catches a capability that already crossed, refusing the MOVE stops it from
+    // crossing. An empty capability carries nothing, so it still moves freely.
+    watchdog guard(watchdog_budget, "a cross-thread move of a capability");
+    utxo_gate gate;
+
+    auto window = gate.write();
+
+    std::atomic<bool> refused{false};
+    std::atomic<bool> stole_it{false};
+    std::thread thief([&] {
+        try {
+            auto taken = std::move(window);
+            stole_it.store(taken.held());
+        } catch (utxo_affinity_error const&) {
+            refused.store(true);
+        }
+    });
+    thief.join();
+
+    CHECK(refused.load());
+    CHECK_FALSE(stole_it.load());
+    // The refused move left the source intact rather than half-transferred: the
+    // window is still held here, and still by this thread.
+    CHECK(window.held());
+    CHECK(window.on_issuing_thread());
+    CHECK(gate.writing());
+}
+
+TEST_CASE("a capability released by another thread opens the gate",
+          "[utxo][gate][affinity]") {
+    // Destruction is deliberately not affinity-checked: a destructor that threw
+    // during unwinding would terminate. What it must do instead is leave the gate
+    // OPEN and uncorrupted, which is what this asserts — because the failure mode
+    // of getting this wrong is a store nobody can ever reach again.
+    watchdog guard(watchdog_budget, "a cross-thread release");
+    utxo_gate gate;
+    guarded_store<fake_store> store(gate);
+
+    // Parked by its owner, which is legal: the move happens on the issuing
+    // thread. What follows is another thread ending its life.
+    std::optional<utxo_write_window> parked = gate.write();
+    REQUIRE(gate.writing());
+
+    std::thread releaser([&] { parked.reset(); });
+    releaser.join();
+
+    CHECK_FALSE(gate.writing());
+
+    // Not merely "the flag is clear": a new writer and a new reader both get in,
+    // which is the property the flag stands for. Neither can be satisfied by a
+    // gate left in a half-released state.
+    {
+        auto const fresh = gate.write();
+        CHECK(fresh.held());
+        CHECK_NOTHROW(store.with_write(fresh, [](auto& s) { ++s.touched; }));
+    }
+    {
+        auto const lease = gate.read();
+        CHECK(lease.held());
+        CHECK_NOTHROW(store.with_read(lease, [](auto const& s) { return s.touched; }));
+    }
+    CHECK(gate.readers() == 0);
+
+    // And from a DIFFERENT thread, so the gate is open in general rather than
+    // only for the one that happens to have run before.
+    std::atomic<bool> got_in{false};
+    std::thread later([&] {
+        auto const window = gate.write();
+        got_in.store(window.held());
+    });
+    later.join();
+    CHECK(got_in.load());
+}
+
+TEST_CASE("a capability moved and used within one thread keeps working",
+          "[utxo][gate][affinity]") {
+    // The negation of the three above: affinity must not cost the ordinary move.
+    // Returning a capability, parking it in an optional and handing it on all
+    // happen on one thread and must remain unremarkable.
+    utxo_gate gate;
+    guarded_store<fake_store> store(gate);
+
+    std::optional<utxo_write_window> parked = gate.write();
+    CHECK_NOTHROW(store.with_write(*parked, [](auto& s) { ++s.touched; }));
+
+    auto moved = std::move(*parked);
+    parked.reset();
+    CHECK(moved.held());
+    CHECK(moved.on_issuing_thread());
+    CHECK_NOTHROW(store.with_write(moved, [](auto& s) { ++s.touched; }));
+
+    // Released here, so what follows is not measuring the window instead of the
+    // lease: with it still held, try_read_for would time out and the thread would
+    // prove nothing while appearing to pass.
+    {
+        auto const spent = std::move(moved);
+    }
+    REQUIRE_FALSE(gate.writing());
+
+    // A capability taken and moved INSIDE another thread is that thread's own,
+    // and works there — affinity is about crossing, not about which thread it is.
+    std::atomic<bool> acquired{false};
+    std::atomic<bool> usable{false};
+    std::thread worker([&] {
+        auto lease = gate.read();
+        acquired.store(true);
+        auto owned = std::move(lease);
+        usable.store(owned.on_issuing_thread() &&
+            store.with_read(owned, [](auto const& s) { return s.touched; }) == 2);
+    });
+    worker.join();
+
+    CHECK(acquired.load());
+    CHECK(usable.load());
+    CHECK(gate.readers() == 0);
+}

--- a/src/blockchain/test/utxo_gate_bench.cpp
+++ b/src/blockchain/test/utxo_gate_bench.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2016-present Knuth Project developers.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test_helpers.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+#include <kth/blockchain/utxo_gate.hpp>
+
+using namespace kth;
+using namespace kth::blockchain;
+
+// =============================================================================
+// A baseline for the gate, so a later change has something to beat (#649)
+// =============================================================================
+//
+// Deliberately small: it measures the gate and nothing else — no store, no
+// blocks — because the question a later change has to answer is what the
+// exclusion itself costs, not what a batch costs.
+//
+// HIDDEN, via the leading [.] tag: these were running in the default suite,
+// where the contended case spends real wall-clock spawning threads and racing a
+// writer to measure something no correctness run needs — and a timing case on a
+// shared CI machine is the classic source of a red build that means nothing.
+// Run them on demand with `[bench]`.
+//
+// Correctness first, and this is not a threshold. It fails only if the gate
+// stops making progress, so nothing here becomes a performance gate. The numbers are printed to be read by a
+// person comparing implementations, which is what the follow-up issue is for:
+// this mutex/condition_variable, a reader fast path on an atomic, std::shared_mutex,
+// and generations inside UTXO-Z if measurement ever justifies that much.
+
+namespace {
+
+template <typename F>
+double per_op_ns(size_t ops, F&& body) {
+    auto const start = std::chrono::steady_clock::now();
+    std::forward<F>(body)();
+    auto const elapsed = std::chrono::steady_clock::now() - start;
+    return double(std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count()) /
+           double(ops);
+}
+
+} // namespace
+
+TEST_CASE("gate baseline: uncontended lease and window", "[.][utxo][gate][bench]") {
+    utxo_gate gate;
+    constexpr size_t ops = 200000;
+
+    auto const read_ns = per_op_ns(ops, [&] {
+        for (size_t i = 0; i < ops; ++i) {
+            auto lease = gate.read();
+        }
+    });
+
+    auto const write_ns = per_op_ns(ops, [&] {
+        for (size_t i = 0; i < ops; ++i) {
+            auto window = gate.write();
+        }
+    });
+
+    std::printf("[gate-bench] uncontended: read %.0f ns/op, window %.0f ns/op\n",
+        read_ns, write_ns);
+
+    // Progress, not a threshold: a gate that stopped admitting anyone would not
+    // reach here at all, and a number regressing is for a person to read.
+    CHECK(read_ns >= 0.0);
+    CHECK(write_ns >= 0.0);
+}
+
+TEST_CASE("gate baseline: readers under contention", "[.][utxo][gate][bench]") {
+    // What the node actually does: several validators probing while a batch
+    // occasionally takes the window. The interesting figure is what a reader
+    // pays when it is not alone.
+    utxo_gate gate;
+    constexpr int threads = 8;
+    constexpr size_t per_thread = 4000;
+
+    std::atomic<bool> stop{false};
+    std::atomic<size_t> windows{0};
+
+    std::thread writer([&] {
+        while ( ! stop.load()) {
+            {
+                // The window is HELD only for the mutation, and released before
+                // the wait. Sleeping inside it measures the benchmark holding the
+                // door shut rather than what the gate costs — the first version
+                // of this loop did exactly that and reported readers paying
+                // hundreds of microseconds they never pay in production.
+                auto window = gate.write();
+                windows.fetch_add(1);
+            }
+            // Spaced like a batch rather than a spin loop.
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        }
+    });
+
+    auto const elapsed_ns = per_op_ns(threads * per_thread, [&] {
+        std::vector<std::thread> readers;
+        for (int t = 0; t < threads; ++t) {
+            readers.emplace_back([&] {
+                for (size_t i = 0; i < per_thread; ++i) {
+                    auto lease = gate.read();
+                }
+            });
+        }
+        for (auto& r : readers) {
+            r.join();
+        }
+    });
+
+    stop.store(true);
+    writer.join();
+
+    std::printf("[gate-bench] %d readers + a writer: %.0f ns/read, %zu windows taken\n",
+        threads, elapsed_ns, windows.load());
+
+    // The writer really did get in, which is what makes the reader figure mean
+    // something: a run where the writer starved would measure the uncontended
+    // case under a different name.
+    CHECK(windows.load() > 0);
+    CHECK(gate.readers() == 0);
+}

--- a/src/database/include/kth/database/databases/utxoz_database.hpp
+++ b/src/database/include/kth/database/databases/utxoz_database.hpp
@@ -414,13 +414,20 @@ struct KD_API utxoz_database {
     /// insert(), compaction or close() in flight. UTXO-Z's internal lock covers
     /// resolve-vs-resolve ONLY and does not extend here.
     ///
-    /// KTH DOES NOT PROVIDE THAT WINDOW YET, and this is a functional blocker
-    /// rather than a limitation to design around — see #649. The two callers of
-    /// this are mutually excluded from each other by the reorg barrier, but
-    /// neither is excluded from the single-transaction validate path, which
-    /// probes lock-free and is reachable over JSON-RPC and the C API. A
-    /// deletion writing through the cache's mappings while a probe reads is a
-    /// use-after-unmap: a crash, not a wrong answer.
+    /// THE CALLER MUST HOLD A `blockchain::utxo_write_window` (#649). That is
+    /// the window: it excludes every find(), resolve(), insert(), compaction and
+    /// close() over this store for as long as it is held, and it is a capability
+    /// rather than a convention — `blockchain::guarded_store` will not hand out
+    /// the database without one, so reaching this method without the exclusion
+    /// does not compile on that side.
+    ///
+    /// It must span the whole logical mutation and not this call, because a
+    /// reader admitted between the inserts and the deletions sees a set still
+    /// holding outputs the blocks spent. What the window prevents here is
+    /// concrete: a deletion writing through the cache's mappings while a probe
+    /// reads is a use-after-unmap — a crash, not a wrong answer — and the
+    /// single-transaction validate path probes lock-free, reachable over
+    /// JSON-RPC and the C API.
     ///
     /// @return erased / absent / unresolved / error. The partition is over
     ///         DISTINCT keys (deduplicated keeping the first occurrence), so the
@@ -452,14 +459,19 @@ struct KD_API utxoz_database {
     [[nodiscard]]
     barrier_outcome sync();
 
-    /// Print statistics to log
+    /// Print statistics to log.
+    ///
+    /// NOT const, and not an observation: UTXO-Z recomputes the fragmentation
+    /// counters as it goes, and documents that this must not overlap a mutation
+    /// nor another statistics call. It takes the exclusive window for that
+    /// reason, unlike the two below.
     void print_statistics();
 
-    /// Print sizing report to log
-    void print_sizing_report();
+    /// Print sizing report to log. Const on both sides: a genuine observation.
+    void print_sizing_report() const;
 
-    /// Print height range stats to log
-    void print_height_range_stats();
+    /// Print height range stats to log. Const on both sides.
+    void print_height_range_stats() const;
 
     // Convert utxoz::raw_outpoint back to domain::chain::point (for error reporting)
     [[nodiscard]]

--- a/src/database/src/databases/utxoz_database.cpp
+++ b/src/database/src/databases/utxoz_database.cpp
@@ -467,13 +467,13 @@ void utxoz_database::print_statistics() {
     }
 }
 
-void utxoz_database::print_sizing_report() {
+void utxoz_database::print_sizing_report() const {
     if (is_open()) {
         db_->print_sizing_report();
     }
 }
 
-void utxoz_database::print_height_range_stats() {
+void utxoz_database::print_height_range_stats() const {
     if (is_open()) {
         db_->print_height_range_stats();
     }

--- a/src/node/src/sync/block_tasks.cpp
+++ b/src/node/src/sync/block_tasks.cpp
@@ -2161,172 +2161,192 @@ uint32_t utxo_batch_len(uint32_t available, uint32_t batch_size, bool stale) {
 
         // Step 4. Apply to UTXO-Z. THE FIRST MUTATION: from here the record is
         // the only thing that says this batch was ever started.
-        if ( ! delta.empty()) {
-            auto result = chain.apply_utxo_inserts_raw(delta.inserts);
-            if (result != database::result_code::success) {
-                spdlog::critical("[utxo_build] Failed to apply UTXO delta at batch {} "
-                    "(operation {:#018x})", batch_start, operation_id);
-                on_fatal("a UTXO delta could not be applied");
-                co_return;
-            }
-        }
-
-        // Step 5. Persist undo data AFTER the delta is applied and BEFORE the
-        // built-height marker advances, so a crash can only leave undo data for a
-        // block that is already connected — never a connected block without undo
-        // data.
+        // ONE window for the whole coherent mutation: the inserts, the undo
+        // capture that reads under the same capability, the deletions, and the
+        // barrier that makes them durable. Opened AFTER the last suspension
+        // above and closed before the next, so the capability never lives across
+        // a co_await — everything between is synchronous (#649).
         //
-        // Each write reports which rev file it landed in. A batch that crosses a
-        // rotation writes into more than one, and the barrier below has to cover
-        // every one of them: syncing "the last file" leaves the rest to the page
-        // cache, which is the shape this replaced.
-        std::vector<int32_t> undo_files;
-        undo_files.reserve(pending_undo.size());
-        for (auto& entry : pending_undo) {
-            auto const file = chain.store_block_undo(entry.idx, entry.undo, entry.prev_hash);
-            if ( ! file) {
-                // After the delta: these blocks are in the UTXO set and now cannot be
-                // disconnected, so a later reorganization would have nothing to
-                // reverse them with.
-                spdlog::critical("[utxo_build] Failed to store undo data for index {}", entry.idx);
-                on_fatal("a connected block has no undo data and cannot be disconnected");
-                co_return;
-            }
-            undo_files.push_back(*file);
-        }
-
-        // Step 6. The deletions this batch owes, applied from a batch the task
-        // OWNS. They are part of this batch's delta, not work that follows it:
-        // until they run, outputs these blocks spent are still in the set. So
-        // they come before the state is published, and a failure is fatal rather
-        // than logged — a spent output left behind is a double spend the node
-        // would accept.
-        //
-        // ORDER MATTERS, and it used to be wrong: the height marker was
-        // persisted first and the deletions applied afterwards. A crash between
-        // the two left a marker saying the batch was complete over a set that
-        // still held every output these blocks spent, and the restart trusted
-        // the marker. The other direction — a crash after the deletions and
-        // before the height — is closed by the record written at step 2.
+        // Per call would keep readers out of the mappings and still admit one
+        // between the inserts and the deletions, where the set holds outputs
+        // these blocks spent and the transition record does not protect a reader
+        // that never consults it.
+        // Steps 4 to 9 ONLY. The window dies with this scope, before step 10:
+        // the organizer takes validation_mutex_ and then a UTXO read lease inside
+        // accept(), so a connect still holding the window when mempool_remove_for_block
+        // takes that same mutex would be acquiring the two in the opposite order —
+        // the AB-BA deadlock. Nothing below step 9 needs the capability, and the
+        // fsyncs of steps 10 and 11 have no business excluding readers.
         {
-            std::vector<utxoz::deferred_deletion_entry> owed;
-            owed.reserve(delta.deletes.size());
-            for (auto const& [key, h] : delta.deletes) {
-                owed.emplace_back(key, h);
-            }
+            auto const window = chain.begin_utxo_write();
 
-            // The SAME policy the reorganization runs, from the same function:
-            // `erased` retired permanently even when the walk reported a fault,
-            // only `unresolved` resent and rebuilt from what came back, a fault
-            // with nothing owed still fatal, bounded attempts. Reimplementing it
-            // here is how the two drifted apart before.
-            //
-            // What differs is the tolerance, and only that: strict_absence()
-            // says no proven absence is legitimate on this path, because a
-            // connect batch nets out anything created and spent inside itself,
-            // so every key it asks to delete was in the set.
-            constexpr int max_deletion_attempts = 3;
-            utxoz::deferred_deletion_entry offender{utxoz::raw_outpoint{}, 0};
-
-            auto const outcome = blockchain::run_deletion_sweep(
-                std::move(owed), blockchain::strict_absence(),
-                [&chain](std::span<utxoz::deferred_deletion_entry const> b) {
-                    return chain.utxo_apply_deletes(b);
-                },
-                max_deletion_attempts,
-                [&](int attempt, utxoz::deletion_progress const& progress) {
-                    if ( ! progress.unresolved.empty() || progress.error) {
-                        spdlog::warn("[utxo_build] attempt {} of {} applied {}, proved {} absent, "
-                            "left {} owed at batch {}-{}{}", attempt, max_deletion_attempts,
-                            progress.erased.size(), progress.absent.size(),
-                            progress.unresolved.size(), batch_start, batch_end,
-                            progress.error
-                                ? fmt::format(", fault: {}",
-                                    database::utxoz_error_name(*progress.error))
-                                : "");
-                    }
-                },
-                &offender);
-
-            switch (outcome) {
-                case blockchain::deletion_sweep_outcome::applied:
-                    break;
-
-                case blockchain::deletion_sweep_outcome::absent_unaccounted:
-                    spdlog::critical("[utxo_build] {} is proven absent at batch {}-{}: the UTXO "
-                        "set does not hold an output these blocks spent",
-                        utxoz::outpoint_to_string(offender.key), batch_start, batch_end);
-                    on_fatal("a batch spent an output the UTXO set does not hold");
-                    co_return;
-
-                case blockchain::deletion_sweep_outcome::fault_reported:
-                    spdlog::critical("[utxo_build] the deletion walk reported a fault at batch "
-                        "{}-{} with nothing left unresolved; refusing to publish over a store "
-                        "that reported one", batch_start, batch_end);
-                    on_fatal("the UTXO store reported a fault while applying deletions");
-                    co_return;
-
-                case blockchain::deletion_sweep_outcome::attempts_exhausted:
-                    spdlog::critical("[utxo_build] deletions could not be applied in {} attempts "
-                        "at batch {}-{}; the UTXO set still holds outputs these blocks spent",
-                        max_deletion_attempts, batch_start, batch_end);
-                    on_fatal("the deletions a batch owed could not be applied");
-                    co_return;
-            }
-        }
-
-        utxo_built_height = batch_end;
-
-        // Steps 7 and 8. Every rev file this batch wrote into, then the
-        // directory entries naming them. Contents and names are two barriers: a
-        // newly created rev*.dat can have every byte on the platter and still
-        // not exist after a power cut, because the entry that reaches it was
-        // never written. Both live inside flush_undo.
-        if (auto const flushed = chain.flush_undo(undo_files); ! flushed) {
-            if (flushed.error().file_number < 0) {
-                spdlog::critical("[utxo_build] The undo directory could not be put on stable "
-                    "storage after batch {}-{}: the rev files this batch wrote may not survive "
-                    "a restart, so these blocks would be connected and not disconnectable",
-                    batch_start, batch_end);
-            } else {
-                spdlog::critical("[utxo_build] The undo records in rev file {} could not be put "
-                    "on stable storage after batch {}-{}: these blocks would be connected and "
-                    "not disconnectable", flushed.error().file_number, batch_start, batch_end);
-            }
-            on_fatal("the undo records of a connected batch could not be made durable");
-            co_return;
-        }
-
-        // Step 9. UTXO-Z's own barrier. `close()` does not run it, so without
-        // this the set's mutations are the one part of the transition still in
-        // the page cache when the record is cleared.
-        //
-        // `unsupported` is not a failure and not a guarantee either: it is the
-        // documented answer where the platform has no barrier at all, and the
-        // node's own durability level already says so. `failed` is fatal on
-        // every platform — a level describes what a platform CAN promise, and it
-        // never turns a barrier that was attempted and refused into a success.
-        switch (chain.utxo_sync()) {
-            case database::barrier_outcome::crossed:
-                break;
-            case database::barrier_outcome::unsupported:
-                if (chain.durability() != database::durability_level::none) {
-                    spdlog::critical("[utxo_build] The UTXO store reports no durability barrier "
-                        "while this node claims '{}'; the two disagree about the same machine",
-                        database::to_string(chain.durability()));
-                    on_fatal("the UTXO store and the node disagree about what this platform can promise");
+            if ( ! delta.empty()) {
+                auto result = chain.apply_utxo_inserts_raw(window, delta.inserts);
+                if (result != database::result_code::success) {
+                    spdlog::critical("[utxo_build] Failed to apply UTXO delta at batch {} "
+                        "(operation {:#018x})", batch_start, operation_id);
+                    on_fatal("a UTXO delta could not be applied");
                     co_return;
                 }
-                spdlog::warn("[utxo_build] This platform exposes no durability barrier; batch "
-                    "{}-{} is published without one", batch_start, batch_end);
-                break;
-            case database::barrier_outcome::failed:
-                spdlog::critical("[utxo_build] The UTXO store's durability barrier failed after "
-                    "batch {}-{} (operation {:#018x}); what it applied is not known to be on "
-                    "disk", batch_start, batch_end, operation_id);
-                on_fatal("the UTXO set of a connected batch could not be made durable");
+            }
+
+            // Step 5. Persist undo data AFTER the delta is applied and BEFORE the
+            // built-height marker advances, so a crash can only leave undo data for a
+            // block that is already connected — never a connected block without undo
+            // data.
+            //
+            // Each write reports which rev file it landed in. A batch that crosses a
+            // rotation writes into more than one, and the barrier below has to cover
+            // every one of them: syncing "the last file" leaves the rest to the page
+            // cache, which is the shape this replaced.
+            std::vector<int32_t> undo_files;
+            undo_files.reserve(pending_undo.size());
+            for (auto& entry : pending_undo) {
+                auto const file = chain.store_block_undo(entry.idx, entry.undo, entry.prev_hash);
+                if ( ! file) {
+                    // After the delta: these blocks are in the UTXO set and now cannot be
+                    // disconnected, so a later reorganization would have nothing to
+                    // reverse them with.
+                    spdlog::critical("[utxo_build] Failed to store undo data for index {}", entry.idx);
+                    on_fatal("a connected block has no undo data and cannot be disconnected");
+                    co_return;
+                }
+                undo_files.push_back(*file);
+            }
+
+            // Step 6. The deletions this batch owes, applied from a batch the task
+            // OWNS. They are part of this batch's delta, not work that follows it:
+            // until they run, outputs these blocks spent are still in the set. So
+            // they come before the state is published, and a failure is fatal rather
+            // than logged — a spent output left behind is a double spend the node
+            // would accept.
+            //
+            // ORDER MATTERS, and it used to be wrong: the height marker was
+            // persisted first and the deletions applied afterwards. A crash between
+            // the two left a marker saying the batch was complete over a set that
+            // still held every output these blocks spent, and the restart trusted
+            // the marker. The other direction — a crash after the deletions and
+            // before the height — is closed by the record written at step 2.
+            {
+                std::vector<utxoz::deferred_deletion_entry> owed;
+                owed.reserve(delta.deletes.size());
+                for (auto const& [key, h] : delta.deletes) {
+                    owed.emplace_back(key, h);
+                }
+
+                // The SAME policy the reorganization runs, from the same function:
+                // `erased` retired permanently even when the walk reported a fault,
+                // only `unresolved` resent and rebuilt from what came back, a fault
+                // with nothing owed still fatal, bounded attempts. Reimplementing it
+                // here is how the two drifted apart before.
+                //
+                // What differs is the tolerance, and only that: strict_absence()
+                // says no proven absence is legitimate on this path, because a
+                // connect batch nets out anything created and spent inside itself,
+                // so every key it asks to delete was in the set.
+                constexpr int max_deletion_attempts = 3;
+                utxoz::deferred_deletion_entry offender{utxoz::raw_outpoint{}, 0};
+
+                auto const outcome = blockchain::run_deletion_sweep(
+                    std::move(owed), blockchain::strict_absence(),
+                    [&chain, &window](std::span<utxoz::deferred_deletion_entry const> b) {
+                        return chain.utxo_apply_deletes(window, b);
+                    },
+                    max_deletion_attempts,
+                    [&](int attempt, utxoz::deletion_progress const& progress) {
+                        if ( ! progress.unresolved.empty() || progress.error) {
+                            spdlog::warn("[utxo_build] attempt {} of {} applied {}, proved {} absent, "
+                                "left {} owed at batch {}-{}{}", attempt, max_deletion_attempts,
+                                progress.erased.size(), progress.absent.size(),
+                                progress.unresolved.size(), batch_start, batch_end,
+                                progress.error
+                                    ? fmt::format(", fault: {}",
+                                        database::utxoz_error_name(*progress.error))
+                                    : "");
+                        }
+                    },
+                    &offender);
+
+                switch (outcome) {
+                    case blockchain::deletion_sweep_outcome::applied:
+                        break;
+
+                    case blockchain::deletion_sweep_outcome::absent_unaccounted:
+                        spdlog::critical("[utxo_build] {} is proven absent at batch {}-{}: the UTXO "
+                            "set does not hold an output these blocks spent",
+                            utxoz::outpoint_to_string(offender.key), batch_start, batch_end);
+                        on_fatal("a batch spent an output the UTXO set does not hold");
+                        co_return;
+
+                    case blockchain::deletion_sweep_outcome::fault_reported:
+                        spdlog::critical("[utxo_build] the deletion walk reported a fault at batch "
+                            "{}-{} with nothing left unresolved; refusing to publish over a store "
+                            "that reported one", batch_start, batch_end);
+                        on_fatal("the UTXO store reported a fault while applying deletions");
+                        co_return;
+
+                    case blockchain::deletion_sweep_outcome::attempts_exhausted:
+                        spdlog::critical("[utxo_build] deletions could not be applied in {} attempts "
+                            "at batch {}-{}; the UTXO set still holds outputs these blocks spent",
+                            max_deletion_attempts, batch_start, batch_end);
+                        on_fatal("the deletions a batch owed could not be applied");
+                        co_return;
+                }
+            }
+
+            utxo_built_height = batch_end;
+
+            // Steps 7 and 8. Every rev file this batch wrote into, then the
+            // directory entries naming them. Contents and names are two barriers: a
+            // newly created rev*.dat can have every byte on the platter and still
+            // not exist after a power cut, because the entry that reaches it was
+            // never written. Both live inside flush_undo.
+            if (auto const flushed = chain.flush_undo(undo_files); ! flushed) {
+                if (flushed.error().file_number < 0) {
+                    spdlog::critical("[utxo_build] The undo directory could not be put on stable "
+                        "storage after batch {}-{}: the rev files this batch wrote may not survive "
+                        "a restart, so these blocks would be connected and not disconnectable",
+                        batch_start, batch_end);
+                } else {
+                    spdlog::critical("[utxo_build] The undo records in rev file {} could not be put "
+                        "on stable storage after batch {}-{}: these blocks would be connected and "
+                        "not disconnectable", flushed.error().file_number, batch_start, batch_end);
+                }
+                on_fatal("the undo records of a connected batch could not be made durable");
                 co_return;
-        }
+            }
+
+            // Step 9. UTXO-Z's own barrier. `close()` does not run it, so without
+            // this the set's mutations are the one part of the transition still in
+            // the page cache when the record is cleared.
+            //
+            // `unsupported` is not a failure and not a guarantee either: it is the
+            // documented answer where the platform has no barrier at all, and the
+            // node's own durability level already says so. `failed` is fatal on
+            // every platform — a level describes what a platform CAN promise, and it
+            // never turns a barrier that was attempted and refused into a success.
+            switch (chain.utxo_sync(window)) {
+                case database::barrier_outcome::crossed:
+                    break;
+                case database::barrier_outcome::unsupported:
+                    if (chain.durability() != database::durability_level::none) {
+                        spdlog::critical("[utxo_build] The UTXO store reports no durability barrier "
+                            "while this node claims '{}'; the two disagree about the same machine",
+                            database::to_string(chain.durability()));
+                        on_fatal("the UTXO store and the node disagree about what this platform can promise");
+                        co_return;
+                    }
+                    spdlog::warn("[utxo_build] This platform exposes no durability barrier; batch "
+                        "{}-{} is published without one", batch_start, batch_end);
+                    break;
+                case database::barrier_outcome::failed:
+                    spdlog::critical("[utxo_build] The UTXO store's durability barrier failed after "
+                        "batch {}-{} (operation {:#018x}); what it applied is not known to be on "
+                        "disk", batch_start, batch_end, operation_id);
+                    on_fatal("the UTXO set of a connected batch could not be made durable");
+                    co_return;
+            }
+        }   // the window ends HERE, before publish_transition
 
         // Step 10. The built height AND the clearing of the record, in ONE
         // transaction. Separately there is an instant where the height says

--- a/src/node/test/reorg_deferred_sweep.cpp
+++ b/src/node/test/reorg_deferred_sweep.cpp
@@ -6,6 +6,10 @@
 
 #include <algorithm>
 #include <array>
+#include <thread>
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
 #include <chrono>
 #include <cstdint>
 #include <exception>
@@ -65,6 +69,31 @@ using namespace kth::test;
 // the same policy against a real store.
 
 namespace {
+
+// Aborts rather than letting a hang wedge the suite. Only ever fires on a
+// genuine exclusion defect: nothing here is expected to reach the deadline.
+struct watchdog_scope {
+    std::atomic<bool> done{false};
+    std::thread barker;
+
+    watchdog_scope(std::chrono::seconds budget, char const* what)
+        : barker([this, budget, what] {
+              auto const deadline = std::chrono::steady_clock::now() + budget;
+              while ( ! done.load()) {
+                  if (std::chrono::steady_clock::now() > deadline) {
+                      std::fprintf(stderr, "\n[watchdog] %s did not finish: "
+                          "treating it as an exclusion defect\n", what);
+                      std::abort();
+                  }
+                  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+              }
+          }) {}
+
+    ~watchdog_scope() {
+        done.store(true);
+        barker.join();
+    }
+};
 
 constexpr uint32_t trunk_len = 100;
 constexpr uint64_t spend_fee = 1000;
@@ -541,8 +570,12 @@ TEST_CASE("the classification is per block, and strict dominates tolerable",
     absence_tolerance tolerated;
     std::vector<utxoz::deferred_deletion_entry> owed;
 
-    REQUIRE(chain.disconnect_block(102, tolerated, owed) == database::disconnect_result::ok);
-    REQUIRE(chain.disconnect_block(101, tolerated, owed) == database::disconnect_result::ok);
+    // The same capability the rewind holds: one window for the whole operation.
+    auto const window = chain.begin_utxo_write();
+    REQUIRE(chain.disconnect_block(102, window, tolerated, owed)
+            == database::disconnect_result::ok);
+    REQUIRE(chain.disconnect_block(101, window, tolerated, owed)
+            == database::disconnect_result::ok);
 
     // Created and spent inside 101: never in the set, so absence is tolerable.
     auto const parent = tolerated.find(key_of(s.tx_parent, 0));
@@ -652,8 +685,16 @@ TEST_CASE("a deletion the rewind did not account for is fatal and publishes noth
 
     std::array<utxoz::deferred_deletion_entry, 1> const strip{
         utxoz::deferred_deletion_entry{coinbase_101, 101}};
-    auto const stripped = chain.utxo_apply_deletes(strip);
-    REQUIRE(stripped.erased.size() == 1);
+    {
+        // Scoped, and it MUST be: resolves() below takes a read lease, and the
+        // gate is deliberately not recursive, so reading while still holding the
+        // window is the self-deadlock the header calls reachable-but-unsupported.
+        // This test formed it and hung — the pattern being real, not a reason to
+        // soften the gate.
+        auto const strip_window = chain.begin_utxo_write();
+        auto const stripped = chain.utxo_apply_deletes(strip_window, strip);
+        REQUIRE(stripped.erased.size() == 1);
+    }
     REQUIRE_FALSE(resolves(chain, coinbase_101, 102));
 
     auto const branch_head = propose_switch(fixture, s);
@@ -680,6 +721,232 @@ TEST_CASE("a deletion the rewind did not account for is fatal and publishes noth
     // operation only; an interrupted transition is never resumed across a
     // restart, it is refused and rebuilt.
     CHECK_FALSE(fixture.restart());
+}
+
+TEST_CASE("a chain starts and makes progress under either storage mode",
+          "[node][reorg][deferred][gate]") {
+    // REGRESSION for a production deadlock full mode cannot reach. start() held
+    // one window across its whole body, and the reference-mode wiring inside it
+    // takes another; the gate is not recursive, so a reference build hung at
+    // startup while every full-mode run stayed green.
+    //
+    // Compiled in both modes, so the reference build actually exercises the
+    // #ifdef branch that deadlocked. Under a watchdog, because the failure it
+    // guards against is a hang rather than a wrong answer.
+    watchdog_scope guard(std::chrono::seconds(60), "starting a chain");
+
+    chain_fixture fixture("gate_start_regression");
+    REQUIRE(fixture.created());
+
+    // The call that hung. Reaching the next line is the assertion.
+    REQUIRE(fixture.start());
+
+    auto& chain = fixture.chain();
+
+    // Progress, not merely "it returned": the store answers, a window can be
+    // taken and released, and a read completes afterwards.
+    CHECK(chain.utxo_size() == 0u);
+    {
+        auto const window = chain.begin_utxo_write();
+        CHECK(window.held());
+    }
+    CHECK(chain.utxo_size() == 0u);
+
+    // And a restart, which closes and reopens — the other lifecycle path that
+    // takes windows.
+    REQUIRE(fixture.restart());
+    CHECK(fixture.chain().utxo_size() == 0u);
+}
+
+TEST_CASE("a deletion under a scoped window is readable once the window ends",
+          "[node][reorg][deferred][gate]") {
+    // REGRESSION. An earlier version held the write window across a resolves()
+    // call, which takes a read lease; the gate is not recursive, so the suite
+    // hung until it was killed. That is the reachable-but-unsupported pattern
+    // the header describes, and it must not come back as a hang someone has to
+    // notice.
+    //
+    // The blocking capability is owned BY THE TEST, in an optional, so the
+    // failure path can release it and let the reader finish. Nothing is ever
+    // detached: a thread parked on the gate that outlived this fixture would be
+    // reading freed memory, which would poison the rest of the suite and every
+    // sanitizer report in it.
+    chain_fixture fixture("gate_scoped_window_regression");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    auto const s = build_and_connect(fixture);
+    auto const target = key_of(s.tx_grand, 0);
+    REQUIRE(resolves(chain, target, 102));
+
+    std::optional<utxo_write_window> blocker = chain.begin_utxo_write();
+    CHECK(blocker->held());
+    {
+        std::array<utxoz::deferred_deletion_entry, 1> const batch{
+            utxoz::deferred_deletion_entry{target, 102}};
+        auto const progress = chain.utxo_apply_deletes(*blocker, batch);
+        CHECK(progress.erased.size() == 1);
+    }
+
+    // THE PROPERTY: released before anything reads.
+    blocker.reset();
+
+    // Re-acquisition after release, which is what this can actually show:
+    // `blocker` was already reset above, so taking a window here proves the
+    // first one gave the gate back rather than proving anything about exclusion
+    // while it was alive. Exclusion during a live window is covered where it can
+    // be forced — see the gate's own suite.
+    {
+        auto const proof = chain.begin_utxo_write();
+        CHECK(proof.held());
+    }
+
+    std::atomic<bool> done{false};
+    std::atomic<bool> still_there{true};
+    std::thread reader;
+
+    // The failure here is a HANG, not a wrong answer: `blocker` was released
+    // above before the reader starts, so the reaper's reset below is a no-op on
+    // every path — it cannot rescue a reader stuck on a window this test no
+    // longer holds. If the read blocks, the FAIL below throws, unwinding reaches
+    // the join, and the join has no deadline of its own. This is what bounds it.
+    watchdog_scope hang_guard(std::chrono::seconds(60), "a read after a scoped window");
+
+    // Joins on EVERY path, including a failed REQUIRE or an exception. The reset
+    // is kept for the shape rather than the effect: if a later edit moves the
+    // release below the thread, the reaper is already correct.
+    struct reaper {
+        std::thread& worker;
+        std::optional<utxo_write_window>& blocking;
+        ~reaper() {
+            if (worker.joinable()) {
+                blocking.reset();
+                worker.join();
+            }
+        }
+    } const guard{reader, blocker};
+
+    // resolves() throws when the store fails or the resolution cannot run, and an
+    // exception leaving a thread function calls std::terminate — which would kill
+    // the whole suite before the FAIL below could say anything. Captured here and
+    // reported by the main thread.
+    std::atomic<bool> threw{false};
+    std::string reason;
+    reader = std::thread([&] {
+        try {
+            still_there.store(resolves(chain, target, 102));
+        } catch (std::exception const& e) {
+            reason = e.what();
+            threw.store(true);
+        } catch (...) {
+            reason = "an unknown exception";
+            threw.store(true);
+        }
+        done.store(true);
+    });
+
+    // Short: the isolated case finishes immediately, so a long budget would only
+    // delay the diagnosis.
+    auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while ( ! done.load() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    // FAIL, not FAIL_CHECK: the reaper above still runs and joins cleanly.
+    if ( ! done.load()) {
+        FAIL("the read did not complete: a write window is being held across it");
+    }
+
+    if (threw.load()) {
+        FAIL("the read failed rather than answering: " << reason);
+    }
+    CHECK(still_there.load() == false);   // deleted, and observable afterwards
+}
+
+TEST_CASE("connect runs its whole mutation under one window and reaches sync",
+          "[node][reorg][deferred][gate]") {
+    // A gate regression here is a HANG, not a wrong answer: build_and_connect
+    // drives the window-taking sync path, and reaching the end is the assertion.
+    // Without this the suite wedges instead of reporting.
+    watchdog_scope guard(std::chrono::seconds(60), "connect under one window");
+    // End to end for the connect path (#649): the batch's inserts, the deletions
+    // it owes and utxo_sync(window) all run under ONE capability, and the effect
+    // is observable afterwards rather than merely "it did not die".
+    //
+    // The timeout is the point as much as the assertions: utxo_sync() used to
+    // take its own window while the batch still held one, which this gate — not
+    // being recursive — turns into a deterministic hang. Reaching the end at all
+    // is what proves that is gone.
+    chain_fixture fixture("gate_connect_e2e");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    auto const s = build_and_connect(fixture);
+
+    // connect_bodies drove utxo_build_task to completion, which is the path that
+    // opens the window, applies the delta, applies the deletions and syncs.
+    auto const heights = chain.get_last_heights();
+    REQUIRE(heights);
+    CHECK(heights->block == 102u);
+
+    auto const built = chain.get_utxo_built_height();
+    REQUIRE(built);
+    CHECK(*built == 102u);
+
+    // The final effect: what the branch created resolves, what it spent does not.
+    CHECK(resolves(chain, key_of(s.tx_grand, 0), 102));
+    CHECK_FALSE(resolves(chain, key_of(s.tx_child, 0), 102));
+    CHECK_FALSE(resolves(chain, key_of(s.tx_parent, 0), 102));
+
+    // Published cleanly, so the sync at the end of the window did happen.
+    CHECK(chain.read_transition_record().status == database::transition_status::clean);
+
+    // And the gate is left open: a window can be taken now, which it could not
+    // be if the batch had abandoned one.
+    auto const after = chain.begin_utxo_write();
+    CHECK(after.held());
+}
+
+TEST_CASE("reorg runs the whole rewind under one window and publishes",
+          "[node][reorg][deferred][gate]") {
+    // Same reason, and run_switch bounds only itself: build_and_connect and
+    // connect_bodies below it are unbounded.
+    watchdog_scope guard(std::chrono::seconds(60), "the rewind under one window");
+    // The same for the switch: restorations, every disconnect, the deletion
+    // sweep and the barrier under ONE capability, ending in a published branch
+    // and a verifiable UTXO set.
+    chain_fixture fixture("gate_reorg_e2e");
+    REQUIRE(fixture.created());
+    REQUIRE(fixture.start());
+    auto& chain = fixture.chain();
+
+    auto const s = build_and_connect(fixture);
+    auto const branch_head = propose_switch(fixture, s);
+    auto const outcome = run_switch(fixture, branch_head, trunk_len, {});
+
+    // It finished — the switch reaches publish_reorg_transition, which syncs
+    // while still holding the rewind's window.
+    CHECK_FALSE(outcome.fatal);
+    REQUIRE(outcome.result.ok);
+    REQUIRE(outcome.result.validated_tip);
+    CHECK(*outcome.result.validated_tip == trunk_len);
+    CHECK(chain.read_transition_record().status == database::transition_status::clean);
+
+    // The branch is published and the UTXO set matches it.
+    connect_bodies(fixture, s.branch_b, 101);
+    auto const heights = chain.get_last_heights();
+    REQUIRE(heights);
+    CHECK(heights->block == 104u);
+
+    CHECK_FALSE(resolves(chain, key_of(s.tx_parent, 0), 104));
+    CHECK_FALSE(resolves(chain, key_of(s.tx_child, 0), 104));
+    CHECK_FALSE(resolves(chain, key_of(s.tx_grand, 0), 104));
+    CHECK(resolves(chain, key_of(s.trunk.front().transactions().front(), 0), 104));
+
+    auto const after = chain.begin_utxo_write();
+    CHECK(after.held());
 }
 
 TEST_CASE("a concurrent resolution keeps its own batch through the switch",

--- a/src/node/test/utxo_batch_atomicity.cpp
+++ b/src/node/test/utxo_batch_atomicity.cpp
@@ -88,7 +88,8 @@ void insert_raw(blockchain::block_chain& chain, utxoz::raw_outpoint const& key, 
     blockchain::utxo_raw_delta delta;
     delta.inserts.emplace(key, blockchain::utxo_raw_value{
         std::vector<uint8_t>(8, 0x11), height});
-    REQUIRE(chain.apply_utxo_inserts_raw(delta.inserts)
+    auto const window = chain.begin_utxo_write();
+    REQUIRE(chain.apply_utxo_inserts_raw(window, delta.inserts)
             == database::result_code::success);
 }
 
@@ -242,9 +243,13 @@ TEST_CASE("a crash after the deletions are applied refuses the next start",
     insert_raw(chain, synthetic_key(0xA2), 4);
 
     // Nothing is owed here: the insert above created no deletion obligation.
-    auto const progress = chain.utxo_apply_deletes({});
-    REQUIRE(progress.erased.empty());
-    REQUIRE(progress.unresolved.empty());
+    {
+        // Scoped for the same reason: everything after this reads or restarts.
+        auto const del_window = chain.begin_utxo_write();
+        auto const progress = chain.utxo_apply_deletes(del_window, {});
+        REQUIRE(progress.erased.empty());
+        REQUIRE(progress.unresolved.empty());
+    }
 
     CHECK_FALSE(fixture.restart());
 }
@@ -265,14 +270,19 @@ TEST_CASE("a crash after every durability barrier refuses the next start",
     open_transition(chain, 4u, 6u);
     insert_raw(chain, synthetic_key(0xA3), 4);
 
-    // No obligation was created by the insert above.
-    auto const progress = chain.utxo_apply_deletes({});
-    REQUIRE(progress.unresolved.empty());
+    {
+        // Scoped: restart() below closes the chain, and close() takes a window of
+        // its own. Holding one across it is the reachable-but-unsupported
+        // pattern, and it hangs.
+        auto const del_window = chain.begin_utxo_write();
+        auto const progress = chain.utxo_apply_deletes(del_window, {});
+        REQUIRE(progress.unresolved.empty());
 
-    std::vector<int32_t> const touched{0};
-    REQUIRE(chain.flush_undo(touched).has_value());
-    CHECK(chain.utxo_sync() != database::barrier_outcome::failed);
-    REQUIRE(chain.env_sync() == database::result_code::success);
+        std::vector<int32_t> const touched{0};
+        REQUIRE(chain.flush_undo(touched).has_value());
+        CHECK(chain.utxo_sync(del_window) != database::barrier_outcome::failed);
+        REQUIRE(chain.env_sync() == database::result_code::success);
+    }
 
     CHECK_FALSE(fixture.restart());
 }


### PR DESCRIPTION
UTXO-Z 0.10 requires `apply_deletes()` to run with no `find()`, `resolve()`, `insert()`, compaction or `close()` in flight: it erases from the active containers **and** writes through the file cache's mappings, and the lock the library added covers resolve-against-resolve only. KTH did not provide that window. The two callers that delete exclude each other through the reorganization barrier, but neither excludes the single-transaction validate path, which probes lock-free and is reachable over JSON-RPC and the C API. A deletion writing through a mapping a probe is reading is a use-after-unmap — a crash, not a wrong answer.

## The mechanism

A readers-or-one-writer gate with **writer preference**, built from a mutex and a condition variable. A writer does not check whether readers are present and proceed; it marks itself pending — which closes the door to readers that have not entered — and then waits until the count reaches zero, so there is no instant where the answer could go stale between the question and the mutation.

The window is a **capability**, not a convention. `utxoz_db_` is a `guarded_store` with no getter, no `operator->` and no way to name it: access is handed to a callback for the duration of a call, and every call names the proof it holds. A method that reaches for the store without one **does not compile**. That is what "structural" has to mean here — the alternative, a rule each caller remembers, is exactly what left the lock-free path uncovered.

It covers the **operation**, not the call. A connect batch holds one window from before its first insert until its deletions have left the set coherent; a rewind holds one across every restoration, every disconnect and the final sweep. Per call would keep readers out of the mappings and still admit one between the inserts and the deletions, where the set holds outputs the blocks spent — and the transition record does not protect a reader that never consults it.

Nothing is held across a suspension point. Every stretch the gate guards is synchronous, the leases carry a count rather than a lock, and each capability taken inside a coroutine was audited against the `co_await`s around it.

## What the design found

Making the window explicit and non-recursive turned three latent reentrancies into deterministic, locatable hangs. All three were introduced by this change and none survived it:

1. `utxo_sync()` took a window of its own while the connect batch and the rewind still held theirs. It takes the capability now, which is also what it should always have been — the barrier belongs to the operation whose writes it makes durable.
2. A test read the store while still holding the window.
3. **`start()` in reference mode** held one window across its whole body and met the `#ifdef` wiring that takes another. A full-mode build could never show it; a reference node would have hung at startup.

The third is why this PR carries a small addition beyond the gate: **fail-fast reentry detection**. The thread that holds the window is recorded and used *only to refuse* — a second window or a read lease from that same thread throws immediately with a named error. It never authorises, bypasses or transfers a capability, and threads that do not hold the window keep the ordinary wait. Scope discipline alone had already failed three times in one change.

## Thread affinity

A capability that carried only its gate pointer would authorise **anywhere**: a window taken in one thread and used in another would open the store for a thread the gate never admitted, while the recorded owner still named the first one — so the thread actually holding the window could ask for another and be told to wait for itself.

The contract is thread-affine, and it is now checkable rather than written down. The scope audit behind it is per function per thread, and the rule that nothing may live across a `co_await` exists precisely because a coroutine resumes on whichever executor thread is free — a thread transfer wearing a different shape.

- **Using** a capability off its issuing thread throws `utxo_affinity_error`. The gate check runs first, because a released or moved-from capability has no meaningful issuing thread and reporting affinity for it would misname the defect.
- **Moving** one off its issuing thread throws too — refusing the use catches a capability that already crossed, refusing the move stops it from crossing. The move is deliberately no longer `noexcept`, and it is checked *before* the release, so a refused move does not destroy the capability it declined to overwrite.
- **Releasing** from another thread stays defined. A destructor that threw during unwinding would call `std::terminate`; it takes the gate's mutex like any other release, opens the door and wakes whoever waits. Refusing the use protects the store — refusing the release would only strand it.
- Moving and using within one thread is unchanged, including taking and moving a capability *inside* another thread: affinity is about crossing, not about which thread it is.

Audited: 19 capability sites in production, none moved — every one a local, passed on only by `const&`, never stored in a member or a container — and **zero `co_await` inside any capability's live scope**, computed by brace depth rather than read by eye.

## Giving up on the window

Writer preference means readers wait for the pending-writer count to reach zero — that count *is* the door. So a writer that stops waiting owes two things and not one: the count restored **and** a notification. A reader already parked in `cv.wait()` re-evaluates its predicate only when notified, so a count restored in silence leaves it waiting for a writer that is already gone.

That bookkeeping is `detail::pending_writer`, and its destructor is the whole of it: decrement under the mutex, release the mutex, then notify. Unguarded decrement would race the readers that read the count; notifying while still holding the mutex wakes readers straight into blocking on it again; and notifying *before* the decrement would be the premature one — the reader wakes, finds its predicate still false and parks again, having consumed the only notification it was going to get. On the success path it stands down instead: the count comes back, nothing is notified (the caller is about to set `writer_active_`, so every reader's predicate stays false either way) and the lock stays held, because the caller still has state to publish under it.

It is a separate type because the exceptional path has no seam inside the gate. `wait(lock, pred)` is `while (!pred()) wait(lock);`, so the only exception it can propagate is the predicate's, and this predicate reads two members. Rather than argue the code is correct, the tests drive `pending_writer` directly, in the sequence the library actually produces — the mutex is re-acquired before an exception propagates, so the guard is destroyed holding it.

**A timed-out `wait_for` is an ordinary return, and evidences nothing about the exceptional path.** The two are separate test cases, and a mutation that notifies on timeout while staying silent on the unwind leaves the first green and the second hanging — which is what makes them not redundant.

## The second lock, and the order between them

Making UTXO reads take a lease gave the node a **second** lock, and two locks have an order. The transaction organizer takes `validation_mutex_` and then, inside `validator_.accept()`, a UTXO read lease. The connect batch was holding the UTXO window across its whole loop body — through `flush_undo`, `publish_transition`, `env_sync`, `mempool_remove_for_block` and `publish_chain_view` — and `mempool_remove_for_block` takes that same `validation_mutex_`. Window→mutex against mutex→lease is the AB-BA deadlock, and it appears as a node that stops with no error and nothing in the log.

This PR created that inversion: before the gate, the read side took no lock at all.

Steps 4 to 9 are now a scope of their own, so the window dies immediately after `utxo_sync(window)` — the last operation that needs the capability — and the two fsyncs and the mempool update run outside it. Readers have no business being excluded across those.

Backing it, a **lock-order control**: `mempool_remove_for_block` refuses with `utxo_lock_order_error` if the calling thread holds the window, before touching `validation_mutex_` and before touching the pool. `utxo_gate::held_by_current_thread()` exists only to refuse — `with_read`/`with_write` still ask the capability, never the thread. The control fails by name, in the thread that formed the pattern, with no wall-clock involved in the verdict; restoring the old scope turns the connect path red deterministically.

It also logs before it throws, and that was learned rather than assumed: the exception leaves a coroutine and does not survive the trip, so what an operator actually read was "two chain transitions overlapped" — a consequence three steps downstream from the cause.

## One lease per thread

A thread holding a lease and asking for a second one self-deadlocks the moment a writer becomes pending: the second request waits for `writers_waiting_ == 0`, the writer waits for `readers_ == 0`, and the first lease holds that above zero. Writer preference is what makes it a deadlock rather than a delay. The gate cannot detect it, for the same reason it cannot detect the read→write upgrade, so the invariant is documented next to `read()` and pinned by a bounded regression: nesting with nobody waiting still works, nesting with a writer pending does not acquire, and releasing the first lease lets the writer through.

`~utxo_gate()` carries a `KTH_CONTRACT` that no capability is outstanding — active in Release, which is the only build a node runs. A capability outliving its gate would release into freed memory, and the crash would surface far from the ordering mistake.

## Honest limits

`begin_utxo_write()` is **reachable** while a read lease is alive. It is not supported and would self-deadlock; the reentry detection above catches the writer-side cases, not this one, and detecting it would need ownership tracking that was deliberately rejected. The evidence is the audit: no caller forms the pattern, and every lease dies with the single function that took it.

One shape of the thread transfer also survives: an owner may park a live capability in shared state, and a second thread that merely **holds** it — never using it — can then ask for a window and wait for one nothing will release. The gate cannot tell that apart from a thread legitimately waiting for a window another thread holds; the two are identical from there. Both *useful* shapes are refused, this one is not, and no production path forms it.

The header says all of this rather than claiming more.

## Validation

| | blockchain | node |
|---|---|---|
| full | 288 cases / 4182 assertions | 200 / 6046 |
| reference | 287 / 4160 | 200 / 6046 |
| ASAN+UBSAN | 288 / 4173 | 28 / 2759 (`[gate]`,`[deferred]`) |
| TSan | 24 / 108 (`[gate]`) — **0 races** | |

The two gate benchmarks were running in the default suite and are now hidden behind `[.]`: a timing case on a shared CI machine is the classic red build that means nothing. They still run on demand with `[bench]`.

Every run under an explicit timeout; no `TIMEOUT` or missing summary, no residual processes, binaries newer than sources.

Negations, each red on its own mutation: readers ignoring the window, a writer not draining readers, a capability not checking its gate, and for affinity — dropping the check on use, dropping it on the move, the release that refuses to work off-thread and strands the gate shut, and — separately for each path — a pending-writer count restored without a notification. None of them reaches a verdict by timing out: each failure is a value or an exception, and the watchdogs are there so a regression aborts by name instead of wedging. Compile-time controls reject a mutation without a token, a getter, `operator->`, a read lease authorising a write, and a callback returning a reference or pointer to the store.

Baseline for the gate: ~17 ns/op uncontended, ~128 ns/read with 8 concurrent readers. Comparison of alternatives is #650, which records non-recursiveness as a **safety** invariant any replacement must preserve or detect equivalently — not a performance characteristic.

Closes #649.
